### PR TITLE
Remove nagger job

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -65,18 +65,6 @@ jobs:
           with:
             version: 'v0.1.39'
             args: '--workspace --locked --output human --backend depinfo'
-  nagger:
-      runs-on: ubuntu-22.04
-      env:
-        RUSTFLAGS: -Dwarnings
-        # TODO: set DYLINT_LIBRARY_PATH with directory path containing dylint lints
-      steps:
-        - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-        - uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.6
-          with:
-            toolchain: 1.65.0
-        - run: cargo +1.65.0 install cargo-dylint dylint-link
-        - run: cargo +1.65.0 dylint --workspace --all
   rustfmt:
       runs-on: ubuntu-22.04
       steps:


### PR DESCRIPTION
This job is right now just a dummy. It builds dylint but runs zero checks with it. Since it didn't use specific version of dylint, it started to fail when the dylint executable started to require rust version newer than what we use. Instead of fixing it now, let's remove it now. It can be re-added once we have our lints open sourced and ready to be used here.



### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean
- [x] README.md is updated
- [x] changelog.md is updated
