### PR TITLE
CI: Enable caching for build jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,6 +69,10 @@ jobs:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         with:
           path: libtelio
+      - uses: Swatinem/rust-cache@b8a6852b4f997182bdea832df3f9e153038b5191 # v2.6.0
+        with:
+          key: ${{ matrix.target_os }}-${{ matrix.arch }}-${{ matrix.target_abi }}
+          workspaces: "libtelio"
       - name: Install packages
         run: sudo apt-get update && sudo apt-get install ${{ matrix.packages }}
         if: ${{ matrix.target_os == 'linux' }}


### PR DESCRIPTION
### Description
Cache for build jobs
In the positive scenario, where the cache is hit it cuts the the time by ~half.
Without cache: https://github.com/NordSecurity/libtelio/actions/runs/5752168035/usage Total time: ~3h40m
With cache: https://github.com/NordSecurity/libtelio/actions/runs/5755230159/usage Total time: ~1h50m
This cache caches on a workspace level, not single compilation units like sccache. So if the feature branch changes dependencies inside Cargo .toml/.lock files the first run will be a cache miss and will require complete rebuild. 
It should be compared to the sccache, but I think it is worth enabling now anyway.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean
- [x] README.md is updated
- [x] changelog.md is updated
