### PR TITLE
nat-lab: Add tests parametrization

### DIFF
--- a/nat-lab/pyproject.toml
+++ b/nat-lab/pyproject.toml
@@ -52,7 +52,8 @@ disable = [
     "global-statement",
     "bare-except",
     "too-many-branches",
-    "duplicate-code"
+    "duplicate-code",
+    "too-many-lines"
 ]
 
 [tool.pytest.ini_options]

--- a/nat-lab/tests/test_connection_states.py
+++ b/nat-lab/tests/test_connection_states.py
@@ -37,7 +37,9 @@ from utils.ping import Ping
             ],
         ),
         pytest.param(
-            ConnectionTag.MAC_VM, telio.AdapterType.Default, marks=pytest.mark.mac
+            ConnectionTag.MAC_VM,
+            telio.AdapterType.BoringTun,
+            marks=pytest.mark.mac,
         ),
     ],
 )

--- a/nat-lab/tests/test_derp_client_message_forward.py
+++ b/nat-lab/tests/test_derp_client_message_forward.py
@@ -13,8 +13,13 @@ TESTING_STRING = "testing"
 @pytest.mark.parametrize(
     "connection_tag",
     [
-        ConnectionTag.DOCKER_CONE_CLIENT_1,
-        pytest.param(ConnectionTag.WINDOWS_VM, marks=[pytest.mark.windows]),
+        pytest.param(
+            ConnectionTag.DOCKER_CONE_CLIENT_1,
+        ),
+        pytest.param(
+            ConnectionTag.WINDOWS_VM,
+            marks=pytest.mark.windows,
+        ),
     ],
 )
 async def test_derp_client_message_forward(connection_tag: ConnectionTag) -> None:

--- a/nat-lab/tests/test_direct_connection.py
+++ b/nat-lab/tests/test_direct_connection.py
@@ -25,6 +25,7 @@ STUN_PROVIDER = ["stun"]
 UPNP_PROVIDER = ["upnp"]
 
 DOCKER_CONE_GW_2_IP = "10.0.254.2"
+DOCKER_CONE_GW_3_IP = "10.0.254.7"
 DOCKER_FULLCONE_GW_1_IP = "10.0.254.9"
 DOCKER_FULLCONE_GW_2_IP = "10.0.254.6"
 DOCKER_OPEN_INTERNET_CLIENT_1_IP = "10.0.11.2"
@@ -33,79 +34,287 @@ DOCKER_OPEN_INTERNET_CLIENT_DUAL_STACK_IP = "10.0.11.4"
 DOCKER_SYMMETRIC_GW_1_IP = "10.0.254.3"
 DOCKER_UPNP_CLIENT_2_IP = "10.0.254.12"
 
+# TODO: Simplify parameters - Jira issue: LLT-4111
 
 UHP_conn_client_types = [
-    (
+    pytest.param(
         STUN_PROVIDER,
         ConnectionTag.DOCKER_FULLCONE_CLIENT_1,
         ConnectionTag.DOCKER_FULLCONE_CLIENT_2,
+        AdapterType.BoringTun,
         DOCKER_FULLCONE_GW_2_IP,
     ),
-    (
+    pytest.param(
         STUN_PROVIDER,
         ConnectionTag.DOCKER_SYMMETRIC_CLIENT_1,
-        ConnectionTag.DOCKER_FULLCONE_CLIENT_1,
-        DOCKER_FULLCONE_GW_1_IP,
+        ConnectionTag.DOCKER_FULLCONE_CLIENT_2,
+        AdapterType.BoringTun,
+        DOCKER_FULLCONE_GW_2_IP,
     ),
-    (
+    pytest.param(
         STUN_PROVIDER,
         ConnectionTag.DOCKER_OPEN_INTERNET_CLIENT_1,
-        ConnectionTag.DOCKER_FULLCONE_CLIENT_1,
-        DOCKER_FULLCONE_GW_1_IP,
+        ConnectionTag.DOCKER_FULLCONE_CLIENT_2,
+        AdapterType.BoringTun,
+        DOCKER_FULLCONE_GW_2_IP,
     ),
-    (
+    pytest.param(
         STUN_PROVIDER,
         ConnectionTag.DOCKER_CONE_CLIENT_1,
-        ConnectionTag.DOCKER_FULLCONE_CLIENT_1,
-        DOCKER_FULLCONE_GW_1_IP,
+        ConnectionTag.DOCKER_FULLCONE_CLIENT_2,
+        AdapterType.BoringTun,
+        DOCKER_FULLCONE_GW_2_IP,
     ),
-    (
+    pytest.param(
         STUN_PROVIDER,
         ConnectionTag.DOCKER_CONE_CLIENT_1,
         ConnectionTag.DOCKER_CONE_CLIENT_2,
+        AdapterType.BoringTun,
         DOCKER_CONE_GW_2_IP,
     ),
-    (
+    pytest.param(
         STUN_PROVIDER,
-        ConnectionTag.DOCKER_CONE_CLIENT_1,
         ConnectionTag.DOCKER_OPEN_INTERNET_CLIENT_1,
-        DOCKER_OPEN_INTERNET_CLIENT_1_IP,
+        ConnectionTag.DOCKER_CONE_CLIENT_2,
+        AdapterType.BoringTun,
+        DOCKER_CONE_GW_2_IP,
     ),
-    (
+    pytest.param(
         LOCAL_PROVIDER,
         ConnectionTag.DOCKER_OPEN_INTERNET_CLIENT_1,
         ConnectionTag.DOCKER_OPEN_INTERNET_CLIENT_2,
+        AdapterType.BoringTun,
         DOCKER_OPEN_INTERNET_CLIENT_2_IP,
     ),
-    (
+    pytest.param(
         STUN_PROVIDER,
         ConnectionTag.DOCKER_OPEN_INTERNET_CLIENT_1,
         ConnectionTag.DOCKER_OPEN_INTERNET_CLIENT_2,
+        AdapterType.BoringTun,
         DOCKER_OPEN_INTERNET_CLIENT_2_IP,
     ),
-    (
+    pytest.param(
         STUN_PROVIDER,
         ConnectionTag.DOCKER_SYMMETRIC_CLIENT_1,
         ConnectionTag.DOCKER_OPEN_INTERNET_CLIENT_1,
+        AdapterType.BoringTun,
         DOCKER_OPEN_INTERNET_CLIENT_1_IP,
     ),
-    (
+    pytest.param(
+        STUN_PROVIDER,
+        ConnectionTag.DOCKER_FULLCONE_CLIENT_1,
+        ConnectionTag.DOCKER_FULLCONE_CLIENT_2,
+        AdapterType.LinuxNativeWg,
+        DOCKER_FULLCONE_GW_2_IP,
+        marks=pytest.mark.linux_native,
+    ),
+    pytest.param(
+        STUN_PROVIDER,
+        ConnectionTag.DOCKER_SYMMETRIC_CLIENT_1,
+        ConnectionTag.DOCKER_FULLCONE_CLIENT_2,
+        AdapterType.LinuxNativeWg,
+        DOCKER_FULLCONE_GW_2_IP,
+        marks=pytest.mark.linux_native,
+    ),
+    pytest.param(
+        STUN_PROVIDER,
+        ConnectionTag.DOCKER_OPEN_INTERNET_CLIENT_1,
+        ConnectionTag.DOCKER_FULLCONE_CLIENT_2,
+        AdapterType.LinuxNativeWg,
+        DOCKER_FULLCONE_GW_2_IP,
+        marks=pytest.mark.linux_native,
+    ),
+    pytest.param(
+        STUN_PROVIDER,
+        ConnectionTag.DOCKER_CONE_CLIENT_1,
+        ConnectionTag.DOCKER_FULLCONE_CLIENT_2,
+        AdapterType.LinuxNativeWg,
+        DOCKER_FULLCONE_GW_2_IP,
+        marks=pytest.mark.linux_native,
+    ),
+    pytest.param(
+        STUN_PROVIDER,
+        ConnectionTag.DOCKER_CONE_CLIENT_1,
+        ConnectionTag.DOCKER_CONE_CLIENT_2,
+        AdapterType.LinuxNativeWg,
+        DOCKER_CONE_GW_2_IP,
+        marks=pytest.mark.linux_native,
+    ),
+    pytest.param(
+        STUN_PROVIDER,
+        ConnectionTag.DOCKER_OPEN_INTERNET_CLIENT_1,
+        ConnectionTag.DOCKER_CONE_CLIENT_2,
+        AdapterType.LinuxNativeWg,
+        DOCKER_CONE_GW_2_IP,
+        marks=pytest.mark.linux_native,
+    ),
+    pytest.param(
+        LOCAL_PROVIDER,
+        ConnectionTag.DOCKER_OPEN_INTERNET_CLIENT_1,
+        ConnectionTag.DOCKER_OPEN_INTERNET_CLIENT_2,
+        AdapterType.LinuxNativeWg,
+        DOCKER_OPEN_INTERNET_CLIENT_2_IP,
+        marks=pytest.mark.linux_native,
+    ),
+    pytest.param(
+        STUN_PROVIDER,
+        ConnectionTag.DOCKER_OPEN_INTERNET_CLIENT_1,
+        ConnectionTag.DOCKER_OPEN_INTERNET_CLIENT_2,
+        AdapterType.LinuxNativeWg,
+        DOCKER_OPEN_INTERNET_CLIENT_2_IP,
+        marks=pytest.mark.linux_native,
+    ),
+    pytest.param(
+        STUN_PROVIDER,
+        ConnectionTag.DOCKER_SYMMETRIC_CLIENT_1,
+        ConnectionTag.DOCKER_OPEN_INTERNET_CLIENT_1,
+        AdapterType.LinuxNativeWg,
+        DOCKER_OPEN_INTERNET_CLIENT_1_IP,
+        marks=pytest.mark.linux_native,
+    ),
+    pytest.param(
+        STUN_PROVIDER,
+        ConnectionTag.DOCKER_FULLCONE_CLIENT_2,
+        ConnectionTag.WINDOWS_VM,
+        AdapterType.WindowsNativeWg,
+        DOCKER_CONE_GW_3_IP,
+        marks=[
+            pytest.mark.windows,
+            pytest.mark.skip(reason="missing firewall API call - Jira issue: LLT-4087"),
+        ],
+    ),
+    pytest.param(
+        STUN_PROVIDER,
+        ConnectionTag.DOCKER_OPEN_INTERNET_CLIENT_1,
+        ConnectionTag.WINDOWS_VM,
+        AdapterType.WindowsNativeWg,
+        DOCKER_CONE_GW_3_IP,
+        marks=[
+            pytest.mark.windows,
+            pytest.mark.skip(reason="missing firewall API call - Jira issue: LLT-4087"),
+        ],
+    ),
+    pytest.param(
+        STUN_PROVIDER,
+        ConnectionTag.DOCKER_CONE_CLIENT_1,
+        ConnectionTag.WINDOWS_VM,
+        AdapterType.WindowsNativeWg,
+        DOCKER_CONE_GW_3_IP,
+        marks=[
+            pytest.mark.windows,
+            pytest.mark.skip(reason="missing firewall API call - Jira issue: LLT-4087"),
+        ],
+    ),
+    pytest.param(
+        STUN_PROVIDER,
+        ConnectionTag.DOCKER_FULLCONE_CLIENT_2,
+        ConnectionTag.WINDOWS_VM,
+        AdapterType.WireguardGo,
+        DOCKER_CONE_GW_3_IP,
+        marks=[
+            pytest.mark.windows,
+            pytest.mark.skip(reason="missing firewall API call - Jira issue: LLT-4087"),
+        ],
+    ),
+    pytest.param(
+        STUN_PROVIDER,
+        ConnectionTag.DOCKER_OPEN_INTERNET_CLIENT_1,
+        ConnectionTag.WINDOWS_VM,
+        AdapterType.WireguardGo,
+        DOCKER_CONE_GW_3_IP,
+        marks=[
+            pytest.mark.windows,
+            pytest.mark.skip(reason="missing firewall API call - Jira issue: LLT-4087"),
+        ],
+    ),
+    pytest.param(
+        STUN_PROVIDER,
+        ConnectionTag.DOCKER_CONE_CLIENT_1,
+        ConnectionTag.WINDOWS_VM,
+        AdapterType.WireguardGo,
+        DOCKER_CONE_GW_3_IP,
+        marks=[
+            pytest.mark.windows,
+            pytest.mark.skip(reason="missing firewall API call - Jira issue: LLT-4087"),
+        ],
+    ),
+    pytest.param(
+        STUN_PROVIDER,
+        ConnectionTag.DOCKER_FULLCONE_CLIENT_2,
+        ConnectionTag.MAC_VM,
+        AdapterType.BoringTun,
+        DOCKER_CONE_GW_3_IP,
+        marks=[
+            pytest.mark.mac,
+            pytest.mark.skip(reason="missing firewall API call - Jira issue: LLT-4087"),
+        ],
+    ),
+    pytest.param(
+        STUN_PROVIDER,
+        ConnectionTag.DOCKER_OPEN_INTERNET_CLIENT_1,
+        ConnectionTag.MAC_VM,
+        AdapterType.BoringTun,
+        DOCKER_CONE_GW_3_IP,
+        marks=[
+            pytest.mark.mac,
+            pytest.mark.skip(reason="missing firewall API call - Jira issue: LLT-4087"),
+        ],
+    ),
+    pytest.param(
+        STUN_PROVIDER,
+        ConnectionTag.DOCKER_CONE_CLIENT_1,
+        ConnectionTag.MAC_VM,
+        AdapterType.BoringTun,
+        DOCKER_CONE_GW_3_IP,
+        marks=[
+            pytest.mark.mac,
+            pytest.mark.skip(reason="missing firewall API call - Jira issue: LLT-4087"),
+        ],
+    ),
+    pytest.param(
         UPNP_PROVIDER,
         ConnectionTag.DOCKER_UPNP_CLIENT_1,
         ConnectionTag.DOCKER_UPNP_CLIENT_2,
+        AdapterType.BoringTun,
         DOCKER_UPNP_CLIENT_2_IP,
     ),
-    (
+    pytest.param(
+        UPNP_PROVIDER,
+        ConnectionTag.DOCKER_UPNP_CLIENT_1,
+        ConnectionTag.DOCKER_UPNP_CLIENT_2,
+        AdapterType.LinuxNativeWg,
+        DOCKER_UPNP_CLIENT_2_IP,
+        marks=pytest.mark.linux_native,
+    ),
+    pytest.param(
         STUN_PROVIDER,
         ConnectionTag.DOCKER_OPEN_INTERNET_CLIENT_DUAL_STACK,
         ConnectionTag.DOCKER_OPEN_INTERNET_CLIENT_2,
+        AdapterType.BoringTun,
         DOCKER_OPEN_INTERNET_CLIENT_2_IP,
     ),
-    (
+    pytest.param(
         LOCAL_PROVIDER,
         ConnectionTag.DOCKER_OPEN_INTERNET_CLIENT_1,
         ConnectionTag.DOCKER_OPEN_INTERNET_CLIENT_DUAL_STACK,
+        AdapterType.BoringTun,
         DOCKER_OPEN_INTERNET_CLIENT_DUAL_STACK_IP,
+    ),
+    pytest.param(
+        STUN_PROVIDER,
+        ConnectionTag.DOCKER_OPEN_INTERNET_CLIENT_DUAL_STACK,
+        ConnectionTag.DOCKER_OPEN_INTERNET_CLIENT_2,
+        AdapterType.LinuxNativeWg,
+        DOCKER_OPEN_INTERNET_CLIENT_2_IP,
+        marks=pytest.mark.linux_native,
+    ),
+    pytest.param(
+        LOCAL_PROVIDER,
+        ConnectionTag.DOCKER_OPEN_INTERNET_CLIENT_1,
+        ConnectionTag.DOCKER_OPEN_INTERNET_CLIENT_DUAL_STACK,
+        AdapterType.LinuxNativeWg,
+        DOCKER_OPEN_INTERNET_CLIENT_DUAL_STACK_IP,
+        marks=pytest.mark.linux_native,
     ),
 ]
 
@@ -132,6 +341,7 @@ async def new_connections_with_mesh_clients(
     client1_type: ConnectionTag,
     endpoint_providers_1: List[str],
     client2_type: ConnectionTag,
+    client2_adapter_type: AdapterType,
     endpoint_providers_2: List[str],
     client3_type: Optional[ConnectionTag] = None,
     endpoint_providers_3: Optional[List[str]] = None,
@@ -198,7 +408,7 @@ async def new_connections_with_mesh_clients(
         telio.Client(
             beta_conn,
             beta,
-            AdapterType.BoringTun,
+            client2_adapter_type,
             telio_features=TelioFeatures(direct=Direct(providers=endpoint_providers_2)),
         ).run_meshnet(
             api.get_meshmap(beta.id),
@@ -258,13 +468,17 @@ async def new_connections_with_mesh_clients(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "endpoint_providers, client1_type, client2_type, _reflexive_ip",
+    (
+        "endpoint_providers, client1_type, client2_type, client2_adapter_type,"
+        " _reflexive_ip"
+    ),
     UHP_conn_client_types,
 )
 async def test_direct_working_paths(
     endpoint_providers,
     client1_type,
     client2_type,
+    client2_adapter_type,
     _reflexive_ip,
 ) -> None:
     async with AsyncExitStack() as exit_stack:
@@ -274,6 +488,7 @@ async def test_direct_working_paths(
                 client1_type,
                 endpoint_providers,
                 client2_type,
+                client2_adapter_type,
                 endpoint_providers,
             )
         )
@@ -319,59 +534,305 @@ async def test_direct_working_paths(
 @pytest.mark.long
 @pytest.mark.timeout(120)
 @pytest.mark.parametrize(
-    "endpoint_providers, client1_type, client2_type",
+    "endpoint_providers, client1_type, client2_type, client2_adapter_type",
     [
-        (
-            ANY_PROVIDERS,
-            ConnectionTag.DOCKER_CONE_CLIENT_1,
-            ConnectionTag.DOCKER_SYMMETRIC_CLIENT_1,
-        ),
-        (
+        pytest.param(
             ANY_PROVIDERS,
             ConnectionTag.DOCKER_CONE_CLIENT_1,
             ConnectionTag.DOCKER_UDP_BLOCK_CLIENT_1,
+            AdapterType.BoringTun,
         ),
-        (
+        pytest.param(
             ANY_PROVIDERS,
             ConnectionTag.DOCKER_SYMMETRIC_CLIENT_1,
             ConnectionTag.DOCKER_SYMMETRIC_CLIENT_2,
+            AdapterType.BoringTun,
         ),
-        (
+        pytest.param(
             ANY_PROVIDERS,
             ConnectionTag.DOCKER_SYMMETRIC_CLIENT_1,
             ConnectionTag.DOCKER_UDP_BLOCK_CLIENT_1,
+            AdapterType.BoringTun,
         ),
-        (
+        pytest.param(
             ANY_PROVIDERS,
             ConnectionTag.DOCKER_OPEN_INTERNET_CLIENT_1,
             ConnectionTag.DOCKER_UDP_BLOCK_CLIENT_1,
+            AdapterType.BoringTun,
         ),
-        (
+        pytest.param(
+            ANY_PROVIDERS,
+            ConnectionTag.DOCKER_UDP_BLOCK_CLIENT_2,
+            ConnectionTag.DOCKER_UDP_BLOCK_CLIENT_1,
+            AdapterType.BoringTun,
+        ),
+        pytest.param(
+            ANY_PROVIDERS,
+            ConnectionTag.DOCKER_CONE_CLIENT_1,
+            ConnectionTag.DOCKER_SYMMETRIC_CLIENT_1,
+            AdapterType.LinuxNativeWg,
+            marks=pytest.mark.linux_native,
+        ),
+        pytest.param(
+            ANY_PROVIDERS,
+            ConnectionTag.DOCKER_CONE_CLIENT_1,
+            ConnectionTag.DOCKER_UDP_BLOCK_CLIENT_1,
+            AdapterType.LinuxNativeWg,
+            marks=pytest.mark.linux_native,
+        ),
+        pytest.param(
+            ANY_PROVIDERS,
+            ConnectionTag.DOCKER_SYMMETRIC_CLIENT_1,
+            ConnectionTag.DOCKER_SYMMETRIC_CLIENT_2,
+            AdapterType.LinuxNativeWg,
+            marks=pytest.mark.linux_native,
+        ),
+        pytest.param(
+            ANY_PROVIDERS,
+            ConnectionTag.DOCKER_SYMMETRIC_CLIENT_1,
+            ConnectionTag.DOCKER_UDP_BLOCK_CLIENT_1,
+            AdapterType.LinuxNativeWg,
+            marks=pytest.mark.linux_native,
+        ),
+        pytest.param(
+            ANY_PROVIDERS,
+            ConnectionTag.DOCKER_OPEN_INTERNET_CLIENT_1,
+            ConnectionTag.DOCKER_UDP_BLOCK_CLIENT_1,
+            AdapterType.LinuxNativeWg,
+            marks=pytest.mark.linux_native,
+        ),
+        pytest.param(
+            ANY_PROVIDERS,
+            ConnectionTag.DOCKER_UDP_BLOCK_CLIENT_2,
+            ConnectionTag.DOCKER_UDP_BLOCK_CLIENT_1,
+            AdapterType.LinuxNativeWg,
+            marks=pytest.mark.linux_native,
+        ),
+        pytest.param(
+            ANY_PROVIDERS,
+            ConnectionTag.DOCKER_SYMMETRIC_CLIENT_1,
+            ConnectionTag.WINDOWS_VM,
+            AdapterType.WireguardGo,
+            marks=[
+                pytest.mark.windows,
+                pytest.mark.skip(
+                    reason="missing firewall API call - Jira issue: LLT-4087"
+                ),
+            ],
+        ),
+        pytest.param(
             ANY_PROVIDERS,
             ConnectionTag.DOCKER_UDP_BLOCK_CLIENT_1,
-            ConnectionTag.DOCKER_UDP_BLOCK_CLIENT_2,
+            ConnectionTag.WINDOWS_VM,
+            AdapterType.WireguardGo,
+            marks=[
+                pytest.mark.windows,
+                pytest.mark.skip(
+                    reason="missing firewall API call - Jira issue: LLT-4087"
+                ),
+            ],
         ),
-        (
+        pytest.param(
+            ANY_PROVIDERS,
+            ConnectionTag.DOCKER_SYMMETRIC_CLIENT_1,
+            ConnectionTag.WINDOWS_VM,
+            AdapterType.WindowsNativeWg,
+            marks=[
+                pytest.mark.windows,
+                pytest.mark.skip(
+                    reason="missing firewall API call - Jira issue: LLT-4087"
+                ),
+            ],
+        ),
+        pytest.param(
+            ANY_PROVIDERS,
+            ConnectionTag.DOCKER_UDP_BLOCK_CLIENT_1,
+            ConnectionTag.WINDOWS_VM,
+            AdapterType.WindowsNativeWg,
+            marks=[
+                pytest.mark.windows,
+                pytest.mark.skip(
+                    reason="missing firewall API call - Jira issue: LLT-4087"
+                ),
+            ],
+        ),
+        pytest.param(
+            ANY_PROVIDERS,
+            ConnectionTag.DOCKER_SYMMETRIC_CLIENT_1,
+            ConnectionTag.MAC_VM,
+            AdapterType.BoringTun,
+            marks=[
+                pytest.mark.mac,
+                pytest.mark.skip(
+                    reason="missing firewall API call - Jira issue: LLT-4087"
+                ),
+            ],
+        ),
+        pytest.param(
+            ANY_PROVIDERS,
+            ConnectionTag.DOCKER_UDP_BLOCK_CLIENT_1,
+            ConnectionTag.MAC_VM,
+            AdapterType.BoringTun,
+            marks=[
+                pytest.mark.mac,
+                pytest.mark.skip(
+                    reason="missing firewall API call - Jira issue: LLT-4087"
+                ),
+            ],
+        ),
+        pytest.param(
             LOCAL_PROVIDER,
             ConnectionTag.DOCKER_OPEN_INTERNET_CLIENT_1,
-            ConnectionTag.DOCKER_FULLCONE_CLIENT_1,
+            ConnectionTag.DOCKER_SYMMETRIC_CLIENT_1,
+            AdapterType.BoringTun,
         ),
-        (
+        pytest.param(
+            LOCAL_PROVIDER,
+            ConnectionTag.DOCKER_FULLCONE_CLIENT_1,
+            ConnectionTag.DOCKER_SYMMETRIC_CLIENT_1,
+            AdapterType.BoringTun,
+        ),
+        pytest.param(
             LOCAL_PROVIDER,
             ConnectionTag.DOCKER_CONE_CLIENT_1,
-            ConnectionTag.DOCKER_OPEN_INTERNET_CLIENT_1,
+            ConnectionTag.DOCKER_SYMMETRIC_CLIENT_1,
+            AdapterType.BoringTun,
         ),
-        (
+        pytest.param(
+            LOCAL_PROVIDER,
+            ConnectionTag.DOCKER_OPEN_INTERNET_CLIENT_1,
+            ConnectionTag.DOCKER_SYMMETRIC_CLIENT_1,
+            AdapterType.LinuxNativeWg,
+            marks=pytest.mark.linux_native,
+        ),
+        pytest.param(
+            LOCAL_PROVIDER,
+            ConnectionTag.DOCKER_FULLCONE_CLIENT_1,
+            ConnectionTag.DOCKER_SYMMETRIC_CLIENT_1,
+            AdapterType.LinuxNativeWg,
+            marks=pytest.mark.linux_native,
+        ),
+        pytest.param(
+            LOCAL_PROVIDER,
+            ConnectionTag.DOCKER_CONE_CLIENT_1,
+            ConnectionTag.DOCKER_SYMMETRIC_CLIENT_1,
+            AdapterType.LinuxNativeWg,
+            marks=pytest.mark.linux_native,
+        ),
+        pytest.param(
+            LOCAL_PROVIDER,
+            ConnectionTag.DOCKER_FULLCONE_CLIENT_1,
+            ConnectionTag.WINDOWS_VM,
+            AdapterType.WireguardGo,
+            marks=[
+                pytest.mark.windows,
+                pytest.mark.skip(
+                    reason="missing firewall API call - Jira issue: LLT-4087"
+                ),
+            ],
+        ),
+        pytest.param(
+            LOCAL_PROVIDER,
+            ConnectionTag.DOCKER_OPEN_INTERNET_CLIENT_1,
+            ConnectionTag.WINDOWS_VM,
+            AdapterType.WireguardGo,
+            marks=[
+                pytest.mark.windows,
+                pytest.mark.skip(
+                    reason="missing firewall API call - Jira issue: LLT-4087"
+                ),
+            ],
+        ),
+        pytest.param(
             LOCAL_PROVIDER,
             ConnectionTag.DOCKER_SYMMETRIC_CLIENT_1,
+            ConnectionTag.WINDOWS_VM,
+            AdapterType.WireguardGo,
+            marks=[
+                pytest.mark.windows,
+                pytest.mark.skip(
+                    reason="missing firewall API call - Jira issue: LLT-4087"
+                ),
+            ],
+        ),
+        pytest.param(
+            LOCAL_PROVIDER,
+            ConnectionTag.DOCKER_FULLCONE_CLIENT_1,
+            ConnectionTag.WINDOWS_VM,
+            AdapterType.WindowsNativeWg,
+            marks=[
+                pytest.mark.windows,
+                pytest.mark.skip(
+                    reason="missing firewall API call - Jira issue: LLT-4087"
+                ),
+            ],
+        ),
+        pytest.param(
+            LOCAL_PROVIDER,
             ConnectionTag.DOCKER_OPEN_INTERNET_CLIENT_1,
+            ConnectionTag.WINDOWS_VM,
+            AdapterType.WindowsNativeWg,
+            marks=[
+                pytest.mark.windows,
+                pytest.mark.skip(
+                    reason="missing firewall API call - Jira issue: LLT-4087"
+                ),
+            ],
+        ),
+        pytest.param(
+            LOCAL_PROVIDER,
+            ConnectionTag.DOCKER_SYMMETRIC_CLIENT_1,
+            ConnectionTag.WINDOWS_VM,
+            AdapterType.WindowsNativeWg,
+            marks=[
+                pytest.mark.windows,
+                pytest.mark.skip(
+                    reason="missing firewall API call - Jira issue: LLT-4087"
+                ),
+            ],
+        ),
+        pytest.param(
+            LOCAL_PROVIDER,
+            ConnectionTag.DOCKER_FULLCONE_CLIENT_1,
+            ConnectionTag.MAC_VM,
+            AdapterType.BoringTun,
+            marks=[
+                pytest.mark.mac,
+                pytest.mark.skip(
+                    reason="missing firewall API call - Jira issue: LLT-4087"
+                ),
+            ],
+        ),
+        pytest.param(
+            LOCAL_PROVIDER,
+            ConnectionTag.DOCKER_OPEN_INTERNET_CLIENT_1,
+            ConnectionTag.MAC_VM,
+            AdapterType.BoringTun,
+            marks=[
+                pytest.mark.mac,
+                pytest.mark.skip(
+                    reason="missing firewall API call - Jira issue: LLT-4087"
+                ),
+            ],
+        ),
+        pytest.param(
+            LOCAL_PROVIDER,
+            ConnectionTag.DOCKER_SYMMETRIC_CLIENT_1,
+            ConnectionTag.MAC_VM,
+            AdapterType.BoringTun,
+            marks=[
+                pytest.mark.mac,
+                pytest.mark.skip(
+                    reason="missing firewall API call - Jira issue: LLT-4087"
+                ),
+            ],
         ),
     ],
 )
 # Not sure this is needed. It will only be helpful to catch if any
 # libtelio change would make any of these setup work.
 async def test_direct_failing_paths(
-    endpoint_providers, client1_type, client2_type
+    endpoint_providers, client1_type, client2_type, client2_adapter_type
 ) -> None:
     async with AsyncExitStack() as exit_stack:
         (alpha, beta, _) = await exit_stack.enter_async_context(
@@ -380,21 +841,30 @@ async def test_direct_failing_paths(
                 client1_type,
                 endpoint_providers,
                 client2_type,
+                client2_adapter_type,
                 endpoint_providers,
             )
         )
 
         await testing.wait_lengthy(
             asyncio.gather(
-                alpha.client.wait_for_state_on_any_derp([telio.State.Connected]),
-                beta.client.wait_for_state_on_any_derp([telio.State.Connected]),
+                alpha.client.wait_for_state_on_any_derp([State.Connected]),
+                beta.client.wait_for_state_on_any_derp([State.Connected]),
             )
         )
 
-        await testing.wait_long(
+        await testing.wait_lengthy(
             asyncio.gather(
-                alpha.client.wait_for_state_on_any_derp([State.Connected]),
-                beta.client.wait_for_state_on_any_derp([State.Connected]),
+                alpha.client.wait_for_state_peer(
+                    beta.node.public_key,
+                    [State.Connected],
+                    [PathType.Relay],
+                ),
+                beta.client.wait_for_state_peer(
+                    alpha.node.public_key,
+                    [State.Connected],
+                    [PathType.Relay],
+                ),
             )
         )
 
@@ -425,8 +895,8 @@ async def test_direct_failing_paths(
 
         await testing.wait_lengthy(
             asyncio.gather(
-                alpha.client.wait_for_state_on_any_derp([State.Connecting]),
-                beta.client.wait_for_state_on_any_derp([State.Connecting]),
+                alpha.client.wait_for_every_derp_disconnection(),
+                beta.client.wait_for_every_derp_disconnection(),
             )
         )
 
@@ -441,13 +911,17 @@ async def test_direct_failing_paths(
 @pytest.mark.asyncio
 @pytest.mark.xfail(reason="test flaky - JIRA issue: LLT-4132")
 @pytest.mark.parametrize(
-    "endpoint_providers, client1_type, client2_type, reflexive_ip",
+    (
+        "endpoint_providers, client1_type, client2_type, client2_adapter_type,"
+        " reflexive_ip"
+    ),
     UHP_conn_client_types,
 )
 async def test_direct_short_connection_loss(
     endpoint_providers,
     client1_type,
     client2_type,
+    client2_adapter_type,
     reflexive_ip,
 ) -> None:
     async with AsyncExitStack() as exit_stack:
@@ -457,6 +931,7 @@ async def test_direct_short_connection_loss(
                 client1_type,
                 endpoint_providers,
                 client2_type,
+                client2_adapter_type,
                 endpoint_providers,
             )
         )
@@ -466,11 +941,6 @@ async def test_direct_short_connection_loss(
             asyncio.gather(
                 alpha.client.wait_for_state_on_any_derp([State.Connected]),
                 beta.client.wait_for_state_on_any_derp([State.Connected]),
-            )
-        )
-
-        await testing.wait_lengthy(
-            asyncio.gather(
                 alpha.conn_track.wait_for_event("derp_1"),
                 beta.conn_track.wait_for_event("derp_1"),
             )
@@ -515,14 +985,14 @@ async def test_direct_short_connection_loss(
 @pytest.mark.asyncio
 @pytest.mark.long
 @pytest.mark.parametrize(
-    "endpoint_providers, client1_type, client2_type, reflexive_ip",
+    (
+        "endpoint_providers, client1_type, client2_type, client2_adapter_type,"
+        " reflexive_ip"
+    ),
     UHP_conn_client_types,
 )
 async def test_direct_connection_loss_for_infinity(
-    endpoint_providers,
-    client1_type,
-    client2_type,
-    reflexive_ip,
+    endpoint_providers, client1_type, client2_type, client2_adapter_type, reflexive_ip
 ) -> None:
     async with AsyncExitStack() as exit_stack:
         (alpha, beta, _) = await exit_stack.enter_async_context(
@@ -531,6 +1001,7 @@ async def test_direct_connection_loss_for_infinity(
                 client1_type,
                 endpoint_providers,
                 client2_type,
+                client2_adapter_type,
                 endpoint_providers,
             )
         )
@@ -538,13 +1009,8 @@ async def test_direct_connection_loss_for_infinity(
 
         await testing.wait_lengthy(
             asyncio.gather(
-                alpha.client.wait_for_state_on_any_derp([telio.State.Connected]),
-                beta.client.wait_for_state_on_any_derp([telio.State.Connected]),
-            )
-        )
-
-        await testing.wait_lengthy(
-            asyncio.gather(
+                alpha.client.wait_for_state_on_any_derp([State.Connected]),
+                beta.client.wait_for_state_on_any_derp([State.Connected]),
                 alpha.conn_track.wait_for_event("derp_1"),
                 beta.conn_track.wait_for_event("derp_1"),
             )
@@ -597,50 +1063,90 @@ async def test_direct_connection_loss_for_infinity(
 @pytest.mark.asyncio
 @pytest.mark.xfail(reason="test is flaky - LLT-4115")
 @pytest.mark.parametrize(
-    "alpha_connection_tag, beta_connection_tag, ep1, ep2",
+    "client1_type, ep1",
     [
         pytest.param(
             ConnectionTag.DOCKER_CONE_CLIENT_1,
-            ConnectionTag.DOCKER_CONE_CLIENT_2,
-            "stun",
             "stun",
         ),
         pytest.param(
             ConnectionTag.DOCKER_UPNP_CLIENT_1,
+            "upnp",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "client2_type, client2_adapter_type, ep2",
+    [
+        pytest.param(
+            ConnectionTag.DOCKER_CONE_CLIENT_2,
+            AdapterType.LinuxNativeWg,
+            "stun",
+            marks=pytest.mark.linux_native,
+        ),
+        pytest.param(
+            ConnectionTag.DOCKER_OPEN_INTERNET_CLIENT_1,
+            AdapterType.BoringTun,
+            "local",
+            marks=pytest.mark.xfail(reason="test is flaky - LLT-4115"),
+        ),
+        pytest.param(
+            ConnectionTag.WINDOWS_VM,
+            AdapterType.WindowsNativeWg,
+            "stun",
+            marks=[
+                pytest.mark.windows,
+                pytest.mark.skip(
+                    reason="missing firewall API call - Jira issue: LLT-4087"
+                ),
+            ],
+        ),
+        pytest.param(
+            ConnectionTag.WINDOWS_VM,
+            AdapterType.WireguardGo,
+            "stun",
+            marks=[
+                pytest.mark.windows,
+                pytest.mark.skip(
+                    reason="missing firewall API call - Jira issue: LLT-4087"
+                ),
+            ],
+        ),
+        pytest.param(
+            ConnectionTag.MAC_VM,
+            AdapterType.BoringTun,
+            "stun",
+            marks=[
+                pytest.mark.mac,
+                pytest.mark.skip(
+                    reason="missing firewall API call - Jira issue: LLT-4087"
+                ),
+            ],
+        ),
+        pytest.param(
             ConnectionTag.DOCKER_UPNP_CLIENT_2,
+            AdapterType.LinuxNativeWg,
             "upnp",
-            "upnp",
-        ),
-        pytest.param(
-            ConnectionTag.DOCKER_UPNP_CLIENT_1,
-            ConnectionTag.DOCKER_CONE_CLIENT_2,
-            "upnp",
-            "stun",
-        ),
-        pytest.param(
-            ConnectionTag.DOCKER_UPNP_CLIENT_1,
-            ConnectionTag.DOCKER_OPEN_INTERNET_CLIENT_1,
-            "upnp",
-            "local",
-        ),
-        pytest.param(
-            ConnectionTag.DOCKER_CONE_CLIENT_1,
-            ConnectionTag.DOCKER_OPEN_INTERNET_CLIENT_1,
-            "stun",
-            "local",
+            marks=pytest.mark.linux_native,
         ),
     ],
 )
 async def test_direct_connection_endpoint_gone(
-    alpha_connection_tag: ConnectionTag,
-    beta_connection_tag: ConnectionTag,
+    client1_type: ConnectionTag,
+    client2_type: ConnectionTag,
+    client2_adapter_type: AdapterType,
     ep1: str,
     ep2: str,
 ) -> None:
     async with AsyncExitStack() as exit_stack:
         (alpha, beta, _) = await exit_stack.enter_async_context(
             new_connections_with_mesh_clients(
-                exit_stack, alpha_connection_tag, [ep1], beta_connection_tag, [ep2]
+                exit_stack,
+                client1_type,
+                [ep1],
+                client2_type,
+                client2_adapter_type,
+                [ep2],
             )
         )
         assert alpha.conn_gw and beta.conn_gw
@@ -661,12 +1167,8 @@ async def test_direct_connection_endpoint_gone(
 
                 await testing.wait_lengthy(
                     asyncio.gather(
-                        alpha.client.wait_for_state_on_any_derp(
-                            [State.Connecting, State.Disconnected],
-                        ),
-                        beta.client.wait_for_state_on_any_derp(
-                            [State.Connecting, State.Disconnected],
-                        ),
+                        alpha.client.wait_for_every_derp_disconnection(),
+                        beta.client.wait_for_every_derp_disconnection(),
                     ),
                 )
 
@@ -677,11 +1179,6 @@ async def test_direct_connection_endpoint_gone(
             asyncio.gather(
                 alpha.client.wait_for_state_on_any_derp([State.Connected]),
                 beta.client.wait_for_state_on_any_derp([State.Connected]),
-            ),
-        )
-
-        await testing.wait_long(
-            asyncio.gather(
                 alpha.conn_track.wait_for_event("derp_1"),
                 beta.conn_track.wait_for_event("derp_1"),
             )
@@ -731,10 +1228,10 @@ async def test_direct_connection_endpoint_gone(
             await testing.wait_lengthy(
                 asyncio.gather(
                     alpha.client.wait_for_state_peer(
-                        beta.node.public_key, [State.Connected]
+                        beta.node.public_key, [State.Connected], [PathType.Relay]
                     ),
                     beta.client.wait_for_state_peer(
-                        alpha.node.public_key, [State.Connected]
+                        alpha.node.public_key, [State.Connected], [PathType.Relay]
                     ),
                 ),
             )

--- a/nat-lab/tests/test_dns.py
+++ b/nat-lab/tests/test_dns.py
@@ -20,7 +20,52 @@ DNS_SERVER_ADDRESS = config.LIBTELIO_DNS_IP
 
 
 @pytest.mark.asyncio
-async def test_dns() -> None:
+@pytest.mark.parametrize(
+    "alpha_connection_tag,adapter_type",
+    [
+        pytest.param(
+            ConnectionTag.DOCKER_CONE_CLIENT_1,
+            AdapterType.BoringTun,
+        ),
+        pytest.param(
+            ConnectionTag.DOCKER_CONE_CLIENT_1,
+            AdapterType.LinuxNativeWg,
+            marks=pytest.mark.linux_native,
+        ),
+        pytest.param(
+            ConnectionTag.WINDOWS_VM,
+            AdapterType.WindowsNativeWg,
+            marks=[
+                pytest.mark.windows,
+                pytest.mark.skip(
+                    reason="missing magicdns support - Jira issue: LLT-4085"
+                ),
+            ],
+        ),
+        pytest.param(
+            ConnectionTag.WINDOWS_VM,
+            AdapterType.WireguardGo,
+            marks=[
+                pytest.mark.windows,
+                pytest.mark.skip(
+                    reason="missing magicdns support - Jira issue: LLT-4085"
+                ),
+            ],
+        ),
+        pytest.param(
+            ConnectionTag.MAC_VM,
+            AdapterType.BoringTun,
+            marks=[
+                pytest.mark.mac,
+                pytest.mark.xfail(reason="unknown why it fails - Jira issue: LLT-4085"),
+            ],
+        ),
+    ],
+)
+async def test_dns(
+    alpha_connection_tag: ConnectionTag,
+    adapter_type: AdapterType,
+) -> None:
     async with AsyncExitStack() as exit_stack:
         api = API()
 
@@ -31,9 +76,9 @@ async def test_dns() -> None:
 
         (connection_alpha, alpha_conn_tracker) = await exit_stack.enter_async_context(
             new_connection_with_conn_tracker(
-                ConnectionTag.DOCKER_CONE_CLIENT_1,
+                alpha_connection_tag,
                 generate_connection_tracker_config(
-                    ConnectionTag.DOCKER_CONE_CLIENT_1,
+                    alpha_connection_tag,
                     derp_1_limits=ConnectionLimits(1, 1),
                 ),
             )
@@ -49,7 +94,13 @@ async def test_dns() -> None:
         )
 
         client_alpha = await exit_stack.enter_async_context(
-            telio.Client(connection_alpha, alpha).run_meshnet(api.get_meshmap(alpha.id))
+            telio.Client(
+                connection_alpha,
+                alpha,
+                adapter_type,
+            ).run_meshnet(
+                api.get_meshmap(alpha.id),
+            )
         )
 
         client_beta = await exit_stack.enter_async_context(
@@ -143,7 +194,52 @@ async def test_dns() -> None:
 
 
 @pytest.mark.asyncio
-async def test_dns_port() -> None:
+@pytest.mark.parametrize(
+    "alpha_connection_tag,adapter_type",
+    [
+        pytest.param(
+            ConnectionTag.DOCKER_CONE_CLIENT_1,
+            AdapterType.BoringTun,
+        ),
+        pytest.param(
+            ConnectionTag.DOCKER_CONE_CLIENT_1,
+            AdapterType.LinuxNativeWg,
+            marks=pytest.mark.linux_native,
+        ),
+        pytest.param(
+            ConnectionTag.WINDOWS_VM,
+            AdapterType.WindowsNativeWg,
+            marks=[
+                pytest.mark.windows,
+                pytest.mark.skip(
+                    reason="missing magicdns support - Jira issue: LLT-4085"
+                ),
+            ],
+        ),
+        pytest.param(
+            ConnectionTag.WINDOWS_VM,
+            AdapterType.WireguardGo,
+            marks=[
+                pytest.mark.windows,
+                pytest.mark.skip(
+                    reason="missing magicdns support - Jira issue: LLT-4085"
+                ),
+            ],
+        ),
+        pytest.param(
+            ConnectionTag.MAC_VM,
+            AdapterType.BoringTun,
+            marks=[
+                pytest.mark.mac,
+                pytest.mark.xfail(reason="unknown why it fails - Jira issue: LLT-4085"),
+            ],
+        ),
+    ],
+)
+async def test_dns_port(
+    alpha_connection_tag: ConnectionTag,
+    adapter_type: AdapterType,
+) -> None:
     async with AsyncExitStack() as exit_stack:
         api = API()
 
@@ -154,9 +250,9 @@ async def test_dns_port() -> None:
 
         (connection_alpha, alpha_conn_tracker) = await exit_stack.enter_async_context(
             new_connection_with_conn_tracker(
-                ConnectionTag.DOCKER_CONE_CLIENT_1,
+                alpha_connection_tag,
                 generate_connection_tracker_config(
-                    ConnectionTag.DOCKER_CONE_CLIENT_1,
+                    alpha_connection_tag,
                     derp_1_limits=ConnectionLimits(1, 1),
                 ),
             )
@@ -172,7 +268,13 @@ async def test_dns_port() -> None:
         )
 
         client_alpha = await exit_stack.enter_async_context(
-            telio.Client(connection_alpha, alpha).run_meshnet(api.get_meshmap(alpha.id))
+            telio.Client(
+                connection_alpha,
+                alpha,
+                adapter_type,
+            ).run_meshnet(
+                api.get_meshmap(alpha.id),
+            )
         )
 
         client_beta = await exit_stack.enter_async_context(
@@ -264,23 +366,68 @@ async def test_dns_port() -> None:
 
 
 @pytest.mark.asyncio
-async def test_vpn_dns() -> None:
+@pytest.mark.parametrize(
+    "alpha_connection_tag,adapter_type",
+    [
+        pytest.param(
+            ConnectionTag.DOCKER_CONE_CLIENT_1,
+            AdapterType.BoringTun,
+        ),
+        pytest.param(
+            ConnectionTag.DOCKER_CONE_CLIENT_1,
+            AdapterType.LinuxNativeWg,
+            marks=pytest.mark.linux_native,
+        ),
+        pytest.param(
+            ConnectionTag.WINDOWS_VM,
+            AdapterType.WindowsNativeWg,
+            marks=[
+                pytest.mark.windows,
+                pytest.mark.skip(
+                    reason="missing magicdns support - Jira issue: LLT-4085"
+                ),
+            ],
+        ),
+        pytest.param(
+            ConnectionTag.WINDOWS_VM,
+            AdapterType.WireguardGo,
+            marks=[
+                pytest.mark.windows,
+                pytest.mark.skip(
+                    reason="missing magicdns support - Jira issue: LLT-4085"
+                ),
+            ],
+        ),
+        pytest.param(
+            ConnectionTag.MAC_VM,
+            AdapterType.BoringTun,
+            marks=[
+                pytest.mark.mac,
+                pytest.mark.xfail(reason="unknown why it fails - Jira issue: LLT-4085"),
+            ],
+        ),
+    ],
+)
+async def test_vpn_dns(
+    alpha_connection_tag: ConnectionTag,
+    adapter_type: AdapterType,
+) -> None:
     async with AsyncExitStack() as exit_stack:
         api = API()
         alpha = api.default_config_one_node()
 
         (connection, conn_tracker) = await exit_stack.enter_async_context(
             new_connection_with_conn_tracker(
-                ConnectionTag.DOCKER_CONE_CLIENT_1,
+                alpha_connection_tag,
                 generate_connection_tracker_config(
-                    ConnectionTag.DOCKER_CONE_CLIENT_1,
+                    alpha_connection_tag,
                     vpn_1_limits=ConnectionLimits(1, 1),
                 ),
             )
         )
 
         client_alpha = await exit_stack.enter_async_context(
-            telio.Client(connection, alpha).run()
+            telio.Client(connection, alpha, adapter_type).run()
         )
 
         wg_server = config.WG_SERVER
@@ -342,7 +489,52 @@ async def test_vpn_dns() -> None:
 
 
 @pytest.mark.asyncio
-async def test_dns_after_mesh_off() -> None:
+@pytest.mark.parametrize(
+    "alpha_connection_tag,adapter_type",
+    [
+        pytest.param(
+            ConnectionTag.DOCKER_CONE_CLIENT_1,
+            AdapterType.BoringTun,
+        ),
+        pytest.param(
+            ConnectionTag.DOCKER_CONE_CLIENT_1,
+            AdapterType.LinuxNativeWg,
+            marks=pytest.mark.linux_native,
+        ),
+        pytest.param(
+            ConnectionTag.WINDOWS_VM,
+            AdapterType.WindowsNativeWg,
+            marks=[
+                pytest.mark.windows,
+                pytest.mark.skip(
+                    reason="missing magicdns support - Jira issue: LLT-4085"
+                ),
+            ],
+        ),
+        pytest.param(
+            ConnectionTag.WINDOWS_VM,
+            AdapterType.WireguardGo,
+            marks=[
+                pytest.mark.windows,
+                pytest.mark.skip(
+                    reason="missing magicdns support - Jira issue: LLT-4085"
+                ),
+            ],
+        ),
+        pytest.param(
+            ConnectionTag.MAC_VM,
+            AdapterType.BoringTun,
+            marks=[
+                pytest.mark.mac,
+                pytest.mark.xfail(reason="unknown why it fails - Jira issue: LLT-4085"),
+            ],
+        ),
+    ],
+)
+async def test_dns_after_mesh_off(
+    alpha_connection_tag: ConnectionTag,
+    adapter_type: AdapterType,
+) -> None:
     async with AsyncExitStack() as exit_stack:
         api = API()
 
@@ -353,14 +545,20 @@ async def test_dns_after_mesh_off() -> None:
 
         (connection_alpha, alpha_conn_tracker) = await exit_stack.enter_async_context(
             new_connection_with_conn_tracker(
-                ConnectionTag.DOCKER_CONE_CLIENT_1,
-                generate_connection_tracker_config(ConnectionTag.DOCKER_CONE_CLIENT_1),
+                alpha_connection_tag,
+                generate_connection_tracker_config(
+                    alpha_connection_tag,
+                ),
             )
         )
 
         client_alpha = await exit_stack.enter_async_context(
-            telio.Client(connection_alpha, alpha).run_meshnet(
-                api.get_meshmap(alpha.id, derp_servers=[])
+            telio.Client(
+                connection_alpha,
+                alpha,
+                adapter_type,
+            ).run_meshnet(
+                api.get_meshmap(alpha.id, derp_servers=[]),
             )
         )
 
@@ -417,7 +615,45 @@ async def test_dns_after_mesh_off() -> None:
 @pytest.mark.timeout(60 * 5 + 60)
 @pytest.mark.parametrize(
     "alpha_connection_tag,adapter_type",
-    [pytest.param(ConnectionTag.DOCKER_CONE_CLIENT_1, AdapterType.BoringTun)],
+    [
+        pytest.param(
+            ConnectionTag.DOCKER_CONE_CLIENT_1,
+            AdapterType.BoringTun,
+        ),
+        pytest.param(
+            ConnectionTag.DOCKER_CONE_CLIENT_1,
+            AdapterType.LinuxNativeWg,
+            marks=pytest.mark.linux_native,
+        ),
+        pytest.param(
+            ConnectionTag.WINDOWS_VM,
+            AdapterType.WindowsNativeWg,
+            marks=[
+                pytest.mark.windows,
+                pytest.mark.skip(
+                    reason="missing magicdns support - Jira issue: LLT-4085"
+                ),
+            ],
+        ),
+        pytest.param(
+            ConnectionTag.WINDOWS_VM,
+            AdapterType.WireguardGo,
+            marks=[
+                pytest.mark.windows,
+                pytest.mark.skip(
+                    reason="missing magicdns support - Jira issue: LLT-4085"
+                ),
+            ],
+        ),
+        pytest.param(
+            ConnectionTag.MAC_VM,
+            AdapterType.BoringTun,
+            marks=[
+                pytest.mark.mac,
+                pytest.mark.xfail(reason="unknown why it fails - Jira issue: LLT-4085"),
+            ],
+        ),
+    ],
 )
 async def test_dns_stability(
     alpha_connection_tag: ConnectionTag, adapter_type: AdapterType
@@ -538,7 +774,52 @@ async def test_dns_stability(
 
 
 @pytest.mark.asyncio
-async def test_set_meshmap_dns_update() -> None:
+@pytest.mark.parametrize(
+    "alpha_connection_tag,adapter_type",
+    [
+        pytest.param(
+            ConnectionTag.DOCKER_CONE_CLIENT_1,
+            AdapterType.BoringTun,
+        ),
+        pytest.param(
+            ConnectionTag.DOCKER_CONE_CLIENT_1,
+            AdapterType.LinuxNativeWg,
+            marks=pytest.mark.linux_native,
+        ),
+        pytest.param(
+            ConnectionTag.WINDOWS_VM,
+            AdapterType.WindowsNativeWg,
+            marks=[
+                pytest.mark.windows,
+                pytest.mark.skip(
+                    reason="missing magicdns support - Jira issue: LLT-4085"
+                ),
+            ],
+        ),
+        pytest.param(
+            ConnectionTag.WINDOWS_VM,
+            AdapterType.WireguardGo,
+            marks=[
+                pytest.mark.windows,
+                pytest.mark.skip(
+                    reason="missing magicdns support - Jira issue: LLT-4085"
+                ),
+            ],
+        ),
+        pytest.param(
+            ConnectionTag.MAC_VM,
+            AdapterType.BoringTun,
+            marks=[
+                pytest.mark.mac,
+                pytest.mark.xfail(reason="unknown why it fails - Jira issue: LLT-4085"),
+            ],
+        ),
+    ],
+)
+async def test_set_meshmap_dns_update(
+    alpha_connection_tag: ConnectionTag,
+    adapter_type: AdapterType,
+) -> None:
     async with AsyncExitStack() as exit_stack:
         api = API()
 
@@ -546,14 +827,20 @@ async def test_set_meshmap_dns_update() -> None:
 
         (connection_alpha, alpha_conn_tracker) = await exit_stack.enter_async_context(
             new_connection_with_conn_tracker(
-                ConnectionTag.DOCKER_CONE_CLIENT_1,
-                generate_connection_tracker_config(ConnectionTag.DOCKER_CONE_CLIENT_1),
+                alpha_connection_tag,
+                generate_connection_tracker_config(
+                    alpha_connection_tag,
+                ),
             )
         )
 
         client_alpha = await exit_stack.enter_async_context(
-            telio.Client(connection_alpha, alpha).run_meshnet(
-                api.get_meshmap(alpha.id, derp_servers=[])
+            telio.Client(
+                connection_alpha,
+                alpha,
+                adapter_type,
+            ).run_meshnet(
+                api.get_meshmap(alpha.id, derp_servers=[]),
             )
         )
 
@@ -585,7 +872,52 @@ async def test_set_meshmap_dns_update() -> None:
 
 
 @pytest.mark.asyncio
-async def test_dns_update() -> None:
+@pytest.mark.parametrize(
+    "alpha_connection_tag,adapter_type",
+    [
+        pytest.param(
+            ConnectionTag.DOCKER_CONE_CLIENT_1,
+            AdapterType.BoringTun,
+        ),
+        pytest.param(
+            ConnectionTag.DOCKER_CONE_CLIENT_1,
+            AdapterType.LinuxNativeWg,
+            marks=pytest.mark.linux_native,
+        ),
+        pytest.param(
+            ConnectionTag.WINDOWS_VM,
+            AdapterType.WindowsNativeWg,
+            marks=[
+                pytest.mark.windows,
+                pytest.mark.skip(
+                    reason="missing magicdns support - Jira issue: LLT-4085"
+                ),
+            ],
+        ),
+        pytest.param(
+            ConnectionTag.WINDOWS_VM,
+            AdapterType.WireguardGo,
+            marks=[
+                pytest.mark.windows,
+                pytest.mark.skip(
+                    reason="missing magicdns support - Jira issue: LLT-4085"
+                ),
+            ],
+        ),
+        pytest.param(
+            ConnectionTag.MAC_VM,
+            AdapterType.BoringTun,
+            marks=[
+                pytest.mark.mac,
+                pytest.mark.xfail(reason="unknown why it fails - Jira issue: LLT-4085"),
+            ],
+        ),
+    ],
+)
+async def test_dns_update(
+    alpha_connection_tag: ConnectionTag,
+    adapter_type: AdapterType,
+) -> None:
     async with AsyncExitStack() as exit_stack:
         api = API()
 
@@ -593,16 +925,16 @@ async def test_dns_update() -> None:
 
         (connection, conn_tracker) = await exit_stack.enter_async_context(
             new_connection_with_conn_tracker(
-                ConnectionTag.DOCKER_CONE_CLIENT_1,
+                alpha_connection_tag,
                 generate_connection_tracker_config(
-                    ConnectionTag.DOCKER_CONE_CLIENT_1,
+                    alpha_connection_tag,
                     vpn_1_limits=ConnectionLimits(1, 1),
                 ),
             )
         )
 
         client_alpha = await exit_stack.enter_async_context(
-            telio.Client(connection, alpha).run()
+            telio.Client(connection, alpha, adapter_type).run()
         )
 
         wg_server = config.WG_SERVER
@@ -644,7 +976,52 @@ async def test_dns_update() -> None:
 
 
 @pytest.mark.asyncio
-async def test_dns_duplicate_requests_on_multiple_forward_servers() -> None:
+@pytest.mark.parametrize(
+    "alpha_connection_tag,adapter_type",
+    [
+        pytest.param(
+            ConnectionTag.DOCKER_CONE_CLIENT_1,
+            AdapterType.BoringTun,
+        ),
+        pytest.param(
+            ConnectionTag.DOCKER_CONE_CLIENT_1,
+            AdapterType.LinuxNativeWg,
+            marks=pytest.mark.linux_native,
+        ),
+        pytest.param(
+            ConnectionTag.WINDOWS_VM,
+            AdapterType.WindowsNativeWg,
+            marks=[
+                pytest.mark.windows,
+                pytest.mark.skip(
+                    reason="missing magicdns support - Jira issue: LLT-4085"
+                ),
+            ],
+        ),
+        pytest.param(
+            ConnectionTag.WINDOWS_VM,
+            AdapterType.WireguardGo,
+            marks=[
+                pytest.mark.windows,
+                pytest.mark.skip(
+                    reason="missing magicdns support - Jira issue: LLT-4085"
+                ),
+            ],
+        ),
+        pytest.param(
+            ConnectionTag.MAC_VM,
+            AdapterType.BoringTun,
+            marks=[
+                pytest.mark.mac,
+                pytest.mark.skip(reason="missing tcpdump wrap - Jira issue: LLT-4104"),
+            ],
+        ),
+    ],
+)
+async def test_dns_duplicate_requests_on_multiple_forward_servers(
+    alpha_connection_tag: ConnectionTag,
+    adapter_type: AdapterType,
+) -> None:
     async with AsyncExitStack() as exit_stack:
         api = API()
 
@@ -655,8 +1032,10 @@ async def test_dns_duplicate_requests_on_multiple_forward_servers() -> None:
 
         (connection_alpha, alpha_conn_tracker) = await exit_stack.enter_async_context(
             new_connection_with_conn_tracker(
-                ConnectionTag.DOCKER_CONE_CLIENT_1,
-                generate_connection_tracker_config(ConnectionTag.DOCKER_CONE_CLIENT_1),
+                alpha_connection_tag,
+                generate_connection_tracker_config(
+                    alpha_connection_tag,
+                ),
             )
         )
 
@@ -667,8 +1046,12 @@ async def test_dns_duplicate_requests_on_multiple_forward_servers() -> None:
         )
 
         client_alpha = await exit_stack.enter_async_context(
-            telio.Client(connection_alpha, alpha).run_meshnet(
-                api.get_meshmap(alpha.id, derp_servers=[])
+            telio.Client(
+                connection_alpha,
+                alpha,
+                adapter_type,
+            ).run_meshnet(
+                api.get_meshmap(alpha.id, derp_servers=[]),
             )
         )
 
@@ -694,7 +1077,52 @@ async def test_dns_duplicate_requests_on_multiple_forward_servers() -> None:
 
 
 @pytest.mark.asyncio
-async def test_dns_aaaa_records() -> None:
+@pytest.mark.parametrize(
+    "alpha_connection_tag,adapter_type",
+    [
+        pytest.param(
+            ConnectionTag.DOCKER_CONE_CLIENT_1,
+            AdapterType.BoringTun,
+        ),
+        pytest.param(
+            ConnectionTag.DOCKER_CONE_CLIENT_1,
+            AdapterType.LinuxNativeWg,
+            marks=pytest.mark.linux_native,
+        ),
+        pytest.param(
+            ConnectionTag.WINDOWS_VM,
+            AdapterType.WindowsNativeWg,
+            marks=[
+                pytest.mark.windows,
+                pytest.mark.skip(
+                    reason="missing magicdns support - Jira issue: LLT-4085"
+                ),
+            ],
+        ),
+        pytest.param(
+            ConnectionTag.WINDOWS_VM,
+            AdapterType.WireguardGo,
+            marks=[
+                pytest.mark.windows,
+                pytest.mark.skip(
+                    reason="missing magicdns support - Jira issue: LLT-4085"
+                ),
+            ],
+        ),
+        pytest.param(
+            ConnectionTag.MAC_VM,
+            AdapterType.BoringTun,
+            marks=[
+                pytest.mark.mac,
+                pytest.mark.xfail(reason="unknown why it fails - Jira issue: LLT-4085"),
+            ],
+        ),
+    ],
+)
+async def test_dns_aaaa_records(
+    alpha_connection_tag: ConnectionTag,
+    adapter_type: AdapterType,
+) -> None:
     async with AsyncExitStack() as exit_stack:
         api = API()
         (alpha, beta) = api.default_config_two_nodes()
@@ -703,11 +1131,13 @@ async def test_dns_aaaa_records() -> None:
         api.assign_ip(beta.id, beta_ipv6)
 
         connection_alpha = await exit_stack.enter_async_context(
-            new_connection_by_tag(ConnectionTag.DOCKER_CONE_CLIENT_1)
+            new_connection_by_tag(alpha_connection_tag)
         )
 
         client_alpha = await exit_stack.enter_async_context(
-            telio.Client(connection_alpha, alpha).run_meshnet(api.get_meshmap(alpha.id))
+            telio.Client(connection_alpha, alpha, adapter_type).run_meshnet(
+                api.get_meshmap(alpha.id),
+            )
         )
         await client_alpha.enable_magic_dns(["1.1.1.1"])
 

--- a/nat-lab/tests/test_dns_through_exit.py
+++ b/nat-lab/tests/test_dns_through_exit.py
@@ -25,12 +25,30 @@ from utils.connection_util import (
             AdapterType.LinuxNativeWg,
             marks=pytest.mark.linux_native,
         ),
-        # This test is failing, but currently is non critical
-        # pytest.param(
-        #     ConnectionTag.MAC_VM,
-        #     AdapterType.BoringTun,
-        #     marks=pytest.mark.mac,
-        # ),
+        pytest.param(
+            ConnectionTag.WINDOWS_VM,
+            AdapterType.WindowsNativeWg,
+            marks=[
+                pytest.mark.windows,
+                pytest.mark.xfail(reason="test fails - Jira issue: LLT-4085"),
+            ],
+        ),
+        pytest.param(
+            ConnectionTag.WINDOWS_VM,
+            AdapterType.WireguardGo,
+            marks=[
+                pytest.mark.windows,
+                pytest.mark.xfail(reason="test fails - Jira issue: LLT-4085"),
+            ],
+        ),
+        pytest.param(
+            ConnectionTag.MAC_VM,
+            AdapterType.BoringTun,
+            marks=[
+                pytest.mark.mac,
+                pytest.mark.xfail(reason="test fails - Jira issue: LLT-4085"),
+            ],
+        ),
     ],
 )
 async def test_dns_through_exit(

--- a/nat-lab/tests/test_events.py
+++ b/nat-lab/tests/test_events.py
@@ -48,9 +48,15 @@ def get_allowed_ip_list(addrs: List[str]) -> List[str]:
             marks=pytest.mark.windows,
         ),
         pytest.param(
-            ConnectionTag.WINDOWS_VM, AdapterType.WireguardGo, marks=pytest.mark.windows
+            ConnectionTag.WINDOWS_VM,
+            AdapterType.WireguardGo,
+            marks=pytest.mark.windows,
         ),
-        pytest.param(ConnectionTag.MAC_VM, AdapterType.Default, marks=pytest.mark.mac),
+        pytest.param(
+            ConnectionTag.MAC_VM,
+            AdapterType.BoringTun,
+            marks=pytest.mark.mac,
+        ),
     ],
 )
 async def test_event_content_meshnet(
@@ -194,7 +200,7 @@ async def test_event_content_meshnet(
         ),
         pytest.param(
             ConnectionTag.MAC_VM,
-            AdapterType.Default,
+            AdapterType.BoringTun,
             "10.0.254.7",
             marks=pytest.mark.mac,
         ),
@@ -318,7 +324,9 @@ async def test_event_content_vpn_connection(
             marks=pytest.mark.windows,
         ),
         pytest.param(
-            ConnectionTag.MAC_VM, telio.AdapterType.Default, marks=pytest.mark.mac
+            ConnectionTag.MAC_VM,
+            telio.AdapterType.BoringTun,
+            marks=pytest.mark.mac,
         ),
     ],
 )
@@ -459,7 +467,7 @@ async def test_event_content_exit_through_peer(
         ),
         pytest.param(
             ConnectionTag.MAC_VM,
-            AdapterType.Default,
+            AdapterType.BoringTun,
             "10.0.254.7",
             marks=pytest.mark.mac,
         ),

--- a/nat-lab/tests/test_fire_connecting_event.py
+++ b/nat-lab/tests/test_fire_connecting_event.py
@@ -19,7 +19,32 @@ from utils.ping import Ping
 @pytest.mark.timeout(180 + 60)
 @pytest.mark.parametrize(
     "alpha_connection_tag,adapter_type",
-    [pytest.param(ConnectionTag.DOCKER_CONE_CLIENT_1, telio.AdapterType.BoringTun)],
+    [
+        pytest.param(
+            ConnectionTag.DOCKER_CONE_CLIENT_1,
+            AdapterType.BoringTun,
+        ),
+        pytest.param(
+            ConnectionTag.DOCKER_CONE_CLIENT_1,
+            AdapterType.LinuxNativeWg,
+            marks=pytest.mark.linux_native,
+        ),
+        pytest.param(
+            ConnectionTag.WINDOWS_VM,
+            AdapterType.WindowsNativeWg,
+            marks=pytest.mark.windows,
+        ),
+        pytest.param(
+            ConnectionTag.WINDOWS_VM,
+            AdapterType.WireguardGo,
+            marks=pytest.mark.windows,
+        ),
+        pytest.param(
+            ConnectionTag.MAC_VM,
+            AdapterType.BoringTun,
+            marks=pytest.mark.mac,
+        ),
+    ],
 )
 async def test_fire_connecting_event(
     alpha_connection_tag: ConnectionTag, adapter_type: AdapterType

--- a/nat-lab/tests/test_mesh_exit_through_peer.py
+++ b/nat-lab/tests/test_mesh_exit_through_peer.py
@@ -36,7 +36,9 @@ from utils.ping import Ping
             marks=pytest.mark.windows,
         ),
         pytest.param(
-            ConnectionTag.MAC_VM, telio.AdapterType.Default, marks=pytest.mark.mac
+            ConnectionTag.MAC_VM,
+            telio.AdapterType.BoringTun,
+            marks=pytest.mark.mac,
         ),
     ],
 )

--- a/nat-lab/tests/test_mesh_plus_vpn.py
+++ b/nat-lab/tests/test_mesh_plus_vpn.py
@@ -32,7 +32,14 @@ from utils.ping import Ping
             marks=pytest.mark.windows,
         ),
         pytest.param(
-            ConnectionTag.WINDOWS_VM, AdapterType.WireguardGo, marks=pytest.mark.windows
+            ConnectionTag.WINDOWS_VM,
+            AdapterType.WireguardGo,
+            marks=pytest.mark.windows,
+        ),
+        pytest.param(
+            ConnectionTag.MAC_VM,
+            AdapterType.BoringTun,
+            marks=pytest.mark.mac,
         ),
         pytest.param(ConnectionTag.MAC_VM, AdapterType.Default, marks=pytest.mark.mac),
     ],
@@ -140,7 +147,14 @@ async def test_mesh_plus_vpn_one_peer(
             marks=pytest.mark.windows,
         ),
         pytest.param(
-            ConnectionTag.WINDOWS_VM, AdapterType.WireguardGo, marks=pytest.mark.windows
+            ConnectionTag.WINDOWS_VM,
+            AdapterType.WireguardGo,
+            marks=pytest.mark.windows,
+        ),
+        pytest.param(
+            ConnectionTag.MAC_VM,
+            AdapterType.BoringTun,
+            marks=pytest.mark.mac,
         ),
         pytest.param(ConnectionTag.MAC_VM, AdapterType.Default, marks=pytest.mark.mac),
     ],
@@ -276,7 +290,7 @@ async def test_mesh_plus_vpn_both_peers(
         ),
         pytest.param(
             ConnectionTag.MAC_VM,
-            AdapterType.Default,
+            AdapterType.BoringTun,
             "10.0.254.7",
             marks=pytest.mark.mac,
         ),
@@ -386,7 +400,14 @@ async def test_vpn_plus_mesh(
             marks=pytest.mark.windows,
         ),
         pytest.param(
-            ConnectionTag.WINDOWS_VM, AdapterType.WireguardGo, marks=pytest.mark.windows
+            ConnectionTag.WINDOWS_VM,
+            AdapterType.WireguardGo,
+            marks=pytest.mark.windows,
+        ),
+        pytest.param(
+            ConnectionTag.MAC_VM,
+            AdapterType.BoringTun,
+            marks=pytest.mark.mac,
         ),
         pytest.param(ConnectionTag.MAC_VM, AdapterType.Default, marks=pytest.mark.mac),
     ],
@@ -530,7 +551,14 @@ async def test_vpn_plus_mesh_over_direct(
             marks=pytest.mark.windows,
         ),
         pytest.param(
-            ConnectionTag.WINDOWS_VM, AdapterType.WireguardGo, marks=pytest.mark.windows
+            ConnectionTag.WINDOWS_VM,
+            AdapterType.WireguardGo,
+            marks=pytest.mark.windows,
+        ),
+        pytest.param(
+            ConnectionTag.MAC_VM,
+            AdapterType.BoringTun,
+            marks=pytest.mark.mac,
         ),
         pytest.param(
             ConnectionTag.MAC_VM,

--- a/nat-lab/tests/test_mesh_remove_node.py
+++ b/nat-lab/tests/test_mesh_remove_node.py
@@ -30,7 +30,14 @@ from utils.ping import Ping
             marks=pytest.mark.windows,
         ),
         pytest.param(
-            ConnectionTag.WINDOWS_VM, AdapterType.WireguardGo, marks=pytest.mark.windows
+            ConnectionTag.WINDOWS_VM,
+            AdapterType.WireguardGo,
+            marks=pytest.mark.windows,
+        ),
+        pytest.param(
+            ConnectionTag.MAC_VM,
+            AdapterType.BoringTun,
+            marks=pytest.mark.mac,
         ),
         pytest.param(ConnectionTag.MAC_VM, AdapterType.Default, marks=pytest.mark.mac),
     ],

--- a/nat-lab/tests/test_node_state_flickering.py
+++ b/nat-lab/tests/test_node_state_flickering.py
@@ -35,7 +35,9 @@ from utils.connection_util import (
             marks=pytest.mark.windows,
         ),
         pytest.param(
-            ConnectionTag.MAC_VM, telio.AdapterType.Default, marks=pytest.mark.mac
+            ConnectionTag.MAC_VM,
+            telio.AdapterType.BoringTun,
+            marks=pytest.mark.mac,
         ),
     ],
 )

--- a/nat-lab/tests/test_pinger.py
+++ b/nat-lab/tests/test_pinger.py
@@ -7,6 +7,7 @@ import telio
 from contextlib import AsyncExitStack
 from mesh_api import API
 from protobuf.pinger_pb2 import Pinger
+from telio import AdapterType
 from utils import testing
 from utils.asyncio_util import run_async_context
 from utils.connection_util import ConnectionTag, new_connection_by_tag, LAN_ADDR_MAP
@@ -18,7 +19,7 @@ class PingType(enum.Enum):
     MALFORMED = 2
 
 
-async def send_ping_pong(ping_type) -> None:
+async def send_ping_pong(connection_tag: ConnectionTag, ping_type: PingType) -> None:
     ping = Pinger()
     ping.message_type = ping.PING  # pylint: disable=no-member
     ping.session = 3
@@ -32,35 +33,69 @@ async def send_ping_pong(ping_type) -> None:
     if ping_type == PingType.PING:
         sock.sendto(
             struct.pack(">BBB", 7, 0, 3) + ping.SerializeToString(),
-            (LAN_ADDR_MAP[ConnectionTag.DOCKER_CONE_CLIENT_1], 5000),
+            (LAN_ADDR_MAP[connection_tag], 5000),
         )
     elif ping_type == PingType.PONG:
         # Send a PONG type message
         ping.message_type = ping.PONG  # pylint: disable=no-member
         sock.sendto(
             struct.pack(">BBB", 9, 0, 3) + ping.SerializeToString(),
-            (LAN_ADDR_MAP[ConnectionTag.DOCKER_CONE_CLIENT_1], 5000),
+            (LAN_ADDR_MAP[connection_tag], 5000),
         )
     else:
         sock.sendto(
             struct.pack(">BBBBBBBBBBBB", 4, 0, 8, 17, 9, 0, 0, 0, 0, 0, 0, 0),
-            (LAN_ADDR_MAP[ConnectionTag.DOCKER_CONE_CLIENT_1], 5000),
+            (LAN_ADDR_MAP[connection_tag], 5000),
         )
 
 
 @pytest.mark.asyncio
-async def test_ping_pong() -> None:
+@pytest.mark.parametrize(
+    "connection_tag,adapter_type",
+    [
+        pytest.param(
+            ConnectionTag.DOCKER_CONE_CLIENT_1,
+            AdapterType.BoringTun,
+        ),
+        pytest.param(
+            ConnectionTag.DOCKER_CONE_CLIENT_1,
+            AdapterType.LinuxNativeWg,
+            marks=pytest.mark.linux_native,
+        ),
+        pytest.param(
+            ConnectionTag.WINDOWS_VM,
+            AdapterType.WindowsNativeWg,
+            marks=pytest.mark.windows,
+        ),
+        pytest.param(
+            ConnectionTag.WINDOWS_VM,
+            AdapterType.WireguardGo,
+            marks=pytest.mark.windows,
+        ),
+        pytest.param(
+            ConnectionTag.MAC_VM,
+            AdapterType.BoringTun,
+            marks=pytest.mark.mac,
+        ),
+    ],
+)
+async def test_ping_pong(
+    connection_tag: ConnectionTag,
+    adapter_type: AdapterType,
+) -> None:
     async with AsyncExitStack() as exit_stack:
         api = API()
 
         alpha = api.default_config_one_node()
 
         connection_alpha = await exit_stack.enter_async_context(
-            new_connection_by_tag(ConnectionTag.DOCKER_CONE_CLIENT_1)
+            new_connection_by_tag(connection_tag)
         )
 
         client_alpha = await exit_stack.enter_async_context(
-            telio.Client(connection_alpha, alpha).run_meshnet(api.get_meshmap(alpha.id))
+            telio.Client(connection_alpha, alpha, adapter_type).run_meshnet(
+                api.get_meshmap(alpha.id)
+            )
         )
 
         pinger_event = client_alpha.wait_for_output("Pinger")
@@ -70,31 +105,65 @@ async def test_ping_pong() -> None:
         await exit_stack.enter_async_context(
             run_async_context(testing.wait_lengthy(client_alpha.receive_ping()))
         )
-        await testing.wait_lengthy(send_ping_pong(PingType.PING))
+        await testing.wait_lengthy(send_ping_pong(connection_tag, PingType.PING))
 
         # Send PONG type message
         await exit_stack.enter_async_context(
             run_async_context(testing.wait_lengthy(client_alpha.receive_ping()))
         )
-        await testing.wait_lengthy(send_ping_pong(PingType.PONG))
+        await testing.wait_lengthy(send_ping_pong(connection_tag, PingType.PONG))
 
         await testing.wait_long(pinger_event.wait())
         await testing.wait_long(ponger_event.wait())
 
 
 @pytest.mark.asyncio
-async def test_send_malform_pinger_packet() -> None:
+@pytest.mark.parametrize(
+    "connection_tag,adapter_type",
+    [
+        pytest.param(
+            ConnectionTag.DOCKER_CONE_CLIENT_1,
+            AdapterType.BoringTun,
+        ),
+        pytest.param(
+            ConnectionTag.DOCKER_CONE_CLIENT_1,
+            AdapterType.LinuxNativeWg,
+            marks=pytest.mark.linux_native,
+        ),
+        pytest.param(
+            ConnectionTag.WINDOWS_VM,
+            AdapterType.WindowsNativeWg,
+            marks=pytest.mark.windows,
+        ),
+        pytest.param(
+            ConnectionTag.WINDOWS_VM,
+            AdapterType.WireguardGo,
+            marks=pytest.mark.windows,
+        ),
+        pytest.param(
+            ConnectionTag.MAC_VM,
+            AdapterType.BoringTun,
+            marks=pytest.mark.mac,
+        ),
+    ],
+)
+async def test_send_malform_pinger_packet(
+    connection_tag: ConnectionTag,
+    adapter_type: AdapterType,
+) -> None:
     async with AsyncExitStack() as exit_stack:
         api = API()
 
         alpha = api.default_config_one_node()
 
         connection_alpha = await exit_stack.enter_async_context(
-            new_connection_by_tag(ConnectionTag.DOCKER_CONE_CLIENT_1)
+            new_connection_by_tag(connection_tag)
         )
 
         client_alpha = await exit_stack.enter_async_context(
-            telio.Client(connection_alpha, alpha).run_meshnet(api.get_meshmap(alpha.id))
+            telio.Client(connection_alpha, alpha, adapter_type).run_meshnet(
+                api.get_meshmap(alpha.id)
+            )
         )
 
         unexpected_packet_event = client_alpha.wait_for_output("Unexpected packet: ")
@@ -103,6 +172,6 @@ async def test_send_malform_pinger_packet() -> None:
         await exit_stack.enter_async_context(
             run_async_context(testing.wait_lengthy(client_alpha.receive_ping()))
         )
-        await testing.wait_lengthy(send_ping_pong(PingType.MALFORMED))
+        await testing.wait_lengthy(send_ping_pong(connection_tag, PingType.MALFORMED))
 
         await testing.wait_long(unexpected_packet_event.wait())

--- a/nat-lab/tests/test_reconnections.py
+++ b/nat-lab/tests/test_reconnections.py
@@ -36,7 +36,9 @@ from utils.ping import Ping
             marks=pytest.mark.windows,
         ),
         pytest.param(
-            ConnectionTag.MAC_VM, telio.AdapterType.Default, marks=pytest.mark.mac
+            ConnectionTag.MAC_VM,
+            telio.AdapterType.BoringTun,
+            marks=pytest.mark.mac,
         ),
     ],
 )

--- a/nat-lab/tests/test_tcli.py
+++ b/nat-lab/tests/test_tcli.py
@@ -33,7 +33,9 @@ from utils.connection_util import (
             marks=pytest.mark.windows,
         ),
         pytest.param(
-            ConnectionTag.MAC_VM, telio.AdapterType.Default, marks=pytest.mark.mac
+            ConnectionTag.MAC_VM,
+            telio.AdapterType.BoringTun,
+            marks=pytest.mark.mac,
         ),
     ],
 )

--- a/nat-lab/tests/test_telio_tasks.py
+++ b/nat-lab/tests/test_telio_tasks.py
@@ -1,9 +1,9 @@
-import asyncio
 import pytest
 from contextlib import AsyncExitStack
 from mesh_api import API
-from telio import Client
+from telio import Client, State
 from telio_features import TelioFeatures, Direct, Lana, Nurse, Qos, ExitDns
+from utils import testing
 from utils.connection_util import ConnectionTag, new_connection_by_tag
 
 
@@ -34,6 +34,7 @@ async def test_telio_tasks_with_all_features() -> None:
                 ),
             ).run_meshnet(api.get_meshmap(alpha.id))
         )
-        # le wait some seconds for everything to start
-        await asyncio.sleep(5)
+        await testing.wait_long(
+            client_alpha.wait_for_state_on_any_derp([State.Connected]),
+        )
         await client_alpha.stop_device()

--- a/nat-lab/tests/test_upnp_connection.py
+++ b/nat-lab/tests/test_upnp_connection.py
@@ -13,8 +13,29 @@ LOCAL_PROVIDER = ["local"]
 UPNP_PROVIDER = ["upnp"]
 
 
+@pytest.mark.parametrize(
+    "alpha_adapter_type,beta_adapter_type",
+    [
+        pytest.param(
+            AdapterType.BoringTun,
+            AdapterType.BoringTun,
+        ),
+        pytest.param(
+            AdapterType.BoringTun,
+            AdapterType.LinuxNativeWg,
+            marks=pytest.mark.linux_native,
+        ),
+        pytest.param(
+            AdapterType.LinuxNativeWg,
+            AdapterType.LinuxNativeWg,
+            marks=pytest.mark.linux_native,
+        ),
+    ],
+)
 @pytest.mark.asyncio
-async def test_upnp_route_removed() -> None:
+async def test_upnp_route_removed(
+    alpha_adapter_type: AdapterType, beta_adapter_type: AdapterType
+) -> None:
     async with AsyncExitStack() as exit_stack:
         api = API()
 
@@ -36,7 +57,7 @@ async def test_upnp_route_removed() -> None:
             Client(
                 alpha_connection,
                 alpha,
-                AdapterType.BoringTun,
+                alpha_adapter_type,
                 telio_features=TelioFeatures(direct=Direct(providers=UPNP_PROVIDER)),
             ).run_meshnet(
                 api.get_meshmap(alpha.id),
@@ -46,7 +67,7 @@ async def test_upnp_route_removed() -> None:
             Client(
                 beta_connection,
                 beta,
-                AdapterType.BoringTun,
+                beta_adapter_type,
                 telio_features=TelioFeatures(direct=Direct(providers=UPNP_PROVIDER)),
             ).run_meshnet(api.get_meshmap(beta.id))
         )

--- a/nat-lab/tests/test_vpn.py
+++ b/nat-lab/tests/test_vpn.py
@@ -75,7 +75,7 @@ async def _connect_vpn(
         ),
         pytest.param(
             ConnectionTag.MAC_VM,
-            AdapterType.Default,
+            AdapterType.BoringTun,
             "10.0.254.7",
             marks=pytest.mark.mac,
         ),
@@ -149,7 +149,7 @@ async def test_vpn_connection(
         ),
         pytest.param(
             ConnectionTag.MAC_VM,
-            AdapterType.Default,
+            AdapterType.BoringTun,
             "10.0.254.7",
             marks=pytest.mark.mac,
         ),


### PR DESCRIPTION
### Description
Some of the tests are only running on linux, excluding windows, macos, besides every possible adapter.

This PR adds `@pytest.mark.parametrize` decorator for each test to run for every platform/adapter combination, where it makes sense.

This changes add 174 tests (221->395), significantly increasing the duration of the nat-lab job.

### :ballot_box_with_check: Definition of Done checklist
- [x] changelog.md is updated
- [x] Commit history is clean
- [x] README.md is updated
