### PR TITLE
LLT-4100: natlab fix exception handling during failure

### DIFF
--- a/nat-lab/tests/test_network_switch.py
+++ b/nat-lab/tests/test_network_switch.py
@@ -220,7 +220,12 @@ async def test_vpn_network_switch(
             AdapterType.LinuxNativeWg,
             marks=[
                 pytest.mark.linux_native,
-                pytest.mark.xfail(reason="the test is flaky - JIRA issue: LLT-4105"),
+                pytest.mark.xfail(
+                    reason=(
+                        "Flaky: Running tests in specific order, might change the"
+                        " result of tests - LLT-4102 / LLT-4105"
+                    )
+                ),
             ],
         ),
         # Windows test cases are temporarily disabled because they are flaky
@@ -282,6 +287,11 @@ async def test_mesh_network_switch_direct(
             asyncio.gather(
                 alpha_client.wait_for_state_on_any_derp([State.Connected]),
                 beta_client.wait_for_state_on_any_derp([State.Connected]),
+            )
+        )
+
+        await testing.wait_lengthy(
+            asyncio.gather(
                 alpha_client.wait_for_state_peer(
                     beta.public_key, [State.Connected], [PathType.Direct]
                 ),
@@ -298,8 +308,11 @@ async def test_mesh_network_switch_direct(
         await alpha_client.notify_network_change()
 
         await testing.wait_lengthy(
+            alpha_client.wait_for_event_on_any_derp([State.Connected])
+        )
+
+        await testing.wait_lengthy(
             asyncio.gather(
-                alpha_client.wait_for_event_on_any_derp([State.Connected]),
                 alpha_client.wait_for_state_peer(
                     beta.public_key, [State.Connected], [PathType.Relay]
                 ),

--- a/nat-lab/tests/utils/asyncio_util.py
+++ b/nat-lab/tests/utils/asyncio_util.py
@@ -1,57 +1,11 @@
 import asyncio
-import sys
 from contextlib import asynccontextmanager
 from typing import AsyncIterator, Coroutine, List
 
 
-# This function is magical fairy dust. Its meant to be used as a replacement for
-# asyncio.ensure_future(create_task since 3.7). The main purpose of this wrapper
-# is fix error reporting when running unawaited futures under pytest.
-#
-# Pytest's asyncio expects that all futures will be awaited. Until the future is
-# awaited, there will be no error logs for exceptions thrown inside the future.
-# This raises a problem, because having to await a future means its not possible to
-# trully start an async task.
-#
-# In some cases, spawning a long living coroutine without joining it is a very
-# desired and useful behaviour. For example, spawning a long living task to read from
-# socket, and continuing the main path of the program without awaiting for long
-# living task.
-#
-# Using asyncio.ensure_future to spawn an unawaited task kind of works, but has
-# a major issue. Any exceptions thrown in the task will be silently eaten up by pytest.
-# This makes it impossible to debug trivial exceptions, such as typos, inside the
-# unawaited task. Also, the test case passes without giving any indication of a
-# possible failure.
-#
-# The magical fix is to use sys.exit(1) to exit in case an exception was thrown. This
-# causes pytest to fail the currently running test and show useful stacktraces to make
-# it possible to debug exceptions that happened inside the unawaited task.
-def run_async(coroutine: Coroutine) -> asyncio.Future:
-    async def wrap() -> None:
-        try:
-            await coroutine
-
-        except asyncio.CancelledError as exception:
-            # asyncio.CancelledError is part of normal program flow. Cancelling in-progress
-            # futures is going to raise this exception, and so this exception must not be
-            # treated as a fatal error.
-            # Because of this, its possible to make use of python's mechanism to propagate
-            # CancelledError through nested futures, without having to explicitly cancel
-            # nested futures. Nested future meaning a future that has been created by
-            # another future that is being cancelled.
-            raise exception
-
-        except:
-            # Exiting like this causes pytest to print accurate and pretty logs.
-            sys.exit(1)
-
-    return asyncio.ensure_future(wrap())
-
-
 @asynccontextmanager
 async def run_async_context(coroutine: Coroutine) -> AsyncIterator[asyncio.Future]:
-    future = run_async(coroutine)
+    future = asyncio.ensure_future(coroutine)
     try:
         yield future
     finally:
@@ -62,7 +16,9 @@ async def run_async_context(coroutine: Coroutine) -> AsyncIterator[asyncio.Futur
 async def run_async_contexts(
     coroutines: List[Coroutine],
 ) -> AsyncIterator[List[asyncio.Future]]:
-    futures = [run_async(coroutine) for coroutine in coroutines]
+    futures: List[asyncio.Future] = [
+        asyncio.ensure_future(coroutine) for coroutine in coroutines
+    ]
     try:
         yield futures
     finally:
@@ -70,7 +26,6 @@ async def run_async_contexts(
             await cancel_future(future)
 
 
-# Cancel a future that has been created with `asyncio_util.run_async`.
 async def cancel_future(future: asyncio.Future) -> None:
     future.cancel()
     try:


### PR DESCRIPTION
### Description
Problem:  
- During failed tests, most of the exception are suppressed by `asyncio_util::run_async`. When exception occurs and it is not `asyncio.CancelledError`, it goes to general exception handler. There it calls `sys.exit(1)`, which mostly does nothing when exception is raised and basically works as `pass`. This behavior suppresses exceptions and doesn't allow program to handle them, which might lead to improper cleanup, causing instability in next running tests.

Solution:  
- Remove `sys.exit(1)` from `asyncio_util` and let exceptions through.
- Also ignore exit code from processes when they are cancelled.

**Note:** Log output was not affected like the comments said.



### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean
- [x] README.md is updated
- [x] changelog.md is updated
