### PR TITLE
[LLT-3626] Add firewall benchmarks for IPv6

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -9,4 +9,4 @@ jobs:
         - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         - name: Telio firewall benchmarks
           working-directory: crates/telio-firewall
-          run: cargo bench --features test_utils --bench firewall_bench "64.*10000" -- --warm-up-time 1 --measurement-time 1
+          run: cargo bench --features test_utils --bench firewall_bench "64" -- --warm-up-time 1 --measurement-time 1

--- a/crates/telio-firewall/src/firewall.rs
+++ b/crates/telio-firewall/src/firewall.rs
@@ -795,8 +795,12 @@ pub mod tests {
 
         let mut ip = MutableIpv4Packet::new(&mut raw).expect("UDP: Bad IP buffer");
         set_ipv4(&mut ip, IpNextHeaderProtocols::Udp, IPV4_HEADER_MIN, ip_len);
-        let source: SocketAddrV4 = src.parse().expect("UDPv4: Bad src address");
-        let destination: SocketAddrV4 = dst.parse().expect("UDPv4: Bad dst address");
+        let source: SocketAddrV4 = src
+            .parse()
+            .expect(&format!("UDPv4: Bad src address: {src}"));
+        let destination: SocketAddrV4 = dst
+            .parse()
+            .expect(&format!("UDPv4: Bad dst address: {dst}"));
         ip.set_source(*source.ip());
         ip.set_destination(*destination.ip());
 
@@ -820,8 +824,12 @@ pub mod tests {
 
         let mut ip = MutableIpv6Packet::new(&mut raw).expect("UDP: Bad IP buffer");
         set_ipv6(&mut ip, IpNextHeaderProtocols::Udp, IPV6_HEADER_MIN, ip_len);
-        let source: SocketAddrV6 = src.parse().expect("UDPv6: Bad src address");
-        let destination: SocketAddrV6 = dst.parse().expect("UDPv6: Bad dst address");
+        let source: SocketAddrV6 = src
+            .parse()
+            .expect(&format!("UDPv6: Bad src address: {src}"));
+        let destination: SocketAddrV6 = dst
+            .parse()
+            .expect(&format!("UDPv6: Bad dst address: {dst}"));
         ip.set_source(*source.ip());
         ip.set_destination(*destination.ip());
 
@@ -844,8 +852,12 @@ pub mod tests {
 
         let mut ip = MutableIpv4Packet::new(&mut raw).expect("TCP: Bad IP buffer");
         set_ipv4(&mut ip, IpNextHeaderProtocols::Tcp, IPV4_HEADER_MIN, ip_len);
-        let source: SocketAddrV4 = src.parse().expect("UDPv4: Bad src address");
-        let destination: SocketAddrV4 = dst.parse().expect("UDPv4: Bad dst address");
+        let source: SocketAddrV4 = src
+            .parse()
+            .expect(&format!("TCPv4: Bad src address: {src}"));
+        let destination: SocketAddrV4 = dst
+            .parse()
+            .expect(&format!("TCPv4: Bad dst address: {dst}"));
         ip.set_source(*source.ip());
         ip.set_destination(*destination.ip());
 
@@ -868,8 +880,12 @@ pub mod tests {
 
         let mut ip = MutableIpv6Packet::new(&mut raw).expect("TCP: Bad IP buffer");
         set_ipv6(&mut ip, IpNextHeaderProtocols::Tcp, IPV6_HEADER_MIN, ip_len);
-        let source: SocketAddrV6 = src.parse().expect("UDPv6: Bad src address");
-        let destination: SocketAddrV6 = dst.parse().expect("UDPv6: Bad dst address");
+        let source: SocketAddrV6 = src
+            .parse()
+            .expect(&format!("TCPv6: Bad src address: {src}"));
+        let destination: SocketAddrV6 = dst
+            .parse()
+            .expect(&format!("TCPv6: Bad dst address: {dst}"));
         ip.set_source(*source.ip());
         ip.set_destination(*destination.ip());
 


### PR DESCRIPTION
Packets sent/received in benchmarks are abstracted to allow for uniform handling of both IPv4 and IPv6 packets (in the same way as we did in the firewall tests). This doubles number of benchmarks.

At the same time different number of packets to send/receive is removed and only the bigger number of packets is used. This halves the number of benchmarks which in the end results in keeping the same number of benchmarks overall.

### Description
*--write your description here--*



### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean
- [x] README.md is updated
- [x] changelog.md is updated
