### PR TITLE
Mark flaky tests with xfail for future investigation

### DIFF
--- a/nat-lab/tests/test_direct_connection.py
+++ b/nat-lab/tests/test_direct_connection.py
@@ -597,12 +597,14 @@ async def test_direct_connection_loss_for_infinity(
             ConnectionTag.DOCKER_OPEN_INTERNET_CLIENT_1,
             "upnp",
             "local",
+            marks=pytest.mark.xfail(reason="test is flaky - LLT-4115"),
         ),
         pytest.param(
             ConnectionTag.DOCKER_CONE_CLIENT_1,
             ConnectionTag.DOCKER_OPEN_INTERNET_CLIENT_1,
             "stun",
             "local",
+            marks=pytest.mark.xfail(reason="test is flaky - LLT-4115"),
         ),
     ],
 )

--- a/nat-lab/tests/test_mesh_plus_vpn.py
+++ b/nat-lab/tests/test_mesh_plus_vpn.py
@@ -531,7 +531,14 @@ async def test_vpn_plus_mesh_over_direct(
         pytest.param(
             ConnectionTag.WINDOWS_VM, AdapterType.WireguardGo, marks=pytest.mark.windows
         ),
-        pytest.param(ConnectionTag.MAC_VM, AdapterType.Default, marks=pytest.mark.mac),
+        pytest.param(
+            ConnectionTag.MAC_VM,
+            AdapterType.Default,
+            marks=[
+                pytest.mark.mac,
+                pytest.mark.xfail(reason="test is flaky - LLT-4116"),
+            ],
+        ),
     ],
 )
 async def test_vpn_plus_mesh_over_different_connection_types(


### PR DESCRIPTION
### Problem
Tests `test_vpn_plus_mesh_over_different_connection_types` and `test_direct_connection_endpoint_gone` are flaky.

### Solution
For now mark them as xfail. In future investigate.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
