### PR TITLE
Start gitlab pipelive with version 0.1.4

### DIFF
--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -21,4 +21,4 @@ jobs:
           ci-api-v4-url: ${{ secrets.CI_API_V4_URL }}
           project-id: ${{ secrets.PROJECT_ID }}
           token: ${{ secrets.TOKEN }}
-          ref: v0.1.2
+          ref: v0.1.4

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,5 +15,5 @@ libtelio-build-pipeline:
 
   trigger:
     project: $LIBTELIO_BUILD_PROJECT_PATH
-    branch: v0.1.2
+    branch: v0.1.4
     strategy: depend


### PR DESCRIPTION
### Description

We skip version 0.1.3 - there was nothing wrong with it, just no-one got to updating github to use it.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean
- [x] README.md is updated
- [x] changelog.md is updated
