### PR TITLE
Llt 3626 firewall speedup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,6 +28,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -35,6 +46,12 @@ checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
 name = "ansi_term"
@@ -308,6 +325,21 @@ name = "base64"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f1e31e207a6b8fb791a38ea3105e6cb541f55e4d029902d3039a4ad07cc4105"
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
@@ -1484,6 +1516,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
+name = "hashbrown"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "312f66718a2d7789ffef4f4b7b213138ed9f1eb3aa1d0d82fc99f88fb3ffd26f"
+dependencies = [
+ "hashbrown 0.14.0",
+]
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1679,7 +1730,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -1870,6 +1921,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
+
+[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1915,6 +1972,9 @@ name = "lru_time_cache"
 version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9106e1d747ffd48e6be5bb2d97fa706ed25b144fbee4d5c02eae110cd8d6badd"
+dependencies = [
+ "sn_fake_clock",
+]
 
 [[package]]
 name = "malloc_buf"
@@ -2142,6 +2202,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -2291,7 +2352,7 @@ dependencies = [
  "cfg-if",
  "instant",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "smallvec",
  "winapi 0.3.9",
 ]
@@ -2304,7 +2365,7 @@ checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "smallvec",
  "windows-sys 0.45.0",
 ]
@@ -2564,6 +2625,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e35c06b98bf36aba164cc17cb25f7e232f5c4aeea73baa14b8a9f0d92dbfa65"
+dependencies = [
+ "bit-set",
+ "bitflags",
+ "byteorder",
+ "lazy_static",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax 0.6.29",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "proptest-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90b46295382dc76166cb7cf2bb4a97952464e4b7ed5a43e6cd34e1fec3349ddc"
+dependencies = [
+ "proc-macro2 0.4.30",
+ "quote 0.6.13",
+ "syn 0.15.44",
+]
+
+[[package]]
 name = "protobuf"
 version = "2.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2659,6 +2751,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "rayon"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2690,13 +2791,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
  "getrandom",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "thiserror",
 ]
 
@@ -2708,7 +2818,7 @@ checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.7.1",
 ]
 
 [[package]]
@@ -2716,6 +2826,12 @@ name = "regex-automata"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -2911,6 +3027,18 @@ name = "rustversion"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "rustyline"
@@ -3212,9 +3340,15 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+
+[[package]]
+name = "sn_fake_clock"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2407d5b1cfd7dd5f3a9d2fa04484473fb9cfe939e701d18a3aa14e15671cb83"
 
 [[package]]
 name = "socket2"
@@ -3552,10 +3686,13 @@ name = "telio-firewall"
 version = "0.1.0"
 dependencies = [
  "criterion",
+ "hashlink",
  "log",
- "lru_time_cache",
  "mockall",
  "pnet_packet 0.28.0",
+ "proptest",
+ "proptest-derive",
+ "rand",
  "rustc-hash",
  "telio-crypto",
  "telio-utils",
@@ -3796,11 +3933,17 @@ name = "telio-utils"
 version = "0.1.0"
 dependencies = [
  "futures",
+ "hashlink",
  "log",
+ "lru_time_cache",
  "mockall",
  "parking_lot 0.12.1",
+ "proptest",
+ "proptest-derive",
+ "rand",
  "rustc-hash",
  "serde",
+ "sn_fake_clock",
  "telio-test",
  "thiserror",
  "tokio",
@@ -3842,6 +3985,20 @@ dependencies = [
  "winapi 0.3.9",
  "wireguard-nt",
  "wireguard-uapi",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "fastrand",
+ "redox_syscall 0.3.5",
+ "rustix",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4226,6 +4383,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4343,6 +4506,15 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "waker-fn"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3556,6 +3556,7 @@ dependencies = [
  "lru_time_cache",
  "mockall",
  "pnet_packet 0.28.0",
+ "rustc-hash",
  "telio-crypto",
  "telio-utils",
 ]

--- a/crates/telio-firewall/Cargo.toml
+++ b/crates/telio-firewall/Cargo.toml
@@ -13,6 +13,7 @@ pnet_packet = "0.28.0"
 mockall = { version = "0.11.3", optional = true }
 telio-crypto = { path = "../telio-crypto" }
 telio-utils = { path = "../telio-utils" }
+rustc-hash = "1.1.0"
 
 [dev-dependencies]
 mockall = "0.11.3"

--- a/crates/telio-firewall/Cargo.toml
+++ b/crates/telio-firewall/Cargo.toml
@@ -8,16 +8,19 @@ publish = false
 
 [dependencies]
 log = {version = "0.4.14", features = ["release_max_level_debug"]}
-lru_time_cache = "0.11.11"
 pnet_packet = "0.28.0"
 mockall = { version = "0.11.3", optional = true }
 telio-crypto = { path = "../telio-crypto" }
 telio-utils = { path = "../telio-utils" }
 rustc-hash = "1.1.0"
+hashlink = "0.8.3"
 
 [dev-dependencies]
 mockall = "0.11.3"
 criterion = "0.3"
+rand = "0.8.5"
+proptest-derive = "0.3.0"
+proptest = "1.2.0"
 
 [features]
 test_utils = [] # For use in benchmarks to avoid duplication of the 'setup' code needed to create buffers with valid packets

--- a/crates/telio-firewall/src/firewall.rs
+++ b/crates/telio-firewall/src/firewall.rs
@@ -462,8 +462,11 @@ impl StatefullFirewall {
             let mut tcp_cache = unwrap_lock_or_return!(self.tcp.lock());
             telio_log_trace!("Connection {:?} closing", key);
             if let Entry::Occupied(mut e) = tcp_cache.entry(key) {
-                e.get_mut().tx_alive = false;
-                if !e.get_mut().rx_alive {
+                let TcpConnectionInfo {
+                    tx_alive, rx_alive, ..
+                } = e.get_mut();
+                *tx_alive = false;
+                if !*rx_alive {
                     telio_log_trace!("Removing TCP conntrack entry {:?}", e.key());
                     e.remove();
                 }

--- a/crates/telio-firewall/src/firewall.rs
+++ b/crates/telio-firewall/src/firewall.rs
@@ -13,8 +13,8 @@ use pnet_packet::{
     udp::UdpPacket,
     Packet,
 };
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use std::{
-    collections::{HashMap, HashSet},
     fmt::{Debug, Formatter},
     net::{IpAddr as StdIpAddr, Ipv4Addr as StdIpv4Addr, Ipv6Addr as StdIpv6Addr},
     sync::{Mutex, RwLock},

--- a/crates/telio-firewall/src/firewall.rs
+++ b/crates/telio-firewall/src/firewall.rs
@@ -2,7 +2,6 @@
 //! with other devices§
 
 use log::error;
-use lru_time_cache::LruCache;
 use pnet_packet::{
     icmp::{IcmpPacket, IcmpType, IcmpTypes},
     icmpv6::{Icmpv6Packet, Icmpv6Type, Icmpv6Types},
@@ -20,6 +19,7 @@ use std::{
     sync::{Mutex, RwLock},
     time::Duration,
 };
+use telio_utils::lru_cache::{Entry, LruCache};
 
 use telio_crypto::PublicKey;
 use telio_utils::{telio_log_debug, telio_log_trace, telio_log_warn};
@@ -233,7 +233,7 @@ struct TcpConnectionInfo {
     conn_remote_initiated: bool,
 }
 
-#[derive(Clone, Copy, Ord, PartialOrd, Eq, PartialEq, Debug)]
+#[derive(Clone, Copy, Ord, PartialOrd, Eq, PartialEq, Debug, Hash)]
 enum IpAddr {
     Ipv4(u32),
     Ipv6(u128),
@@ -260,7 +260,7 @@ impl From<IpAddr> for StdIpAddr {
     }
 }
 
-#[derive(Clone, Ord, PartialOrd, Eq, PartialEq)]
+#[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
 struct IpConnWithPort {
     remote_addr: IpAddr,
     remote_port: u16,
@@ -324,8 +324,8 @@ impl StatefullFirewall {
     pub fn new_custom(capacity: usize, ttl: u64) -> Self {
         let ttl = Duration::from_millis(ttl);
         Self {
-            tcp: Mutex::new(LruCache::with_expiry_duration_and_capacity(ttl, capacity)),
-            udp: Mutex::new(LruCache::with_expiry_duration_and_capacity(ttl, capacity)),
+            tcp: Mutex::new(LruCache::new(ttl, capacity)),
+            udp: Mutex::new(LruCache::new(ttl, capacity)),
             whitelist: RwLock::new(Whitelist::default()),
         }
     }
@@ -410,13 +410,13 @@ impl StatefullFirewall {
             local_port: udp_packet.get_source(),
         };
         let mut udp_cache = unwrap_lock_or_return!(self.udp.lock());
-        // If key already exists, dont change the value, just update timer with get()
-        if udp_cache.get(&key).is_none() {
+        // If key already exists, dont change the value, just update timer with entry
+        if let Entry::Vacant(e) = udp_cache.entry(key) {
             let conninfo = UdpConnectionInfo {
                 is_remote_initiated: false,
             };
-            telio_log_trace!("Inserting new UDP conntrack entry {:?}", key);
-            udp_cache.insert(key, conninfo);
+            telio_log_trace!("Inserting new UDP conntrack entry {:?}", e.key());
+            e.insert(conninfo);
         }
     }
 
@@ -450,9 +450,8 @@ impl StatefullFirewall {
                 local_port: tcp_packet.get_source(),
             };
 
-            let mut tcp_cache = unwrap_lock_or_return!(self.tcp.lock());
             telio_log_trace!("Removing TCP conntrack entry {:?}", key);
-            tcp_cache.remove(&key);
+            unwrap_lock_or_return!(self.tcp.lock()).remove(&key);
         } else if flags & TcpFlags::FIN == TcpFlags::FIN {
             let key = IpConnWithPort {
                 remote_addr: ip.get_destination().into(),
@@ -463,11 +462,11 @@ impl StatefullFirewall {
 
             let mut tcp_cache = unwrap_lock_or_return!(self.tcp.lock());
             telio_log_trace!("Connection {:?} closing", key);
-            if let Some(connection) = tcp_cache.get_mut(&key) {
-                connection.tx_alive = false;
-                if !connection.rx_alive {
-                    telio_log_trace!("Removing TCP conntrack entry {:?}", key);
-                    tcp_cache.remove(&key);
+            if let Entry::Occupied(mut e) = tcp_cache.entry(key) {
+                e.get_mut().tx_alive = false;
+                if !e.get_mut().rx_alive {
+                    telio_log_trace!("Removing TCP conntrack entry {:?}", e.key());
+                    e.remove();
                 }
             }
         }
@@ -1248,6 +1247,55 @@ pub mod tests {
             assert_eq!(fw.process_outbound_packet(&make_peer(), &make_tcp(us, them, TcpFlags::FIN)), true);
             assert_eq!(fw.tcp.lock().unwrap().len(), 1);
             assert_eq!(fw.process_inbound_packet(&make_peer(), &make_tcp(them, us, TcpFlags::FIN)), true);
+            assert_eq!(fw.tcp.lock().unwrap().len(), 0);
+        }
+    }
+
+    #[rustfmt::skip]
+    #[test]
+    fn firewall_tcp_connection_is_removed_when_outbound_fin_is_after_inbound_one() {
+        struct TestInput {
+            us: &'static str,
+            them: &'static str,
+            make_tcp: MakeTcp,
+        }
+
+        impl TestInput {
+            fn us_port(&self) -> u16 { self.us.parse::<StdSocketAddr>().unwrap().port() }
+            fn them_port(&self) -> u16 { self.them.parse::<StdSocketAddr>().unwrap().port() }
+            fn us_ip(&self) -> IpAddr { self.us.parse::<StdSocketAddr>().unwrap().ip().into() }
+            fn them_ip(&self) -> IpAddr { self.them.parse::<StdSocketAddr>().unwrap().ip().into() }
+        }
+
+        let test_inputs = vec![
+            TestInput{ us: "127.0.0.1:1111", them: "8.8.8.8:8888",                 make_tcp: &make_tcp },
+            TestInput{ us: "[::1]:1111",     them: "[2001:4860:4860::8888]:8888",  make_tcp: &make_tcp6 },
+        ];
+        for test_input @ TestInput { us, them, make_tcp } in test_inputs {
+            let fw = StatefullFirewall::new_custom(3, LRU_TIMEOUT);
+
+            let outgoing_init_packet = make_tcp(us, them, TcpFlags::SYN);
+            assert_eq!(fw.process_outbound_packet(&make_peer(), &outgoing_init_packet), true);
+            assert_eq!(fw.tcp.lock().unwrap().len(), 1);
+            let conn_key = IpConnWithPort {
+                remote_addr: test_input.them_ip(),
+                remote_port: test_input.them_port(),
+                local_addr: test_input.us_ip(),
+                local_port: test_input.us_port(),
+            };
+
+            assert_eq!(fw.tcp.lock().unwrap().get(&conn_key), Some(&TcpConnectionInfo{
+                tx_alive: true, rx_alive: true, conn_remote_initiated: false
+            }));
+
+            assert_eq!(fw.process_inbound_packet(&make_peer(), &make_tcp(them, us, TcpFlags::FIN)), true);
+            assert_eq!(fw.tcp.lock().unwrap().len(), 1);
+
+            assert_eq!(fw.tcp.lock().unwrap().get(&conn_key), Some(&TcpConnectionInfo{
+                tx_alive: true, rx_alive: false, conn_remote_initiated: false
+            }));
+
+            assert_eq!(fw.process_outbound_packet(&make_peer(), &make_tcp(us, them, TcpFlags::FIN)), true);
             assert_eq!(fw.tcp.lock().unwrap().len(), 0);
         }
     }

--- a/crates/telio-utils/Cargo.toml
+++ b/crates/telio-utils/Cargo.toml
@@ -16,9 +16,15 @@ log = {version = "0.4.14", features = ["release_max_level_debug"]}
 parking_lot = "0.12"
 rustc-hash = "1"
 tracing = { version = "0.1.37", features = ["release_max_level_debug"] }
+hashlink = "0.8.3"
 
 
 [dev-dependencies]
 mockall = { version = "0.11.3" }
 tokio = { version = ">=1.22", features = ["time", "rt", "macros", "test-util"] }
 telio-test = { version = "1.0.0", path = "../telio-test" }
+rand = "0.8.5"
+proptest = "1.2.0"
+proptest-derive = "0.3.0"
+sn_fake_clock = "0.4.14"
+lru_time_cache = { version = "0.11.11", features = ["sn_fake_clock"] }

--- a/crates/telio-utils/proptest-regressions/lru_cache.txt
+++ b/crates/telio-utils/proptest-regressions/lru_cache.txt
@@ -1,0 +1,10 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 6b9d4356d61b506b914a3649ebb86368494dbc998e06bbff85efc4b76e89efcd # shrinks to init = (0, 0), ops = [Insert(0)]
+cc 10dc7db51b0c073137260e5b162effcfcb08acae661faf7f171cc606a887fcbb # shrinks to init = (27, 0), ops = [Insert(12), GetMut(12)]
+cc 1d2f8eb5108b9f6a21167328a5c2306d358c0bd8e49bd56a32222c9f00cf5ca8 # shrinks to init = (158, 1), ops = [Insert(B), Insert(A), Sleep(22), GetUsingEntry(B), Sleep(138)]
+cc 2b02f504b6709385ef927d4a41cb2bd3ab3d6d8f4469cb9e61fd946f4440a30c # shrinks to init = (0, 0), ops = [Insert(A), Insert(B)]

--- a/crates/telio-utils/src/lib.rs
+++ b/crates/telio-utils/src/lib.rs
@@ -23,7 +23,7 @@ pub mod exponential_backoff;
 pub mod hidden;
 pub use hidden::*;
 
-/// Functions for dealing with git.
+/// Functions for dealing with git
 pub mod git;
 pub use git::*;
 
@@ -34,3 +34,7 @@ pub use ::tokio::*;
 /// Utils for dealing with tracing crate
 pub mod tracing;
 pub use ::tracing::*;
+
+/// Least Recently Used cache implementation
+pub mod lru_cache;
+pub use lru_cache::*;

--- a/crates/telio-utils/src/lru_cache.rs
+++ b/crates/telio-utils/src/lru_cache.rs
@@ -1,0 +1,612 @@
+use hashlink::lru_cache::RawOccupiedEntryMut;
+use hashlink::{linked_hash_map::RawEntryMut, LinkedHashMap};
+use rustc_hash::FxHasher;
+use std::hash::{BuildHasher, Hasher};
+use std::{
+    borrow::Borrow,
+    hash::{BuildHasherDefault, Hash},
+    time::Duration,
+};
+
+#[cfg(test)]
+use sn_fake_clock::FakeClock as Instant;
+#[cfg(not(test))]
+use std::time::Instant;
+
+/// A view into a single entry in a map, which may either be vacant or occupied.
+pub enum Entry<'a, K, V> {
+    /// An occupied entry.
+    Occupied(OccupiedEntry<'a, K, V>),
+    /// A vacant entry.
+    Vacant(VacantEntry<'a, K, V>),
+}
+
+/// A view into an occupied entry in a `LruCache`.
+pub struct OccupiedEntry<'a, K, V> {
+    key: K,
+    hash: u64,
+    map: &'a mut LinkedHashMap<K, TimedValue<V>, BuildHasherDefault<FxHasher>>,
+}
+
+impl<'a, K: Hash + Eq, V> OccupiedEntry<'a, K, V> {
+    /// Gets a reference to the key in the entry.
+    pub fn key(&self) -> &K {
+        &self.key
+    }
+
+    /// Gets a mutable reference to the value in the entry.
+    pub fn get_mut(&mut self) -> &mut V {
+        &mut self.occupied_entry().into_mut().data
+    }
+
+    /// Removes the entry from the map.
+    pub fn remove(&mut self) {
+        self.occupied_entry().remove();
+    }
+
+    fn occupied_entry(&'_ mut self) -> RawOccupiedEntryMut<'_, K, TimedValue<V>> {
+        if let RawEntryMut::Occupied(e) = self
+            .map
+            .raw_entry_mut()
+            .from_key_hashed_nocheck(self.hash, &self.key)
+        {
+            e
+        } else {
+            unreachable!()
+        }
+    }
+}
+
+/// A view into a vacant entry in a `LruCache`.
+pub struct VacantEntry<'a, K, V> {
+    key: K,
+    hash: u64,
+    max_map_size: usize,
+    map: &'a mut LinkedHashMap<K, TimedValue<V>, BuildHasherDefault<FxHasher>>,
+}
+
+impl<'a, K, V> VacantEntry<'a, K, V> {
+    /// Gets a reference to the key in the entry.
+    pub fn key(&self) -> &K {
+        &self.key
+    }
+
+    /// Sets the value of the entry with the VacantEntry’s key, and returns a mutable reference to it.
+    pub fn insert(self, value: V)
+    where
+        K: Hash + Eq,
+    {
+        if let RawEntryMut::Vacant(e) = self
+            .map
+            .raw_entry_mut()
+            .from_key_hashed_nocheck(self.hash, &self.key)
+        {
+            e.insert_hashed_nocheck(self.hash, self.key, TimedValue::new(value));
+            if self.map.len() > self.max_map_size {
+                self.map.pop_front();
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+struct TimedValue<V> {
+    data: V,
+    last_access: Instant,
+}
+
+impl<V> TimedValue<V> {
+    fn new(data: V) -> Self {
+        Self {
+            data,
+            last_access: Instant::now(),
+        }
+    }
+
+    fn update_last_access(&mut self, new_last_access: Instant) {
+        self.last_access = new_last_access;
+    }
+
+    fn is_expired(&self, ttl: Duration, now: Instant) -> bool {
+        self.last_access + ttl < now
+    }
+}
+
+/// Implementation of a Least Recently Used
+/// [caching algorithm](http://en.wikipedia.org/wiki/Cache_algorithms) in a container which may be
+/// limited by size or time, ordered by most recently seen.
+#[derive(Debug)]
+pub struct LruCache<Key, Value> {
+    map: LinkedHashMap<Key, TimedValue<Value>, BuildHasherDefault<FxHasher>>,
+    ttl: Duration,
+    capacity: usize,
+}
+
+impl<Key: Clone + Eq + Hash, Value> LruCache<Key, Value> {
+    /// Constructor for dual-feature capacity and time based `LruCache`.
+    pub fn new(ttl: Duration, capacity: usize) -> LruCache<Key, Value> {
+        LruCache {
+            map: LinkedHashMap::default(),
+            ttl,
+            capacity,
+        }
+    }
+
+    /// Returns the size of the cache, i.e. the number of cached non-expired key-value pairs.
+    /// Also removes expired elements.
+    pub fn len(&mut self) -> usize {
+        self.remove_expired();
+        self.map.len()
+    }
+
+    /// Returns true if the map contains no elements.
+    /// Also removes expired elements.
+    pub fn is_empty(&mut self) -> bool {
+        self.remove_expired();
+        self.map.is_empty()
+    }
+
+    /// Gets the given key’s corresponding entry in the map for in-place manipulation.
+    pub fn entry(&mut self, key: Key) -> Entry<'_, Key, Value> {
+        let mut state = self.map.hasher().build_hasher();
+        key.hash(&mut state);
+        let hash = state.finish();
+        match self.map.raw_entry_mut().from_key_hashed_nocheck(hash, &key) {
+            RawEntryMut::Occupied(mut e) => {
+                Self::update_last_time(&mut e, Instant::now());
+                Entry::Occupied(OccupiedEntry {
+                    key,
+                    hash,
+                    map: &mut self.map,
+                })
+            }
+            RawEntryMut::Vacant(_) => Entry::Vacant(VacantEntry {
+                key,
+                hash,
+                map: &mut self.map,
+                max_map_size: self.capacity,
+            }),
+        }
+    }
+
+    /// Retrieves a reference to the value stored under `key`, or `None` if the key doesn't exist.
+    /// Also removes expired elements and updates the time.
+    pub fn get<Q: ?Sized>(&mut self, key: &Q) -> Option<&Value>
+    where
+        Key: Borrow<Q>,
+        Q: Hash + Eq,
+    {
+        self.get_mut(key).map(|value| &*value)
+    }
+
+    /// Retrieves a mutable reference to the value stored under `key`, or `None` if the key doesn't
+    /// exist.  Also removes expired elements and updates the time.
+    pub fn get_mut<Q: ?Sized>(&mut self, key: &Q) -> Option<&mut Value>
+    where
+        Key: Borrow<Q>,
+        Q: Hash + Eq,
+    {
+        let now = self.remove_expired().0;
+
+        if let RawEntryMut::Occupied(mut entry) = self.map.raw_entry_mut().from_key(key) {
+            Self::update_last_time(&mut entry, now);
+            Some(&mut entry.into_mut().data)
+        } else {
+            None
+        }
+    }
+
+    /// Inserts a key-value pair into the cache.
+    ///
+    /// If the key already existed in the cache, the existing value is overwritten in
+    /// the cache.  Otherwise, the new key-value pair is inserted.
+    pub fn insert(&mut self, key: Key, value: Value) {
+        self.map.insert(key, TimedValue::new(value));
+
+        if self.map.len() > self.capacity {
+            self.map.pop_front();
+        }
+    }
+
+    /// Removes a key-value pair from the cache.
+    pub fn remove(&mut self, key: &Key) -> Option<Value> {
+        self.map.remove(key).map(|v| v.data)
+    }
+
+    /// Returns a reference to the value with the given `key`, if present and not expired, without
+    /// updating the timestamp.
+    #[cfg(test)]
+    pub fn peek<Q: ?Sized>(&self, key: &Q) -> Option<&Value>
+    where
+        Key: Borrow<Q>,
+        Q: Hash + Eq,
+    {
+        if let Some(timed_value) = self.map.get(key) {
+            return if !timed_value.is_expired(self.ttl, Instant::now()) {
+                Some(&timed_value.data)
+            } else {
+                None
+            };
+        }
+
+        None
+    }
+
+    /// Removes expired items from the cache and returns all removed keys.
+    fn remove_expired(&mut self) -> (Instant, Vec<Key>) {
+        let now = Instant::now();
+        let expired_keys: Vec<_> = self
+            .map
+            .iter()
+            .take_while(|(_, timed_value)| timed_value.is_expired(self.ttl, now))
+            .map(|(key, _)| key.clone())
+            .collect();
+
+        for k in &expired_keys {
+            self.map.remove(k);
+        }
+        (now, expired_keys)
+    }
+
+    fn update_last_time(entry: &mut RawOccupiedEntryMut<'_, Key, TimedValue<Value>>, now: Instant) {
+        entry.get_mut().update_last_access(now);
+        entry.to_back();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::distributions::{Distribution, Standard};
+    use rand::thread_rng;
+    use std::time::Duration;
+
+    fn sleep_ms(time: u64) {
+        sn_fake_clock::FakeClock::advance_time(time);
+    }
+
+    // Tests copied from the lru_time_cache
+    #[test]
+    fn size_only() {
+        let size = 10usize;
+        let mut lru_cache = LruCache::<usize, usize>::new(Duration::from_secs(10), size);
+
+        for i in 0..10 {
+            assert_eq!(lru_cache.len(), i);
+            let _ = lru_cache.insert(i, i);
+            assert_eq!(lru_cache.len(), i + 1);
+        }
+
+        for i in 10..1000 {
+            let _ = lru_cache.insert(i, i);
+            assert_eq!(lru_cache.len(), size);
+        }
+
+        for _ in (0..1000).rev() {
+            assert!(lru_cache.peek(&(1000 - 1)).is_some());
+            assert!(lru_cache.get(&(1000 - 1)).is_some());
+            assert_eq!(*lru_cache.get(&(1000 - 1)).unwrap(), 1000 - 1);
+        }
+    }
+
+    #[test]
+    fn time_only() {
+        let time_to_live = Duration::from_millis(100);
+        let mut lru_cache = LruCache::<usize, usize>::new(time_to_live, usize::MAX);
+
+        for i in 0..10 {
+            assert_eq!(lru_cache.len(), i);
+            let _ = lru_cache.insert(i, i);
+            assert_eq!(lru_cache.len(), i + 1);
+        }
+
+        sleep_ms(101);
+        let _ = lru_cache.insert(11, 11);
+
+        assert_eq!(lru_cache.len(), 1);
+
+        for i in 0..10 {
+            assert_eq!(lru_cache.len(), i + 1);
+            let _ = lru_cache.insert(i, i);
+            assert_eq!(lru_cache.len(), i + 2);
+        }
+
+        sleep_ms(101);
+        assert_eq!(0, lru_cache.len());
+    }
+
+    #[test]
+    fn time_only_check() {
+        let time_to_live = Duration::from_millis(50);
+        let mut lru_cache = LruCache::<usize, usize>::new(time_to_live, usize::MAX);
+
+        assert_eq!(lru_cache.len(), 0);
+        let _ = lru_cache.insert(0, 0);
+        assert_eq!(lru_cache.len(), 1);
+
+        sleep_ms(101);
+
+        assert!(!lru_cache.peek(&0).is_some());
+        assert_eq!(lru_cache.len(), 0);
+    }
+
+    #[test]
+    fn time_and_size() {
+        let size = 10usize;
+        let time_to_live = Duration::from_millis(100);
+        let mut lru_cache = LruCache::<usize, usize>::new(time_to_live, size);
+
+        for i in 0..1000 {
+            if i < size {
+                assert_eq!(lru_cache.len(), i);
+            }
+
+            let _ = lru_cache.insert(i, i);
+
+            if i < size {
+                assert_eq!(lru_cache.len(), i + 1);
+            } else {
+                assert_eq!(lru_cache.len(), size);
+            }
+        }
+
+        sleep_ms(101);
+        let _ = lru_cache.insert(1, 1);
+
+        assert_eq!(lru_cache.len(), 1);
+    }
+
+    #[test]
+    fn remove() {
+        let time_to_live = Duration::from_millis(50);
+        let mut lru_cache = LruCache::<usize, usize>::new(time_to_live, usize::MAX);
+
+        let _ = lru_cache.insert(0, 1);
+        assert_eq!(lru_cache.len(), 1);
+        assert_eq!(lru_cache.remove(&0), Some(1));
+        assert_eq!(lru_cache.len(), 0);
+    }
+
+    fn generate_random_vec<T>(len: usize) -> Vec<T>
+    where
+        Standard: Distribution<T>,
+    {
+        Standard.sample_iter(&mut thread_rng()).take(len).collect()
+    }
+
+    #[derive(PartialEq, PartialOrd, Ord, Clone, Eq, Hash)]
+    struct Temp {
+        id: Vec<u8>,
+    }
+
+    #[test]
+    fn time_size_struct_value() {
+        let size = 100usize;
+        let time_to_live = Duration::from_millis(100);
+
+        let mut lru_cache = LruCache::<Temp, usize>::new(time_to_live, size);
+
+        for i in 0..1000 {
+            if i < size {
+                assert_eq!(lru_cache.len(), i);
+            }
+
+            let _ = lru_cache.insert(
+                Temp {
+                    id: generate_random_vec::<u8>(64),
+                },
+                i,
+            );
+
+            if i < size {
+                assert_eq!(lru_cache.len(), i + 1);
+            } else {
+                assert_eq!(lru_cache.len(), size);
+            }
+        }
+
+        sleep_ms(101);
+        let _ = lru_cache.insert(
+            Temp {
+                id: generate_random_vec::<u8>(64),
+            },
+            1,
+        );
+
+        assert_eq!(lru_cache.len(), 1);
+    }
+
+    #[test]
+    fn update_time_check() {
+        let time_to_live = Duration::from_millis(500);
+        let mut lru_cache = LruCache::<usize, usize>::new(time_to_live, usize::MAX);
+
+        assert_eq!(lru_cache.len(), 0);
+        let _ = lru_cache.insert(0, 0);
+        assert_eq!(lru_cache.len(), 1);
+
+        sleep_ms(300);
+        assert_eq!(Some(&0), lru_cache.get(&0));
+        sleep_ms(300);
+        assert_eq!(Some(&0), lru_cache.peek(&0));
+        sleep_ms(300);
+        assert_eq!(None, lru_cache.peek(&0));
+    }
+
+    #[test]
+    fn update_time_check_entry() {
+        let time_to_live = Duration::from_millis(500);
+        let mut lru_cache = LruCache::<usize, usize>::new(time_to_live, usize::MAX);
+
+        assert_eq!(lru_cache.len(), 0);
+        let _ = lru_cache.insert(0, 0);
+        assert_eq!(lru_cache.len(), 1);
+
+        sleep_ms(300);
+        lru_cache.entry(0);
+        sleep_ms(300);
+        assert_eq!(Some(&0), lru_cache.peek(&0));
+        sleep_ms(300);
+        assert_eq!(None, lru_cache.peek(&0));
+    }
+
+    mod remove_expired {
+        use super::*;
+
+        #[test]
+        fn it_removes_expired_entries_from_the_map() {
+            let ttl = Duration::from_millis(200);
+            let mut lru_cache = LruCache::<usize, usize>::new(ttl, usize::MAX);
+            let _ = lru_cache.insert(1, 1);
+            let _ = lru_cache.insert(2, 2);
+            sleep_ms(150);
+            let _ = lru_cache.insert(3, 3);
+            let _ = lru_cache.insert(4, 4);
+            sleep_ms(60);
+
+            let _ = lru_cache.remove_expired();
+
+            assert_eq!(lru_cache.map.len(), 2);
+            assert_eq!(lru_cache.map[&3].data, 3);
+            assert_eq!(lru_cache.map[&4].data, 4);
+        }
+
+        #[test]
+        fn it_removes_expired_entries_from_the_list() {
+            let ttl = Duration::from_millis(200);
+            let mut lru_cache = LruCache::<usize, usize>::new(ttl, usize::MAX);
+            let _ = lru_cache.insert(1, 1);
+            let _ = lru_cache.insert(2, 2);
+            sleep_ms(150);
+            let _ = lru_cache.insert(3, 3);
+            let _ = lru_cache.insert(4, 4);
+            sleep_ms(60);
+
+            let _ = lru_cache.remove_expired();
+
+            assert_eq!(lru_cache.map.len(), 2);
+            assert_eq!(*lru_cache.map.iter().nth(0).unwrap().0, 3);
+            assert_eq!(*lru_cache.map.iter().nth(1).unwrap().0, 4);
+        }
+
+        #[test]
+        fn it_returns_expired_entries() {
+            let ttl = Duration::from_millis(200);
+            let mut lru_cache = LruCache::<usize, usize>::new(ttl, usize::MAX);
+            let _ = lru_cache.insert(1, 1);
+            let _ = lru_cache.insert(2, 2);
+            sleep_ms(150);
+            let _ = lru_cache.insert(3, 3);
+            sleep_ms(60);
+
+            let (_, expired) = lru_cache.remove_expired();
+
+            assert_eq!(expired.len(), 2);
+            assert_eq!(expired[0], 1);
+            assert_eq!(expired[1], 2);
+        }
+    }
+
+    // End of copied tests
+
+    mod proptests {
+        use super::*;
+
+        use lru_time_cache::LruCache as OldLruCache;
+        use proptest::prelude::*;
+        use proptest_derive::Arbitrary;
+
+        // Small set of keys to make it more likely to detect any issues
+        #[derive(Arbitrary, Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+        enum Key {
+            A,
+            B,
+            C,
+            D,
+            E,
+        }
+
+        // List of possible operations that can be performed on the lru cache
+        #[derive(Arbitrary, Debug)]
+        enum Op {
+            Insert(Key),
+            Get(Key),
+            GetMut(Key),
+            Peek(Key),
+            Remove(Key),
+            GetUsingEntry(Key),
+            GetMutUsingEntry(Key),
+            Sleep(u8),
+        }
+
+        fn verify_equality(new: &mut LruCache<Key, u32>, old: &mut OldLruCache<Key, u32>) {
+            assert_eq!(new.is_empty(), old.is_empty());
+            assert_eq!(new.len(), old.len());
+            let keys: Vec<_> = new.map.keys().collect();
+            for key in keys {
+                assert_eq!(new.peek(&key), old.peek(&key));
+            }
+        }
+
+        proptest! {
+            #[test]
+            fn test_same_behaviour_as_the_old_external_lru_cache(init: (u8, u8), ops: Vec<Op>) {
+                let ttl = Duration::from_secs(1 + init.0 as u64);
+                let capacity = 1 + init.1 as usize;
+                let mut new = LruCache::<Key, u32>::new(ttl, capacity);
+                let mut old = OldLruCache::<Key, u32>::with_expiry_duration_and_capacity(ttl, capacity);
+
+                for op in ops {
+                    match op {
+                        Op::Insert(k) => {
+                            new.insert(k, k as u32);
+                            old.insert(k, k as u32);
+                        },
+                        Op::Get(k) => {
+                            assert_eq!(new.get(&k), old.get(&k));
+                        },
+                        Op::GetMut(k) => {
+                            let new_val = new.get_mut(&k);
+                            let old_val = old.get_mut(&k);
+                            assert_eq!(new_val, old_val);
+                            if let (Some(new_val), Some(old_val)) = (new_val, old_val) {
+                                *new_val += 1;
+                                *old_val += 1;
+                            }
+                        },
+                        Op::Peek(k) => {
+                            assert_eq!(new.peek(&k), old.peek(&k));
+                        },
+                        Op::Remove(k) => {
+                            new.remove(&k);
+                            old.remove(&k);
+                        },
+                        Op::GetUsingEntry(k) => {
+                            let new_val = match new.entry(k) {
+                                Entry::Occupied(mut e) => {
+                                    Some(*e.get_mut())
+                                },
+                                Entry::Vacant(_) => {
+                                    None
+                                }
+                            };
+                            assert_eq!(new_val, old.get(&k).copied());
+                        },
+                        Op::GetMutUsingEntry(k) => {
+                            if let Entry::Occupied(mut e) = new.entry(k) {
+                                *e.get_mut() += 1;
+                            }
+                            if let Some(v) = old.get_mut(&k) {
+                                *v += 1;
+                            }
+                        },
+                        Op::Sleep(t) => {
+                            sleep_ms(t as u64 * 1000);
+                        }
+                    }
+                    verify_equality(&mut new, &mut old);
+                }
+            }
+        }
+    }
+}

--- a/crates/telio-utils/src/lru_cache.rs
+++ b/crates/telio-utils/src/lru_cache.rs
@@ -30,16 +30,19 @@ pub struct OccupiedEntry<'a, K, V> {
 
 impl<'a, K: Hash + Eq, V> OccupiedEntry<'a, K, V> {
     /// Gets a reference to the key in the entry.
+    #[inline(always)]
     pub fn key(&self) -> &K {
         &self.key
     }
 
     /// Gets a mutable reference to the value in the entry.
+    #[inline(always)]
     pub fn get_mut(&mut self) -> &mut V {
         &mut self.occupied_entry().into_mut().data
     }
 
     /// Removes the entry from the map.
+    #[inline(always)]
     pub fn remove(&mut self) {
         self.occupied_entry().remove();
     }
@@ -67,11 +70,13 @@ pub struct VacantEntry<'a, K, V> {
 
 impl<'a, K, V> VacantEntry<'a, K, V> {
     /// Gets a reference to the key in the entry.
+    #[inline(always)]
     pub fn key(&self) -> &K {
         &self.key
     }
 
     /// Sets the value of the entry with the VacantEntry’s key, and returns a mutable reference to it.
+    #[inline(always)]
     pub fn insert(self, value: V)
     where
         K: Hash + Eq,
@@ -124,6 +129,7 @@ pub struct LruCache<Key, Value> {
 
 impl<Key: Clone + Eq + Hash, Value> LruCache<Key, Value> {
     /// Constructor for dual-feature capacity and time based `LruCache`.
+    #[inline(always)]
     pub fn new(ttl: Duration, capacity: usize) -> LruCache<Key, Value> {
         LruCache {
             map: LinkedHashMap::default(),
@@ -134,6 +140,7 @@ impl<Key: Clone + Eq + Hash, Value> LruCache<Key, Value> {
 
     /// Returns the size of the cache, i.e. the number of cached non-expired key-value pairs.
     /// Also removes expired elements.
+    #[inline(always)]
     pub fn len(&mut self) -> usize {
         self.remove_expired();
         self.map.len()
@@ -141,12 +148,14 @@ impl<Key: Clone + Eq + Hash, Value> LruCache<Key, Value> {
 
     /// Returns true if the map contains no elements.
     /// Also removes expired elements.
+    #[inline(always)]
     pub fn is_empty(&mut self) -> bool {
         self.remove_expired();
         self.map.is_empty()
     }
 
     /// Gets the given key’s corresponding entry in the map for in-place manipulation.
+    #[inline(always)]
     pub fn entry(&mut self, key: Key) -> Entry<'_, Key, Value> {
         let mut state = self.map.hasher().build_hasher();
         key.hash(&mut state);
@@ -171,6 +180,7 @@ impl<Key: Clone + Eq + Hash, Value> LruCache<Key, Value> {
 
     /// Retrieves a reference to the value stored under `key`, or `None` if the key doesn't exist.
     /// Also removes expired elements and updates the time.
+    #[inline(always)]
     pub fn get<Q: ?Sized>(&mut self, key: &Q) -> Option<&Value>
     where
         Key: Borrow<Q>,
@@ -181,6 +191,7 @@ impl<Key: Clone + Eq + Hash, Value> LruCache<Key, Value> {
 
     /// Retrieves a mutable reference to the value stored under `key`, or `None` if the key doesn't
     /// exist.  Also removes expired elements and updates the time.
+    #[inline(always)]
     pub fn get_mut<Q: ?Sized>(&mut self, key: &Q) -> Option<&mut Value>
     where
         Key: Borrow<Q>,
@@ -200,6 +211,7 @@ impl<Key: Clone + Eq + Hash, Value> LruCache<Key, Value> {
     ///
     /// If the key already existed in the cache, the existing value is overwritten in
     /// the cache.  Otherwise, the new key-value pair is inserted.
+    #[inline(always)]
     pub fn insert(&mut self, key: Key, value: Value) {
         self.map.insert(key, TimedValue::new(value));
 
@@ -209,6 +221,7 @@ impl<Key: Clone + Eq + Hash, Value> LruCache<Key, Value> {
     }
 
     /// Removes a key-value pair from the cache.
+    #[inline(always)]
     pub fn remove(&mut self, key: &Key) -> Option<Value> {
         self.map.remove(key).map(|v| v.data)
     }


### PR DESCRIPTION
### Description
**Already reviewed**
### Original description:
### Description
This MR improves the performance of telio-firewall as measured by the internal benchmarks. Improvements are separated into distinct commits for easier reviewing:
- Replace default hashing algorithm of standard hash map with a rustc_hash. The default one in known to be quite slow but gives some benefits (eg. protection against [Hash flooding](https://en.wikipedia.org/wiki/Collision_attack#Hash_flooding)). The new one is used in the rustc compiler and is much faster and works well for relatively small keys.
- The common path for the outbound tcp packets has been cleaned up to avoid any unnecessary work.
- LRU cache has been reimplemented. The one we used previously was using BTreeMap which is in general slower than HashMap and [it also performed many operations in O(n)](https://github.com/maidsafe/lru_time_cache/issues/143). Our new implementation is based on the [LinkedHashMap](https://docs.rs/hashlink/latest/hashlink/linked_hash_map/struct.LinkedHashMap.html) (hash map with custom order for iteration). To ensure correctness property based tests verify that the new implementation behaves the same way as the old one.
- In some places peer whitelist was searched twice for the same packet which is now no longer the case.
- Instead of getting the same key/value pair twice we now keep one reference where applicable.
- Since lru cache is in the utils crate all methods had been marked as always inline

Results of comparing performance in benchmarks of this MR (and IPv6) with the main commit f183bdf4f4150a5fd6c50943ca90e2614a4805bf (without IPv6) are below. The only benchmarks that are not better are first two which check how much time we spend in processing inbound tcp packets when there are 0 peers - which is a artificial case.

### Conformity
- [ ] [Changelog entry]

Closes LLT-3626

[firewal.benchmark.results.txt](https://github.com/NordSecurity/libtelio/files/12158504/firewal.benchmark.results.txt)


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean
- [x] README.md is updated
- [x] changelog.md is updated
