### PR TITLE
CI improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,7 @@
 name: Build
-on: [push, pull_request]
+on: [workflow_call]
 permissions: {}
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+on: [push, pull_request]
+permissions: {}
+
+jobs:
+  skipper:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@12aca0a884f6137d619d6a8a09fcc3406ced5281 # v5.3.0
+        with:
+          concurrent_skipping: 'same_content_newer'
+
+  build:
+    needs: skipper
+    if: needs.skipper.outputs.should_skip != 'true'
+    uses: ./.github/workflows/build.yml
+  linters:
+    needs: skipper
+    if: needs.skipper.outputs.should_skip != 'true'
+    uses: ./.github/workflows/linters.yml
+  tests:
+    needs: skipper
+    if: needs.skipper.outputs.should_skip != 'true'
+    uses: ./.github/workflows/tests.yml
+  fuzzing:
+    needs: skipper
+    if: needs.skipper.outputs.should_skip != 'true'
+    uses: ./.github/workflows/fuzzing.yml
+
+  check-all-green:
+    needs:
+    - build
+    - linters
+    - tests
+    - fuzzing
+    - skipper
+    if: needs.skipper.outputs.should_skip != 'true'
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Collect statuses from all jobs
+      uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
+      with:
+        jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/dod.yml
+++ b/.github/workflows/dod.yml
@@ -2,6 +2,7 @@ name: Definition of Done
 on:
   pull_request:
     types: [opened, edited]
+permissions: {}
 
 jobs:
   check-dod:
@@ -9,8 +10,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-20.04
     steps:
-      - name: Clone Repo
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       - name: Check DoD
         uses: platisd/definition-of-done@99622dd6e4480530c0c6c571651b58d3283583b4 # v2.0.0
         with:

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -1,6 +1,7 @@
 name: Fuzzing
-on: [push, pull_request]
+on: [workflow_call]
 permissions: {}
+
 jobs:
   telio-proto-fuzzing:
       runs-on: ubuntu-22.04

--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -2,14 +2,21 @@ name: GitLab CI Pipeline
 on:
   pull_request_target:
     branches: [main]
-    types: [labeled]
   push:
-    branches: [main]
 permissions: {}
+
 jobs:
   trigger-gitlab-pipeline:
     runs-on: [self-hosted, libtelio]
-    if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'run tests')) }}
+    if: |
+      github.event_name == 'push' ||
+      (
+        github.event_name == 'pull_request_target' &&
+        (
+          contains(github.event.pull_request.labels.*.name, 'run tests') ||
+          (github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name)
+        )
+      )
     steps:
       - uses: NordSecurity/trigger-gitlab-pipeline@fd24fd4a3d03065fe67ae1e98d05d4283d7bb104 # v1
         with:

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -1,6 +1,7 @@
 name: Linters
-on: [push, pull_request]
+on: [workflow_call]
 permissions: {}
+
 jobs:
   check:
       runs-on: ubuntu-22.04

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -5,7 +5,6 @@ on:
     - cron: "43 5 * * 0"
   push:
     branches: [ "main" ]
-
 permissions: read-all
 
 jobs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,7 @@
 name: Tests
-on: [push, pull_request]
+on: [workflow_call]
 permissions: {}
+
 jobs:
   test-linux:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
### Description
Few improvements to the CI:
1. Gitlab pipeline is run automatically for PRs where feature branch is residing inside NordSecurity repository. This way there is no need to add `run tests` label in order to trigger gitlab pipelines for internal PRs.
2. build, linters, tests and fuzzing were put into one `CI` workflow in order to use `check-all-green` and `skip-duplicate-actions` actions more easily
3. `skip-duplicate-actions` is used to skip actions if multiple of them are running for the same sha. We have this situation because we run our actions for both `push` and `pull_request` events. Alternatively we could also not run them for push (leave only push to master) but the advantage of keeping both of them is that you can push your feature branch and check the actions without needing to open a PR. I was sometimes using it on Gitlab and I think we should leave this behavior and only think about dropping it if it turns out that this `skip-duplicate-actions` does not work correctly.
4. `check-all-green` is used to collect status checks from multiple jobs in order to easily add it into the settings under: `Require status checks to pass before merging`. Without it we would need to specify ~30 of them there and modify every time we change our CI.
5. Top level permission added to `dod.yml`



### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean
- [x] README.md is updated
- [x] changelog.md is updated
