### PR TITLE
Next CI improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,38 +3,32 @@ on: [push, pull_request]
 permissions: {}
 
 jobs:
-  skipper:
-    runs-on: ubuntu-latest
-    permissions:
-      actions: write
-      contents: read
-    outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+  trigger:
+    if: |
+      github.event_name == 'push' ||
+      (
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+      )
+    runs-on: ubuntu-22.04
     steps:
-      - id: skip_check
-        uses: fkirc/skip-duplicate-actions@12aca0a884f6137d619d6a8a09fcc3406ced5281 # v5.3.0
-        with:
-          concurrent_skipping: 'same_content_newer'
+      - name: CI Trigger
+        run: echo "Triggering CI"
 
   build:
-    needs: skipper
-    if: needs.skipper.outputs.should_skip != 'true'
+    needs: trigger
     uses: ./.github/workflows/build.yml
   linters:
-    needs: skipper
-    if: needs.skipper.outputs.should_skip != 'true'
+    needs: trigger
     uses: ./.github/workflows/linters.yml
   tests:
-    needs: skipper
-    if: needs.skipper.outputs.should_skip != 'true'
+    needs: trigger
     uses: ./.github/workflows/tests.yml
   fuzzing:
-    needs: skipper
-    if: needs.skipper.outputs.should_skip != 'true'
+    needs: trigger
     uses: ./.github/workflows/fuzzing.yml
   benchmarks:
-    needs: skipper
-    if: needs.skipper.outputs.should_skip != 'true'
+    needs: trigger
     uses: ./.github/workflows/benchmarks.yml
 
   check-all-green:
@@ -44,8 +38,6 @@ jobs:
     - tests
     - fuzzing
     - benchmarks
-    - skipper
-    if: needs.skipper.outputs.should_skip != 'true'
     runs-on: ubuntu-22.04
     steps:
     - name: Collect statuses from all jobs

--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -13,7 +13,7 @@ jobs:
       (
         github.event_name == 'pull_request_target' &&
         github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name &&
-        contains(github.event.pull_request.labels.*.name, 'run tests')
+        github.event.label.name == 'run tests'
       )
     steps:
       - uses: NordSecurity/trigger-gitlab-pipeline@fd24fd4a3d03065fe67ae1e98d05d4283d7bb104 # v1

--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -1,9 +1,8 @@
 name: GitLab CI Pipeline
 on:
   pull_request_target:
-    branches: [main]
+    types: [labeled]
   push:
-    branches: [main]
 permissions: {}
 
 jobs:
@@ -13,10 +12,8 @@ jobs:
       github.event_name == 'push' ||
       (
         github.event_name == 'pull_request_target' &&
-        (
-          contains(github.event.pull_request.labels.*.name, 'run tests') ||
-          (github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name)
-        )
+        github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name &&
+        contains(github.event.pull_request.labels.*.name, 'run tests')
       )
     steps:
       - uses: NordSecurity/trigger-gitlab-pipeline@fd24fd4a3d03065fe67ae1e98d05d4283d7bb104 # v1

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -33,7 +33,19 @@ jobs:
         - uses: actions-rs/cargo@ae10961054e4aa8b4aa7dffede299aaf087aa33b # v1.0.3
           with:
             command: clippy
-            args: --target "x86_64-pc-windows-gnu" --lib --color always -- --deny warnings --allow unknown-lints
+            args: --target "x86_64-pc-windows-gnu" --lib --color always -- --deny warnings --allow unknown-lints -W clippy::expect_used -W clippy::panic -W clippy::unwrap_used
+  clippy-mac:
+      runs-on: macos-12
+      steps:
+        - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        - uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.6
+          with:
+            target: x86_64-apple-darwin
+            components: clippy
+        - uses: actions-rs/cargo@ae10961054e4aa8b4aa7dffede299aaf087aa33b # v1.0.3
+          with:
+            command: clippy
+            args: --target "x86_64-apple-darwin" --lib --color always -- --deny warnings --allow unknown-lints -W clippy::expect_used -W clippy::panic -W clippy::unwrap_used
   deny:
       runs-on: ubuntu-22.04
       steps:
@@ -79,13 +91,13 @@ jobs:
   python-format:
       runs-on: ubuntu-22.04
       steps:
-        - uses: actions/checkout@v3
+        - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         - run: pip3 install -r ./requirements.txt
         - run: black --check --diff --color ./nat-lab
   natlab-typecheck:
       runs-on: ubuntu-22.04
       steps:
-        - uses: actions/checkout@v3
+        - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         - run: pip3 install -r ./nat-lab/requirements.txt
         - run: ./run_local.py --nobuild --notests
           working-directory: nat-lab


### PR DESCRIPTION
1. Move clippy-mac from gitlab pipeline and unify arguments between linux, win and mac jobs
2. Remove skip-duplicate-actions and replace it with our own check. The idea is as follows: for all internal PRs `push` trigger is enough. It basically is equivalent to how pipelines work on gitlab. `pull request` trigger is only needed because pipelines would not otherwise be triggered for PRs from fork because obviously `push` is not triggered for them. So lets just run our pipelines only for `push` and  lets use  `pull request` trigger only for pull requests from forks.
3. Improve gitlab triggering: Again, similarly to point 2 run them only on 'push' trigger for our PRs and  'pull request target' in case of PRs from forks, but run them for forks only once when 'run tests' label is added. 

One more note:
If you look at the workflows run for this PR you will notice that gitlab is triggered twice. It's correct behavior. It is because gitlab triggering work in target branch context (because `pull_request_target` trigger is used). That means that the code from main is checked out to run this workflow, not the code from this branch. Once this is merged and becomes a main PRs opened to the main will use workflow with updates from this branch. I've tested that it works correctly by opening dummy PR with this branch set as a target branch. And it works :)

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean
- [x] README.md is updated
- [x] changelog.md is updated
