### PR TITLE
LLT-4013: Add conntrack logic for ICMP

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -30,6 +30,7 @@
 * LLT-3628: Enable IPv6 and add tests for it (unit and nat-lab).
 * LLT-4042: IPv6 firewall nat-lab tests.
 * LLT-3914: Add apple tvOS support
+* LLT-4013: Add conntrack rules for icmp
 
 <br>
 


### PR DESCRIPTION
### Description
So far there has been no conntrack logic for ICMP. The firewall flow for an inbound ICMP packet has been:
1. If peer is on whitelist, allow
2. If ICMP packet type is blocked, block
3. Allow

With these changes, outbound ICMP connections create cache entries, and the firewall flow becomes:
1. If peer is on whitelist, allow
2. If peer connection is in the cache, allow
3. If ICMP packet type is blocked, block
4. Allow



### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean
- [x] README.md is updated
- [x] changelog.md is updated
