### PR TITLE
Resolve LLT-4012: fix firewall, so tcp won't be stuck in last_ack state

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 * LLT-4002: Review log-levels of spammy log messages
 * LLT-3990: Add initial heartbeat interval to feature config
 * LLT-4008: Add support for AAAA records in telio-dns
+* LLT-4012: Fix firewall being stuck on LAST_ACK after FIN
 
 <br>
 

--- a/crates/telio-utils/src/lru_cache.rs
+++ b/crates/telio-utils/src/lru_cache.rs
@@ -228,7 +228,6 @@ impl<Key: Clone + Eq + Hash, Value> LruCache<Key, Value> {
 
     /// Returns a reference to the value with the given `key`, if present and not expired, without
     /// updating the timestamp.
-    #[cfg(test)]
     pub fn peek<Q: ?Sized>(&self, key: &Q) -> Option<&Value>
     where
         Key: Borrow<Q>,

--- a/nat-lab/tests/test_mesh_firewall.py
+++ b/nat-lab/tests/test_mesh_firewall.py
@@ -525,3 +525,304 @@ async def test_mesh_firewall_file_share_port(
 
         assert alpha_conn_tracker.get_out_of_limits() is None
         assert beta_conn_tracker.get_out_of_limits() is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "alpha_adapter_type, beta_adapter_type",
+    [
+        (telio.AdapterType.BoringTun, telio.AdapterType.BoringTun),
+        (telio.AdapterType.BoringTun, telio.AdapterType.LinuxNativeWg),
+        (telio.AdapterType.LinuxNativeWg, telio.AdapterType.LinuxNativeWg),
+        (telio.AdapterType.LinuxNativeWg, telio.AdapterType.BoringTun),
+    ],
+)
+async def test_mesh_firewall_tcp_stuck_in_last_ack_state_conn_kill_from_server_side(
+    alpha_adapter_type: telio.AdapterType, beta_adapter_type: telio.AdapterType
+) -> None:
+    async with AsyncExitStack() as exit_stack:
+        api = API()
+        (alpha, beta) = api.default_config_two_nodes()
+
+        CLIENT_ALPHA_IP = alpha.ip_addresses[0]
+        CLIENT_BETA_IP = beta.ip_addresses[0]
+        PORT = 12345
+
+        beta.set_peer_firewall_settings(alpha.id, allow_incoming_connections=False)
+
+        (connection_alpha, alpha_conn_tracker) = await exit_stack.enter_async_context(
+            new_connection_with_conn_tracker(
+                ConnectionTag.DOCKER_CONE_CLIENT_1,
+                generate_connection_tracker_config(
+                    ConnectionTag.DOCKER_CONE_CLIENT_1,
+                    derp_1_limits=ConnectionLimits(1, 1),
+                ),
+            )
+        )
+        (connection_beta, beta_conn_tracker) = await exit_stack.enter_async_context(
+            new_connection_with_conn_tracker(
+                ConnectionTag.DOCKER_CONE_CLIENT_2,
+                generate_connection_tracker_config(
+                    ConnectionTag.DOCKER_CONE_CLIENT_2,
+                    derp_1_limits=ConnectionLimits(1, 1),
+                ),
+            )
+        )
+
+        client_alpha = await exit_stack.enter_async_context(
+            telio.Client(connection_alpha, alpha, alpha_adapter_type).run_meshnet(
+                api.get_meshmap(alpha.id)
+            )
+        )
+
+        client_beta = await exit_stack.enter_async_context(
+            telio.Client(connection_beta, beta, beta_adapter_type).run_meshnet(
+                api.get_meshmap(beta.id)
+            )
+        )
+
+        await testing.wait_long(
+            asyncio.gather(
+                client_alpha.wait_for_any_derp_state([telio.State.Connected]),
+                client_beta.wait_for_any_derp_state([telio.State.Connected]),
+            )
+        )
+
+        await testing.wait_long(
+            asyncio.gather(
+                alpha_conn_tracker.wait_for_event("derp_1"),
+                beta_conn_tracker.wait_for_event("derp_1"),
+            )
+        )
+
+        await testing.wait_long(
+            asyncio.gather(
+                client_alpha.handshake(beta.public_key),
+                client_beta.handshake(alpha.public_key),
+            )
+        )
+
+        output_notifier = OutputNotifier()
+
+        async def on_stdout(stdout: str) -> None:
+            for line in stdout.splitlines():
+                output_notifier.handle_output(line)
+
+        async def conntrack_on_stdout(stdout: str) -> None:
+            for line in stdout.splitlines():
+                if f"src={CLIENT_BETA_IP} dst={CLIENT_ALPHA_IP}" in line:
+                    output_notifier.handle_output(line)
+
+        listening_start_event = asyncio.Event()
+        sender_start_event = asyncio.Event()
+        connected_event = asyncio.Event()
+        last_ack_event = asyncio.Event()
+        time_wait_event = asyncio.Event()
+
+        output_notifier.notify_output(
+            f"listening on [{CLIENT_ALPHA_IP}] {str(PORT)}", listening_start_event
+        )
+
+        output_notifier.notify_output(
+            f"[{CLIENT_ALPHA_IP}] {str(PORT)} (?) open", sender_start_event
+        )
+
+        output_notifier.notify_output(
+            f"connect to [{CLIENT_ALPHA_IP}] from (UNKNOWN) [{CLIENT_BETA_IP}]",
+            connected_event,
+        )
+
+        output_notifier.notify_output("LAST_ACK", last_ack_event)
+        output_notifier.notify_output("TIME_WAIT", time_wait_event)
+
+        async with connection_beta.create_process(["conntrack", "-E"]).run(
+            stdout_callback=conntrack_on_stdout
+        ) as conntrack_proc:
+            await testing.wait_normal(conntrack_proc.wait_stdin_ready())
+            # registering on_stdout callback on both streams, cuz most of the stdout goes to stderr somehow
+            async with connection_alpha.create_process(
+                [
+                    "nc",
+                    "-nlvv",
+                    "-p",
+                    str(PORT),
+                    "-s",
+                    CLIENT_ALPHA_IP,
+                    CLIENT_BETA_IP,
+                ]
+            ).run(stdout_callback=on_stdout, stderr_callback=on_stdout) as listener:
+                await testing.wait_normal(listener.wait_stdin_ready())
+                await testing.wait_normal(listening_start_event.wait())
+                await exit_stack.enter_async_context(
+                    connection_beta.create_process(
+                        [
+                            "nc",
+                            "-nvv",
+                            "-s",
+                            CLIENT_BETA_IP,
+                            CLIENT_ALPHA_IP,
+                            str(PORT),
+                        ]
+                    ).run(stdout_callback=on_stdout, stderr_callback=on_stdout)
+                )
+                await testing.wait_normal(sender_start_event.wait())
+                await testing.wait_normal(connected_event.wait())
+
+            # kill server and check what is happening in conntrack events
+            # if everything is correct -> conntrack should show LAST_ACK -> TIME_WAIT
+            # if something goes wrong, it will be stuck at LAST_ACK state
+            await testing.wait_long(last_ack_event.wait())
+            await testing.wait_long(time_wait_event.wait())
+
+        assert alpha_conn_tracker.get_out_of_limits() is None
+        assert beta_conn_tracker.get_out_of_limits() is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "alpha_adapter_type, beta_adapter_type",
+    [
+        (telio.AdapterType.BoringTun, telio.AdapterType.BoringTun),
+        (telio.AdapterType.BoringTun, telio.AdapterType.LinuxNativeWg),
+        (telio.AdapterType.LinuxNativeWg, telio.AdapterType.LinuxNativeWg),
+        (telio.AdapterType.LinuxNativeWg, telio.AdapterType.BoringTun),
+    ],
+)
+async def test_mesh_firewall_tcp_stuck_in_last_ack_state_conn_kill_from_client_side(
+    alpha_adapter_type: telio.AdapterType, beta_adapter_type: telio.AdapterType
+) -> None:
+    async with AsyncExitStack() as exit_stack:
+        api = API()
+        (alpha, beta) = api.default_config_two_nodes()
+
+        CLIENT_ALPHA_IP = alpha.ip_addresses[0]
+        CLIENT_BETA_IP = beta.ip_addresses[0]
+        PORT = 12345
+
+        beta.set_peer_firewall_settings(alpha.id, allow_incoming_connections=False)
+
+        (connection_alpha, alpha_conn_tracker) = await exit_stack.enter_async_context(
+            new_connection_with_conn_tracker(
+                ConnectionTag.DOCKER_CONE_CLIENT_1,
+                generate_connection_tracker_config(
+                    ConnectionTag.DOCKER_CONE_CLIENT_1,
+                    derp_1_limits=ConnectionLimits(1, 1),
+                ),
+            )
+        )
+        (connection_beta, beta_conn_tracker) = await exit_stack.enter_async_context(
+            new_connection_with_conn_tracker(
+                ConnectionTag.DOCKER_CONE_CLIENT_2,
+                generate_connection_tracker_config(
+                    ConnectionTag.DOCKER_CONE_CLIENT_2,
+                    derp_1_limits=ConnectionLimits(1, 1),
+                ),
+            )
+        )
+
+        client_alpha = await exit_stack.enter_async_context(
+            telio.Client(connection_alpha, alpha, alpha_adapter_type).run_meshnet(
+                api.get_meshmap(alpha.id)
+            )
+        )
+
+        client_beta = await exit_stack.enter_async_context(
+            telio.Client(connection_beta, beta, beta_adapter_type).run_meshnet(
+                api.get_meshmap(beta.id)
+            )
+        )
+
+        await testing.wait_long(
+            asyncio.gather(
+                client_alpha.wait_for_any_derp_state([telio.State.Connected]),
+                client_beta.wait_for_any_derp_state([telio.State.Connected]),
+            )
+        )
+
+        await testing.wait_long(
+            asyncio.gather(
+                alpha_conn_tracker.wait_for_event("derp_1"),
+                beta_conn_tracker.wait_for_event("derp_1"),
+            )
+        )
+
+        await testing.wait_long(
+            asyncio.gather(
+                client_alpha.handshake(beta.public_key),
+                client_beta.handshake(alpha.public_key),
+            )
+        )
+
+        output_notifier = OutputNotifier()
+
+        async def on_stdout(stdout: str) -> None:
+            for line in stdout.splitlines():
+                output_notifier.handle_output(line)
+
+        async def conntrack_on_stdout(stdout: str) -> None:
+            for line in stdout.splitlines():
+                if f"src={CLIENT_ALPHA_IP} dst={CLIENT_BETA_IP}" in line:
+                    output_notifier.handle_output(line)
+
+        listening_start_event = asyncio.Event()
+        sender_start_event = asyncio.Event()
+        connected_event = asyncio.Event()
+        last_ack_event = asyncio.Event()
+        time_wait_event = asyncio.Event()
+
+        output_notifier.notify_output(
+            f"listening on [{CLIENT_ALPHA_IP}] {str(PORT)}", listening_start_event
+        )
+
+        output_notifier.notify_output(
+            f"[{CLIENT_ALPHA_IP}] {str(PORT)} (?) open", sender_start_event
+        )
+
+        output_notifier.notify_output(
+            f"connect to [{CLIENT_ALPHA_IP}] from (UNKNOWN) [{CLIENT_BETA_IP}]",
+            connected_event,
+        )
+
+        output_notifier.notify_output("LAST_ACK", last_ack_event)
+        output_notifier.notify_output("TIME_WAIT", time_wait_event)
+
+        async with connection_beta.create_process(["conntrack", "-E"]).run(
+            stdout_callback=conntrack_on_stdout
+        ) as conntrack_proc:
+            await testing.wait_normal(conntrack_proc.wait_stdin_ready())
+            async with connection_alpha.create_process(
+                [
+                    "nc",
+                    "-nlvv",
+                    "-p",
+                    str(PORT),
+                    "-s",
+                    CLIENT_ALPHA_IP,
+                    CLIENT_BETA_IP,
+                ]
+            ).run(stdout_callback=on_stdout, stderr_callback=on_stdout) as listener:
+                await testing.wait_normal(listener.wait_stdin_ready())
+                await testing.wait_normal(listening_start_event.wait())
+                # registering on_stdout callback on both streams, cuz most of the stdout goes to stderr somehow
+                async with connection_beta.create_process(
+                    [
+                        "nc",
+                        "-nvv",
+                        "-s",
+                        CLIENT_BETA_IP,
+                        CLIENT_ALPHA_IP,
+                        str(PORT),
+                    ]
+                ).run(stdout_callback=on_stdout, stderr_callback=on_stdout) as client:
+                    await testing.wait_normal(client.wait_stdin_ready())
+                    await testing.wait_normal(sender_start_event.wait())
+                    await testing.wait_normal(connected_event.wait())
+
+                # kill client and check what is happening in conntrack events
+                # if everything is correct -> conntrack should show LAST_ACK -> TIME_WAIT
+                # if something goes wrong, it will be stuck at LAST_ACK state
+                await testing.wait_long(last_ack_event.wait())
+                await testing.wait_long(time_wait_event.wait())
+
+        assert alpha_conn_tracker.get_out_of_limits() is None
+        assert beta_conn_tracker.get_out_of_limits() is None


### PR DESCRIPTION
### Description
#### Root cause:
when analyzing the following sequence from perspective of Node1:
![image](https://github.com/NordSecurity/libtelio/assets/69630990/360aecc3-3346-4726-abcf-cc1f2678f67e)
The rx_alive as well as tx_alive will both be set to false whenever the FIN&ACK packet is sent out, consequently, the tcp_cache entry will be removed here: https://github.com/NordSecurity/libtelio/blob/main/crates/telio-firewall/src/firewall.rs#L454C1-L454C44. Thus upon receiving the ACK no tcp_cache entry will exist and the packet will be dropped.

#### Reproduction steps  
1. Using boringtun start meshnet
2. Add one peer to meshnet which is not allowed to do the incoming connections
3. Create TCP connection using nc between those nodes
4. Shutdown the connection from the peer (added in step 2) side
5. Observe connection left over in LAST_ACK stage

#### Solution
After FIN is being sent/recieved, shutdown tx / rx and then wait for last ACK before removing `tcp_cache` entry

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean
- [x] README.md is updated
- [x] changelog.md is updated
