### PR TITLE
Add task monitor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3770,6 +3770,7 @@ dependencies = [
  "strum_macros",
  "telio-crypto",
  "telio-utils",
+ "tokio",
 ]
 
 [[package]]
@@ -3921,6 +3922,7 @@ dependencies = [
  "async-trait",
  "futures",
  "log",
+ "telio-model",
  "telio-utils",
  "thiserror",
  "tokio",

--- a/changelog.md
+++ b/changelog.md
@@ -35,6 +35,8 @@
 * LLT-4360: Bump rust version to 1.72
 * LLT-4286: Add icmp error packet handling to firewall
 * LLT-4432: Use forked system-configuration crate to prevent iOS linking errors
+* LLT-3670: Add task monitor
+* LLT-3792: Dedublicate monitor configs
 
 <br>
 

--- a/clis/tcli/src/main.rs
+++ b/clis/tcli/src/main.rs
@@ -98,6 +98,14 @@ fn main() -> Result<()> {
                             );
                         }
                     }
+                    DevEvent::Monitor { body } => {
+                        if let Some(b) = body.as_ref() {
+                            println!(
+                                "event monitor: {}",
+                                serde_json::to_string(&b).unwrap_or_else(|_| "".to_string())
+                            );
+                        }
+                    }
                     _ => (),
                 },
                 Error(e) => {

--- a/crates/telio-model/Cargo.toml
+++ b/crates/telio-model/Cargo.toml
@@ -22,6 +22,7 @@ serde.workspace = true
 serde_with.workspace = true
 serde_json.workspace = true
 strum.workspace = true
+tokio = { workspace = true, features = ["rt"]}
 
 telio-crypto.workspace = true
 telio-utils.workspace = true

--- a/crates/telio-model/src/lib.rs
+++ b/crates/telio-model/src/lib.rs
@@ -4,6 +4,7 @@ pub mod api_config;
 pub mod config;
 pub mod event;
 pub mod mesh;
+pub mod task_monitor;
 
 pub use std::collections::HashMap;
 pub use std::net::SocketAddr;

--- a/crates/telio-model/src/task_monitor.rs
+++ b/crates/telio-model/src/task_monitor.rs
@@ -1,0 +1,78 @@
+//! Information reported by task monitor
+
+use std::error::Error;
+
+use serde::Serialize;
+use tokio::task::JoinError;
+
+/// Event reported by [TaskMonitor]
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize)]
+#[serde(tag = "event")]
+#[serde(rename_all = "snake_case")]
+pub enum MonitorEvent {
+    /// Task has been looping excessively
+    TaskBusyLoop {
+        /// Name of the task
+        name: &'static str,
+    },
+    /// Task was started
+    TaskStart {
+        /// Name of the task
+        name: &'static str,
+    },
+    /// Task was stopped
+    TaskStop {
+        /// Name of the task
+        name: &'static str,
+        /// Stop reason
+        reason: StopReason,
+    },
+}
+
+/// Possible reasons why task was stopped
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize)]
+#[serde(tag = "type", content = "message")]
+#[serde(rename_all = "snake_case")]
+pub enum StopReason {
+    /// Task stopped manually by calling [Task::stop]
+    /// We expect for all task to be stopped manualy
+    Manual,
+    /// Task stopped via drop
+    Dropped,
+    /// Task stopped due to inner panic
+    Panic,
+    /// Task stopped due to inner error
+    Error(String),
+    /// Task stopped by [tokio::task::JoinHandle::abort]
+    Cancel,
+}
+
+/// How task was stopped
+pub enum StopKind {
+    /// Task was stopped manualy, calling stop
+    /// We expect use of manual stop, to ensure we wait for
+    /// tasks to close properly
+    Manual,
+    /// Task was stopped using Drop
+    Dropped,
+}
+
+impl<E: Error> From<&Result<Result<StopKind, E>, JoinError>> for StopReason {
+    fn from(value: &Result<Result<StopKind, E>, JoinError>) -> Self {
+        use StopReason::*;
+        match value {
+            Ok(res) => match res {
+                Ok(StopKind::Manual) => Manual,
+                Ok(StopKind::Dropped) => Dropped,
+                Err(e) => Error(e.to_string()),
+            },
+            Err(e) => {
+                if e.is_cancelled() {
+                    Cancel
+                } else {
+                    Panic
+                }
+            }
+        }
+    }
+}

--- a/crates/telio-nurse/src/heartbeat.rs
+++ b/crates/telio-nurse/src/heartbeat.rs
@@ -2,6 +2,7 @@ use async_trait::async_trait;
 use bitflags::bitflags;
 use nat_detect::NatType;
 use std::collections::BTreeSet;
+use std::convert::Infallible;
 use std::fmt::Write;
 use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
@@ -249,7 +250,7 @@ pub struct Analytics {
 impl Runtime for Analytics {
     const NAME: &'static str = "Nurse Heartbeat Analytics";
 
-    type Err = ();
+    type Err = Infallible;
 
     async fn wait(&mut self) -> WaitResponse<'_, Self::Err> {
         tokio::select! {

--- a/crates/telio-nurse/src/qos.rs
+++ b/crates/telio-nurse/src/qos.rs
@@ -2,6 +2,7 @@ use async_trait::async_trait;
 use histogram::Histogram;
 use serde::Deserialize;
 use std::collections::{BTreeSet, HashMap};
+use std::convert::Infallible;
 use std::net::IpAddr;
 use std::time::Instant;
 
@@ -158,7 +159,7 @@ pub struct Analytics {
 impl Runtime for Analytics {
     const NAME: &'static str = "Nurse QoS Analytics";
 
-    type Err = ();
+    type Err = Infallible;
 
     async fn wait(&mut self) -> WaitResponse<'_, Self::Err> {
         tokio::select! {

--- a/crates/telio-relay/src/derp/mod.rs
+++ b/crates/telio-relay/src/derp/mod.rs
@@ -14,6 +14,7 @@ use async_trait::async_trait;
 use futures::{future::select_all, Future};
 use generic_array::typenum::Unsigned;
 use std::collections::{HashMap, HashSet};
+use std::convert::Infallible;
 use std::net::{IpAddr, SocketAddr};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -643,7 +644,7 @@ impl State {
 impl Runtime for State {
     const NAME: &'static str = "DerpRelay";
 
-    type Err = ();
+    type Err = Infallible;
 
     async fn wait_with_update<F>(&mut self, update: F) -> Result<(), Self::Err>
     where

--- a/crates/telio-relay/src/multiplexer/inout.rs
+++ b/crates/telio-relay/src/multiplexer/inout.rs
@@ -1,7 +1,7 @@
 use std::mem::replace;
 
 use futures::{
-    stream::{ReuniteError, SplitSink, SplitStream},
+    stream::{SplitSink, SplitStream},
     Sink, Stream, StreamExt,
 };
 
@@ -11,6 +11,8 @@ pub struct InOut<T, I>(Inner<T, I>);
 enum Inner<T, I> {
     Joined(T),
     Split(SplitSink<T, I>, SplitStream<T>),
+    // This is only allowed to be used for a short time while we are
+    // remapping self into other state
     Empty,
 }
 use Inner::*;
@@ -25,21 +27,22 @@ where
     }
 
     /// Get references to split halves
-    pub fn split(&mut self) -> Option<(&mut SplitSink<T, I>, &mut SplitStream<T>)> {
+    pub fn split(&mut self) -> (&mut SplitSink<T, I>, &mut SplitStream<T>) {
         self.in_place(Self::into_split);
         match &mut self.0 {
-            Split(tx, rx) => Some((tx, rx)),
-            _ => None,
+            Split(tx, rx) => (tx, rx),
+            _ => unreachable!("After in_place(Self::into_split) self will always be split"),
         }
     }
 
     /// Get reference to joined type
-    pub fn joined(&mut self) -> Result<Option<&mut T>, ReuniteError<T, I>> {
-        self.try_in_place(Self::into_joined)?;
-        Ok(match &mut self.0 {
-            Joined(j) => Some(j),
-            _ => None,
-        })
+    pub fn joined(&mut self) -> &mut T {
+        self.in_place(Self::into_joined);
+
+        match &mut self.0 {
+            Joined(j) => j,
+            _ => unreachable!("into_join enusures self will always be Joined"),
+        }
     }
 
     fn into_split(self) -> Self {
@@ -52,24 +55,25 @@ where
         }
     }
 
-    fn into_joined(self) -> Result<Self, ReuniteError<T, I>> {
-        Ok(match self {
-            Self(Split(tx, rx)) => Self(Joined(tx.reunite(rx)?)),
+    fn into_joined(self) -> Self {
+        match self {
+            Self(Split(tx, rx)) => Self(Joined(match tx.reunite(rx) {
+                Ok(v) => v,
+                Err(_) => {
+                    unreachable!("We are always working with the same channel in this struct")
+                }
+            })),
             v => v,
-        })
+        }
     }
 
     #[inline(always)]
     fn in_place(&mut self, map: impl FnOnce(Self) -> Self) {
-        *self = map(replace(self, Self(Empty)));
-    }
-
-    #[inline(always)]
-    fn try_in_place(
-        &mut self,
-        map: impl FnOnce(Self) -> Result<Self, ReuniteError<T, I>>,
-    ) -> Result<(), ReuniteError<T, I>> {
-        *self = map(replace(self, Self(Empty)))?;
-        Ok(())
+        let new = map(replace(self, Self(Empty)));
+        assert!(
+            !matches!(new.0, Inner::Empty),
+            "Map is not allowed to map to Empty, it would break invariance"
+        );
+        *self = new;
     }
 }

--- a/crates/telio-task/Cargo.toml
+++ b/crates/telio-task/Cargo.toml
@@ -17,5 +17,5 @@ futures.workspace = true
 log.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["full"] }
-
 telio-utils.workspace = true
+telio-model.workspace = true

--- a/crates/telio-task/src/lib.rs
+++ b/crates/telio-task/src/lib.rs
@@ -17,5 +17,4 @@ mod task;
 pub mod io;
 
 pub use macros::*;
-pub use task::BoxAction;
 pub use task::*;

--- a/crates/telio-task/src/task/error.rs
+++ b/crates/telio-task/src/task/error.rs
@@ -1,0 +1,70 @@
+use std::any::Any;
+
+use tokio::task::JoinError;
+
+/// Task was stopped during execution.
+#[derive(Debug, thiserror::Error)]
+#[error("Failed to execute.")]
+pub struct ExecError;
+
+/// Task stop status.
+#[derive(Debug)]
+pub enum StopResult<E> {
+    /// Task was stopped succesfully
+    Ok,
+    /// Task stopped due to internal error.
+    Err(E),
+    /// Task panic'ed
+    Panic(Box<dyn Any + Send + 'static>),
+}
+
+impl<E> StopResult<E> {
+    /// Stopped successfully
+    pub fn is_ok(&self) -> bool {
+        matches!(self, &StopResult::Ok)
+    }
+
+    /// Stopped due to internal error
+    pub fn is_err(&self) -> bool {
+        matches!(self, &StopResult::Err(_))
+    }
+
+    /// Stopped due to inner panic
+    pub fn is_panic(&self) -> bool {
+        matches!(self, &StopResult::Panic(_))
+    }
+
+    /// Return Ok for proper stop or Err if internal error occurred.
+    ///
+    /// # Panics
+    /// Propagates panic if task stopped due to panic
+    pub fn resume_unwind(self) -> Result<(), E> {
+        match self {
+            Self::Ok => Ok(()),
+            Self::Err(e) => Err(e),
+            Self::Panic(p) => std::panic::resume_unwind(p),
+        }
+    }
+}
+
+impl<E: PartialEq> PartialEq for StopResult<E> {
+    fn eq(&self, other: &Self) -> bool {
+        match (&self, &other) {
+            (&Self::Ok, &Self::Ok) => true,
+            (&Self::Err(el), &Self::Err(er)) => el == er,
+            _ => false,
+        }
+    }
+}
+
+impl<T, E> From<Result<Result<T, E>, JoinError>> for StopResult<E> {
+    fn from(value: Result<Result<T, E>, JoinError>) -> Self {
+        match value {
+            Ok(Ok(_)) => StopResult::Ok,
+            Ok(Err(e)) => StopResult::Err(e),
+            Err(e) if e.is_panic() => StopResult::Panic(e.into_panic()),
+            // Match arm for cancelled case
+            _ => StopResult::Ok,
+        }
+    }
+}

--- a/crates/telio-task/src/task/mod.rs
+++ b/crates/telio-task/src/task/mod.rs
@@ -1,0 +1,9 @@
+mod error;
+mod monitor;
+mod runtime;
+mod wait_response;
+
+pub use error::{ExecError, StopResult};
+pub use monitor::TaskMonitor;
+pub use runtime::{Action, BoxAction, Runtime, Task};
+pub use wait_response::{RuntimeExt, WaitResponse};

--- a/crates/telio-task/src/task/monitor.rs
+++ b/crates/telio-task/src/task/monitor.rs
@@ -1,0 +1,456 @@
+use std::{
+    cell::RefCell,
+    collections::HashMap,
+    panic,
+    sync::{Arc, Mutex},
+    time::{Duration, Instant},
+};
+
+use futures::{future::poll_fn, Future};
+
+use telio_model::{
+    api_config::FeatureTaskMonitor as MonitorConfig,
+    task_monitor::{MonitorEvent, StopKind, StopReason},
+};
+use telio_utils::{runtime::Builder, task, telio_log_warn};
+
+use crate::Runtime;
+
+type TaskMonitorHandler = Arc<dyn Fn(MonitorEvent) + Send + Sync + 'static>;
+
+/// Telio Task Monitor
+///
+/// Allowes monitoring of exits and other failues of all task created using [task::Runtime]
+#[derive(Clone)]
+pub struct TaskMonitor {
+    config: MonitorConfig,
+    handler: TaskMonitorHandler,
+}
+
+impl TaskMonitor {
+    /// Create a new task monitor
+    pub fn new<H>(config: MonitorConfig, handler: H) -> Self
+    where
+        H: Fn(MonitorEvent) + Send + Sync + 'static,
+    {
+        let event_limiter: Mutex<HashMap<MonitorEvent, Instant>> = Mutex::new(HashMap::new());
+        let debounce_time = Duration::from_millis(
+            config
+                .duration_between_reporting_same_event_ms
+                .unwrap_or(MonitorConfig::DEFAULT_DURATION_BETWEEN_REPORTING_SAME_EVENT),
+        );
+        Self {
+            config,
+            handler: Arc::new(move |event| {
+                if let Ok(mut el) = event_limiter.lock() {
+                    let now = Instant::now();
+                    let can_send = el
+                        .get(&event)
+                        .map(|last| now.duration_since(*last) > debounce_time)
+                        .unwrap_or(true);
+
+                    if can_send {
+                        el.insert(event.clone(), now);
+                        (handler)(event)
+                    }
+                }
+            }),
+        }
+    }
+
+    /// Setup task monitor for tokio thread pool
+    pub fn on_thread_start(&self) {
+        CURRENT_MONITOR.with(|m| *m.borrow_mut() = Some(self.clone()))
+    }
+
+    /// Cleanup task monitor for tokio thread pool
+    pub fn on_thread_stop(&self) {
+        CURRENT_MONITOR.with(|m| *m.borrow_mut() = None)
+    }
+
+    pub(crate) fn report(&self, event: MonitorEvent) {
+        (self.handler)(event)
+    }
+
+    /// This must be called from within a tokio task
+    pub(crate) fn watch<R: Runtime>(
+        &self,
+        inner: impl Future<Output = Result<StopKind, R::Err>> + Send + 'static,
+    ) -> impl Future<Output = Result<StopKind, R::Err>> + Send + 'static {
+        let handler = self.handler.clone();
+        async move {
+            (handler)(MonitorEvent::TaskStart { name: R::NAME });
+
+            // This is the simplest way to capture panic.
+            // It should be possible to do this with catch_unwind,
+            // but it is way too complex to implement for a functionality that
+            // is primarily used for debugging.
+            let res = tokio::spawn(inner).await;
+
+            let reason: StopReason = { &res }.into();
+
+            (handler)(MonitorEvent::TaskStop {
+                name: R::NAME,
+                reason,
+            });
+
+            // This future is also run as a task, so we need to propogate inner result
+            match res {
+                Ok(res) => res,
+                Err(err) if err.is_cancelled() => {
+                    // This should not be really reachable as there are no cancel calls
+                    // to inner task
+                    telio_log_warn!("Task {} was cancelled", R::NAME);
+                    Ok(StopKind::Dropped)
+                }
+                Err(err) => panic::resume_unwind(err.into_panic()),
+            }
+        }
+    }
+
+    /// Create task wait loop watcher
+    pub(crate) fn loop_watch<R: Runtime>(&self) -> LoopWatcher {
+        LoopWatcher {
+            task_name: R::NAME,
+            monitor: self.clone(),
+            immediate_poll_count: 0,
+        }
+    }
+}
+
+pub trait TokioBuilderExt {
+    /// Setup task monitor for tokio runtime
+    ///
+    /// # Note
+    /// If on_thread_start/stop are used somethere this can be overrided
+    fn setup_global_task_monitor(&mut self, monitor: &TaskMonitor) -> &mut Self;
+}
+
+impl TokioBuilderExt for Builder {
+    fn setup_global_task_monitor(&mut self, monitor: &TaskMonitor) -> &mut Self {
+        self.on_thread_start({
+            let monitor = monitor.clone();
+            move || monitor.on_thread_start()
+        })
+        .on_thread_stop({
+            let monitor = monitor.clone();
+            move || monitor.on_thread_stop()
+        })
+    }
+}
+
+pub(crate) struct LoopWatcher {
+    task_name: &'static str,
+    monitor: TaskMonitor,
+    immediate_poll_count: u64,
+}
+
+impl LoopWatcher {
+    pub(crate) async fn step<Fut>(&mut self, step: Fut) -> Fut::Output
+    where
+        Fut: Future,
+    {
+        let max_polls = self
+            .monitor
+            .config
+            .max_polls_immediately
+            .unwrap_or(MonitorConfig::DEFAULT_MAX_POLLS_IMMEDIATELY);
+
+        if self.immediate_poll_count > max_polls {
+            self.immediate_poll_count = 0;
+            self.monitor.report(MonitorEvent::TaskBusyLoop {
+                name: self.task_name,
+            });
+            task::yield_now().await;
+        }
+
+        let mut step = std::pin::pin!(step);
+
+        let mut poll_count = 0;
+        poll_fn(|cx| {
+            poll_count += 1;
+            let poll = step.as_mut().poll(cx);
+
+            if poll.is_ready() {
+                if poll_count == 1 {
+                    self.immediate_poll_count += 1;
+                } else {
+                    self.immediate_poll_count = 0;
+                }
+            }
+
+            poll
+        })
+        .await
+    }
+}
+
+thread_local! {
+    static CURRENT_MONITOR: RefCell<Option<TaskMonitor>> = RefCell::new(None);
+}
+
+/// Get current handle as set in thread local
+pub(crate) fn with_current_option<R>(f: impl FnOnce(Option<&TaskMonitor>) -> R) -> R {
+    CURRENT_MONITOR.with(|mon| f(mon.borrow().as_ref()))
+}
+
+/// Calls inner fuction if current monitor exists
+pub(crate) fn with_current<R>(f: impl FnOnce(&TaskMonitor) -> R) -> Option<R> {
+    CURRENT_MONITOR.with(|mon| mon.borrow().as_ref().map(f))
+}
+
+#[cfg(test)]
+mod test {
+    use std::{
+        future::pending,
+        io,
+        sync::{Arc, Mutex},
+        time::Duration,
+    };
+
+    use super::*;
+
+    use async_trait::async_trait;
+    use futures::{future::BoxFuture, Future};
+    use telio_utils::time::sleep;
+    use tokio::runtime::Builder;
+
+    use crate::{task_exec, Runtime, RuntimeExt, StopResult, Task, WaitResponse};
+
+    type Events = Arc<Mutex<Vec<MonitorEvent>>>;
+
+    #[test]
+    fn test_monitor_reports_busy_loop() {
+        run_with_monitor(|_mon, events| async move {
+            let task = Simple::start();
+
+            task.set_busy_loop(true).await;
+            sleep(Duration::from_millis(900)).await;
+
+            {
+                let events = events.lock().unwrap();
+                assert_eq!(
+                    &*events,
+                    &[
+                        MonitorEvent::TaskStart { name: "simple" },
+                        MonitorEvent::TaskBusyLoop { name: "simple" }
+                    ]
+                );
+            }
+
+            let _ = task.stop().await;
+        });
+    }
+
+    #[test]
+    fn test_monitor_does_not_report_busy_loop_with_timeout() {
+        run_with_monitor(|_mon, events| async move {
+            let task = Simple::start();
+
+            task.set_poll_loop(Duration::from_millis(1)).await;
+            sleep(Duration::from_secs(2)).await;
+
+            {
+                let events = events.lock().unwrap();
+                assert_eq!(&*events, &[MonitorEvent::TaskStart { name: "simple" }]);
+            }
+
+            let _ = task.stop().await;
+        });
+    }
+
+    #[test]
+    fn test_monitor_captures_manual_stop() {
+        run_with_monitor(|_mon, events| async move {
+            let task = Simple::start();
+            let _ = task.stop().await;
+
+            sleep(Duration::from_secs(1)).await;
+
+            let events = events.lock().unwrap();
+            assert_eq!(
+                &*events,
+                &[
+                    MonitorEvent::TaskStart { name: "simple" },
+                    MonitorEvent::TaskStop {
+                        name: "simple",
+                        reason: StopReason::Manual
+                    }
+                ]
+            )
+        });
+    }
+
+    #[test]
+    fn test_monitor_captures_drop_stop() {
+        run_with_monitor(|_mon, events| async move {
+            {
+                let _task = Simple::start();
+            }
+
+            sleep(Duration::from_secs(1)).await;
+
+            let events = events.lock().unwrap();
+            assert_eq!(
+                &*events,
+                &[
+                    MonitorEvent::TaskStart { name: "simple" },
+                    MonitorEvent::TaskStop {
+                        name: "simple",
+                        reason: StopReason::Dropped
+                    }
+                ]
+            )
+        });
+    }
+
+    #[test]
+    fn test_monitor_captures_error_out() {
+        run_with_monitor(|_mon, events| async move {
+            let task = Simple::start();
+
+            task.test_fail().await;
+
+            sleep(Duration::from_secs(1)).await;
+
+            {
+                let events = events.lock().unwrap();
+                assert_eq!(
+                    &*events,
+                    &[
+                        MonitorEvent::TaskStart { name: "simple" },
+                        MonitorEvent::TaskStop {
+                            name: "simple",
+                            reason: StopReason::Error("connection aborted".to_string())
+                        },
+                    ]
+                );
+            }
+
+            let _ = task.stop().await;
+        });
+    }
+
+    #[test]
+    fn test_monitor_captures_panic_out() {
+        run_with_monitor(|_mon, events| async move {
+            let task = Simple::start();
+
+            task.test_panic().await;
+
+            sleep(Duration::from_secs(1)).await;
+
+            {
+                let events = events.lock().unwrap();
+                assert_eq!(
+                    &*events,
+                    &[
+                        MonitorEvent::TaskStart { name: "simple" },
+                        MonitorEvent::TaskStop {
+                            name: "simple",
+                            reason: StopReason::Panic,
+                        }
+                    ]
+                )
+            }
+
+            let _ = task.stop().await;
+        });
+    }
+
+    fn run_with_monitor<F, Ft>(f: F) -> Events
+    where
+        F: FnOnce(TaskMonitor, Events) -> Ft,
+        Ft: Future<Output = ()> + Send + 'static,
+    {
+        let events = Arc::new(Mutex::new(Vec::new()));
+
+        let monitor = TaskMonitor::new(
+            MonitorConfig {
+                max_polls_immediately: Some(100),
+                ..Default::default()
+            },
+            {
+                let events = events.clone();
+                move |event| {
+                    let mut guard = events.lock().expect("no panic");
+                    guard.push(event);
+                }
+            },
+        );
+
+        Builder::new_multi_thread()
+            .enable_all()
+            .setup_global_task_monitor(&monitor)
+            .build()
+            .unwrap()
+            .block_on(f(monitor, events.clone()));
+
+        events
+    }
+
+    struct Simple(Task<State>);
+    #[derive(Default)]
+    struct State {
+        busy_loop: bool,
+        poll_loop: Option<Duration>,
+    }
+
+    impl Simple {
+        fn start() -> Self {
+            Self(Task::start(State::default()))
+        }
+
+        async fn test_fail(&self) {
+            let _ = task_exec!(&self.0, async move |_s| -> Result<(), io::Error> {
+                Err(io::Error::from(io::ErrorKind::ConnectionAborted))
+            })
+            .await;
+        }
+
+        async fn test_panic(&self) {
+            let _ = task_exec!(&self.0, async move |_s| -> Result<(), io::Error> {
+                panic!("inner_pannic")
+            })
+            .await;
+        }
+
+        async fn set_busy_loop(&self, val: bool) {
+            let _ = task_exec!(&self.0, async move |s| {
+                s.busy_loop = val;
+                Ok(())
+            })
+            .await;
+        }
+
+        async fn set_poll_loop(&self, interval: Duration) {
+            let _ = task_exec!(&self.0, async move |s| {
+                s.poll_loop = Some(interval);
+                Ok(())
+            })
+            .await;
+        }
+
+        async fn stop(self) -> StopResult<io::Error> {
+            self.0.stop().await
+        }
+    }
+
+    #[async_trait]
+    impl Runtime for State {
+        const NAME: &'static str = "simple";
+
+        type Err = io::Error;
+
+        async fn wait(&mut self) -> WaitResponse<'_, Self::Err> {
+            if self.busy_loop {
+                Self::next()
+            } else if let Some(time) = self.poll_loop {
+                sleep(time).await;
+                Self::next()
+            } else {
+                pending().await
+            }
+        }
+    }
+}

--- a/crates/telio-task/src/task/wait_response.rs
+++ b/crates/telio-task/src/task/wait_response.rs
@@ -1,0 +1,41 @@
+use super::Runtime;
+
+use std::future::{pending, ready};
+
+use async_trait::async_trait;
+use futures::{future::BoxFuture, Future, FutureExt};
+
+/// Response from [Runtime::wait].
+///
+/// It's recommended to use [RuntimeExt] methods.
+pub struct WaitResponse<'a, E>(pub(crate) BoxFuture<'a, Result<(), E>>);
+
+/// Typical responses from wait implementation.
+#[async_trait]
+pub trait RuntimeExt: Runtime {
+    /// Guard multiple async operations from being interrupted by exec.
+    fn guard<'a, F>(block: F) -> WaitResponse<'a, Self::Err>
+    where
+        F: Future<Output = Result<(), Self::Err>> + Send + 'a,
+    {
+        WaitResponse(block.boxed())
+    }
+
+    /// Continue to next loop iteration.
+    fn next() -> WaitResponse<'static, Self::Err> {
+        WaitResponse(ready(Ok(())).boxed())
+    }
+
+    /// Error out with [Runtime::Err]
+    fn error(e: Self::Err) -> WaitResponse<'static, Self::Err> {
+        WaitResponse(ready(Err(e)).boxed())
+    }
+
+    /// Sleep forever in loop, loop is stopped, but not deallocated.
+    /// Task loop can be re-triggered using exec.
+    async fn sleep_forever() -> WaitResponse<'static, Self::Err> {
+        pending().await
+    }
+}
+
+impl<T> RuntimeExt for T where T: Runtime {}

--- a/crates/telio-traversal/src/endpoint_providers/upnp/mod.rs
+++ b/crates/telio-traversal/src/endpoint_providers/upnp/mod.rs
@@ -9,6 +9,7 @@ use igd::{search_gateway, Gateway, PortMappingProtocol};
 use ipnet::Ipv4Net;
 use rand::Rng;
 use rupnp::Error::HttpErrorCode;
+use std::convert::Infallible;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4};
 use std::sync::Arc;
 use std::time::Duration;
@@ -544,7 +545,7 @@ impl<Wg: WireGuard, I: UpnpEpCommands, E: Backoff> State<Wg, I, E> {
 impl<Wg: WireGuard, I: UpnpEpCommands, E: Backoff> Runtime for State<Wg, I, E> {
     const NAME: &'static str = "UpnpEndpointProvider";
 
-    type Err = ();
+    type Err = Infallible;
 
     #[allow(index_access_check)]
     async fn wait_with_update<F>(&mut self, update: F) -> std::result::Result<(), Self::Err>

--- a/crates/telio-traversal/src/session_keeper.rs
+++ b/crates/telio-traversal/src/session_keeper.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 use futures::Future;
+use std::convert::Infallible;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::sync::Arc;
 use std::time::Duration;
@@ -209,7 +210,7 @@ struct State {
 #[async_trait]
 impl Runtime for State {
     const NAME: &'static str = "SessionKeeper";
-    type Err = ();
+    type Err = Infallible;
 
     async fn wait_with_update<F>(&mut self, update: F) -> std::result::Result<(), Self::Err>
     where
@@ -226,7 +227,7 @@ impl Runtime for State {
                     .map_or_else(|e| {
                         telio_log_warn!("({}) Error sending keepalive to {} node: {}", Self::NAME, pk, e.to_string());
                         Ok(())
-                    }, |_| Ok(()))?;
+                    }, |_| Ok::<(), Self::Err>(()))?;
             }
             update = update => {
                 return update(self).await;

--- a/crates/telio-traversal/src/upgrade_sync.rs
+++ b/crates/telio-traversal/src/upgrade_sync.rs
@@ -1,8 +1,8 @@
 use async_trait::async_trait;
 use futures::Future;
-use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::time::Duration;
+use std::{collections::HashMap, convert::Infallible};
 use telio_crypto::PublicKey;
 use telio_proto::UpgradeMsg;
 use telio_task::{io::chan, io::Chan, task_exec, BoxAction, Runtime, Task};
@@ -243,7 +243,7 @@ impl State {
 #[async_trait]
 impl Runtime for State {
     const NAME: &'static str = "UpgradeSync";
-    type Err = ();
+    type Err = Infallible;
 
     async fn wait_with_update<F>(&mut self, update: F) -> std::result::Result<(), Self::Err>
     where

--- a/nat-lab/tests/telio_features.py
+++ b/nat-lab/tests/telio_features.py
@@ -53,6 +53,13 @@ class Nurse(DataClassJsonMixin):
 
 @dataclass_json(undefined=Undefined.EXCLUDE)
 @dataclass
+class TaskMonitor:
+    max_polls_immediately: Optional[int] = None
+    duration_between_reporting_same_event_ms: Optional[int] = None
+
+
+@dataclass_json(undefined=Undefined.EXCLUDE)
+@dataclass
 class TelioFeatures(DataClassJsonMixin):
     is_test_env: Optional[bool] = True
     exit_dns: Optional[ExitDns] = field(
@@ -61,3 +68,4 @@ class TelioFeatures(DataClassJsonMixin):
     direct: Optional[Direct] = None
     lana: Optional[Lana] = None
     nurse: Optional[Nurse] = None
+    task_monitor: Optional[TaskMonitor] = None


### PR DESCRIPTION
### Description
Improving telio-task

### Changes
Split telio_task::task into 3 smaller parts: (see first commit)
- runtime
- error
- wait_response

Added tool to monitor behavior of telio task's, enabled by telio_monitor feature.
This tool will report:
- start of task
- stop of task and reason for that stop
- excessive looping of a task

This feature is now used with all integration test's

To make Errors reported by Task's a bit more useful in `trait Runtime` requires them to implement `std::error::Error` trait.
For task, that does not actually produces failure error, a new std::convert::Infallible should be used






### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
