### PR TITLE
Add git commit message requirements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,10 @@ On top of the CI being green, every PR will go through code review, and you can 
 
 **A clean history can make things easier**. Some PRs are easier to review commit-by-commit, rather than looking at the full changelist in one go. To enable that, prefer `rebase` over `merge` when updating your branch. Keeping PRs small and short-lived will also help keep your history clean since there's less time for upstream to change that much.
 
+### Commit message requirements
+
+Read [requirements](docs/git_commit_messages_requirements.md)
+
 ## Licensing
 Libtelio is released under GPL-3.0 License. For more details please refer to [LICENSE.md](LICENSE.md). 
 

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,5 @@
-### Description
-*--write your description here--*
+### Problem
+*--describe problem being solved--*
 
+### Solution
+*--describe selected solution--*

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 * LLT-4008: Add support for AAAA records in telio-dns
 * LLT-4012: Fix firewall being stuck on LAST_ACK after FIN
 * LLT-4023: Add validation that meshnet and device keys match
+* LLT-4056: Add git commit requirements
 
 <br>
 

--- a/docs/git_commit_messages_requirements.md
+++ b/docs/git_commit_messages_requirements.md
@@ -1,0 +1,115 @@
+# Git Commit Message Requirements
+
+## 1. Use the body to explain why this commit exists and on a high level what was done
+
+Good
+```
+Fix buffer overflow
+
+The buffer overflow was caused by off-by-one error when copying strings.
+The source string buffer includes the null terminator, while the
+destination string buffer does not.
+```
+
+Bad
+```
+Fix buffer overflow
+
+Add -1 to the length of bytes being copied from the source string buffer
+to the destination string buffer.
+```
+
+## 2. When there is a body, its separated from subject by a blank line
+
+Note: subject line is mandatory, body is optional
+
+Good
+```
+Fix buffer overflow
+
+The buffer overflow was caused by off-by-one error when copying strings.
+The source string buffer includes the null terminator, while the
+destination string buffer does not.
+```
+
+Bad
+```
+Fix buffer overflow
+The buffer overflow was caused by off-by-one error when copying strings.
+The source string buffer includes the null terminator, while the
+destination string buffer does not.
+```
+
+## 3. Limit the subject line to 50 characters
+
+Good
+```
+Fix buffer overflow
+```
+
+Bad
+```
+Fix buffer overflow that was caused by off-by-one error when copying strings
+```
+
+## 4. Capitalize the subject line
+
+Good
+```
+Fix buffer overflow
+```
+
+Bad
+```
+fix buffer overflow
+```
+
+## 5. Do not end the subject line with a period
+
+Good
+```
+Fix buffer overflow
+```
+
+Bad
+```
+Fix buffer overflow.
+```
+
+## 6. Use the imperative mood in the subject line
+
+Good
+```
+Fix buffer overflow
+```
+
+Bad
+```
+Fixed buffer overflow
+
+Fixing buffer overflow
+
+Buffer overflow fixed
+```
+
+## 7. Wrap the body at 72 characters
+
+Good
+```
+Fix buffer overflow
+
+The buffer overflow was caused by off-by-one error when copying strings.
+The source string buffer includes the null terminator, while the
+destination string buffer does not.
+```
+
+Bad
+```
+Fix buffer overflow
+
+The buffer overflow was caused by off-by-one error when copying strings. The source string buffer includes the null terminator, while the destination string buffer does not.
+```
+
+## Sources
+
+- [How to write git commit messages](https://cbea.ms/git-commit/)

--- a/dod.yml
+++ b/dod.yml
@@ -1,4 +1,4 @@
 dod:
-  - 'Commit history is clean'
+  - 'Commit history is clean ([requirements](../../blob/main/docs/git_commit_messages_requirements.md))'
   - 'README.md is updated'
   - 'changelog.md is updated'


### PR DESCRIPTION
### Description

Adding document that indictates how project's commit messages should look like.



### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean
- [x] Commit message adhere to [requirements](docs/git_commit_messages_requirements.md)
- [x] README.md is updated
- [x] changelog.md is updated
