### PR TITLE
Resolve LLT-4051: Reenable flaky tests with XFAIL pytest

### DIFF
--- a/nat-lab/tests/test_connection_states.py
+++ b/nat-lab/tests/test_connection_states.py
@@ -31,12 +31,18 @@ from utils import (
         pytest.param(
             ConnectionTag.WINDOWS_VM,
             telio.AdapterType.WindowsNativeWg,
-            marks=pytest.mark.windows,
+            marks=[
+                pytest.mark.windows,
+                pytest.mark.xfail(reason="test is flaky - Jira issue: LLT-4064"),
+            ],
         ),
         pytest.param(
             ConnectionTag.WINDOWS_VM,
             telio.AdapterType.WireguardGo,
-            marks=pytest.mark.windows,
+            marks=[
+                pytest.mark.windows,
+                pytest.mark.xfail(reason="test is flaky - Jira issue: LLT-4064"),
+            ],
         ),
         pytest.param(
             ConnectionTag.MAC_VM,

--- a/nat-lab/tests/test_direct_connection.py
+++ b/nat-lab/tests/test_direct_connection.py
@@ -372,7 +372,7 @@ async def test_direct_short_connection_loss(
     UHP_conn_client_types,
 )
 @pytest.mark.timeout(4 * 60)
-@pytest.mark.skip(reason="the test is flaky - JIRA issue: LLT-3079")
+@pytest.mark.xfail(reason="the test is flaky - JIRA issue: LLT-3079")
 async def test_direct_connection_loss_for_infinity(
     endpoint_providers, client1_type, client2_type, reflexive_ip
 ) -> None:

--- a/nat-lab/tests/test_network_switch.py
+++ b/nat-lab/tests/test_network_switch.py
@@ -37,7 +37,7 @@ from utils import (
             "10.0.254.8",
             marks=[
                 pytest.mark.mac,
-                pytest.mark.skip(reason="the test is flaky - JIRA issue: LLT-2393"),
+                pytest.mark.xfail(reason="the test is flaky - JIRA issue: LLT-2393"),
             ],
         ),
     ],

--- a/nat-lab/tests/test_verify_pk_on_packets.py
+++ b/nat-lab/tests/test_verify_pk_on_packets.py
@@ -23,7 +23,7 @@ async def check_fake_derp_connection(client: telio.Client) -> Optional[telio.Cli
 
 
 @pytest.mark.asyncio
-@pytest.mark.skip(reason="the test is flaky - JIRA issue: LLT-3078")
+@pytest.mark.xfail(reason="the test is flaky - JIRA issue: LLT-3078")
 async def test_verify_pk_on_packets() -> None:
     async with AsyncExitStack() as exit_stack:
         api = API()


### PR DESCRIPTION
### Problem
whenever flaky test appeared, we disabled it by skipping it. Sometimes losing some important information.
### Solution
mark them as `possible to fail` using XFAIL. XFAIL mark allows to indicate that tests might fail (being falky). Test will run, but no traceback will be reported when it fails. And also, end result (exit code) will not be affected



### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean
- [x] README.md is updated
- [x] changelog.md is updated
