### PR TITLE
add initial heartbeat interval to feature config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,7 @@ target/
 /ffi/bindings/windows/wrap/java_wrap.gnuld_exports.lst
 /ffi/helpers/go/go.mod
 __pycache__
+event.db
+alpha-events.db
+beta-events.db
+gamma-events.db

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 ---
 * LLT-3777: Apply rebinding logic to all Apple platforms
 * LLT-4002: Review log-levels of spammy log messages
+* LLT-3990: Add initial heartbeat interval to feature config
 
 <br>
 

--- a/crates/telio-model/src/api_config.rs
+++ b/crates/telio-model/src/api_config.rs
@@ -84,6 +84,8 @@ pub struct FeatureNurse {
     pub fingerprint: String,
     /// Heartbeat interval in seconds. Default value is 3600.
     pub heartbeat_interval: Option<u32>,
+    /// Initial heartbeat interval in seconds. Default value is None.
+    pub initial_heartbeat_interval: Option<u32>,
     /// QoS configuration for Nurse
     pub qos: Option<FeatureQoS>,
     /// Enable/disable collecting nat type
@@ -317,6 +319,7 @@ mod tests {
         nurse: Some(FeatureNurse {
             fingerprint: "fingerprint_test".to_string(),
             heartbeat_interval: None,
+            initial_heartbeat_interval: None,
             qos: None,
             enable_nat_type_collection: None,
         }),
@@ -352,6 +355,7 @@ mod tests {
         nurse: Some(FeatureNurse {
             fingerprint: "fingerprint_test".to_string(),
             heartbeat_interval: None,
+            initial_heartbeat_interval: None,
             qos: None,
             enable_nat_type_collection: None,
         }),
@@ -518,6 +522,7 @@ mod tests {
             nurse: Some(FeatureNurse {
                 fingerprint: String::from("fingerprint_test"),
                 heartbeat_interval: Some(3600),
+                initial_heartbeat_interval: None,
                 qos: Some(FeatureQoS {
                     rtt_interval: Some(3600),
                     rtt_tries: Some(5),
@@ -538,6 +543,7 @@ mod tests {
             nurse: Some(FeatureNurse {
                 fingerprint: String::from("fingerprint_test"),
                 heartbeat_interval: None,
+                initial_heartbeat_interval: None,
                 qos: Some(FeatureQoS {
                     rtt_interval: None,
                     rtt_tries: None,
@@ -558,6 +564,7 @@ mod tests {
             nurse: Some(FeatureNurse {
                 fingerprint: String::from("fingerprint_test"),
                 heartbeat_interval: None,
+                initial_heartbeat_interval: None,
                 qos: None,
                 enable_nat_type_collection: None,
             }),

--- a/crates/telio-nurse/src/config.rs
+++ b/crates/telio-nurse/src/config.rs
@@ -50,7 +50,13 @@ impl HeartbeatConfig {
             .map(|interval| Duration::from_secs(interval.into()))
             .unwrap_or(Self::DEFAULT_HEARTBEAT_INTERVAL);
 
+        let initial_collect_interval = features
+            .initial_heartbeat_interval
+            .map(|interval| Some(Duration::from_secs(interval.into())))
+            .unwrap_or(None);
+
         Self {
+            initial_collect_interval,
             fingerprint: features.fingerprint.clone(),
             collect_interval,
             is_nat_type_collection_enabled: features.enable_nat_type_collection.unwrap_or(false),

--- a/crates/telio-nurse/src/config.rs
+++ b/crates/telio-nurse/src/config.rs
@@ -53,7 +53,7 @@ impl HeartbeatConfig {
         let initial_collect_interval = features
             .initial_heartbeat_interval
             .map(|interval| Some(Duration::from_secs(interval.into())))
-            .unwrap_or(None);
+            .unwrap_or_default();
 
         Self {
             initial_collect_interval,

--- a/nat-lab/tests/telio_features.py
+++ b/nat-lab/tests/telio_features.py
@@ -37,6 +37,7 @@ class Qos:
 class Nurse:
     fingerprint: str
     heartbeat_interval: Optional[int] = None
+    initial_heartbeat_interval: Optional[int] = None
     qos: Optional[Qos] = None
     enable_nat_type_collection: bool = False
 

--- a/nat-lab/tests/test_telio_features.py
+++ b/nat-lab/tests/test_telio_features.py
@@ -39,12 +39,13 @@ def test_telio_features():
                 rtt_tries=3,
                 rtt_types=["Ping"],
                 buckets=5,
-                heartbeat_interval=3600,
             ),
+            heartbeat_interval=3600,
+            initial_heartbeat_interval=10,
         )
     )
     expected_nurse_qos = TelioFeatures.from_json(
-        """{"is_test_env": true, "exit_dns": {"auto_switch_dns_ips": true}, "nurse": {"fingerprint": "fingerprint", "qos": {"rtt_interval": 5, "rtt_tries": 3, "rtt_types": ["Ping"], "buckets": 5, "heartbeat_interval": 3600}}}"""
+        """{"is_test_env": true, "exit_dns": {"auto_switch_dns_ips": true}, "nurse": {"fingerprint": "fingerprint", "qos": {"rtt_interval": 5, "rtt_tries": 3, "rtt_types": ["Ping"], "buckets": 5}, "heartbeat_interval": 3600, "initial_heartbeat_interval": 10}}"""
     )
     assert nurse_qos_features == expected_nurse_qos
     assert nurse_qos_features.to_json() == expected_nurse_qos.to_json()
@@ -61,12 +62,13 @@ def test_telio_features():
                 rtt_tries=3,
                 rtt_types=["Ping"],
                 buckets=5,
-                heartbeat_interval=3600,
             ),
+            heartbeat_interval=3600,
+            initial_heartbeat_interval=10,
         ),
     )
     expected_full = TelioFeatures.from_json(
-        """{"is_test_env": false, "exit_dns": {"auto_switch_dns_ips": true}, "direct": {"providers": ["stun", "local"]}, "lana": {"prod": false, "event_path": "/"}, "nurse": {"fingerprint": "alpha", "qos": {"rtt_interval": 5, "rtt_tries": 3, "rtt_types": ["Ping"], "buckets": 5, "heartbeat_interval": 3600}}}"""
+        """{"is_test_env": false, "exit_dns": {"auto_switch_dns_ips": true}, "direct": {"providers": ["stun", "local"]}, "lana": {"prod": false, "event_path": "/"}, "nurse": {"fingerprint": "alpha", "qos": {"rtt_interval": 5, "rtt_tries": 3, "rtt_types": ["Ping"], "buckets": 5}, "heartbeat_interval": 3600, "initial_heartbeat_interval": 10}}"""
     )
     assert full_features == expected_full
     assert full_features.to_json() == expected_full.to_json()

--- a/nat-lab/tests/test_telio_tasks.py
+++ b/nat-lab/tests/test_telio_tasks.py
@@ -26,6 +26,7 @@ async def test_telio_tasks_with_all_features() -> None:
                     nurse=Nurse(
                         fingerprint="alpha",
                         heartbeat_interval=3600,
+                        initial_heartbeat_interval=10,
                         qos=Qos(
                             rtt_interval=5,
                             rtt_tries=3,


### PR DESCRIPTION
### Description
Add a configurable parameter within feature config, defining how long should libtelio wait until sending first heartbeat event.



### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean
- [x] README.md is updated
- [x] changelog.md is updated
