### PR TITLE
nat-lab: Refactor event handling

### DIFF
--- a/nat-lab/tests/derp_cli.py
+++ b/nat-lab/tests/derp_cli.py
@@ -7,15 +7,6 @@ import telio
 from contextlib import asynccontextmanager
 
 
-async def check_derp_connection(client: telio.Client, server_ip: str, state: bool):
-    await client.wait_for_derp_state(
-        server_ip,
-        [telio.State.Connected]
-        if state
-        else [telio.State.Disconnected, telio.State.Connecting],
-    )
-
-
 class DerpTarget:
     _process: Process
     _output_notifier: OutputNotifier

--- a/nat-lab/tests/telio.py
+++ b/nat-lab/tests/telio.py
@@ -166,9 +166,7 @@ class AdapterType(Enum):
 
 class Runtime:
     _output_notifier: OutputNotifier
-    _peer_info: Dict[str, PeerInfo]
     _peer_state_events: List[PeerInfo]
-    _derp_state: Dict[str, DerpServer]
     _derp_state_events: List[DerpServer]
     _started_tasks: List[str]
     _stopped_tasks: List[str]
@@ -176,9 +174,7 @@ class Runtime:
 
     def __init__(self) -> None:
         self._output_notifier = OutputNotifier()
-        self._peer_info = {}
         self._peer_state_events = []
-        self._derp_state = {}
         self._derp_state_events = []
         self._started_tasks = []
         self._stopped_tasks = []
@@ -213,66 +209,88 @@ class Runtime:
         public_key: str,
         states: List[State],
         paths: List[PathType],
-        new_event_explicitly: bool = False,
     ) -> None:
-        def _get_events() -> Set[PeerInfo]:
-            return {
-                event
-                for event in self._peer_state_events
-                if event.public_key == public_key
-                and event.state in states
-                and event.path in paths
-            }
-
-        old_events = _get_events()
         while True:
             peer = self.get_peer_info(public_key)
-            events = _get_events()
-            if (
-                not new_event_explicitly
-                and (
-                    (peer and peer.path in paths and peer.state in states)
-                    or any(events)
-                )
-            ) or (new_event_explicitly and set(events) - set(old_events)):
-                self._peer_state_events = list(set(self._peer_state_events) - events)
+            if peer and peer.path in paths and peer.state in states:
+                return
+            await asyncio.sleep(0.01)
+
+    async def notify_peer_event(
+        self,
+        public_key: str,
+        states: List[State],
+        paths: List[PathType],
+    ) -> None:
+        def _get_events() -> List[PeerInfo]:
+            return [
+                peer
+                for peer in self._peer_state_events
+                if peer
+                and peer.public_key == public_key
+                and peer.path in paths
+                and peer.state in states
+            ]
+
+        old_events = _get_events()
+
+        while True:
+            new_events = _get_events()[len(old_events) :]
+            if new_events:
                 return
             await asyncio.sleep(0.01)
 
     def get_peer_info(self, public_key: str) -> Optional[PeerInfo]:
-        return self._peer_info.get(public_key)
+        events = [
+            peer_event
+            for peer_event in self._peer_state_events
+            if peer_event.public_key == public_key
+        ]
+        if events:
+            return events[-1]
+        else:
+            return None
 
     async def notify_derp_state(
-        self, server_ip: str, states: List[State], new_event_explicitly: bool = False
+        self,
+        server_ip: str,
+        states: List[State],
     ) -> None:
-        def _get_events() -> Set[DerpServer]:
-            return {
-                event
-                for event in self._derp_state_events
-                if event.ipv4 == server_ip and (event.conn_state in states)
-            }
-
-        old_events = _get_events()
         while True:
             derp = self.get_derp_info(server_ip)
-            events = _get_events()
-            if (
-                not new_event_explicitly
-                and (
-                    (derp and (derp.ipv4 == server_ip and derp.conn_state in states))
-                    or any(events)
-                )
-            ) or (new_event_explicitly and set(events) - set(old_events)):
-                self._derp_state_events = list(set(self._derp_state_events) - events)
+            if derp and derp.ipv4 == server_ip and derp.conn_state in states:
+                return
+            await asyncio.sleep(0.01)
+
+    async def notify_derp_event(
+        self,
+        server_ip: str,
+        states: List[State],
+    ) -> None:
+        def _get_events() -> List[DerpServer]:
+            return [
+                event
+                for event in self._derp_state_events
+                if event.ipv4 == server_ip and event.conn_state in states
+            ]
+
+        old_events = _get_events()
+
+        while True:
+            new_events = _get_events()[len(old_events) :]
+            if new_events:
                 return
             await asyncio.sleep(0.01)
 
     def get_derp_info(self, server_ip: str) -> Optional[DerpServer]:
-        return self._derp_state.get(server_ip)
+        events = [event for event in self._derp_state_events if event.ipv4 == server_ip]
+        if events:
+            return events[-1]
+        else:
+            return None
 
     def _set_peer(self, peer: PeerInfo) -> None:
         assert peer.public_key in self.allowed_pub_keys
-        self._peer_info[peer.public_key] = peer
         self._peer_state_events.append(peer)
 
     def _handle_node_event(self, line) -> bool:
@@ -291,7 +309,6 @@ class Runtime:
         return False
 
     def _set_derp(self, derp: DerpServer) -> None:
-        self._derp_state[derp.ipv4] = derp
         self._derp_state_events.append(derp)
 
     def _handle_derp_event(self, line) -> bool:
@@ -332,29 +349,35 @@ class Events:
         )
         await event.wait()
 
-    async def wait_for_peer_state(
+    async def wait_for_state_peer(
         self,
         public_key: str,
         state: List[State],
         path: List[PathType],
     ) -> None:
-        await self._runtime.notify_peer_state(public_key, state, path, False)
+        await self._runtime.notify_peer_state(public_key, state, path)
 
-    async def wait_for_new_peer_state(
+    async def wait_for_event_peer(
         self,
         public_key: str,
-        state: List[State],
-        path: List[PathType],
+        states: List[State],
+        paths: List[PathType],
     ) -> None:
-        await self._runtime.notify_peer_state(public_key, state, path, True)
+        await self._runtime.notify_peer_event(public_key, states, paths)
 
-    async def wait_for_derp_state(self, server_ip: str, states: List[State]) -> None:
-        await self._runtime.notify_derp_state(server_ip, states, False)
-
-    async def wait_for_new_derp_state(
-        self, server_ip: str, states: List[State]
+    async def wait_for_state_derp(
+        self,
+        server_ip: str,
+        states: List[State],
     ) -> None:
-        await self._runtime.notify_derp_state(server_ip, states, True)
+        await self._runtime.notify_derp_state(server_ip, states)
+
+    async def wait_for_event_derp(
+        self,
+        server_ip: str,
+        states: List[State],
+    ) -> None:
+        await self._runtime.notify_derp_event(server_ip, states)
 
 
 class Client:
@@ -447,67 +470,92 @@ class Client:
             ],
         )
 
-    async def handshake(self, public_key, path=PathType.Relay) -> None:
-        await self.get_events().wait_for_peer_state(
-            public_key, [State.Connected], [path]
-        )
+    async def wait_for_state_peer(
+        self,
+        public_key,
+        states: List[State],
+        paths: List[PathType] = [PathType.Relay],
+    ) -> None:
+        await self.get_events().wait_for_state_peer(public_key, states, paths)
 
-    async def disconnect(self, public_key, path=PathType.Relay) -> None:
-        await self.get_events().wait_for_peer_state(
-            public_key, [State.Disconnected], [path]
-        )
-
-    async def connecting(self, public_key, path=PathType.Relay) -> None:
-        await self.get_events().wait_for_peer_state(
-            public_key, [State.Connecting], [path]
-        )
-
-    async def wait_for_any_new_node_event(self, public_key) -> None:
-        await self.get_events().wait_for_new_peer_state(
+    async def wait_for_event_peer(
+        self,
+        public_key: str,
+        states: List[State],
+        paths: List[PathType] = [PathType.Relay],
+    ) -> None:
+        await self.get_events().wait_for_event_peer(
             public_key,
-            [State.Connected, State.Disconnected, State.Connecting],
-            [PathType.Relay, PathType.Direct],
+            states,
+            paths,
         )
 
-    async def wait_for_derp_state(
+    async def wait_for_state_derp(
         self,
-        server_ip: str,
-        state: List[State],
+        derp_ip,
+        states: List[State],
     ) -> None:
-        await self.get_events().wait_for_derp_state(server_ip, state)
+        await self.get_events().wait_for_state_derp(
+            derp_ip,
+            states,
+        )
 
-    async def wait_for_new_derp_state(
+    async def wait_for_state_on_any_derp(
         self,
-        server_ip: str,
-        state: List[State],
+        states: List[State],
     ) -> None:
-        await self.get_events().wait_for_new_derp_state(server_ip, state)
-
-    async def wait_for_any_new_derp_state(self) -> None:
         async with asyncio_util.run_async_contexts(
             [
-                self.wait_for_new_derp_state(
-                    str(derp["ipv4"]),
-                    [State.Connected, State.Disconnected, State.Connecting],
-                )
-                for derp in DERP_SERVERS
-            ]
-        ) as futures:
-            while not any([fut for fut in futures if fut.done()]):
-                await asyncio.sleep(0.001)
-
-    async def wait_for_any_derp_state(self, states: List[State]) -> None:
-        async with asyncio_util.run_async_contexts(
-            [
-                self.wait_for_derp_state(
+                self.get_events().wait_for_state_derp(
                     str(derp["ipv4"]),
                     states,
                 )
                 for derp in DERP_SERVERS
             ]
         ) as futures:
-            while not any([fut for fut in futures if fut.done()]):
+            while not any([fut.done() for fut in futures]):
+                await asyncio.sleep(0.01)
+
+    async def wait_for_every_derp_disconnection(
+        self,
+    ) -> None:
+        async with asyncio_util.run_async_contexts(
+            [
+                self.get_events().wait_for_state_derp(
+                    str(derp["ipv4"]),
+                    [State.Disconnected, State.Connecting],
+                )
+                for derp in DERP_SERVERS
+            ]
+        ) as futures:
+            while not all([fut.done() for fut in futures]):
                 await asyncio.sleep(0.001)
+
+    async def wait_for_event_derp(
+        self,
+        derp_ip,
+        states: List[State],
+    ) -> None:
+        await self.get_events().wait_for_event_derp(
+            derp_ip,
+            states,
+        )
+
+    async def wait_for_event_on_any_derp(
+        self,
+        states: List[State],
+    ) -> None:
+        async with asyncio_util.run_async_contexts(
+            [
+                self.get_events().wait_for_event_derp(
+                    str(derp["ipv4"]),
+                    states,
+                )
+                for derp in DERP_SERVERS
+            ]
+        ) as futures:
+            while not any([fut.done() for fut in futures]):
+                await asyncio.sleep(0.01)
 
     async def set_meshmap(self, meshmap: Dict[str, Any]) -> None:
         made_changes = await self._configure_interface()
@@ -551,9 +599,11 @@ class Client:
             ],
         )
 
-    async def disconnect_from_vpn(self, public_key, path=PathType.Relay) -> None:
+    async def disconnect_from_vpn(
+        self, public_key, path: List[PathType] = [PathType.Relay]
+    ) -> None:
         await self._write_command(["vpn", "off"])
-        await self.disconnect(public_key, path)
+        await self.wait_for_state_peer(public_key, [State.Disconnected], path)
         await self.get_router().delete_vpn_route()
 
     async def disconnect_from_exit_nodes(self) -> None:
@@ -617,7 +667,7 @@ class Client:
         self._interface_configured = False
         assert Counter(self.get_runtime().get_started_tasks()) == Counter(
             self.get_runtime().get_stopped_tasks()
-        ), f"started tasks and stopped tasks differ!"
+        ), "started tasks and stopped tasks differ!"
 
     def get_node_state(self, public_key: str) -> Optional[PeerInfo]:
         return self.get_runtime().get_peer_info(public_key)

--- a/nat-lab/tests/test_connection_states.py
+++ b/nat-lab/tests/test_connection_states.py
@@ -17,7 +17,7 @@ from utils import (
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "alpha_connection_tag,adapter_type",
+    "alpha_connection_tag, adapter_type",
     [
         pytest.param(
             ConnectionTag.DOCKER_CONE_CLIENT_1,
@@ -91,24 +91,22 @@ async def test_connected_state_after_routing(
             )
         )
 
-        await testing.wait_long(
+        await testing.wait_lengthy(
             asyncio.gather(
-                client_alpha.wait_for_any_derp_state([telio.State.Connected]),
-                client_beta.wait_for_any_derp_state([telio.State.Connected]),
-            )
-        )
-
-        await testing.wait_long(
-            asyncio.gather(
+                client_alpha.wait_for_state_on_any_derp([telio.State.Connected]),
+                client_beta.wait_for_state_on_any_derp([telio.State.Connected]),
                 alpha_conn_tracker.wait_for_event("derp_1"),
                 beta_conn_tracker.wait_for_event("derp_1"),
             )
         )
-
-        await testing.wait_long(
+        await testing.wait_lengthy(
             asyncio.gather(
-                client_alpha.handshake(beta.public_key),
-                client_beta.handshake(alpha.public_key),
+                client_alpha.wait_for_state_peer(
+                    beta.public_key, [telio.State.Connected]
+                ),
+                client_beta.wait_for_state_peer(
+                    alpha.public_key, [telio.State.Connected]
+                ),
             )
         )
 
@@ -118,11 +116,17 @@ async def test_connected_state_after_routing(
                 beta.public_key,
             )
         )
-        await testing.wait_long(client_alpha.handshake(beta.public_key))
+
+        await testing.wait_long(
+            client_alpha.wait_for_event_peer(beta.public_key, [telio.State.Connected])
+        )
 
         await testing.wait_long(client_alpha.disconnect_from_exit_nodes())
 
-        await testing.wait_long(client_alpha.handshake(beta.public_key))
+        await testing.wait_long(
+            client_alpha.wait_for_event_peer(beta.public_key, [telio.State.Connected])
+        )
+
         async with Ping(connection_alpha, beta.ip_addresses[0]).run() as ping:
             await testing.wait_long(ping.wait_for_next_ping())
 

--- a/nat-lab/tests/test_dns.py
+++ b/nat-lab/tests/test_dns.py
@@ -58,24 +58,22 @@ async def test_dns() -> None:
             )
         )
 
-        await testing.wait_long(
+        await testing.wait_lengthy(
             asyncio.gather(
-                client_alpha.wait_for_any_derp_state([telio.State.Connected]),
-                client_beta.wait_for_any_derp_state([telio.State.Connected]),
-            )
-        )
-
-        await testing.wait_long(
-            asyncio.gather(
+                client_alpha.wait_for_state_on_any_derp([telio.State.Connected]),
+                client_beta.wait_for_state_on_any_derp([telio.State.Connected]),
                 alpha_conn_tracker.wait_for_event("derp_1"),
                 beta_conn_tracker.wait_for_event("derp_1"),
             )
         )
-
-        await testing.wait_long(
+        await testing.wait_lengthy(
             asyncio.gather(
-                client_alpha.handshake(beta.public_key),
-                client_beta.handshake(alpha.public_key),
+                client_alpha.wait_for_state_peer(
+                    beta.public_key, [telio.State.Connected]
+                ),
+                client_beta.wait_for_state_peer(
+                    alpha.public_key, [telio.State.Connected]
+                ),
             )
         )
 
@@ -187,24 +185,22 @@ async def test_dns_port() -> None:
             )
         )
 
-        await testing.wait_long(
+        await testing.wait_lengthy(
             asyncio.gather(
-                client_alpha.wait_for_any_derp_state([telio.State.Connected]),
-                client_beta.wait_for_any_derp_state([telio.State.Connected]),
-            )
-        )
-
-        await testing.wait_long(
-            asyncio.gather(
+                client_alpha.wait_for_state_on_any_derp([telio.State.Connected]),
+                client_beta.wait_for_state_on_any_derp([telio.State.Connected]),
                 alpha_conn_tracker.wait_for_event("derp_1"),
                 beta_conn_tracker.wait_for_event("derp_1"),
             )
         )
-
-        await testing.wait_long(
+        await testing.wait_lengthy(
             asyncio.gather(
-                client_alpha.handshake(beta.public_key),
-                client_beta.handshake(alpha.public_key),
+                client_alpha.wait_for_state_peer(
+                    beta.public_key, [telio.State.Connected]
+                ),
+                client_beta.wait_for_state_peer(
+                    alpha.public_key, [telio.State.Connected]
+                ),
             )
         )
 
@@ -307,7 +303,9 @@ async def test_vpn_dns() -> None:
         await testing.wait_long(conn_tracker.wait_for_event("vpn_1"))
 
         await testing.wait_lengthy(
-            client_alpha.handshake(wg_server["public_key"], path=PathType.Direct)
+            client_alpha.wait_for_state_peer(
+                wg_server["public_key"], [telio.State.Connected], [PathType.Direct]
+            )
         )
 
         # After we connect to the VPN, enable magic DNS
@@ -481,22 +479,20 @@ async def test_dns_stability(
 
         await testing.wait_long(
             asyncio.gather(
-                client_alpha.wait_for_any_derp_state([telio.State.Connected]),
-                client_beta.wait_for_any_derp_state([telio.State.Connected]),
-            )
-        )
-
-        await testing.wait_long(
-            asyncio.gather(
+                client_alpha.wait_for_state_on_any_derp([telio.State.Connected]),
+                client_beta.wait_for_state_on_any_derp([telio.State.Connected]),
                 alpha_conn_tracker.wait_for_event("derp_1"),
                 beta_conn_tracker.wait_for_event("derp_1"),
             )
         )
-
-        await testing.wait_long(
+        await testing.wait_lengthy(
             asyncio.gather(
-                client_alpha.handshake(beta.public_key),
-                client_beta.handshake(alpha.public_key),
+                client_alpha.wait_for_state_peer(
+                    beta.public_key, [telio.State.Connected]
+                ),
+                client_beta.wait_for_state_peer(
+                    alpha.public_key, [telio.State.Connected]
+                ),
             )
         )
 
@@ -636,16 +632,16 @@ async def test_dns_update() -> None:
 
         wg_server = config.WG_SERVER
 
-        await testing.wait_long(
-            client_alpha.connect_to_vpn(
-                wg_server["ipv4"], wg_server["port"], wg_server["public_key"]
-            )
-        )
-
-        await testing.wait_long(conn_tracker.wait_for_event("vpn_1"))
-
         await testing.wait_lengthy(
-            client_alpha.handshake(wg_server["public_key"], path=PathType.Direct)
+            asyncio.gather(
+                client_alpha.connect_to_vpn(
+                    wg_server["ipv4"], wg_server["port"], wg_server["public_key"]
+                ),
+                conn_tracker.wait_for_event("vpn_1"),
+                client_alpha.wait_for_state_peer(
+                    wg_server["public_key"], [telio.State.Connected], [PathType.Direct]
+                ),
+            )
         )
 
         # Don't forward anything yet

--- a/nat-lab/tests/test_fire_connecting_event.py
+++ b/nat-lab/tests/test_fire_connecting_event.py
@@ -1,7 +1,7 @@
 from utils import Ping
 from contextlib import AsyncExitStack
 from mesh_api import API
-from telio import AdapterType
+from telio import AdapterType, State
 import asyncio
 import pytest
 import telio
@@ -68,24 +68,14 @@ async def test_fire_connecting_event(
             )
         )
 
-        await testing.wait_long(
+        await testing.wait_lengthy(
             asyncio.gather(
-                client_alpha.wait_for_any_derp_state([telio.State.Connected]),
-                client_beta.wait_for_any_derp_state([telio.State.Connected]),
-            )
-        )
-
-        await testing.wait_long(
-            asyncio.gather(
+                client_alpha.wait_for_state_on_any_derp([State.Connected]),
+                client_beta.wait_for_state_on_any_derp([State.Connected]),
                 alpha_conn_tracker.wait_for_event("derp_1"),
                 beta_conn_tracker.wait_for_event("derp_1"),
-            )
-        )
-
-        await testing.wait_long(
-            asyncio.gather(
-                client_alpha.handshake(beta.public_key),
-                client_beta.handshake(alpha.public_key),
+                client_alpha.wait_for_state_peer(beta.public_key, [State.Connected]),
+                client_beta.wait_for_state_peer(alpha.public_key, [State.Connected]),
             )
         )
 
@@ -98,7 +88,10 @@ async def test_fire_connecting_event(
             async with Ping(connection_alpha, beta.ip_addresses[0]).run() as ping:
                 await testing.wait_long(ping.wait_for_next_ping())
 
-        await asyncio.wait_for(client_alpha.connecting(beta.public_key), 180)
+        await testing.wait_defined(
+            client_alpha.wait_for_event_peer(beta.public_key, [State.Connecting]),
+            180,
+        )
 
         assert alpha_conn_tracker.get_out_of_limits() is None
         assert beta_conn_tracker.get_out_of_limits() is None

--- a/nat-lab/tests/test_mesh_exit_through_peer.py
+++ b/nat-lab/tests/test_mesh_exit_through_peer.py
@@ -1,7 +1,7 @@
 from utils import Ping, stun
 from contextlib import AsyncExitStack
 from mesh_api import API
-from telio import AdapterType
+from telio import AdapterType, State
 import config
 import pytest
 import telio
@@ -87,24 +87,18 @@ async def test_mesh_exit_through_peer(
             )
         )
 
-        await testing.wait_long(
+        await testing.wait_lengthy(
             asyncio.gather(
-                client_alpha.wait_for_any_derp_state([telio.State.Connected]),
-                client_beta.wait_for_any_derp_state([telio.State.Connected]),
-            )
-        )
-
-        await testing.wait_long(
-            asyncio.gather(
+                client_alpha.wait_for_state_on_any_derp([State.Connected]),
+                client_beta.wait_for_state_on_any_derp([State.Connected]),
                 alpha_conn_tracker.wait_for_event("derp_1"),
                 beta_conn_tracker.wait_for_event("derp_1"),
             )
         )
-
-        await testing.wait_long(
+        await testing.wait_lengthy(
             asyncio.gather(
-                client_alpha.handshake(beta.public_key),
-                client_beta.handshake(alpha.public_key),
+                client_alpha.wait_for_state_peer(beta.public_key, [State.Connected]),
+                client_beta.wait_for_state_peer(alpha.public_key, [State.Connected]),
             )
         )
 
@@ -117,7 +111,9 @@ async def test_mesh_exit_through_peer(
                 beta.public_key,
             )
         )
-        await testing.wait_long(client_alpha.handshake(beta.public_key))
+        await testing.wait_long(
+            client_alpha.wait_for_state_peer(beta.public_key, [State.Connected])
+        )
 
         ip_alpha = await testing.wait_long(
             stun.get(connection_alpha, config.STUN_SERVER)

--- a/nat-lab/tests/test_mesh_firewall.py
+++ b/nat-lab/tests/test_mesh_firewall.py
@@ -58,22 +58,20 @@ async def test_mesh_firewall_successful_passthrough() -> None:
 
         await testing.wait_long(
             asyncio.gather(
-                client_alpha.wait_for_any_derp_state([telio.State.Connected]),
-                client_beta.wait_for_any_derp_state([telio.State.Connected]),
-            )
-        )
-
-        await testing.wait_long(
-            asyncio.gather(
+                client_alpha.wait_for_state_on_any_derp([telio.State.Connected]),
+                client_beta.wait_for_state_on_any_derp([telio.State.Connected]),
                 alpha_conn_tracker.wait_for_event("derp_1"),
                 beta_conn_tracker.wait_for_event("derp_1"),
             )
         )
-
-        await testing.wait_long(
+        await testing.wait_lengthy(
             asyncio.gather(
-                client_alpha.handshake(beta.public_key),
-                client_beta.handshake(alpha.public_key),
+                client_alpha.wait_for_state_peer(
+                    beta.public_key, [telio.State.Connected]
+                ),
+                client_beta.wait_for_state_peer(
+                    alpha.public_key, [telio.State.Connected]
+                ),
             )
         )
 
@@ -135,22 +133,20 @@ async def test_mesh_firewall_reject_packet() -> None:
 
         await testing.wait_long(
             asyncio.gather(
-                client_alpha.wait_for_any_derp_state([telio.State.Connected]),
-                client_beta.wait_for_any_derp_state([telio.State.Connected]),
-            )
-        )
-
-        await testing.wait_long(
-            asyncio.gather(
+                client_alpha.wait_for_state_on_any_derp([telio.State.Connected]),
+                client_beta.wait_for_state_on_any_derp([telio.State.Connected]),
                 alpha_conn_tracker.wait_for_event("derp_1"),
                 beta_conn_tracker.wait_for_event("derp_1"),
             )
         )
-
-        await testing.wait_long(
+        await testing.wait_lengthy(
             asyncio.gather(
-                client_alpha.handshake(beta.public_key),
-                client_beta.handshake(alpha.public_key),
+                client_alpha.wait_for_state_peer(
+                    beta.public_key, [telio.State.Connected]
+                ),
+                client_beta.wait_for_state_peer(
+                    alpha.public_key, [telio.State.Connected]
+                ),
             )
         )
 
@@ -219,22 +215,20 @@ async def test_blocking_incoming_connections_from_exit_node() -> None:
 
         await testing.wait_long(
             asyncio.gather(
-                client_alpha.wait_for_any_derp_state([telio.State.Connected]),
-                client_exit_node.wait_for_any_derp_state([telio.State.Connected]),
-            )
-        )
-
-        await testing.wait_long(
-            asyncio.gather(
+                client_alpha.wait_for_state_on_any_derp([telio.State.Connected]),
+                client_exit_node.wait_for_state_on_any_derp([telio.State.Connected]),
                 alpha_conn_tracker.wait_for_event("derp_1"),
                 exit_node_conn_tracker.wait_for_event("derp_1"),
             )
         )
-
-        await testing.wait_long(
+        await testing.wait_lengthy(
             asyncio.gather(
-                client_alpha.handshake(exit_node.public_key),
-                client_exit_node.handshake(alpha.public_key),
+                client_alpha.wait_for_state_peer(
+                    exit_node.public_key, [telio.State.Connected]
+                ),
+                client_exit_node.wait_for_state_peer(
+                    alpha.public_key, [telio.State.Connected]
+                ),
             )
         )
 
@@ -307,7 +301,11 @@ async def test_blocking_incoming_connections_from_exit_node() -> None:
             )
         )
 
-        await testing.wait_long(client_alpha.handshake(exit_node.public_key))
+        await testing.wait_long(
+            client_alpha.wait_for_state_peer(
+                exit_node.public_key, [telio.State.Connected]
+            )
+        )
 
         # Both nodes should have the same external ip
 
@@ -423,22 +421,20 @@ async def test_mesh_firewall_file_share_port(
 
         await testing.wait_long(
             asyncio.gather(
-                client_alpha.wait_for_any_derp_state([telio.State.Connected]),
-                client_beta.wait_for_any_derp_state([telio.State.Connected]),
-            )
-        )
-
-        await testing.wait_long(
-            asyncio.gather(
+                client_alpha.wait_for_state_on_any_derp([telio.State.Connected]),
+                client_beta.wait_for_state_on_any_derp([telio.State.Connected]),
                 alpha_conn_tracker.wait_for_event("derp_1"),
                 beta_conn_tracker.wait_for_event("derp_1"),
             )
         )
-
-        await testing.wait_long(
+        await testing.wait_lengthy(
             asyncio.gather(
-                client_alpha.handshake(beta.public_key),
-                client_beta.handshake(alpha.public_key),
+                client_alpha.wait_for_state_peer(
+                    beta.public_key, [telio.State.Connected]
+                ),
+                client_beta.wait_for_state_peer(
+                    alpha.public_key, [telio.State.Connected]
+                ),
             )
         )
 
@@ -583,8 +579,8 @@ async def test_mesh_firewall_tcp_stuck_in_last_ack_state_conn_kill_from_server_s
 
         await testing.wait_long(
             asyncio.gather(
-                client_alpha.wait_for_any_derp_state([telio.State.Connected]),
-                client_beta.wait_for_any_derp_state([telio.State.Connected]),
+                client_alpha.wait_for_state_on_any_derp([telio.State.Connected]),
+                client_beta.wait_for_state_on_any_derp([telio.State.Connected]),
             )
         )
 
@@ -597,8 +593,12 @@ async def test_mesh_firewall_tcp_stuck_in_last_ack_state_conn_kill_from_server_s
 
         await testing.wait_long(
             asyncio.gather(
-                client_alpha.handshake(beta.public_key),
-                client_beta.handshake(alpha.public_key),
+                client_alpha.wait_for_state_peer(
+                    beta.public_key, [telio.State.Connected]
+                ),
+                client_beta.wait_for_state_peer(
+                    alpha.public_key, [telio.State.Connected]
+                ),
             )
         )
 
@@ -734,8 +734,8 @@ async def test_mesh_firewall_tcp_stuck_in_last_ack_state_conn_kill_from_client_s
 
         await testing.wait_long(
             asyncio.gather(
-                client_alpha.wait_for_any_derp_state([telio.State.Connected]),
-                client_beta.wait_for_any_derp_state([telio.State.Connected]),
+                client_alpha.wait_for_state_on_any_derp([telio.State.Connected]),
+                client_beta.wait_for_state_on_any_derp([telio.State.Connected]),
             )
         )
 
@@ -748,8 +748,12 @@ async def test_mesh_firewall_tcp_stuck_in_last_ack_state_conn_kill_from_client_s
 
         await testing.wait_long(
             asyncio.gather(
-                client_alpha.handshake(beta.public_key),
-                client_beta.handshake(alpha.public_key),
+                client_alpha.wait_for_state_peer(
+                    beta.public_key, [telio.State.Connected]
+                ),
+                client_beta.wait_for_state_peer(
+                    alpha.public_key, [telio.State.Connected]
+                ),
             )
         )
 

--- a/nat-lab/tests/test_mesh_remove_node.py
+++ b/nat-lab/tests/test_mesh_remove_node.py
@@ -102,30 +102,36 @@ async def test_mesh_remove_node(
             )
         )
 
-        await testing.wait_long(
+        await testing.wait_lengthy(
             asyncio.gather(
-                client_alpha.wait_for_any_derp_state([telio.State.Connected]),
-                client_beta.wait_for_any_derp_state([telio.State.Connected]),
-                client_gamma.wait_for_any_derp_state([telio.State.Connected]),
-            )
-        )
-
-        await testing.wait_long(
-            asyncio.gather(
+                client_alpha.wait_for_state_on_any_derp([telio.State.Connected]),
+                client_beta.wait_for_state_on_any_derp([telio.State.Connected]),
+                client_gamma.wait_for_state_on_any_derp([telio.State.Connected]),
                 alpha_conn_tracker.wait_for_event("derp_1"),
                 beta_conn_tracker.wait_for_event("derp_1"),
                 gamma_conn_tracker.wait_for_event("derp_1"),
             )
         )
-
         await testing.wait_lengthy(
             asyncio.gather(
-                client_alpha.handshake(beta.public_key),
-                client_alpha.handshake(gamma.public_key),
-                client_beta.handshake(alpha.public_key),
-                client_beta.handshake(gamma.public_key),
-                client_gamma.handshake(alpha.public_key),
-                client_gamma.handshake(beta.public_key),
+                client_alpha.wait_for_state_peer(
+                    beta.public_key, [telio.State.Connected]
+                ),
+                client_alpha.wait_for_state_peer(
+                    gamma.public_key, [telio.State.Connected]
+                ),
+                client_beta.wait_for_state_peer(
+                    alpha.public_key, [telio.State.Connected]
+                ),
+                client_beta.wait_for_state_peer(
+                    gamma.public_key, [telio.State.Connected]
+                ),
+                client_gamma.wait_for_state_peer(
+                    alpha.public_key, [telio.State.Connected]
+                ),
+                client_gamma.wait_for_state_peer(
+                    beta.public_key, [telio.State.Connected]
+                ),
             )
         )
 

--- a/nat-lab/tests/test_tcli.py
+++ b/nat-lab/tests/test_tcli.py
@@ -85,22 +85,20 @@ async def test_register_meshnet_client(
 
         await testing.wait_long(
             asyncio.gather(
-                client_alpha.wait_for_any_derp_state([telio.State.Connected]),
-                client_beta.wait_for_any_derp_state([telio.State.Connected]),
-            )
-        )
-
-        await testing.wait_long(
-            asyncio.gather(
+                client_alpha.wait_for_state_on_any_derp([telio.State.Connected]),
+                client_beta.wait_for_state_on_any_derp([telio.State.Connected]),
                 alpha_conn_tracker.wait_for_event("derp_1"),
                 beta_conn_tracker.wait_for_event("derp_1"),
             )
         )
-
-        await testing.wait_long(
+        await testing.wait_lengthy(
             asyncio.gather(
-                client_alpha.handshake(beta.public_key),
-                client_beta.handshake(alpha.public_key),
+                client_alpha.wait_for_state_peer(
+                    beta.public_key, [telio.State.Connected]
+                ),
+                client_beta.wait_for_state_peer(
+                    alpha.public_key, [telio.State.Connected]
+                ),
             )
         )
 

--- a/nat-lab/tests/test_upnp_connection.py
+++ b/nat-lab/tests/test_upnp_connection.py
@@ -54,15 +54,14 @@ async def test_upnp_route_corrupted() -> None:
 
         await testing.wait_lengthy(
             asyncio.gather(
-                alpha_client.wait_for_any_derp_state([telio.State.Connected]),
-                beta_client.wait_for_any_derp_state([telio.State.Connected]),
-            )
-        )
-
-        await testing.wait_lengthy(
-            asyncio.gather(
-                alpha_client.handshake(beta.public_key, PathType.Direct),
-                beta_client.handshake(alpha.public_key, PathType.Direct),
+                alpha_client.wait_for_state_on_any_derp([telio.State.Connected]),
+                beta_client.wait_for_state_on_any_derp([telio.State.Connected]),
+                alpha_client.wait_for_state_peer(
+                    beta.public_key, [telio.State.Connected], [PathType.Direct]
+                ),
+                beta_client.wait_for_state_peer(
+                    alpha.public_key, [telio.State.Connected], [PathType.Direct]
+                ),
             )
         )
 
@@ -81,12 +80,14 @@ async def test_upnp_route_corrupted() -> None:
 
         await testing.wait_lengthy(
             asyncio.gather(
-                alpha_client.handshake(beta.public_key, PathType.Direct),
-                beta_client.handshake(alpha.public_key, PathType.Direct),
+                alpha_client.wait_for_event_peer(
+                    beta.public_key, [telio.State.Connected], [PathType.Direct]
+                ),
+                beta_client.wait_for_event_peer(
+                    alpha.public_key, [telio.State.Connected], [PathType.Direct]
+                ),
             )
         )
-
-        time.sleep(10)
 
         async with Ping(beta_connection, alpha.ip_addresses[0]).run() as ping:
             await testing.wait_long(ping.wait_for_next_ping())

--- a/nat-lab/tests/test_vpn.py
+++ b/nat-lab/tests/test_vpn.py
@@ -3,7 +3,7 @@ import utils.testing as testing
 from contextlib import AsyncExitStack
 import config
 from mesh_api import API
-from telio import AdapterType, PathType, Client
+from telio import AdapterType, PathType, Client, State
 from utils import (
     Connection,
     ConnectionTag,
@@ -32,7 +32,9 @@ async def _connect_vpn(
     )
 
     await testing.wait_lengthy(
-        client.handshake(wg_server["public_key"], PathType.Direct)
+        client.wait_for_state_peer(
+            wg_server["public_key"], [State.Connected], [PathType.Direct]
+        )
     )
 
     await testing.wait_long(conn_tracker.wait_for_event(connection_key))
@@ -180,7 +182,7 @@ async def test_vpn_reconnect(
 
         await testing.wait_long(
             client_alpha.disconnect_from_vpn(
-                config.WG_SERVER["public_key"], PathType.Direct
+                config.WG_SERVER["public_key"], [PathType.Direct]
             )
         )
 


### PR DESCRIPTION
### Description
Some nat-lab tests were not handling events correctly, causing flakyness. After initial investigation on test_direct_connection_endpoint_gone() flakyness it was found that most calls to wait_for_event functions were checking historic events where they should instead be waiting for new events/states (node & derp servers). Also it was using wait_for_any_derp_state which looks for a state in any derp, where they should be checking on every derp (eg: blocking every derp servers connection).
In this PR, the checks were splitted into two distint category of functions, `wait_for_state_<derp/peer>` and `wait_for_event_<derp/peer>`. `wait_for_state_<derp/peer>` functions wait for a state report that matches with the given arguments, and `wait_for_event_<derp/peer>` functions wait for a new event report on stdout that matches the given states list. The difference is that the state functions checks (can also wait) for that state, while the event functions exclusively wait for new events from the instant they are called ~~OR they can take a asyncio.Event() as argument which is later set() in a way that the caller is able to launch the function before executing a specific action, ensuring that events are caught and thus avoiding data races~~ (Removed).

Note1: critical changes were introduced in telio.py and the rest are adjustments.
Note2: to avoid bigger MR, I decided to tackle [LLT-3880](https://nordsec.atlassian.net/browse/LLT-3880)
and [LLT-3846](https://nordsec.atlassian.net/browse/LLT-3846) on a separated MR.
Note3: probably a lock could solve the need for wait_for_event functions, it would synchronize quick event changes (Disconnected -> Connecting -> Connected). 

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean
- [x] README.md is updated
- [x] changelog.md is updated
