### PR TITLE
Add telio-firewall benchmarks CI job

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,12 @@
+name: Benchmarks
+on: [workflow_call]
+permissions: {}
+
+jobs:
+  telio-firewall:
+      runs-on: ubuntu-22.04
+      steps:
+        - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        - name: Telio firewall benchmarks
+          working-directory: crates/telio-firewall
+          run: cargo bench --features test_utils --bench firewall_bench "64.*10000" -- --warm-up-time 1 --measurement-time 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,10 @@ jobs:
     needs: skipper
     if: needs.skipper.outputs.should_skip != 'true'
     uses: ./.github/workflows/fuzzing.yml
+  benchmarks:
+    needs: skipper
+    if: needs.skipper.outputs.should_skip != 'true'
+    uses: ./.github/workflows/benchmarks.yml
 
   check-all-green:
     needs:
@@ -39,6 +43,7 @@ jobs:
     - linters
     - tests
     - fuzzing
+    - benchmarks
     - skipper
     if: needs.skipper.outputs.should_skip != 'true'
     runs-on: ubuntu-22.04


### PR DESCRIPTION
### Description
This job is just to keep the benchmarks from being broken. This is why the durations are reduced - we only care that it compiles and runs correctly. The timings on CI are not useful since the machine they are run on can be arbitrarily configured and loaded.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean
- [x] README.md is updated
- [x] changelog.md is updated
