### PR TITLE
Add unit tests to github actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,25 @@
+name: Tests
+on: [push, pull_request]
+permissions: {}
+jobs:
+  test-linux:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --all -- --nocapture
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --all --features pretend_to_be_macos -- --nocapture
+
+  test-windows:
+    runs-on: windows-2022
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --all --lib -- --nocapture


### PR DESCRIPTION
### Description
Add unit tests to github actions.
Right now we have windows and linux unit tests in gitlab pipelines. Mac tests are not working at the moment so I didn't turn them on. I think we should fix them on mac, add them to the pipelines and remove `pretend_to_be_macos` feature. This can be done as a separate task.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean
- [x] README.md is updated
- [x] changelog.md is updated
