### PR TITLE
Define UniFFI UDL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,7 +135,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
 dependencies = [
- "quote 1.0.33",
+ "quote 1.0.35",
  "syn 1.0.109",
 ]
 
@@ -247,9 +247,9 @@ version = "0.1.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
 dependencies = [
- "proc-macro2 1.0.69",
- "quote 1.0.33",
- "syn 2.0.38",
+ "proc-macro2 1.0.78",
+ "quote 1.0.35",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -582,8 +582,8 @@ checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
 dependencies = [
  "heck",
  "proc-macro-error",
- "proc-macro2 1.0.69",
- "quote 1.0.33",
+ "proc-macro2 1.0.78",
+ "quote 1.0.35",
  "syn 1.0.109",
 ]
 
@@ -594,9 +594,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0862016ff20d69b84ef8247369fabf5c008a7417002411897d40ee1f4532b873"
 dependencies = [
  "heck",
- "proc-macro2 1.0.69",
- "quote 1.0.33",
- "syn 2.0.38",
+ "proc-macro2 1.0.78",
+ "quote 1.0.35",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -827,7 +827,7 @@ version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
 dependencies = [
- "quote 1.0.33",
+ "quote 1.0.35",
  "syn 1.0.109",
 ]
 
@@ -876,9 +876,9 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fdaf97f4804dcebfa5862639bc9ce4121e82140bec2a987ac5140294865b5b"
 dependencies = [
- "proc-macro2 1.0.69",
- "quote 1.0.33",
- "syn 2.0.38",
+ "proc-macro2 1.0.78",
+ "quote 1.0.35",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -909,8 +909,8 @@ checksum = "8e91455b86830a1c21799d94524df0845183fa55bafd9aa137b01c7d1065fa36"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.69",
- "quote 1.0.33",
+ "proc-macro2 1.0.78",
+ "quote 1.0.35",
  "strsim",
  "syn 1.0.109",
 ]
@@ -923,8 +923,8 @@ checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.69",
- "quote 1.0.33",
+ "proc-macro2 1.0.78",
+ "quote 1.0.35",
  "strsim",
  "syn 1.0.109",
 ]
@@ -936,7 +936,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29b5acf0dea37a7f66f7b25d2c5e93fd46f8f6968b1a5d7a3e02e97768afc95a"
 dependencies = [
  "darling_core 0.12.4",
- "quote 1.0.33",
+ "quote 1.0.35",
  "syn 1.0.109",
 ]
 
@@ -947,7 +947,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
  "darling_core 0.13.4",
- "quote 1.0.33",
+ "quote 1.0.35",
  "syn 1.0.109",
 ]
 
@@ -979,8 +979,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66e616858f6187ed828df7c64a6d71720d83767a7f19740b2d1b6fe6327b36e5"
 dependencies = [
  "darling 0.12.4",
- "proc-macro2 1.0.69",
- "quote 1.0.33",
+ "proc-macro2 1.0.78",
+ "quote 1.0.35",
  "syn 1.0.109",
 ]
 
@@ -1135,9 +1135,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ffccbb6966c05b32ef8fbac435df276c4ae4d3dc55a8cd0eb9745e6c12f546a"
 dependencies = [
  "heck",
- "proc-macro2 1.0.69",
- "quote 1.0.33",
- "syn 2.0.38",
+ "proc-macro2 1.0.78",
+ "quote 1.0.35",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1155,9 +1155,9 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04d0b288e3bb1d861c4403c1774a6f7a798781dfc519b3647df2a3dd4ae95f25"
 dependencies = [
- "proc-macro2 1.0.69",
- "quote 1.0.33",
- "syn 2.0.38",
+ "proc-macro2 1.0.78",
+ "quote 1.0.35",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1347,9 +1347,9 @@ version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
- "proc-macro2 1.0.69",
- "quote 1.0.33",
- "syn 2.0.38",
+ "proc-macro2 1.0.78",
+ "quote 1.0.35",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2135,8 +2135,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ce75669015c4f47b289fd4d4f56e894e4c96003ffdf3ac51313126f94c6cbb"
 dependencies = [
  "cfg-if",
- "proc-macro2 1.0.69",
- "quote 1.0.33",
+ "proc-macro2 1.0.78",
+ "quote 1.0.35",
  "syn 1.0.109",
 ]
 
@@ -2251,8 +2251,8 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99a81eb400abc87063f829560bc5c5c835177703b83d1cd991960db0b2a00abe"
 dependencies = [
- "proc-macro2 1.0.69",
- "quote 1.0.33",
+ "proc-macro2 1.0.78",
+ "quote 1.0.35",
  "syn 1.0.109",
 ]
 
@@ -2264,8 +2264,8 @@ checksum = "b10db009e117aca57cbfb70ac332348f9a89d09ff7204497c283c0f7a0c96323"
 dependencies = [
  "ntest_proc_macro_helper",
  "proc-macro-crate",
- "proc-macro2 1.0.69",
- "quote 1.0.33",
+ "proc-macro2 1.0.78",
+ "quote 1.0.35",
  "syn 1.0.109",
 ]
 
@@ -2336,9 +2336,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96667db765a921f7b295ffee8b60472b686a51d4f21c2ee4ffdb94c7013b65a6"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.69",
- "quote 1.0.33",
- "syn 2.0.38",
+ "proc-macro2 1.0.78",
+ "quote 1.0.35",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2546,8 +2546,8 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30490e0852e58402b8fae0d39897b08a24f493023a4d6cf56b2e30f31ed57548"
 dependencies = [
- "proc-macro2 1.0.69",
- "quote 1.0.33",
+ "proc-macro2 1.0.78",
+ "quote 1.0.35",
  "regex",
  "syn 1.0.109",
 ]
@@ -2558,8 +2558,8 @@ version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a780e80005c2e463ec25a6e9f928630049a10b43945fea83207207d4a7606f4"
 dependencies = [
- "proc-macro2 1.0.69",
- "quote 1.0.33",
+ "proc-macro2 1.0.78",
+ "quote 1.0.35",
  "regex",
  "syn 1.0.109",
 ]
@@ -2698,8 +2698,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.69",
- "quote 1.0.33",
+ "proc-macro2 1.0.78",
+ "quote 1.0.35",
  "syn 1.0.109",
  "version_check",
 ]
@@ -2710,8 +2710,8 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.69",
- "quote 1.0.33",
+ "proc-macro2 1.0.78",
+ "quote 1.0.35",
  "version_check",
 ]
 
@@ -2726,9 +2726,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.69"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
@@ -2806,11 +2806,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.78",
 ]
 
 [[package]]
@@ -3039,8 +3039,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2288c66aeafe3b2ed227c981f364f9968fa952ef0b30e84ada4486e7ee24d00a"
 dependencies = [
  "cfg-if",
- "proc-macro2 1.0.69",
- "quote 1.0.33",
+ "proc-macro2 1.0.78",
+ "quote 1.0.35",
  "rustc_version",
  "syn 1.0.109",
 ]
@@ -3313,9 +3313,9 @@ checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
 
 [[package]]
 name = "serde"
-version = "1.0.188"
+version = "1.0.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
+checksum = "63261df402c67811e9ac6def069e4786148c4563f4b50fd4bf30aa370d626b02"
 dependencies = [
  "serde_derive",
 ]
@@ -3332,13 +3332,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.188"
+version = "1.0.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
+checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
 dependencies = [
- "proc-macro2 1.0.69",
- "quote 1.0.33",
- "syn 2.0.38",
+ "proc-macro2 1.0.78",
+ "quote 1.0.35",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -3381,8 +3381,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
 dependencies = [
  "darling 0.13.4",
- "proc-macro2 1.0.69",
- "quote 1.0.33",
+ "proc-macro2 1.0.78",
+ "quote 1.0.35",
  "syn 1.0.109",
 ]
 
@@ -3406,8 +3406,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1b95bb2f4f624565e8fe8140c789af7e2082c0e0561b5a82a1b678baa9703dc"
 dependencies = [
  "proc-macro-error",
- "proc-macro2 1.0.69",
- "quote 1.0.33",
+ "proc-macro2 1.0.78",
+ "quote 1.0.35",
  "rustversion",
  "syn 1.0.109",
 ]
@@ -3636,8 +3636,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
  "heck",
- "proc-macro2 1.0.69",
- "quote 1.0.33",
+ "proc-macro2 1.0.78",
+ "quote 1.0.35",
  "rustversion",
  "syn 1.0.109",
 ]
@@ -3709,19 +3709,19 @@ version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
- "proc-macro2 1.0.69",
- "quote 1.0.33",
+ "proc-macro2 1.0.78",
+ "quote 1.0.35",
  "unicode-ident",
 ]
 
 [[package]]
 name = "syn"
-version = "2.0.38"
+version = "2.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
+checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
 dependencies = [
- "proc-macro2 1.0.69",
- "quote 1.0.33",
+ "proc-macro2 1.0.78",
+ "quote 1.0.35",
  "unicode-ident",
 ]
 
@@ -3834,6 +3834,7 @@ dependencies = [
  "jni",
  "lazy_static",
  "libc",
+ "maplit",
  "mockall",
  "modifier",
  "ntest",
@@ -4302,9 +4303,9 @@ version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
 dependencies = [
- "proc-macro2 1.0.69",
- "quote 1.0.33",
- "syn 2.0.38",
+ "proc-macro2 1.0.78",
+ "quote 1.0.35",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -4385,9 +4386,9 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
- "proc-macro2 1.0.69",
- "quote 1.0.33",
- "syn 2.0.38",
+ "proc-macro2 1.0.78",
+ "quote 1.0.35",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -4486,9 +4487,9 @@ version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
- "proc-macro2 1.0.69",
- "quote 1.0.33",
- "syn 2.0.38",
+ "proc-macro2 1.0.78",
+ "quote 1.0.35",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -4552,7 +4553,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebeb235c5847e2f82cfe0f07eb971d1e5f6804b18dac2ae16349cc604380f82f"
 dependencies = [
- "quote 1.0.33",
+ "quote 1.0.35",
  "syn 1.0.109",
 ]
 
@@ -4745,8 +4746,8 @@ dependencies = [
  "bumpalo",
  "log",
  "once_cell",
- "proc-macro2 1.0.69",
- "quote 1.0.33",
+ "proc-macro2 1.0.78",
+ "quote 1.0.35",
  "syn 1.0.109",
  "wasm-bindgen-shared",
 ]
@@ -4769,7 +4770,7 @@ version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
 dependencies = [
- "quote 1.0.33",
+ "quote 1.0.35",
  "wasm-bindgen-macro-support",
 ]
 
@@ -4779,8 +4780,8 @@ version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
 dependencies = [
- "proc-macro2 1.0.69",
- "quote 1.0.33",
+ "proc-macro2 1.0.78",
+ "quote 1.0.35",
  "syn 1.0.109",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
@@ -5103,9 +5104,9 @@ version = "0.7.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3c129550b3e6de3fd0ba67ba5c81818f9805e58b8d7fee80a3a59d2c9fc601a"
 dependencies = [
- "proc-macro2 1.0.69",
- "quote 1.0.33",
- "syn 2.0.38",
+ "proc-macro2 1.0.78",
+ "quote 1.0.35",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -5123,7 +5124,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
- "proc-macro2 1.0.69",
- "quote 1.0.33",
- "syn 2.0.38",
+ "proc-macro2 1.0.78",
+ "quote 1.0.35",
+ "syn 2.0.48",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,6 +124,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
 
 [[package]]
+name = "askama"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b79091df18a97caea757e28cd2d5fda49c6cd4bd01ddffd7ff01ace0c0ad2c28"
+dependencies = [
+ "askama_derive",
+ "askama_escape",
+]
+
+[[package]]
+name = "askama_derive"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19fe8d6cb13c4714962c072ea496f3392015f0989b1a2847bb4b2d9effd71d83"
+dependencies = [
+ "askama_parser",
+ "basic-toml",
+ "mime",
+ "mime_guess",
+ "proc-macro2 1.0.78",
+ "quote 1.0.35",
+ "serde",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "askama_escape"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "619743e34b5ba4e9703bba34deac3427c72507c7159f5fd030aea8cac0cfe341"
+
+[[package]]
+name = "askama_parser"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acb1161c6b64d1c3d83108213c2a2533a342ac225aabd0bda218278c2ddb00c0"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "assert_matches"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -321,6 +362,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
 
 [[package]]
+name = "basic-toml"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2db21524cad41c5591204d22d75e1970a2d1f71060214ca931dc7d5afe2c14e5"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -461,6 +520,38 @@ name = "bytes"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+
+[[package]]
+name = "camino"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ceed8ef69d8518a5dda55c07425450b58a4e1946f4951eab6d7191ee86c2443d"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
 
 [[package]]
 name = "cast"
@@ -1279,6 +1370,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
+name = "fs-err"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1399,6 +1499,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b32dfe1fdfc0bbde1f22a5da25355514b5e450c33a6af6770884c8750aedfbc"
 
 [[package]]
+name = "generator"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc16584ff22b460a382b7feec54b23d2908d858152e5739a120b949293bd74e"
+dependencies = [
+ "cc",
+ "libc",
+ "log",
+ "rustversion",
+ "windows 0.48.0",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1441,6 +1554,17 @@ dependencies = [
  "futures-core",
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "goblin"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d6b4de4a8eb6c46a8c77e1d3be942cb9a8bf073c22374578e5ba4b08ed0ff68"
+dependencies = [
+ "log",
+ "plain",
+ "scroll",
 ]
 
 [[package]]
@@ -2010,6 +2134,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "loom"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff50ecb28bb86013e935fb6683ab1f6d3a20016f123c76fd4c27470076ac30f5"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "pin-utils",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "lru-cache"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2047,6 +2185,15 @@ name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
 
 [[package]]
 name = "md5"
@@ -2092,6 +2239,22 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -2221,6 +2384,16 @@ name = "no-std-net"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43794a0ace135be66a25d3ae77d41b91615fb68ae937f904090203e81f755b65"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
 
 [[package]]
 name = "normalize-line-endings"
@@ -2395,6 +2568,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
+name = "oneshot"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f6640c6bda7731b1fdbab747981a0f896dd1fedaf9f4a53fa237a04a84431f4"
+dependencies = [
+ "loom",
+]
+
+[[package]]
 name = "oorandom"
 version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2463,6 +2645,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2490,6 +2678,12 @@ dependencies = [
  "fastrand 2.0.1",
  "futures-io",
 ]
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "platforms"
@@ -2934,6 +3128,9 @@ name = "regex-automata"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
+]
 
 [[package]]
 name = "regex-automata"
@@ -2945,6 +3142,12 @@ dependencies = [
  "memchr",
  "regex-syntax 0.8.1",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -3245,10 +3448,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "scroll"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04c565b551bafbef4157586fa379538366e4385d42082f255bfd96e4fe8519da"
+dependencies = [
+ "scroll_derive",
+]
+
+[[package]]
+name = "scroll_derive"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1db149f81d46d2deba7cd3c50772474707729550221e69588478ebf9ada425ae"
+dependencies = [
+ "proc-macro2 1.0.78",
+ "quote 1.0.35",
+ "syn 2.0.48",
+]
 
 [[package]]
 name = "sct"
@@ -3310,6 +3539,9 @@ name = "semver"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "serde"
@@ -3471,6 +3703,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3557,6 +3795,12 @@ name = "smallvec"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
+
+[[package]]
+name = "smawk"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
 name = "sn_fake_clock"
@@ -3869,6 +4113,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "uniffi",
  "uuid",
  "wasm-bindgen",
  "winapi",
@@ -4113,7 +4358,7 @@ dependencies = [
  "tracing",
  "version-compare",
  "winapi",
- "windows",
+ "windows 0.34.0",
 ]
 
 [[package]]
@@ -4287,6 +4532,11 @@ name = "textwrap"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
+ "unicode-width",
+]
 
 [[package]]
 name = "thiserror"
@@ -4519,11 +4769,15 @@ version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "time",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]
@@ -4576,6 +4830,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
+name = "unicase"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4586,6 +4849,12 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-normalization"
@@ -4613,6 +4882,126 @@ name = "unicode-xid"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
+
+[[package]]
+name = "uniffi"
+version = "0.25.0"
+source = "git+https://github.com/NordSecurity/uniffi-rs.git?tag=v0.25.0-1#de1e773204d0ddcda58faac0a77570f1f8056679"
+dependencies = [
+ "anyhow",
+ "uniffi_build",
+ "uniffi_core",
+ "uniffi_macros",
+]
+
+[[package]]
+name = "uniffi_bindgen"
+version = "0.25.0"
+source = "git+https://github.com/NordSecurity/uniffi-rs.git?tag=v0.25.0-1#de1e773204d0ddcda58faac0a77570f1f8056679"
+dependencies = [
+ "anyhow",
+ "askama",
+ "camino",
+ "cargo_metadata",
+ "fs-err",
+ "glob",
+ "goblin",
+ "heck",
+ "once_cell",
+ "paste",
+ "serde",
+ "textwrap 0.16.0",
+ "toml",
+ "uniffi_meta",
+ "uniffi_testing",
+ "uniffi_udl",
+]
+
+[[package]]
+name = "uniffi_build"
+version = "0.25.0"
+source = "git+https://github.com/NordSecurity/uniffi-rs.git?tag=v0.25.0-1#de1e773204d0ddcda58faac0a77570f1f8056679"
+dependencies = [
+ "anyhow",
+ "camino",
+ "uniffi_bindgen",
+]
+
+[[package]]
+name = "uniffi_checksum_derive"
+version = "0.25.0"
+source = "git+https://github.com/NordSecurity/uniffi-rs.git?tag=v0.25.0-1#de1e773204d0ddcda58faac0a77570f1f8056679"
+dependencies = [
+ "quote 1.0.35",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "uniffi_core"
+version = "0.25.0"
+source = "git+https://github.com/NordSecurity/uniffi-rs.git?tag=v0.25.0-1#de1e773204d0ddcda58faac0a77570f1f8056679"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "camino",
+ "log",
+ "once_cell",
+ "oneshot",
+ "paste",
+ "static_assertions",
+]
+
+[[package]]
+name = "uniffi_macros"
+version = "0.25.0"
+source = "git+https://github.com/NordSecurity/uniffi-rs.git?tag=v0.25.0-1#de1e773204d0ddcda58faac0a77570f1f8056679"
+dependencies = [
+ "bincode",
+ "camino",
+ "fs-err",
+ "once_cell",
+ "proc-macro2 1.0.78",
+ "quote 1.0.35",
+ "serde",
+ "syn 2.0.48",
+ "toml",
+ "uniffi_build",
+ "uniffi_meta",
+]
+
+[[package]]
+name = "uniffi_meta"
+version = "0.25.0"
+source = "git+https://github.com/NordSecurity/uniffi-rs.git?tag=v0.25.0-1#de1e773204d0ddcda58faac0a77570f1f8056679"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "siphasher",
+ "uniffi_checksum_derive",
+]
+
+[[package]]
+name = "uniffi_testing"
+version = "0.25.0"
+source = "git+https://github.com/NordSecurity/uniffi-rs.git?tag=v0.25.0-1#de1e773204d0ddcda58faac0a77570f1f8056679"
+dependencies = [
+ "anyhow",
+ "camino",
+ "cargo_metadata",
+ "fs-err",
+ "once_cell",
+]
+
+[[package]]
+name = "uniffi_udl"
+version = "0.25.0"
+source = "git+https://github.com/NordSecurity/uniffi-rs.git?tag=v0.25.0-1#de1e773204d0ddcda58faac0a77570f1f8056679"
+dependencies = [
+ "anyhow",
+ "uniffi_meta",
+ "uniffi_testing",
+ "weedle2",
+]
 
 [[package]]
 name = "universal-hash"
@@ -4810,6 +5199,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
 
 [[package]]
+name = "weedle2"
+version = "4.0.0"
+source = "git+https://github.com/NordSecurity/uniffi-rs.git?tag=v0.25.0-1#de1e773204d0ddcda58faac0a77570f1f8056679"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "wg-go-rust-wrapper"
 version = "1.0.0"
 dependencies = [
@@ -4877,6 +5274,15 @@ dependencies = [
  "windows_i686_msvc 0.34.0",
  "windows_x86_64_gnu 0.34.0",
  "windows_x86_64_msvc 0.34.0",
+]
+
+[[package]]
+name = "windows"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+dependencies = [
+ "windows-targets",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ rand.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["full"] }
 tracing.workspace = true
+uniffi.workspace = true
 uuid.workspace = true
 
 telio-crypto.workspace = true
@@ -87,6 +88,7 @@ telio-wg = { workspace = true, features = ["mockall", "test-adapter"] }
 [build-dependencies]
 anyhow.workspace = true
 cc.workspace = true
+uniffi = { workspace = true, features = ["build"] }
 
 [target.'cfg(windows)'.build-dependencies]
 winres = "0.1"
@@ -151,6 +153,7 @@ time = { version = "0.3.9", features = ["formatting"] }
 tokio = ">=1.22"
 tracing-subscriber = { version = "0.3.17", features = ["local-time"] }
 tracing-appender = "0.2.3"
+uniffi = { git = "https://github.com/NordSecurity/uniffi-rs.git", tag = "v0.25.0-1" }
 url = "2.2.2"
 uuid = { version = "1.1.2", features = ["v4"] }
 winapi = { version = "0.3", features = ["netioapi", "ws2def"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,11 @@ once_cell.workspace = true
 jni = "0.19"
 rustls-platform-verifier = { git = "https://github.com/tomaszklak/rustls-platform-verifier.git", rev = "2db68dd17d76eadb062176b913040341b99ef4f3" }
 
+[target.'cfg(windows)'.dependencies]
+winapi = { workspace = true, features = ["ntdef", "winerror"] }
+
 [dev-dependencies]
+maplit.workspace = true
 slog-async = "2.7"
 slog-term = "2.8"
 
@@ -83,9 +87,6 @@ telio-wg = { workspace = true, features = ["mockall", "test-adapter"] }
 [build-dependencies]
 anyhow.workspace = true
 cc.workspace = true
-
-[target.'cfg(windows)'.dependencies]
-winapi = { workspace = true, features = ["ntdef", "winerror"] }
 
 [target.'cfg(windows)'.build-dependencies]
 winres = "0.1"

--- a/build.rs
+++ b/build.rs
@@ -86,6 +86,8 @@ fn compile_and_enforce_bindings_export(target_os: &str, lang_wrapper: &str) -> R
 }
 
 fn main() -> Result<()> {
+    uniffi::generate_scaffolding("./src/libtelio.udl")?;
+
     let target_os = env::var("CARGO_CFG_TARGET_OS")?;
 
     let langs: HashSet<&str> = HashSet::from_iter(["GO", "JAVA", "CS"].iter().copied());

--- a/crates/telio-utils/src/hidden.rs
+++ b/crates/telio-utils/src/hidden.rs
@@ -10,6 +10,9 @@ use serde::{Deserialize, Serialize};
 #[serde(transparent)]
 pub struct Hidden<T>(pub T);
 
+/// Type alias for UniFFI
+pub type HiddenString = Hidden<String>;
+
 impl<T> fmt::Debug for Hidden<T>
 where
     T: fmt::Debug,

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -499,7 +499,7 @@ impl Device {
         }
     }
 
-    pub fn try_shutdown(mut self, timeout: Duration) -> Result {
+    pub fn try_shutdown(&mut self, timeout: Duration) -> Result {
         let art = self.art.take().ok_or(Error::NotStarted)?;
         let art = Arc::try_unwrap(art);
         match art {
@@ -2595,7 +2595,7 @@ mod tests {
         let (sender, _receiver) = tokio::sync::broadcast::channel(1);
         let features = Features {
             direct: Some(FeatureDirect {
-                providers: Some(HashSet::<telio_model::api_config::EndpointProvider>::new()),
+                providers: Some(HashSet::new()),
                 endpoint_interval_secs: None,
                 skip_unresponsive_peers: Default::default(),
             }),
@@ -2676,10 +2676,11 @@ mod tests {
 
         let (sender, _receiver) = tokio::sync::broadcast::channel(1);
 
-        let mut providers = HashSet::<telio_model::api_config::EndpointProvider>::new();
-        providers.insert(telio_model::api_config::EndpointProvider::Stun);
-        providers.insert(telio_model::api_config::EndpointProvider::Upnp);
-        providers.insert(telio_model::api_config::EndpointProvider::Local);
+        let providers = maplit::hashset! {
+            telio_model::api_config::EndpointProvider::Stun,
+            telio_model::api_config::EndpointProvider::Upnp,
+            telio_model::api_config::EndpointProvider::Local,
+        };
 
         let features = Features {
             direct: Some(FeatureDirect {

--- a/src/device/wg_controller.rs
+++ b/src/device/wg_controller.rs
@@ -1258,8 +1258,12 @@ mod tests {
                     paths: None,
                     direct: None,
                     exit_dns: None,
-                    #[cfg(any(target_os = "macos", feature = "pretend_to_be_macos"))]
-                    is_test_env: Some(true),
+                    is_test_env: if cfg!(any(target_os = "macos", feature = "pretend_to_be_macos"))
+                    {
+                        Some(true)
+                    } else {
+                        None
+                    },
                     derp: None,
                     validate_keys: Default::default(),
                     ipv6: true,

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -1,5 +1,9 @@
+// TODO(Mathias): Remove this in cleanup PR
+#![allow(dead_code)]
+
 pub mod types;
 
+use anyhow::anyhow;
 use base64::{decode as base64decode, encode as base64encode};
 use ffi_helpers::{error_handling, panic as panic_handling};
 use ipnetwork::IpNetwork;
@@ -7,7 +11,7 @@ use libc::c_char;
 use rand::Rng;
 use telio_crypto::{PublicKey, SecretKey};
 use telio_wg::AdapterType;
-use tracing::{error, trace, Subscriber};
+use tracing::{error, trace, Level, Subscriber};
 
 #[cfg(target_os = "linux")]
 use libc::c_uint;
@@ -22,16 +26,21 @@ use std::{
     ffi::{CStr, CString},
     fmt,
     net::{IpAddr, SocketAddr},
-    panic,
+    panic::{self, AssertUnwindSafe},
     process::abort,
     ptr::null,
-    sync::{Mutex, Once},
+    sync::{Arc, Mutex, Once},
     time::Duration,
 };
 
 use self::types::*;
 use crate::device::{Device, DeviceConfig, Result as DevResult};
-use telio_model::{api_config::Features, config::PartialConfig, event::*, mesh::ExitNode};
+use telio_model::{
+    api_config::Features,
+    config::{Config, PartialConfig},
+    event::*,
+    mesh::{ExitNode, Node},
+};
 
 // debug tools
 use telio_utils::{
@@ -71,6 +80,31 @@ macro_rules! ffi_catch_panic {
     }};
 }
 
+/// Execute a given closure and catch any panics
+///
+/// If the closure returns an error or panics, the inner errors or panic message is added to LAST_ERROR storage
+fn catch_ffi_panic<T, F>(expr: F) -> FFIResult<T>
+where
+    F: FnMut() -> FFIResult<T>,
+{
+    let result = panic::catch_unwind(AssertUnwindSafe(expr)).map_err(|e| {
+        let message = panic_handling::recover_panic_message(e)
+            .unwrap_or_else(|| DEFAULT_PANIC_MSG.to_string());
+        anyhow::Error::from(panic_handling::Panic { message })
+    });
+    match result {
+        Ok(Ok(res)) => Ok(res),
+        Ok(Err(err)) => {
+            error_handling::update_last_error(anyhow!(err.to_string()));
+            Err(err)
+        }
+        Err(err) => {
+            error_handling::update_last_error(anyhow!(err.to_string()));
+            Err(TelioError::UnknownError(anyhow!(err)))
+        }
+    }
+}
+
 /// Length of a public or private key
 const KEY_SIZE: usize = 32;
 
@@ -85,10 +119,612 @@ lazy_static::lazy_static! {
     };
 }
 
+/// Set the global logger.
+/// # Parameters
+/// - `log_level`: Max log level to log.
+/// - `logger`: Callback to handle logging events.
+pub fn set_global_logger(log_level: TelioLogLevel, logger: Box<dyn TelioLoggerCb>) {
+    let tracing_subscriber = TelioTracingSubscriber {
+        callback: SubscriberCallback::Uniffi(logger),
+        max_level: log_level.into(),
+    };
+    if tracing::subscriber::set_global_default(tracing_subscriber).is_err() {
+        telio_log_warn!("Could not set logger, because logger had already been set by previous libtelio instance");
+    }
+}
+
+/// Get default recommended adapter type for platform.
+pub fn uniffi_telio_get_default_adapter() -> TelioAdapterType {
+    AdapterType::default().into()
+}
+
+/// Get current version tag.
+pub fn uniffi_telio_get_version_tag() -> String {
+    version_tag().to_owned()
+}
+
+/// Get current commit sha.
+pub fn uniffi_telio_get_commit_sha() -> String {
+    commit_sha().to_owned()
+}
+
+/// Generate a new secret key.
+pub fn generate_secret_key() -> SecretKey {
+    SecretKey::gen()
+}
+
+/// Get the public key that corresponds to a given private key.
+pub fn generate_public_key(secret_key: SecretKey) -> PublicKey {
+    secret_key.public()
+}
+
+// TODO(Mathias): Remove this in cleanup PR
 #[allow(non_camel_case_types)]
 pub struct telio {
-    inner: Mutex<Device>,
+    inner: Mutex<Option<Device>>,
     id: usize,
+}
+
+impl telio {
+    /// Create new telio library instance
+    /// # Parameters
+    /// - `events`:     Events callback
+    /// - `features`:   JSON string of enabled features
+    pub fn new(features: Features, events: Box<dyn TelioEventCb>) -> FFIResult<Self> {
+        unsafe {
+            fortify_source();
+        }
+        let serialized_event_fn = format!("{:?}", events);
+        let ret = Self::new_common(&features, events, None);
+        Self::log_entry(features, serialized_event_fn, &ret);
+        ret
+    }
+
+    /// Create new telio library instance
+    /// # Parameters
+    /// - `events`:     Events callback
+    /// - `features`:   JSON string of enabled features
+    /// - `protect`:    Callback executed after exit-node connect (for VpnService::protectFromVpn())
+    pub fn new_with_protect(
+        features: Features,
+        events: Box<dyn TelioEventCb>,
+        protect: Box<dyn TelioProtectCb>,
+    ) -> FFIResult<Self> {
+        let serialized_event_fn = format!("{:?}", events);
+        let ret = Self::new_common(&features, events, Some(protect));
+        Self::log_entry(features, serialized_event_fn, &ret);
+        ret
+    }
+
+    fn new_common(
+        features: &Features,
+        events: Box<dyn TelioEventCb>,
+        #[allow(unused)] protect_cb: Option<Box<dyn TelioProtectCb>>,
+    ) -> FFIResult<Self> {
+        let events = Arc::new(events);
+        let event_dispatcher = move |e: Box<Event>| {
+            let payload = e
+                .to_json()
+                .unwrap_or_else(|_| String::from("event_to_json error"));
+            events.event(payload);
+        };
+
+        let panic_event_dispatcher = event_dispatcher.clone();
+        PANIC_HOOK.call_once(|| {
+            let events = panic_event_dispatcher;
+            panic::set_hook(Box::new(move |info| {
+                // We need it on the logs as well ...
+                error!("{}", info);
+
+                let err = {
+                    let message = {
+                        if let Some(msg) = info.payload().downcast_ref::<String>() {
+                            msg.clone()
+                        } else if let Some(msg) = info.payload().downcast_ref::<&str>() {
+                            msg.to_string()
+                        } else {
+                            DEFAULT_PANIC_MSG.to_string()
+                        }
+                    };
+                    anyhow::Error::from(panic_handling::Panic { message })
+                };
+
+                // Updating LAST_ERROR.
+                // NOTE: this "could" duplicate updating error, if the error happens on ffi call stack as well ...
+                error_handling::update_last_error(err);
+
+                // Send this "cry for help" to whoever is on the upper side
+                let e = Box::new(
+                    Event::new::<Error>()
+                        .set(ErrorCode::Unknown)
+                        .set(ErrorLevel::Critical)
+                        .set(format!("{}", info)),
+                );
+
+                telio_log_debug!("call_once: {:?}", e);
+                events(e);
+            }));
+        });
+
+        #[cfg(not(target_os = "android"))]
+        let protect = None;
+        #[cfg(target_os = "android")]
+        let protect: Option<Protect> = match protect_cb {
+            Some(protect) if cfg!(windows) => {
+                let protect = protect;
+                Some(Arc::new(move |fd| {
+                    protect.protect(fd);
+                }))
+            }
+            _ => None,
+        };
+
+        catch_ffi_panic(|| {
+            let features = features.clone();
+            let event_dispatcher = event_dispatcher.clone();
+            let protect = protect.clone();
+            let device = Device::new(features, event_dispatcher, protect)?;
+            Ok(Self {
+                inner: Mutex::new(Some(device)),
+                id: rand::thread_rng().gen::<usize>(),
+            })
+        })
+    }
+
+    fn log_entry(features: Features, serialized_event_fn: String, ret: &Result<telio, TelioError>) {
+        telio_log_info!(
+            "Telio::new entry. features: {:?}. Event_ptr: {serialized_event_fn}. Return value: {:?}",
+            features,
+            ret.as_ref().map(|_| ())
+        );
+    }
+
+    fn device_op<F, R>(&self, break_on_lock_error: bool, op: F) -> FFIResult<R>
+    where
+        F: Fn(&mut Device) -> FFIResult<R>,
+    {
+        let mut dev = match self.inner.lock() {
+            Ok(dev) => dev,
+            Err(poisoned) => {
+                telio_log_debug!("main telio lock has been poisoned");
+                match break_on_lock_error {
+                    true => return Err(TelioError::LockError),
+                    false => poisoned.into_inner(),
+                }
+            }
+        };
+
+        match *dev {
+            Some(ref mut dev) => op(dev),
+            None => Err(TelioError::NotStarted),
+        }
+    }
+
+    /// Completely stop and uninit telio lib.
+    pub fn destroy(&self) -> FFIResult<()> {
+        catch_ffi_panic(|| {
+            self.device_op(false, |dev| {
+                dev.stop();
+                dev.shutdown_art();
+                Ok(())
+            })
+        })
+    }
+
+    /// Explicitly deallocate telio object and shutdown async rt.
+    pub fn destroy_hard(&self) -> FFIResult<()> {
+        let res = catch_ffi_panic(|| {
+            let mut dev = match self.inner.lock() {
+                Ok(dev) => dev,
+                Err(poisoned) => poisoned.into_inner(),
+            };
+            let mut shutdown = false;
+            if let Some(ref mut dev) = *dev {
+                shutdown = dev.try_shutdown(Duration::from_millis(1000)).is_ok();
+            }
+            *dev = None;
+            Ok(shutdown)
+        });
+
+        if res.is_ok() {
+            telio_log_debug!("Telio::destroy_hard sucessfull");
+            return Ok(());
+        }
+
+        telio_log_debug!("Unknown error - Telio::destroy_hard");
+        Err(TelioError::UnknownError(anyhow!(
+            "Unknown error - Telio::destroy_hard"
+        )))
+    }
+
+    /// Start telio with specified adapter.
+    ///
+    /// Adapter will attempt to open its own tunnel.
+    pub fn start(&self, private_key: SecretKey, adapter: TelioAdapterType) -> FFIResult<()> {
+        telio_log_info!(
+            "Telio::start entry with instance id: {}. Public key: {:?}. Adapter: {:?}",
+            self.id,
+            private_key.public(),
+            &adapter
+        );
+        catch_ffi_panic(|| {
+            self.device_op(true, |dev| {
+                dev.start(&DeviceConfig {
+                    private_key,
+                    adapter: adapter.into(),
+                    fwmark: None,
+                    name: None,
+                    tun: None,
+                })
+                .log_result("Telio::start")
+            })
+        })
+    }
+
+    /// Start telio with specified adapter and name.
+    ///
+    /// Adapter will attempt to open its own tunnel.
+    pub fn start_named(
+        &self,
+        private_key: SecretKey,
+        adapter: TelioAdapterType,
+        name: String,
+    ) -> FFIResult<()> {
+        telio_log_info!(
+            "Telio::start entry with instance id: {}. Public key: {:?}. Adapter: {:?}. Name: {}",
+            self.id,
+            private_key.public(),
+            &adapter,
+            &name,
+        );
+        catch_ffi_panic(|| {
+            self.device_op(true, |dev| {
+                dev.start(&DeviceConfig {
+                    private_key,
+                    adapter: adapter.into(),
+                    fwmark: None,
+                    name: Some(name.clone()),
+                    tun: None,
+                })
+                .log_result("Telio::start_named")
+            })
+        })
+    }
+
+    /// Start telio device with specified adapter and already open tunnel.
+    ///
+    /// Telio will take ownership of tunnel , and close it on stop.
+    ///
+    /// The file descriptor in the `tun` parameter is not forwarded
+    /// on windows
+    ///
+    /// # Parameters
+    /// - `private_key`: base64 encoded private_key.
+    /// - `adapter`: Adapter type.
+    /// - `tun`: A valid filedescriptor to tun device.
+    ///
+    pub fn start_with_tun(
+        &self,
+        private_key: SecretKey,
+        adapter: TelioAdapterType,
+        _tun: i32,
+    ) -> FFIResult<()> {
+        telio_log_info!(
+            "Telio::start entry with instance id: {}. Public key: {:?}. Adapter: {:?}. Tun: {_tun}",
+            self.id,
+            private_key.public(),
+            &adapter
+        );
+        #[cfg(not(target_os = "windows"))]
+        let tun = Some(_tun);
+        #[cfg(target_os = "windows")]
+        let tun = None;
+        catch_ffi_panic(|| {
+            self.device_op(true, |dev| {
+                dev.start(&DeviceConfig {
+                    private_key,
+                    adapter: adapter.into(),
+                    fwmark: None,
+                    name: None,
+                    tun,
+                })
+                .log_result("Telio::start_with_tun")
+            })
+        })
+    }
+
+    /// Stop telio device.
+    pub fn stop(&self) -> FFIResult<()> {
+        telio_log_info!("Telio::stop entry with instance id: {}.", self.id,);
+        catch_ffi_panic(|| {
+            self.device_op(false, |dev| {
+                dev.stop();
+                Ok(())
+            })
+        })
+    }
+
+    /// get device luid.
+    pub fn get_adapter_luid(&self) -> u64 {
+        self.device_op(true, |dev| Ok(dev.get_adapter_luid()))
+            .unwrap_or_else(|e| {
+                telio_log_error!("Telio::get_adapter_luid() failed {:?}", e);
+                0
+            })
+    }
+
+    /// Sets private key for started device.
+    ///
+    /// If private_key is not set, device will never connect.
+    ///
+    /// # Parameters
+    /// - `private_key`: Base64-encoded WireGuard private key.
+    ///
+    pub fn set_secret_key(&self, private_key: &SecretKey) -> FFIResult<()> {
+        telio_log_info!(
+            "Telio::set_private_key entry with instance id: {}. Public key: {:?}",
+            self.id,
+            private_key.public()
+        );
+        catch_ffi_panic(|| {
+            self.device_op(true, |dev| {
+                dev.set_private_key(private_key).map_err(TelioError::from)
+            })
+        })
+    }
+
+    pub fn get_secret_key(&self) -> SecretKey {
+        self.device_op(true, |dev| dev.get_private_key().map_err(|e| e.into()))
+            .unwrap_or_else(|err| {
+                telio_log_error!("Telio::get_secret_key: dev.get_private_key: {}", err);
+                SecretKey::default()
+            })
+    }
+
+    /// Sets fmark for started device.
+    ///
+    /// This function only does something on linux.
+    ///
+    /// # Parameters
+    /// - `fwmark`: unsigned 32-bit integer
+    ///
+    pub fn set_fwmark(&self, _fwmark: u32) -> FFIResult<()> {
+        telio_log_info!(
+            "Telio::set_fwmark entry with instance id: {}. fwmark: {}",
+            self.id,
+            _fwmark
+        );
+        #[cfg(not(target_os = "linux"))]
+        return Ok(());
+        #[cfg(target_os = "linux")]
+        catch_ffi_panic(|| {
+            self.device_op(true, |dev| {
+                dev.set_fwmark(_fwmark).map_err(TelioError::from)
+            })
+        })
+    }
+
+    /// Notify telio with network state changes.
+    ///
+    /// # Parameters
+    /// - `network_info`: Json-encoded network state info.
+    ///                   Format to be decided, pass empty string for now.
+    pub fn notify_network_change(&self, network_info: String) -> FFIResult<()> {
+        #![allow(unused_variables)]
+
+        telio_log_info!(
+            "Telio::notify_network_change entry with instance id: {}.",
+            self.id
+        );
+        catch_ffi_panic(|| {
+            self.device_op(true, |dev| {
+                dev.notify_network_change()
+                    .log_result("Telio::notify_network_change")
+            })
+        })
+    }
+
+    /// Wrapper for `Telio::connect_to_exit_node_with_id` that doesn't take an identifier
+    pub fn connect_to_exit_node(
+        &self,
+        public_key: PublicKey,
+        allowed_ips: Option<Vec<IpNetwork>>,
+        endpoint: Option<SocketAddr>,
+    ) -> FFIResult<()> {
+        telio_log_info!(
+            "Telio::connect_to_exit_node entry with instance id :{}. Public Key: {:?}. Allowed IP: {:?}. Endpoint: {:?}",
+            self.id,
+            public_key,
+            allowed_ips,
+            endpoint,
+        );
+        self.connect_to_exit_node_with_id(None, public_key, allowed_ips, endpoint)
+    }
+
+    /// Connects to an exit node. (VPN if endpoint is not NULL, Peer if endpoint is NULL)
+    ///
+    /// Routing should be set by the user accordingly.
+    ///
+    /// # Parameters
+    /// - `identifier`: String that identifies the exit node, will be generated if null is passed.
+    /// - `public_key`: WireGuard public key for an exit node.
+    /// - `allowed_ips`: List of subnets which will be routed to the exit node.
+    ///                  Can be None, same as "0.0.0.0/0".
+    /// - `endpoint`: An endpoint to an exit node. Can be None, must contain a port.
+    pub fn connect_to_exit_node_with_id(
+        &self,
+        identifier: Option<String>,
+        public_key: PublicKey,
+        allowed_ips: Option<Vec<IpNetwork>>,
+        endpoint: Option<SocketAddr>,
+    ) -> FFIResult<()> {
+        telio_log_info!(
+            "Telio::connect_to_exit_node_with_id entry with instance id :{}. Identifier: {:?}, Public Key: {:?}. Allowed IP: {:?}. Endpoint: {:?}",
+            self.id,
+            identifier,
+            public_key,
+            allowed_ips,
+            endpoint,
+        );
+        let identifier = identifier.unwrap_or_else(|| Uuid::new_v4().to_string());
+        let node = ExitNode {
+            identifier,
+            public_key,
+            allowed_ips,
+            endpoint,
+        };
+        catch_ffi_panic(|| {
+            self.device_op(true, |dev| {
+                dev.connect_exit_node(&node)
+                    .log_result("Telio::connect_to_exit_node")
+            })
+        })
+    }
+
+    /// Enables magic DNS if it was not enabled yet,
+    ///
+    /// Routing should be set by the user accordingly.
+    ///
+    /// # Parameters
+    /// - 'forward_servers': List of DNS servers to route the requests trough.
+    pub fn enable_magic_dns(&self, forward_servers: &[IpAddr]) -> FFIResult<()> {
+        telio_log_info!(
+            "Telio::enable_magic_dns entry with instance id: {}. DNS Server: {:?}",
+            self.id,
+            forward_servers
+        );
+        catch_ffi_panic(|| {
+            self.device_op(true, |dev| {
+                dev.enable_magic_dns(forward_servers)
+                    .log_result("Telio::enable_magic_dns")
+            })
+        })
+    }
+
+    /// Disables magic DNS if it was enabled.
+    pub fn disable_magic_dns(&self) -> FFIResult<()> {
+        telio_log_info!(
+            "Telio::disable_magic_dns entry with instance id: {}.",
+            self.id
+        );
+        catch_ffi_panic(|| {
+            self.device_op(true, |dev| {
+                dev.disable_magic_dns()
+                    .log_result("Telio::disable_magic_dns")
+            })
+        })
+    }
+
+    /// Disconnects from specified exit node.
+    ///
+    /// # Parameters
+    /// - `public_key`: WireGuard public key for exit node.
+    ///
+    pub fn disconnect_from_exit_node(&self, public_key: &PublicKey) -> FFIResult<()> {
+        telio_log_info!(
+            "Telio::disconnect_from_exit_node entry with instance id: {}. Public Key: {:?}",
+            self.id,
+            public_key
+        );
+        catch_ffi_panic(|| {
+            self.device_op(true, |dev| {
+                dev.disconnect_exit_node(public_key)
+                    .log_result("Telio::disconnect_from_exit_node")
+            })
+        })
+    }
+
+    /// Disconnects from all exit nodes with no parameters required.
+    pub fn disconnect_from_exit_nodes(&self) -> FFIResult<()> {
+        telio_log_info!(
+            "Telio::disconnect_from_exit_nodes entry with instance id: {}.",
+            self.id
+        );
+        catch_ffi_panic(|| {
+            self.device_op(true, |dev| {
+                dev.disconnect_exit_nodes()
+                    .log_result("Telio::disconnect_from_exit_nodes")
+            })
+        })
+    }
+
+    /// Enables meshnet if it is not enabled yet.
+    /// In case meshnet is enabled, this updates the peer map with the specified one.
+    ///
+    /// # Parameters
+    /// - `cfg`: Output of GET /v1/meshnet/machines/{machineIdentifier}/map
+    ///
+    pub fn set_meshnet(&self, cfg: Config) -> FFIResult<()> {
+        telio_log_info!(
+            "Telio::set_meshnet entry with instance id: {}. Meshmap: {:?}",
+            self.id,
+            &cfg
+        );
+        catch_ffi_panic(|| {
+            self.device_op(true, |dev| {
+                let cfg = cfg.clone();
+                let cfg = Some(cfg);
+                dev.set_config(&cfg).log_result("telio_set_meshnet")
+            })
+        })
+    }
+
+    /// Disables the meshnet functionality by closing all the connections.
+    pub fn set_meshnet_off(&self) -> FFIResult<()> {
+        telio_log_info!(
+            "Telio::set_meshnet_off entry with instance id: {}.",
+            self.id
+        );
+        catch_ffi_panic(|| {
+            self.device_op(true, |dev| {
+                dev.set_config(&None).log_result("Telio::set_meshnet_off")
+            })
+        })
+    }
+
+    pub fn get_status_map(&self) -> Vec<Node> {
+        trace!("acquiring dev lock");
+        match self.device_op(true, |dev| dev.external_nodes().map_err(|e| e.into())) {
+            Ok(d) => d,
+            Err(err) => {
+                error!("Telio::get_status_map: external_nodes: {}", err);
+                vec![]
+            }
+        }
+    }
+
+    /// Get last error's message length, including trailing null
+    pub fn get_last_error(&self) -> String {
+        error_handling::error_message().unwrap_or_else(|| "".to_owned())
+    }
+
+    #[allow(clippy::panic)]
+    /// For testing only.
+    pub fn generate_stack_panic(&self) -> FFIResult<()> {
+        catch_ffi_panic(|| {
+            if let Ok(true) = self.device_op(true, |dev| Ok(dev.is_running())) {
+                panic!("runtime_panic_test_call_stack");
+            }
+            telio_log_debug!("Unknown error ( Telio::generate_stack_panic )");
+            Err(TelioError::UnknownError(anyhow!("")))
+        })
+    }
+
+    /// For testing only.
+    pub fn generate_thread_panic(&self) -> FFIResult<()> {
+        catch_ffi_panic(|| {
+            self.device_op(true, |dev| {
+                if dev.is_running() {
+                    let res = dev._panic();
+                    if res.is_ok() {
+                        return Ok(());
+                    }
+                }
+                telio_log_debug!("Unknown error ( Telio::generate_thread_panic )");
+                Err(TelioError::UnknownError(anyhow!("")))
+            })
+        })
+    }
 }
 
 /// cbindgen:ignore
@@ -235,7 +871,7 @@ fn telio_new_common(
     #[cfg(target_os = "android")] protect_cb: Option<telio_protect_cb>,
 ) -> telio_result {
     let tracing_subscriber = TelioTracingSubscriber {
-        callback: logger,
+        callback: SubscriberCallback::Swig(logger),
         max_level: log_level.into(),
     };
     if tracing::subscriber::set_global_default(tracing_subscriber).is_err() {
@@ -293,7 +929,7 @@ fn telio_new_common(
         let protect = None;
         #[cfg(target_os = "android")]
         let protect: Option<Protect> = match protect_cb {
-            Some(protect) => Some(std::sync::Arc::new(move |fd| unsafe {
+            Some(protect) => Some(Arc::new(move |fd| unsafe {
                 (protect.cb)(protect.ctx, fd);
             })),
             None => None,
@@ -303,7 +939,7 @@ fn telio_new_common(
 
         unsafe {
             *dev = Box::into_raw(Box::new(telio {
-                inner: Mutex::new(device),
+                inner: Mutex::new(Some(device)),
                 id: rand::thread_rng().gen::<usize>(),
             }))
         };
@@ -312,30 +948,76 @@ fn telio_new_common(
     })
 }
 
-#[no_mangle]
-/// Completely stop and uninit telio lib.
-pub extern "C" fn telio_destroy(dev: *mut telio) {
-    let dev = unsafe { Box::from_raw(dev) };
+fn telio_device_op<F>(dev: &telio, break_on_lock_error: bool, op: F) -> telio_result
+where
+    F: Fn(&mut Device) -> telio_result,
+{
     let mut dev = match dev.inner.lock() {
         Ok(dev) => dev,
         Err(poisoned) => {
             telio_log_debug!("main telio lock has been poisoned");
-            poisoned.into_inner()
+            match break_on_lock_error {
+                true => return TELIO_RES_LOCK_ERROR,
+                false => poisoned.into_inner(),
+            }
         }
     };
-    dev.stop();
-    dev.shutdown_art();
+
+    match *dev {
+        Some(ref mut dev) => op(dev),
+        None => TELIO_RES_ERROR,
+    }
+}
+
+fn telio_device_op_ret<F, R>(
+    dev: &telio,
+    break_on_lock_error: bool,
+    op: F,
+) -> Result<R, telio_result>
+where
+    F: Fn(&mut Device) -> Result<R, telio_result>,
+{
+    let mut dev = match dev.inner.lock() {
+        Ok(dev) => dev,
+        Err(poisoned) => {
+            telio_log_debug!("main telio lock has been poisoned");
+            match break_on_lock_error {
+                true => return Err(TELIO_RES_LOCK_ERROR),
+                false => poisoned.into_inner(),
+            }
+        }
+    };
+
+    match *dev {
+        Some(ref mut dev) => op(dev),
+        None => Err(TELIO_RES_ERROR),
+    }
+}
+
+#[no_mangle]
+/// Completely stop and uninit telio lib.
+pub extern "C" fn telio_destroy(dev: *mut telio) {
+    let dev = unsafe { Box::from_raw(dev) };
+    let _ = telio_device_op(dev.as_ref(), false, |dev| {
+        dev.stop();
+        dev.shutdown_art();
+        TELIO_RES_OK
+    });
 }
 
 #[no_mangle]
 /// Explicitly deallocate telio object and shutdown async rt.
 pub extern "C" fn telio_destroy_hard(dev: *mut telio) -> telio_result {
     let dev_b = unsafe { Box::from_raw(dev) };
-    let device = dev_b.inner.into_inner().unwrap_or_else(|e| e.into_inner());
+    let mut device = dev_b.inner.lock().unwrap_or_else(|e| e.into_inner());
 
-    let res = device.try_shutdown(Duration::from_millis(1000));
+    let res = device
+        .as_mut()
+        .map(|ref mut dev| dev.try_shutdown(Duration::from_millis(1000)))
+        .ok_or(TELIO_RES_ERROR);
+    *device = None;
 
-    if res.is_ok() {
+    if matches!(res, Ok(Ok(_))) {
         telio_log_debug!("telio_destroy_hard sucessfull");
         return TELIO_RES_OK;
     }
@@ -368,16 +1050,16 @@ pub extern "C" fn telio_start(
     );
 
     ffi_catch_panic!({
-        let mut dev = ffi_try!(dev.inner.lock().map_err(|_| TELIO_RES_LOCK_ERROR));
-
-        dev.start(&DeviceConfig {
-            private_key,
-            adapter: adapter.into(),
-            fwmark: None,
-            name: None,
-            tun: None,
+        telio_device_op(dev, true, |dev| {
+            dev.start(&DeviceConfig {
+                private_key,
+                adapter: adapter.into(),
+                fwmark: None,
+                name: None,
+                tun: None,
+            })
+            .telio_log_result("telio_start")
         })
-        .telio_log_result("telio_start")
     })
 }
 
@@ -392,18 +1074,18 @@ pub extern "C" fn telio_start_named(
     name: *const c_char,
 ) -> telio_result {
     ffi_catch_panic!({
-        let mut dev = ffi_try!(dev.inner.lock().map_err(|_| TELIO_RES_LOCK_ERROR));
-
-        let private_key = ffi_try!(char_ptr_to_type::<SecretKey>(private_key));
-        let name = ffi_try!(char_ptr_to_type::<String>(name));
-        dev.start(&DeviceConfig {
-            private_key,
-            adapter: adapter.into(),
-            fwmark: None,
-            name: Some(name),
-            tun: None,
+        telio_device_op(dev, true, |dev| {
+            let private_key = ffi_try!(char_ptr_to_type::<SecretKey>(private_key));
+            let name = ffi_try!(char_ptr_to_type::<String>(name));
+            dev.start(&DeviceConfig {
+                private_key,
+                adapter: adapter.into(),
+                fwmark: None,
+                name: Some(name),
+                tun: None,
+            })
+            .telio_log_result("telio_start_named")
         })
-        .telio_log_result("telio_start_named")
     })
 }
 
@@ -425,16 +1107,17 @@ pub extern "C" fn telio_start_with_tun(
     tun: c_int,
 ) -> telio_result {
     ffi_catch_panic!({
-        let mut dev = ffi_try!(dev.inner.lock().map_err(|_| TELIO_RES_LOCK_ERROR));
-        let private_key = ffi_try!(char_ptr_to_type::<SecretKey>(private_key));
-        dev.start(&DeviceConfig {
-            private_key,
-            adapter: adapter.into(),
-            fwmark: None,
-            name: None,
-            tun: Some(tun),
+        telio_device_op(dev, true, |dev| {
+            let private_key = ffi_try!(char_ptr_to_type::<SecretKey>(private_key));
+            dev.start(&DeviceConfig {
+                private_key,
+                adapter: adapter.into(),
+                fwmark: None,
+                name: None,
+                tun: Some(tun),
+            })
+            .telio_log_result("telio_start_with_tun")
         })
-        .telio_log_result("telio_start_with_tun")
     })
 }
 
@@ -443,25 +1126,20 @@ pub extern "C" fn telio_start_with_tun(
 pub extern "C" fn telio_stop(dev: &telio) -> telio_result {
     telio_log_info!("telio_stop entry with instance id: {}.", dev.id,);
     ffi_catch_panic!({
-        let mut dev = match dev.inner.lock() {
-            Ok(dev) => dev,
-            Err(poisoned) => poisoned.into_inner(),
-        };
-        dev.stop();
-        TELIO_RES_OK
+        telio_device_op(dev, false, |dev| {
+            dev.stop();
+            TELIO_RES_OK
+        })
     })
 }
 
 #[no_mangle]
 /// get device luid.
 pub extern "C" fn telio_get_adapter_luid(dev: &telio) -> u64 {
-    match dev.inner.lock() {
-        Ok(mut d) => d.get_adapter_luid(),
-        Err(e) => {
-            telio_log_error!("telio_get_adapter_luid() failed {:?}", e);
-            0
-        }
-    }
+    telio_device_op_ret(dev, false, |dev| Ok(dev.get_adapter_luid())).unwrap_or_else(|e| {
+        telio_log_error!("telio_get_adapter_luid() failed {:?}", e);
+        0
+    })
 }
 
 fn char_ptr_to_type<T: std::str::FromStr>(value: *const c_char) -> Result<T, telio_result>
@@ -491,24 +1169,22 @@ pub extern "C" fn telio_set_private_key(dev: &telio, private_key: *const c_char)
         private_key.public()
     );
     ffi_catch_panic!({
-        let dev = ffi_try!(dev.inner.lock().map_err(|_| TELIO_RES_LOCK_ERROR));
-        ffi_try!(dev.set_private_key(&private_key));
-        TELIO_RES_OK
+        telio_device_op(dev, true, |dev| {
+            ffi_try!(dev.set_private_key(&private_key));
+            TELIO_RES_OK
+        })
     })
 }
 
 #[no_mangle]
 pub extern "C" fn telio_get_private_key(dev: &telio) -> *mut c_char {
-    let dev = match dev.inner.lock() {
-        Ok(dev) => dev,
-        Err(err) => {
-            telio_log_error!("telio_get_private_key: dev.get_private_key: {}", err);
-            return bytes_to_zero_terminated_unmanaged_bytes(&[0_u8]);
-        }
-    };
-
-    match dev.get_private_key() {
-        Ok(key) => key_to_c_zero_terminated_string_unmanaged(key.as_bytes()),
+    let res = telio_device_op_ret(dev, true, |dev| {
+        dev.get_private_key()
+            .map(|key| key_to_c_zero_terminated_string_unmanaged(key.as_bytes()))
+            .map_err(|e| e.into())
+    });
+    match res {
+        Ok(res) => res,
         Err(err) => {
             telio_log_error!("telio_get_private_key: dev.get_private_key: {}", err);
             bytes_to_zero_terminated_unmanaged_bytes(&[0_u8])
@@ -530,9 +1206,12 @@ pub extern "C" fn telio_set_fwmark(dev: &telio, fwmark: c_uint) -> telio_result 
             dev.id,
             fwmark
         );
-        let dev = ffi_try!(dev.inner.lock().map_err(|_| TELIO_RES_LOCK_ERROR));
-        ffi_try!(dev.set_fwmark(fwmark));
-        TELIO_RES_OK
+        match telio_device_op_ret(dev, true, |dev| {
+            dev.set_fwmark(fwmark).map_err(telio_result::from)
+        }) {
+            Ok(_) => TELIO_RES_OK,
+            Err(res) => res,
+        }
     })
 }
 
@@ -553,9 +1232,10 @@ pub extern "C" fn telio_notify_network_change(
         dev.id
     );
     ffi_catch_panic!({
-        let dev = ffi_try!(dev.inner.lock().map_err(|_| TELIO_RES_LOCK_ERROR));
-        dev.notify_network_change()
-            .telio_log_result("telio_notify_network_change")
+        telio_device_op(dev, true, |dev| {
+            dev.notify_network_change()
+                .telio_log_result("telio_notify_network_change")
+        })
     })
 }
 
@@ -622,7 +1302,6 @@ pub extern "C" fn telio_connect_to_exit_node_with_id(
     endpoint: *const c_char,
 ) -> telio_result {
     ffi_catch_panic!({
-        let dev = ffi_try!(dev.inner.lock().map_err(|_| TELIO_RES_LOCK_ERROR));
         let identifier = if !identifier.is_null() {
             let cstr = ffi_try!(unsafe { CStr::from_ptr(identifier) }
                 .to_str()
@@ -675,8 +1354,10 @@ pub extern "C" fn telio_connect_to_exit_node_with_id(
             allowed_ips,
             endpoint,
         };
-        dev.connect_exit_node(&node)
-            .telio_log_result("telio_connect_to_exit_node")
+        telio_device_op(dev, true, |dev| {
+            dev.connect_exit_node(&node)
+                .telio_log_result("telio_connect_to_exit_node")
+        })
     })
 }
 
@@ -709,9 +1390,10 @@ pub extern "C" fn telio_enable_magic_dns(
         servers
     );
     ffi_catch_panic!({
-        let dev = ffi_try!(dev.inner.lock().map_err(|_| TELIO_RES_BAD_CONFIG));
-        dev.enable_magic_dns(&servers)
-            .telio_log_result("telio_enable_magic_dns")
+        telio_device_op(dev, true, |dev| {
+            dev.enable_magic_dns(&servers)
+                .telio_log_result("telio_enable_magic_dns")
+        })
     })
 }
 
@@ -723,10 +1405,10 @@ pub extern "C" fn telio_disable_magic_dns(dev: &telio) -> telio_result {
         dev.id
     );
     ffi_catch_panic!({
-        let dev = ffi_try!(dev.inner.lock().map_err(|_| TELIO_RES_BAD_CONFIG));
-
-        dev.disable_magic_dns()
-            .telio_log_result("telio_disable_magic_dns")
+        telio_device_op(dev, true, |dev| {
+            dev.disable_magic_dns()
+                .telio_log_result("telio_disable_magic_dns")
+        })
     })
 }
 
@@ -746,7 +1428,6 @@ pub extern "C" fn telio_disconnect_from_exit_node(
         public_key
     );
     ffi_catch_panic!({
-        let dev = ffi_try!(dev.inner.lock().map_err(|_| TELIO_RES_LOCK_ERROR));
         let public_key = if !public_key.is_null() {
             ffi_try!(char_ptr_to_type::<PublicKey>(public_key))
         } else {
@@ -754,8 +1435,10 @@ pub extern "C" fn telio_disconnect_from_exit_node(
             return TELIO_RES_ERROR;
         };
 
-        dev.disconnect_exit_node(&public_key)
-            .telio_log_result("telio_disconnect_from_exit_node")
+        telio_device_op(dev, true, |dev| {
+            dev.disconnect_exit_node(&public_key)
+                .telio_log_result("telio_disconnect_from_exit_node")
+        })
     })
 }
 
@@ -767,10 +1450,10 @@ pub extern "C" fn telio_disconnect_from_exit_nodes(dev: &telio) -> telio_result 
         dev.id
     );
     ffi_catch_panic!({
-        let dev = ffi_try!(dev.inner.lock().map_err(|_| TELIO_RES_LOCK_ERROR));
-
-        dev.disconnect_exit_nodes()
-            .telio_log_result("telio_disconnect_from_exit_nodes")
+        telio_device_op(dev, true, |dev| {
+            dev.disconnect_exit_nodes()
+                .telio_log_result("telio_disconnect_from_exit_nodes")
+        })
     })
 }
 
@@ -783,40 +1466,40 @@ pub extern "C" fn telio_disconnect_from_exit_nodes(dev: &telio) -> telio_result 
 ///
 pub extern "C" fn telio_set_meshnet(dev: &telio, cfg: *const c_char) -> telio_result {
     ffi_catch_panic!({
-        let telio_dev = ffi_try!(dev.inner.lock().map_err(|_| TELIO_RES_LOCK_ERROR));
+        telio_device_op(dev, true, |telio_dev| {
+            if cfg.is_null() {
+                telio_log_debug!("Stopping meshnet due to empty config");
+                telio_dev
+                    .set_config(&None)
+                    .telio_log_result("telio_set_meshnet")
+            } else {
+                let cfg_str = ffi_try!(unsafe { CStr::from_ptr(cfg) }
+                    .to_str()
+                    .map_err(|_| TELIO_RES_INVALID_STRING));
+                if cfg_str.as_bytes().len() > MAX_CONFIG_LENGTH {
+                    telio_log_error!(
+                        "config string exceeds maximum allowed length ({}): {}",
+                        MAX_CONFIG_LENGTH,
+                        cfg_str.as_bytes().len()
+                    );
+                    return TELIO_RES_INVALID_STRING;
+                }
+                let cfg: PartialConfig = ffi_try!(serde_json::from_str(cfg_str));
+                let (cfg, peer_deserialization_failures) = cfg.to_config();
+                for failure in peer_deserialization_failures {
+                    telio_log_warn!("Failed to deserialize one of the peers: {}", failure);
+                }
 
-        if cfg.is_null() {
-            telio_log_debug!("Stopping meshnet due to empty config");
-            telio_dev
-                .set_config(&None)
-                .telio_log_result("telio_set_meshnet")
-        } else {
-            let cfg_str = ffi_try!(unsafe { CStr::from_ptr(cfg) }
-                .to_str()
-                .map_err(|_| TELIO_RES_INVALID_STRING));
-            if cfg_str.as_bytes().len() > MAX_CONFIG_LENGTH {
-                telio_log_error!(
-                    "config string exceeds maximum allowed length ({}): {}",
-                    MAX_CONFIG_LENGTH,
-                    cfg_str.as_bytes().len()
+                telio_log_info!(
+                    "telio_set_meshnet entry with instance id: {}. Meshmap: {:?}",
+                    dev.id,
+                    &cfg
                 );
-                return TELIO_RES_INVALID_STRING;
+                telio_dev
+                    .set_config(&Some(cfg))
+                    .telio_log_result("telio_set_meshnet")
             }
-            let cfg: PartialConfig = ffi_try!(serde_json::from_str(cfg_str));
-            let (cfg, peer_deserialization_failures) = cfg.to_config();
-            for failure in peer_deserialization_failures {
-                telio_log_warn!("Failed to deserialize one of the peers: {}", failure);
-            }
-
-            telio_log_info!(
-                "telio_set_meshnet entry with instance id: {}. Meshmap: {:?}",
-                dev.id,
-                &cfg
-            );
-            telio_dev
-                .set_config(&Some(cfg))
-                .telio_log_result("telio_set_meshnet")
-        }
+        })
     })
 }
 
@@ -825,10 +1508,10 @@ pub extern "C" fn telio_set_meshnet(dev: &telio, cfg: *const c_char) -> telio_re
 pub extern "C" fn telio_set_meshnet_off(dev: &telio) -> telio_result {
     telio_log_info!("telio_set_meshnet_off entry with instance id: {}.", dev.id);
     ffi_catch_panic!({
-        let dev = ffi_try!(dev.inner.lock().map_err(|_| TELIO_RES_LOCK_ERROR));
-
-        dev.set_config(&None)
-            .telio_log_result("telio_set_meshnet_off")
+        telio_device_op(dev, true, |dev| {
+            dev.set_config(&None)
+                .telio_log_result("telio_set_meshnet_off")
+        })
     })
 }
 
@@ -876,22 +1559,15 @@ pub extern "C" fn telio_get_commit_sha() -> *mut c_char {
 
 #[no_mangle]
 pub extern "C" fn telio_get_status_map(dev: &telio) -> *mut c_char {
-    trace!("acquiring dev lock");
-    let dev = match dev.inner.lock() {
-        Ok(dev) => dev,
-        Err(err) => {
-            error!("telio_get_status_map: dev lock: {}", err);
-            return std::ptr::null_mut();
-        }
-    };
-    trace!("retrieving external nodes");
-    let nodes = match dev.external_nodes() {
-        Ok(nodes) => nodes,
-        Err(err) => {
-            error!("telio_get_status_map: external_nodes: {}", err);
-            return std::ptr::null_mut();
-        }
-    };
+    trace!("acquiring dev lock and retrieving external nodes");
+    let nodes =
+        match telio_device_op_ret(dev, true, |dev| dev.external_nodes().map_err(|e| e.into())) {
+            Ok(nodes) => nodes,
+            Err(err) => {
+                error!("telio_get_status_map: external_nodes: {}", err);
+                return std::ptr::null_mut();
+            }
+        };
     trace!("serializing");
     let json = match serde_json::to_string(&nodes) {
         Ok(json) => json,
@@ -919,14 +1595,14 @@ pub extern "C" fn telio_get_last_error(_dev: &telio) -> *mut c_char {
 /// For testing only.
 pub extern "C" fn __telio_generate_stack_panic(dev: &telio) -> telio_result {
     ffi_catch_panic!({
-        let dev = ffi_try!(dev.inner.lock().map_err(|_| TELIO_RES_LOCK_ERROR));
+        telio_device_op(dev, true, |dev| {
+            if dev.is_running() {
+                panic!("runtime_panic_test_call_stack");
+            }
 
-        if dev.is_running() {
-            panic!("runtime_panic_test_call_stack");
-        }
-
-        telio_log_debug!("Unknown error ( __telio_generate_stack_panic )");
-        TELIO_RES_ERROR
+            telio_log_debug!("Unknown error ( __telio_generate_stack_panic )");
+            TELIO_RES_ERROR
+        })
     })
 }
 
@@ -934,18 +1610,18 @@ pub extern "C" fn __telio_generate_stack_panic(dev: &telio) -> telio_result {
 /// For testing only.
 pub extern "C" fn __telio_generate_thread_panic(dev: &telio) -> telio_result {
     ffi_catch_panic!({
-        let dev = ffi_try!(dev.inner.lock().map_err(|_| TELIO_RES_LOCK_ERROR));
+        telio_device_op(dev, true, |dev| {
+            if dev.is_running() {
+                let res = dev._panic();
 
-        if dev.is_running() {
-            let res = dev._panic();
-
-            if res.is_ok() {
-                return TELIO_RES_OK;
+                if res.is_ok() {
+                    return TELIO_RES_OK;
+                }
             }
-        }
 
-        telio_log_debug!("Unknown error ( __telio_generate_thread_panic )");
-        TELIO_RES_ERROR
+            telio_log_debug!("Unknown error ( __telio_generate_thread_panic )");
+            TELIO_RES_ERROR
+        })
     })
 }
 
@@ -1000,13 +1676,41 @@ impl<'a> tracing::field::Visit for TraceFieldVisitor<'a> {
     }
 }
 
+pub enum SubscriberCallback {
+    Swig(telio_logger_cb),
+    Uniffi(Box<dyn TelioLoggerCb>),
+}
+
+impl SubscriberCallback {
+    fn log(&self, level: Level, message: String) {
+        match self {
+            SubscriberCallback::Swig(cb) => {
+                if let Ok(cstr) = CString::new(message) {
+                    unsafe { (cb.cb)(cb.ctx, level.into(), cstr.as_ptr()) };
+                }
+            }
+            SubscriberCallback::Uniffi(cb) => {
+                cb.log(level.into(), message);
+            }
+        }
+    }
+
+    fn enter(&self, _span: &tracing::span::Id) {
+        // TODO
+    }
+
+    fn exit(&self, _span: &tracing::span::Id) {
+        // TODO
+    }
+}
+
 pub struct TelioTracingSubscriber {
-    callback: telio_logger_cb,
+    callback: SubscriberCallback,
     max_level: tracing::Level,
 }
 
 impl TelioTracingSubscriber {
-    pub fn new(callback: telio_logger_cb, max_level: tracing::Level) -> Self {
+    pub fn new(callback: SubscriberCallback, max_level: tracing::Level) -> Self {
         TelioTracingSubscriber {
             callback,
             max_level,
@@ -1048,9 +1752,7 @@ impl Subscriber for TelioTracingSubscriber {
         event.record(&mut visitor);
 
         if let Some(filtered_msg) = filter_log_message(visitor.message) {
-            if let Ok(cstr) = CString::new(filtered_msg) {
-                unsafe { (self.callback.cb)(self.callback.ctx, level.into(), cstr.as_ptr()) };
-            }
+            self.callback.log(level, filtered_msg);
         }
     }
 
@@ -1065,6 +1767,7 @@ impl Subscriber for TelioTracingSubscriber {
 
 trait FFILog {
     fn telio_log_result(self, caller: &str) -> telio_result;
+    fn log_result(self, caller: &str) -> FFIResult<()>;
 }
 
 impl FFILog for DevResult {
@@ -1076,6 +1779,19 @@ impl FFILog for DevResult {
             _ => telio_log_error!("{}: {}", caller, msg),
         };
         res
+    }
+
+    fn log_result(self, caller: &str) -> FFIResult<()> {
+        match &self {
+            Ok(_) => {
+                telio_log_debug!("{}: {:?}", caller, self);
+                Ok(())
+            }
+            Err(err) => {
+                telio_log_error!("{}: {:?}", caller, self);
+                Err(err.into())
+            }
+        }
     }
 }
 
@@ -1176,7 +1892,7 @@ mod tests {
         let features = Features::default();
         let event_cb = Box::new(|_event| {});
         let telio_dev = telio {
-            inner: Mutex::new(Device::new(features, event_cb, None)?),
+            inner: Mutex::new(Some(Device::new(features, event_cb, None)?)),
             id: rand::thread_rng().gen::<usize>(),
         };
 
@@ -1274,7 +1990,7 @@ mod tests {
         let event_cb = Box::new(|_event| {});
         let id = rand::thread_rng().gen::<usize>();
         let telio_dev: *mut *mut telio = Box::into_raw(Box::new(Box::into_raw(Box::new(telio {
-            inner: Mutex::new(Device::new(features, event_cb, None)?),
+            inner: Mutex::new(Some(Device::new(features, event_cb, None)?)),
             id,
         }))));
         let res = get_instance_id_from_ptr(telio_dev);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 
 mod ffi;
 pub use ffi::types as ffi_types;
-pub use ffi::TelioTracingSubscriber;
+pub use ffi::{SubscriberCallback, TelioTracingSubscriber};
 
 /// cbindgen:ignore
 pub mod device;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 mod ffi;
+use crate::ffi::*;
+use crate::types::*;
 pub use ffi::types as ffi_types;
 pub use ffi::{SubscriberCallback, TelioTracingSubscriber};
 
@@ -51,3 +53,370 @@ pub use telio_lana;
 
 /// cbindgen:ignore
 pub use telio_firewall;
+
+pub use uniffi_libtelio::*;
+#[allow(clippy::panic, clippy::unwrap_used, clippy::expect_used, unwrap_check)]
+mod uniffi_libtelio {
+    use std::convert::TryInto;
+    use std::net::{IpAddr, SocketAddr};
+
+    use ipnetwork::IpNetwork;
+
+    use super::crypto::{PublicKey, SecretKey};
+    use super::*;
+
+    use telio_model::api_config::*;
+    use telio_model::config::*;
+    use telio_model::mesh::*;
+    use telio_utils::{Hidden, HiddenString};
+
+    impl UniffiCustomTypeConverter for PublicKey {
+        type Builtin = Vec<u8>;
+
+        fn into_custom(val: Self::Builtin) -> uniffi::Result<Self> {
+            Ok(PublicKey::new(
+                val.try_into().map_err(|_| TelioError::InvalidKey)?,
+            ))
+        }
+
+        fn from_custom(obj: Self) -> Self::Builtin {
+            obj.0.to_vec()
+        }
+    }
+
+    impl UniffiCustomTypeConverter for SecretKey {
+        type Builtin = Vec<u8>;
+
+        fn into_custom(val: Self::Builtin) -> uniffi::Result<Self> {
+            Ok(SecretKey::new(
+                val.try_into().map_err(|_| TelioError::InvalidKey)?,
+            ))
+        }
+
+        fn from_custom(obj: Self) -> Self::Builtin {
+            obj.as_bytes().to_vec()
+        }
+    }
+
+    impl UniffiCustomTypeConverter for IpAddr {
+        type Builtin = String;
+
+        fn into_custom(val: Self::Builtin) -> uniffi::Result<Self> {
+            Ok(val.parse().map_err(|_| {
+                TelioError::UnknownError(anyhow::anyhow!("Invalid IP address".to_owned()))
+            })?)
+        }
+
+        fn from_custom(obj: Self) -> Self::Builtin {
+            obj.to_string()
+        }
+    }
+
+    impl UniffiCustomTypeConverter for IpNetwork {
+        type Builtin = String;
+
+        fn into_custom(val: Self::Builtin) -> uniffi::Result<Self> {
+            Ok(val.parse().map_err(|_| {
+                TelioError::UnknownError(anyhow::anyhow!("Invalid IP address".to_owned()))
+            })?)
+        }
+
+        fn from_custom(obj: Self) -> Self::Builtin {
+            obj.to_string()
+        }
+    }
+
+    impl UniffiCustomTypeConverter for Ipv4Addr {
+        type Builtin = String;
+
+        fn into_custom(val: Self::Builtin) -> uniffi::Result<Self> {
+            val.parse()
+                .map_err(|_| anyhow::anyhow!("Invalid IP address"))
+        }
+
+        fn from_custom(obj: Self) -> Self::Builtin {
+            obj.to_string()
+        }
+    }
+
+    impl UniffiCustomTypeConverter for SocketAddr {
+        type Builtin = String;
+
+        fn into_custom(val: Self::Builtin) -> uniffi::Result<Self> {
+            Ok(val.parse().map_err(|_| {
+                TelioError::UnknownError(anyhow::anyhow!("Invalid IP address".to_owned()))
+            })?)
+        }
+
+        fn from_custom(obj: Self) -> Self::Builtin {
+            obj.to_string()
+        }
+    }
+
+    impl UniffiCustomTypeConverter for HiddenString {
+        type Builtin = String;
+
+        fn into_custom(val: Self::Builtin) -> uniffi::Result<Self> {
+            Ok(Hidden(val))
+        }
+
+        fn from_custom(obj: Self) -> Self::Builtin {
+            obj.to_string()
+        }
+    }
+
+    impl UniffiCustomTypeConverter for EndpointProviders {
+        type Builtin = Vec<EndpointProvider>;
+
+        fn into_custom(val: Self::Builtin) -> uniffi::Result<Self> {
+            Ok(val.iter().copied().collect())
+        }
+
+        fn from_custom(obj: Self) -> Self::Builtin {
+            obj.iter().copied().collect()
+        }
+    }
+
+    impl UniffiCustomTypeConverter for FeatureValidateKeys {
+        type Builtin = bool;
+
+        fn into_custom(val: Self::Builtin) -> uniffi::Result<Self> {
+            Ok(FeatureValidateKeys(val))
+        }
+
+        fn from_custom(obj: Self) -> Self::Builtin {
+            obj.0
+        }
+    }
+
+    impl UniffiCustomTypeConverter for FeatureBoringtunResetConns {
+        type Builtin = bool;
+
+        fn into_custom(val: Self::Builtin) -> uniffi::Result<Self> {
+            Ok(FeatureBoringtunResetConns(val))
+        }
+
+        fn from_custom(obj: Self) -> Self::Builtin {
+            obj.0
+        }
+    }
+
+    uniffi::include_scaffolding!("libtelio");
+
+    #[cfg(test)]
+    mod tests {
+        use ipnetwork::{Ipv4Network, Ipv6Network};
+        use std::{collections::HashSet, net::Ipv6Addr};
+
+        use super::*;
+        use rstest::*;
+
+        #[rstest]
+        #[case(SecretKey::gen().public())]
+        #[case(SecretKey::gen().public())]
+        fn test_public_key_conversion(#[case] key: PublicKey) {
+            let serialized = PublicKey::from_custom(key.clone());
+            let deserialized = PublicKey::into_custom(serialized).unwrap();
+
+            assert_eq!(deserialized, key);
+        }
+
+        #[rstest]
+        #[case(SecretKey::gen())]
+        #[case(SecretKey::gen())]
+        fn test_secret_key_conversion(#[case] key: SecretKey) {
+            let serialized = SecretKey::from_custom(key.clone());
+            let deserialized = SecretKey::into_custom(serialized).unwrap();
+
+            assert_eq!(deserialized, key);
+        }
+
+        #[rstest]
+        #[case("127.0.0.1".to_owned(), IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), true, false)]
+        #[case("10.0.64.1".to_owned(), IpAddr::V4(Ipv4Addr::new(10, 0, 64, 1)), true, false)]
+        #[case("::1".to_owned(), IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)), false, true)]
+        #[case("fd74:656c:696f::2".to_owned(), IpAddr::V6(Ipv6Addr::new(0xfd74, 0x656c, 0x696f, 0, 0, 0, 0, 2)), false, true)]
+        fn test_to_ip_addr(
+            #[case] ip_str: String,
+            #[case] expected: IpAddr,
+            #[case] is_v4: bool,
+            #[case] is_v6: bool,
+        ) {
+            let actual = IpAddr::into_custom(ip_str).unwrap();
+
+            assert_eq!(actual, expected);
+            assert_eq!(actual.is_ipv4(), is_v4);
+            assert_eq!(actual.is_ipv6(), is_v6);
+        }
+
+        #[rstest]
+        #[case("127.0.0.1".to_owned(), IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)))]
+        #[case("10.0.64.1".to_owned(), IpAddr::V4(Ipv4Addr::new(10, 0, 64, 1)))]
+        #[case("::1".to_owned(), IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)))]
+        #[case("fd74:656c:696f::2".to_owned(), IpAddr::V6(Ipv6Addr::new(0xfd74, 0x656c, 0x696f, 0, 0, 0, 0, 2)))]
+        fn test_from_ip_addr(#[case] expected: String, #[case] addr: IpAddr) {
+            let actual = IpAddr::from_custom(addr);
+
+            assert_eq!(actual, expected);
+        }
+
+        #[rstest]
+        #[case("100.64.0.2/32".to_owned(), IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(100, 64, 0, 2), 32).unwrap()))]
+        #[case("100.64.0.3/24".to_owned(), IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(100, 64, 0, 3), 24).unwrap()))]
+        #[case("fd74:656c:696f::2/128".to_owned(), IpNetwork::V6(Ipv6Network::new(Ipv6Addr::new(0xfd74, 0x656c, 0x696f, 0, 0, 0, 0, 2), 128).unwrap()))]
+        #[case("fd74:656c:696f::3/16".to_owned(), IpNetwork::V6(Ipv6Network::new(Ipv6Addr::new(0xfd74, 0x656c, 0x696f, 0, 0, 0, 0, 3), 16).unwrap()))]
+        fn test_to_ip_network(#[case] ip_str: String, #[case] expected: IpNetwork) {
+            let actual = IpNetwork::into_custom(ip_str).unwrap();
+
+            assert_eq!(actual, expected);
+        }
+
+        #[rstest]
+        #[case("100.64.0.2/32".to_owned(), IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(100, 64, 0, 2), 32).unwrap()))]
+        #[case("100.64.0.3/24".to_owned(), IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(100, 64, 0, 3), 24).unwrap()))]
+        #[case("fd74:656c:696f::2/128".to_owned(), IpNetwork::V6(Ipv6Network::new(Ipv6Addr::new(0xfd74, 0x656c, 0x696f, 0, 0, 0, 0, 2), 128).unwrap()))]
+        #[case("fd74:656c:696f::3/16".to_owned(), IpNetwork::V6(Ipv6Network::new(Ipv6Addr::new(0xfd74, 0x656c, 0x696f, 0, 0, 0, 0, 3), 16).unwrap()))]
+        fn test_from_ip_network(#[case] expected: String, #[case] network: IpNetwork) {
+            let actual = IpNetwork::from_custom(network);
+
+            assert_eq!(actual, expected);
+        }
+
+        #[rstest]
+        #[case("10.0.80.80".to_owned(), Ipv4Addr::new(10, 0, 80, 80))]
+        #[case("10.0.1.1".to_owned(), Ipv4Addr::new(10, 0, 1, 1))]
+        fn test_to_ipv4_addr(#[case] ip_str: String, #[case] expected: Ipv4Addr) {
+            let actual = Ipv4Addr::into_custom(ip_str).unwrap();
+
+            assert_eq!(actual, expected);
+        }
+
+        #[rstest]
+        #[case("10.0.80.80".to_owned(), Ipv4Addr::new(10, 0, 80, 80))]
+        #[case("10.0.1.1".to_owned(), Ipv4Addr::new(10, 0, 1, 1))]
+        fn test_from_ipv4_addr(#[case] expected: String, #[case] addr: Ipv4Addr) {
+            let actual = Ipv4Addr::from_custom(addr);
+
+            assert_eq!(actual, expected);
+        }
+
+        #[rstest]
+        #[case("127.0.0.1:1234".to_owned(), SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 1234), 1234, true, false)]
+        #[case("10.0.64.1:53".to_owned(), SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 64, 1)), 53), 53, true, false)]
+        #[case("[::1]:1111".to_owned(), SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)), 1111), 1111, false, true)]
+        #[case("[fd74:656c:696f::2]:80".to_owned(), SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0xfd74, 0x656c, 0x696f, 0, 0, 0, 0, 2)), 80), 80, false, true)]
+        fn test_to_socket_addr(
+            #[case] ip_str: String,
+            #[case] expected: SocketAddr,
+            #[case] port: u16,
+            #[case] is_v4: bool,
+            #[case] is_v6: bool,
+        ) {
+            let actual = SocketAddr::into_custom(ip_str).unwrap();
+
+            assert_eq!(actual, expected);
+            assert_eq!(actual.port(), port);
+            assert_eq!(actual.is_ipv4(), is_v4);
+            assert_eq!(actual.is_ipv6(), is_v6);
+        }
+
+        #[rstest]
+        #[case("127.0.0.1:1234".to_owned(), SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 1234))]
+        #[case("10.0.64.1:53".to_owned(), SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 64, 1)), 53))]
+        #[case("[::1]:1111".to_owned(), SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)), 1111))]
+        #[case("[fd74:656c:696f::2]:80".to_owned(), SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0xfd74, 0x656c, 0x696f, 0, 0, 0, 0, 2)), 80))]
+        fn test_from_socket_addr(#[case] expected: String, #[case] addr: SocketAddr) {
+            let actual = SocketAddr::from_custom(addr);
+
+            assert_eq!(actual, expected);
+        }
+
+        #[rstest]
+        #[case("".to_owned(), Hidden("".to_owned()))]
+        #[case("hidden".to_owned(), Hidden("hidden".to_owned()))]
+        #[case("hidden sentence".to_owned(), Hidden("hidden sentence".to_owned()))]
+        fn test_to_hidden_string(#[case] str_to_hide: String, #[case] expected: HiddenString) {
+            let actual = HiddenString::into_custom(str_to_hide).unwrap();
+
+            assert_eq!(actual, expected);
+        }
+
+        #[rstest]
+        #[case("".to_owned(), Hidden("".to_owned()))]
+        #[case("hidden".to_owned(), Hidden("hidden".to_owned()))]
+        #[case("hidden sentence".to_owned(), Hidden("hidden sentence".to_owned()))]
+        fn test_from_hidden_string(#[case] expected: String, #[case] hidden: HiddenString) {
+            let actual = HiddenString::from_custom(hidden);
+
+            assert_eq!(actual, expected);
+        }
+
+        #[rstest]
+        #[case(vec![], maplit::hashset!{})]
+        #[case(vec![EndpointProvider::Stun], maplit::hashset! {EndpointProvider::Stun})]
+        #[case(vec![EndpointProvider::Local, EndpointProvider::Stun], maplit::hashset!{EndpointProvider::Stun, EndpointProvider::Local})]
+        fn test_to_endpoint_providers(
+            #[case] providers: Vec<EndpointProvider>,
+            #[case] expected: HashSet<EndpointProvider>,
+        ) {
+            let actual = EndpointProviders::into_custom(providers).unwrap();
+
+            assert_eq!(actual.len(), expected.len());
+            assert!(actual.iter().all(|ep| expected.contains(ep)));
+        }
+
+        #[rstest]
+        #[case(vec![], maplit::hashset!{})]
+        #[case(vec![EndpointProvider::Stun], maplit::hashset! {EndpointProvider::Stun})]
+        #[case(vec![EndpointProvider::Local, EndpointProvider::Stun], maplit::hashset!{EndpointProvider::Stun, EndpointProvider::Local})]
+        fn test_from_endpoint_providers(
+            #[case] expected: Vec<EndpointProvider>,
+            #[case] providers: HashSet<EndpointProvider>,
+        ) {
+            let actual = EndpointProviders::from_custom(providers);
+
+            assert_eq!(actual.len(), expected.len());
+            assert!(actual.iter().all(|ep| expected.contains(ep)));
+        }
+
+        #[rstest]
+        #[case(true)]
+        #[case(false)]
+        fn test_to_feature_validate_keys(#[case] val: bool) {
+            let expected = FeatureValidateKeys(val);
+            let actual = FeatureValidateKeys::into_custom(val).unwrap();
+
+            assert_eq!(actual, expected);
+        }
+
+        #[rstest]
+        #[case(true)]
+        #[case(false)]
+        fn test_from_feature_validate_keys(#[case] val: bool) {
+            let expected = val;
+            let actual = FeatureValidateKeys::from_custom(FeatureValidateKeys(val));
+
+            assert_eq!(actual, expected);
+        }
+
+        #[rstest]
+        #[case(true)]
+        #[case(false)]
+        fn test_to_feature_boring_tun_reset_conns(#[case] val: bool) {
+            let expected = FeatureBoringtunResetConns(val);
+            let actual = FeatureBoringtunResetConns::into_custom(val).unwrap();
+
+            assert_eq!(actual, expected);
+        }
+
+        #[rstest]
+        #[case(true)]
+        #[case(false)]
+        fn test_from_feature_boring_tun_reset_conns(#[case] val: bool) {
+            let expected = val;
+            let actual = FeatureBoringtunResetConns::from_custom(FeatureBoringtunResetConns(val));
+
+            assert_eq!(actual, expected);
+        }
+    }
+}

--- a/src/libtelio.udl
+++ b/src/libtelio.udl
@@ -1,0 +1,558 @@
+/// Mesh connection path type
+enum PathType {
+    /// Nodes connected via a middle-man relay
+    "Relay",
+    /// Nodes connected directly via WG
+    "Direct",
+};
+
+/// Available Endpoint Providers for meshnet direct connections
+enum EndpointProvider {
+    /// Use local interface ips as possible endpoints
+    "Local",
+    /// Use stun and wg-stun results as possible endpoints
+    "Stun",
+    /// Use IGD and upnp to generate endpoints
+    "Upnp",
+};
+
+[Error]
+enum TelioError {
+    "UnknownError",
+    "InvalidKey",
+    "BadConfig",
+    "LockError",
+    "InvalidString",
+    "AlreadyStarted",
+    "NotStarted"
+};
+
+/// Possible adapters.
+enum TelioAdapterType {
+    /// Userland rust implementation.
+    "BoringTun",
+    /// Linux in-kernel WireGuard implementation
+    "LinuxNativeTun",
+    /// WireguardGo implementation
+    "WireguardGoTun",
+    /// WindowsNativeWireguardNt implementation
+    "WindowsNativeTun",
+};
+
+/// Possible log levels.
+enum TelioLogLevel {
+    "Error",
+    "Warning",
+    "Info",
+    "Debug",
+    "Trace",
+};
+
+/// Connection state of the node
+enum NodeState {
+    /// Node is disconnected
+    "Disconnected",
+    /// Trying to connect to the Node
+    "Connecting",
+    /// Node is connected
+    "Connected",
+};
+
+/// The currrent state of our connection to derp server
+enum RelayState {
+    /// Disconnected from the Derp server
+    "Disconnected",
+    /// Connecting to the Derp server
+    "Connecting",
+    /// Connected to the Derp server
+    "Connected",
+};
+
+[Custom]
+typedef bytes PublicKey;
+
+[Custom]
+typedef bytes SecretKey;
+
+[Custom]
+typedef string IpAddr;
+
+[Custom]
+typedef string IpNetwork;
+
+[Custom]
+typedef string Ipv4Addr;
+
+[Custom]
+typedef string SocketAddr;
+
+[Custom]
+typedef string HiddenString;
+
+[Custom]
+typedef sequence<EndpointProvider> EndpointProviders;
+
+[Custom]
+typedef boolean FeatureValidateKeys;
+
+[Custom]
+typedef boolean FeatureBoringtunResetConns;
+
+namespace libtelio {
+    /// Set the global logger.
+    /// # Parameters
+    /// - `log_level`: Max log level to log.
+    /// - `logger`: Callback to handle logging events.
+    void set_global_logger(TelioLogLevel log_level, TelioLoggerCb logger);
+
+    /// Get default recommended adapter type for platform.
+    TelioAdapterType uniffi_telio_get_default_adapter();
+
+    /// Get current version tag.
+    string uniffi_telio_get_version_tag();
+
+    /// Get current commit sha.
+    string uniffi_telio_get_commit_sha();
+
+    /// Generate a new secret key.
+    SecretKey generate_secret_key();
+
+    /// Get the public key that corresponds to a given private key.
+    PublicKey generate_public_key(SecretKey secret_key);
+};
+
+interface telio {
+    /// Create new telio library instance
+    /// # Parameters
+    /// - `events`:     Events callback
+    /// - `features`:   JSON string of enabled features
+    [Throws=TelioError]
+    constructor(Features features, TelioEventCb events);
+
+    /// Create new telio library instance
+    /// # Parameters
+    /// - `events`:     Events callback
+    /// - `features`:   JSON string of enabled features
+    /// - `protect`:    Callback executed after exit-node connect (for VpnService::protectFromVpn())
+    [Name=new_with_protect, Throws=TelioError]
+    constructor(Features features, TelioEventCb events, TelioProtectCb protect);
+
+    /// Completely stop and uninit telio lib.
+    [Throws=TelioError]
+    void destroy();
+
+    /// Explicitly deallocate telio object and shutdown async rt.
+    [Throws=TelioError]
+    void destroy_hard();
+
+    /// Stop telio device.
+    [Throws=TelioError]
+    void stop();
+
+    /// Start telio with specified adapter.
+    ///
+    /// Adapter will attempt to open its own tunnel.
+    [Throws=TelioError]
+    void start(SecretKey secret_key, TelioAdapterType adapter);
+
+    /// Start telio with specified adapter and name.
+    ///
+    /// Adapter will attempt to open its own tunnel.
+    [Throws=TelioError]
+    void start_named(SecretKey secret_key, TelioAdapterType adapter, string name);
+
+    /// Start telio device with specified adapter and already open tunnel.
+    ///
+    /// Telio will take ownership of tunnel , and close it on stop.
+    ///
+    /// # Parameters
+    /// - `private_key`: base64 encoded private_key.
+    /// - `adapter`: Adapter type.
+    /// - `tun`: A valid filedescriptor to tun device.
+    ///
+    [Throws=TelioError]
+    void start_with_tun(SecretKey secret_key, TelioAdapterType adapter, i32 tun);
+
+    /// get device luid.
+    u64 get_adapter_luid();
+
+    /// Sets private key for started device.
+    ///
+    /// If private_key is not set, device will never connect.
+    ///
+    /// # Parameters
+    /// - `private_key`: WireGuard private key.
+    ///
+    [Throws=TelioError]
+    void set_secret_key([ByRef] SecretKey secret_key);
+
+
+    SecretKey get_secret_key();
+
+    /// Sets fmark for started device.
+    ///
+    /// # Parameters
+    /// - `fwmark`: unsigned 32-bit integer
+    ///
+    [Throws=TelioError]
+    void set_fwmark(u32 fwmark);
+
+    /// Notify telio with network state changes.
+    ///
+    /// # Parameters
+    /// - `network_info`: Json encoded network sate info.
+    ///                   Format to be decided, pass empty string for now.
+    [Throws=TelioError]
+    void notify_network_change(string network_info);
+
+    /// Wrapper for `telio_connect_to_exit_node_with_id` that doesn't take an identifier
+    [Throws=TelioError]
+    void connect_to_exit_node(PublicKey public_key, sequence<IpNetwork>? allowed_ips, SocketAddr? endpoint);
+    
+    /// Connects to an exit node. (VPN if endpoint is not NULL, Peer if endpoint is NULL)
+    ///
+    /// Routing should be set by the user accordingly.
+    ///
+    /// # Parameters
+    /// - `identifier`: String that identifies the exit node, will be generated if null is passed.
+    /// - `public_key`: WireGuard public key for an exit node.
+    /// - `allowed_ips`: List of subnets which will be routed to the exit node.
+    ///                  Can be None, same as "0.0.0.0/0".
+    /// - `endpoint`: An endpoint to an exit node. Can be None, must contain a port.
+    ///
+    /// # Examples
+    ///
+    /// ```c
+    /// // Connects to VPN exit node.
+    /// telio_connect_to_exit_node_with_id(
+    ///     "5e0009e1-75cf-4406-b9ce-0cbb4ea50366",
+    ///     "QKyApX/ewza7QEbC03Yt8t2ghu6nV5/rve/ZJvsecXo=",
+    ///     "0.0.0.0/0", // Equivalent
+    ///     "1.2.3.4:5678"
+    /// );
+    ///
+    /// // Connects to VPN exit node, with specified allowed_ips.
+    /// telio_connect_to_exit_node_with_id(
+    ///     "5e0009e1-75cf-4406-b9ce-0cbb4ea50366",
+    ///     "QKyApX/ewza7QEbC03Yt8t2ghu6nV5/rve/ZJvsecXo=",
+    ///     "100.100.0.0/16;10.10.23.0/24",
+    ///     "1.2.3.4:5678"
+    /// );
+    ///
+    /// // Connect to exit peer via DERP
+    /// telio_connect_to_exit_node_with_id(
+    ///     "5e0009e1-75cf-4406-b9ce-0cbb4ea50366",
+    ///     "QKyApX/ewza7QEbC03Yt8t2ghu6nV5/rve/ZJvsecXo=",
+    ///     "0.0.0.0/0",
+    ///     NULL
+    /// );
+    /// ```
+    ///
+    [Throws=TelioError]
+    void connect_to_exit_node_with_id(string? identifier, PublicKey public_key, sequence<IpNetwork>? allowed_ips, SocketAddr? endpoint);
+    
+    /// Disconnects from specified exit node.
+    ///
+    /// # Parameters
+    /// - `public_key`: WireGuard public key for exit node.
+    ///
+    [Throws=TelioError]
+    void disconnect_from_exit_node([ByRef] PublicKey public_key);
+    
+    /// Disconnects from all exit nodes with no parameters required.
+    [Throws=TelioError]
+    void disconnect_from_exit_nodes();
+
+    /// Enables magic DNS if it was not enabled yet,
+    ///
+    /// Routing should be set by the user accordingly.
+    ///
+    /// # Parameters
+    /// - 'forward_servers': List of DNS servers to route the requests trough.
+    ///
+    /// # Examples
+    ///
+    /// ```c
+    /// // Enable magic dns with some forward servers
+    /// telio_enable_magic_dns("[\"1.1.1.1\", \"8.8.8.8\"]");
+    ///
+    /// // Enable magic dns with no forward server
+    /// telio_enable_magic_dns("[\"\"]");
+    /// ```
+    [Throws=TelioError]
+    void enable_magic_dns([ByRef] sequence<IpAddr> forward_servers);
+    
+    /// Disables magic DNS if it was enabled.
+    [Throws=TelioError]
+    void disable_magic_dns();
+
+    /// Enables meshnet if it is not enabled yet.
+    /// In case meshnet is enabled, this updates the peer map with the specified one.
+    ///
+    /// # Parameters
+    /// - `cfg`: Output of GET /v1/meshnet/machines/{machineIdentifier}/map
+    ///
+    [Throws=TelioError]
+    void set_meshnet(Config cfg);
+    
+    /// Disables the meshnet functionality by closing all the connections.
+    [Throws=TelioError]
+    void set_meshnet_off();
+    
+    
+    sequence<Node> get_status_map();
+    
+    /// Get last error's message length, including trailing null
+    string get_last_error();
+
+    /// For testing only.
+    [Throws=TelioError]
+    void generate_stack_panic();
+    
+    /// For testing only.
+    [Throws=TelioError]
+    void generate_thread_panic();
+};
+
+callback interface TelioEventCb {
+    void event(string payload);
+};
+
+callback interface TelioLoggerCb {
+    void log(TelioLogLevel log_level, string payload);
+};
+
+callback interface TelioProtectCb {
+    void protect(i32 payload);
+};
+
+/// Encompasses all of the possible features that can be enabled
+dictionary Features {
+    /// Additional wireguard configuration
+    FeatureWireguard wireguard;
+    /// Nurse features that can be configured for QoS
+    FeatureNurse? nurse;
+    /// Event logging configurable features
+    FeatureLana? lana;
+    /// Deprecated by direct since 4.0.0
+    FeaturePaths? paths;
+    /// Configure options for exit dns
+    FeatureExitDns? exit_dns;
+    /// Configure options for direct WG connections
+    FeatureDirect? direct;
+    /// Should only be set for macos sideload
+    boolean? is_test_env;
+    /// Derp server specific configuration
+    FeatureDerp? derp;
+    /// Flag to specify if keys should be validated
+    FeatureValidateKeys validate_keys;
+    /// IPv6 support
+    boolean ipv6;
+    /// Nicknames support
+    boolean nicknames;
+    /// Flag to turn on connection reset upon VPN server change for boringtun adapter
+    FeatureBoringtunResetConns boringtun_reset_connections;
+    /// If and for how long to flush events when stopping telio. Setting to Some(0) means waiting until all events have been flushed, regardless of how long it takes
+    u64? flush_events_on_stop_timeout_seconds;
+};
+
+/// Configurable features for Wireguard peers
+dictionary FeatureWireguard {
+    /// Configurable persistent keepalive periods for wireguard peers
+    FeaturePersistentKeepalive persistent_keepalive;
+};
+
+/// Configurable persistent keepalive periods for different types of peers
+dictionary FeaturePersistentKeepalive {
+    /// Persistent keepalive period given for VPN peers (in seconds) [default 15s]
+    u32? vpn;
+    /// Persistent keepalive period for direct peers (in seconds) [default 5s]
+    u32 direct;
+    /// Persistent keepalive period for proxying peers (in seconds) [default 25s]
+    u32? proxying;
+    /// Persistent keepalive period for stun peers (in seconds) [default 25s]
+    u32? stun;
+};
+
+/// Configurable features for Nurse module
+dictionary FeatureNurse {
+    /// The unique identifier of the device, used for meshnet ID
+    string fingerprint;
+    /// Heartbeat interval in seconds. Default value is 3600.
+    u32? heartbeat_interval;
+    /// Initial heartbeat interval in seconds. Default value is None.
+    u32? initial_heartbeat_interval;
+    /// QoS configuration for Nurse
+    FeatureQoS? qos;
+    /// Enable/disable collecting nat type
+    boolean? enable_nat_type_collection;
+};
+
+/// QoS configuration options
+dictionary FeatureQoS {
+    /// How often to collect rtt data in seconds. Default value is 300.
+    u32? rtt_interval;
+    /// Number of tries for each node. Default value is 3.
+    u32? rtt_tries;
+    /// Types of rtt analytics. Default is Ping.
+    sequence<string>? rtt_types;
+    /// Number of buckets used for rtt and throughput. Default value is 5.
+    u32? buckets;
+};
+
+/// Configurable features for Lana module
+dictionary FeatureLana {
+    /// Path of the file where events will be stored. If such file does not exist, it will be created, otherwise reused
+    string event_path;
+    /// Whether the events should be sent to produciton or not
+    boolean prod;
+};
+
+/// Enable wanted paths for telio
+dictionary FeaturePaths {
+    /// Enable paths in increasing priority: 0 is worse then 1 is worse then 2 ...
+    /// [PathType::Relay] always assumed as -1
+    sequence<PathType> priority;
+    /// Force only one specific path to be used.
+    PathType? force;
+};
+
+/// Configurable features for exit Dns
+dictionary FeatureExitDns {
+    /// Controls if it is allowed to reconfigure DNS peer when exit node is
+    /// (dis)connected.
+    boolean? auto_switch_dns_ips;
+};
+
+/// Enable meshent direct connection
+dictionary FeatureDirect {
+    /// Endpoint providers [default all]
+    EndpointProviders? providers;
+    /// Polling interval for endpoints [default 10s]
+    u64? endpoint_interval_secs;
+    /// Configuration options for skipping unresponsive peers
+    FeatureSkipUnresponsivePeers? skip_unresponsive_peers;
+};
+
+/// Avoid sending periodic messages to peers with no traffic reported by wireguard
+dictionary FeatureSkipUnresponsivePeers {
+    /// Time after which peers is considered unresponsive if it didn't receive any packets
+    u64 no_rx_threshold_secs;
+};
+
+/// Configure derp behaviour
+dictionary FeatureDerp {
+    /// Tcp keepalive set on derp server's side [default 15s]
+    u32? tcp_keepalive;
+    /// Derp will send empty messages after this many seconds of not sending/receiving any data [default 60s]
+    u32? derp_keepalive;
+    /// Enable polling of remote peer states to reduce derp traffic
+    boolean? enable_polling;
+    /// Use Mozilla's root certificates instead of OS ones [default false]
+    boolean use_built_in_root_certificates;
+};
+
+/// Rust representation of [meshnet map]
+/// A network map of all the Peers and the servers
+dictionary Config {
+    /// Description of the local peer
+    PeerBase this;
+    /// List of connected peers
+    sequence<Peer>? peers;
+    /// List of available derp servers
+    sequence<Server>? derp_servers;
+    /// Dns configuration
+    DnsConfig? dns;
+};
+
+/// Characterstics describing a peer
+dictionary PeerBase {
+    /// 32-character identifier of the peer
+    string identifier;
+    /// Public key of the peer
+    PublicKey public_key;
+    /// Hostname of the peer
+    HiddenString hostname;
+    /// Ip address of peer
+    sequence<IpAddr>? ip_addresses;
+    /// Nickname for the peer
+    string? nickname;
+};
+
+/// Description of a peer
+dictionary Peer {
+    /// The base object describing a peer
+    PeerBase base;
+    /// The peer is local, when the flag is set
+    boolean is_local;
+    /// Flag to control whether the peer allows incoming connections
+    boolean allow_incoming_connections;
+    /// Flag to control whether the peer allows incoming files
+    boolean allow_peer_send_files;
+};
+
+/// Representation of a server, which might be used
+/// both as a Relay server and Stun Server
+dictionary Server {
+    /// Server region code
+    string region_code;
+    /// Short name for the server
+    string name;
+    /// Hostname of the server
+    string hostname;
+    /// IP address of the server
+    Ipv4Addr ipv4;
+    /// Port on which server listens to relay requests
+    u16 relay_port;
+    /// Port on which server listens to stun requests
+    u16 stun_port;
+    /// Port on which server listens for unencrypted stun requests
+    u16 stun_plaintext_port;
+    /// Server public key
+    PublicKey public_key;
+    /// Determines in which order the client tries to connect to the derp servers
+    u32 weight;
+
+    /// When enabled the connection to servers is not encrypted
+    boolean use_plain_text;
+
+    /// Status of the connection with the server
+    RelayState conn_state;
+};
+
+/// Representation of DNS configuration
+dictionary DnsConfig {
+    /// List of DNS servers
+    sequence<IpAddr>? dns_servers;
+};
+
+/// Description of a Node
+dictionary Node {
+    /// An identifier for a node
+    /// Makes it possible to distinguish different nodes in the presence of key reuse
+    string identifier;
+    /// Public key of the Node
+    PublicKey public_key;
+    /// Nickname for the peer
+    string? nickname;   
+    /// State of the node (Connecting, connected, or disconnected)
+    NodeState state;
+    /// Is the node exit node
+    boolean is_exit;
+    /// Is the node is a vpn server.
+    boolean is_vpn;
+    /// IP addresses of the node
+    sequence<IpAddr> ip_addresses;
+    /// List of IP's which can connect to the node
+    sequence<IpNetwork> allowed_ips;
+    /// Endpoint used by node
+    SocketAddr? endpoint;
+    /// Hostname of the node
+    string? hostname;
+    /// Flag to control whether the Node allows incoming connections
+    boolean allow_incoming_connections;
+    /// Flag to control whether the Node allows incoming files
+    boolean allow_peer_send_files;
+    /// Connection type in the network mesh (through Relay or hole punched directly)
+    PathType path;
+};

--- a/tests/logger.rs
+++ b/tests/logger.rs
@@ -7,6 +7,8 @@ use telio::TelioTracingSubscriber;
 mod test_module {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
+    use telio::SubscriberCallback;
+
     use super::*;
 
     #[test]
@@ -20,7 +22,7 @@ mod test_module {
             assert_eq!(telio::ffi_types::telio_log_level::TELIO_LOG_INFO, level);
             let message = CStr::from_ptr(message);
             assert_eq!(
-                r#""logger::test_module":36 test message"#,
+                r#""logger::test_module":39 test message"#,
                 message.to_str().unwrap()
             );
             let call_count: &AtomicUsize = &*(ctx as *const AtomicUsize);
@@ -30,7 +32,8 @@ mod test_module {
             ctx: &call_count as *const AtomicUsize as *mut c_void,
             cb: test_telio_logger_fn,
         };
-        let tracing_subscriber = TelioTracingSubscriber::new(logger, tracing::Level::INFO);
+        let tracing_subscriber =
+            TelioTracingSubscriber::new(SubscriberCallback::Swig(logger), tracing::Level::INFO);
         tracing::subscriber::set_global_default(tracing_subscriber).unwrap();
 
         tracing::info!("test message");

--- a/tests/uniffi_logger.rs
+++ b/tests/uniffi_logger.rs
@@ -1,0 +1,44 @@
+use telio;
+use telio::TelioTracingSubscriber;
+
+mod test_module {
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
+
+    use telio::{ffi_types::TelioLoggerCb, SubscriberCallback};
+
+    use super::*;
+
+    #[test]
+    fn uniffi_test_logger() {
+        let call_count = Arc::new(AtomicUsize::new(0));
+
+        #[derive(Debug)]
+        struct TestLogger {
+            call_count: Arc<AtomicUsize>,
+        }
+        impl TelioLoggerCb for TestLogger {
+            fn log(&self, log_level: telio::ffi_types::TelioLogLevel, payload: String) {
+                assert!(matches!(log_level, telio::ffi_types::TelioLogLevel::Info));
+                assert_eq!(r#""uniffi_logger::test_module":40 test message"#, payload);
+                assert_eq!(0, self.call_count.fetch_add(1, Ordering::Relaxed));
+            }
+        }
+
+        let logger = TestLogger {
+            call_count: call_count.clone(),
+        };
+
+        let tracing_subscriber = TelioTracingSubscriber::new(
+            SubscriberCallback::Uniffi(Box::new(logger)),
+            tracing::Level::INFO,
+        );
+        tracing::subscriber::set_global_default(tracing_subscriber).unwrap();
+
+        tracing::info!("test message");
+        assert_eq!(1, call_count.load(Ordering::Relaxed));
+        tracing::debug!("this will be ignored since it's below info");
+    }
+}


### PR DESCRIPTION
### Description
This PR is the first introduction of UniFFI into libtelio, but so far UniFFI isn't actually used. That comes in a later PR. 

With UniFFI we can make changes to our FFI code that is incompatible with SWIG and do general cleanup, so UniFFI is a breaking change, but this PR doesn't actually break anything yet. Instead it duplicates out FFI code and then cleans up the duplicate, but fear not, the duplication is not going to be long-lived.



### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
