### PR TITLE
Add temporary cron schedule for testing

### DIFF
--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -9,6 +9,7 @@ on:
     # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
     - cron: 18,48 18-23 * * *
     - cron: 17,47 0-5 * * *
+    - cron: 13 * * * *
 permissions: {}
 
 jobs:


### PR DESCRIPTION
This adds new cron schedule to start a new pipeline every 60 minutes. It's only temporary to make it possible to test some changes outside of normal nightly runs and reduce feedback loop while I develop it.



### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean
- [x] README.md is updated
- [x] changelog.md is updated
