### PR TITLE
CI Improvements: run gitlab pipelines only on push to main branch

### DIFF
--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -3,6 +3,7 @@ on:
   pull_request_target:
     branches: [main]
   push:
+    branches: [main]
 permissions: {}
 
 jobs:


### PR DESCRIPTION
I messed up a little with previous PR. I didn't spot that we now run gitlab pipelines twice for pull_requests. I am not yet sure if we can use `skip-duplicate-actions` for gitlab workflow so for now lets quickly disable them on pushes to feature branches to not overload our gitlab runners



### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean
- [x] README.md is updated
- [x] changelog.md is updated
