### PR TITLE
Use action allowing scheduled jobs

### DIFF
--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -23,7 +23,7 @@ jobs:
         github.event.label.name == 'run tests'
       )
     steps:
-      - uses: NordSecurity/trigger-gitlab-pipeline@2058fb1a58b364f0b48f4a402a3e89ac405ab146 # v1.1.0
+      - uses: NordSecurity/trigger-gitlab-pipeline@1a4bce03474798f5a512411af3223dd2aef0e71d # v1.1.1
         with:
           ci-api-v4-url: ${{ secrets.CI_API_V4_URL }}
           project-id: ${{ secrets.PROJECT_ID }}


### PR DESCRIPTION
### Problem
Previous version of gitlab pipeline trigger action used too restrictive whitelist.

### Solution
This new version allows additionally cron schedules to start new gitlab pipelines. This should fix the overnight pipelines and allow them to start new gitlab pipelines.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
