### PR TITLE
Add support for IPv6 packet handling in telio-dns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ alpha-events.db
 beta-events.db
 gamma-events.db
 nat-lab/report.html
+events-moose.log

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,7 @@
 * LLT-3913: Deduplicate IPs of external wireguard peers
 * LLT-3869: Turn off relayed traffic to offline peers
 * LLT-3775: Add test for lana validators
+* LLT-4050: Add support for IPv6 packet handling in telio-dns
 
 <br>
 

--- a/crates/telio-dns/src/dns.rs
+++ b/crates/telio-dns/src/dns.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 use boringtun::crypto::x25519::{X25519PublicKey, X25519SecretKey};
 use boringtun::noise::Tunn;
 use ipnetwork::IpNetwork;
-use std::net::{IpAddr, Ipv4Addr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::{net::SocketAddr, sync::Arc};
 use telio_crypto::{PublicKey, SecretKey};
 use telio_wg::uapi::Peer;
@@ -161,17 +161,25 @@ impl DnsResolver for LocalDnsResolver {
         vec![
             IpAddr::V4(Ipv4Addr::new(100, 64, 0, 2)).into(),
             IpAddr::V4(Ipv4Addr::new(100, 64, 0, 3)).into(),
+            IpAddr::V6(Ipv6Addr::new(0xfc74, 0x656c, 0x696f, 0, 0, 0, 0, 2)).into(),
+            IpAddr::V6(Ipv6Addr::new(0xfc74, 0x656c, 0x696f, 0, 0, 0, 0, 3)).into(),
         ]
     }
 
     #[allow(unwrap_check)]
     fn get_exit_connected_dns_allowed_ips(&self) -> Vec<IpNetwork> {
-        vec![IpAddr::V4(Ipv4Addr::new(100, 64, 0, 2)).into()]
+        vec![
+            IpAddr::V4(Ipv4Addr::new(100, 64, 0, 2)).into(),
+            IpAddr::V6(Ipv6Addr::new(0xfc74, 0x656c, 0x696f, 0, 0, 0, 0, 2)).into(),
+        ]
     }
 
     #[allow(unwrap_check)]
     fn get_default_dns_servers(&self) -> Vec<IpAddr> {
-        vec![IpAddr::V4(Ipv4Addr::new(100, 64, 0, 3))]
+        vec![
+            IpAddr::V4(Ipv4Addr::new(100, 64, 0, 3)),
+            IpAddr::V6(Ipv6Addr::new(0xfc74, 0x656c, 0x696f, 0, 0, 0, 0, 3)),
+        ]
     }
 }
 
@@ -187,7 +195,9 @@ mod tests {
         assert_eq!(
             vec![
                 "100.64.0.2/32".parse::<IpNetwork>().unwrap(),
-                "100.64.0.3/32".parse().unwrap(),
+                "100.64.0.3/32".parse::<IpNetwork>().unwrap(),
+                "fc74:656c:696f::2/128".parse::<IpNetwork>().unwrap(),
+                "fc74:656c:696f::3/128".parse::<IpNetwork>().unwrap(),
             ],
             resolver.get_default_dns_allowed_ips()
         );
@@ -199,7 +209,10 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(
-            vec!["100.64.0.2/32".parse::<IpNetwork>().unwrap()],
+            vec![
+                "100.64.0.2/32".parse::<IpNetwork>().unwrap(),
+                "fc74:656c:696f::2/128".parse::<IpNetwork>().unwrap(),
+            ],
             resolver.get_exit_connected_dns_allowed_ips()
         );
     }
@@ -210,7 +223,10 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(
-            vec!["100.64.0.3".parse::<IpAddr>().unwrap()],
+            vec![
+                "100.64.0.3".parse::<IpAddr>().unwrap(),
+                "fc74:656c:696f::3".parse::<IpAddr>().unwrap(),
+            ],
             resolver.get_default_dns_servers()
         );
     }

--- a/crates/telio-dns/src/nameserver.rs
+++ b/crates/telio-dns/src/nameserver.rs
@@ -7,11 +7,12 @@ use boringtun::noise::{Tunn, TunnResult};
 use pnet_packet::{
     ip::IpNextHeaderProtocols,
     ipv4::{checksum, Ipv4Packet, MutableIpv4Packet},
-    udp::{ipv4_checksum, MutableUdpPacket, UdpPacket},
+    ipv6::{Ipv6Packet, MutableIpv6Packet},
+    udp::{ipv4_checksum, ipv6_checksum, MutableUdpPacket, UdpPacket},
     Packet,
 };
 use std::{
-    net::{IpAddr, SocketAddr},
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     str::FromStr,
     sync::Arc,
 };
@@ -25,7 +26,8 @@ use trust_dns_server::server::{Protocol, Request};
 
 use telio_utils::{telio_log_debug, telio_log_error, telio_log_trace, telio_log_warn};
 
-const IP_HEADER: usize = 20; // bytes
+const IPV4_HEADER: usize = 20; // bytes
+const IPV6_HEADER: usize = 40; // bytes
 const MAX_PACKET: usize = 2048;
 const UDP_HEADER: usize = 8;
 const MAX_CONCURRENT_QUERIES: usize = 256;
@@ -63,6 +65,421 @@ impl LocalNameServer {
         }));
         ns.forward(forward_ips).await?;
         Ok(ns)
+    }
+
+    async fn dns_service(
+        peer: Arc<Tunn>,
+        nameserver: Arc<RwLock<LocalNameServer>>,
+        socket: Arc<UdpSocket>,
+        dst_address: SocketAddr,
+    ) {
+        let mut receiving_buffer = vec![0u8; MAX_PACKET];
+        let mut sending_buffer = vec![0u8; MAX_PACKET];
+        let semaphore = Arc::new(Semaphore::new(MAX_CONCURRENT_QUERIES));
+        loop {
+            let bytes_read = match socket.recv(&mut receiving_buffer).await {
+                Ok(bytes) => bytes,
+                Err(e) => {
+                    telio_log_error!("[DNS] Failed to read bytes: {:?}", e);
+                    continue;
+                }
+            };
+
+            loop {
+                match peer.update_timers(&mut sending_buffer) {
+                    TunnResult::WriteToNetwork(packet) => {
+                        if let Err(e) = socket.send_to(packet, dst_address).await {
+                            telio_log_warn!("[DNS] Failed to send timer update packet : {:?}", e)
+                        };
+                    }
+                    TunnResult::Err(e) => {
+                        telio_log_error!("[DNS] Failed to update Tunn timers : {:?}", e);
+                        break;
+                    }
+                    _ => break,
+                };
+            }
+
+            let peer = peer.clone();
+            let socket = socket.clone();
+            let nameserver = nameserver.clone();
+            let mut receiving_buffer = receiving_buffer.clone();
+            let mut sending_buffer = sending_buffer.clone();
+            let semaphore = semaphore.clone();
+            tokio::spawn(async move {
+                match peer.decapsulate(
+                    None,
+                    receiving_buffer.get(..bytes_read).unwrap_or(&[]),
+                    &mut sending_buffer,
+                ) {
+                    // Handshake packets
+                    TunnResult::WriteToNetwork(packet) => {
+                        if let Err(e) = socket.send_to(packet, dst_address).await {
+                            telio_log_warn!("[DNS] Failed to send handshake packet  : {:?}", e);
+                            return;
+                        };
+                        let mut temporary_buffer = [0u8; MAX_PACKET];
+
+                        while let TunnResult::WriteToNetwork(empty) =
+                            peer.decapsulate(None, &[], &mut temporary_buffer)
+                        {
+                            if let Err(e) = socket.send_to(empty, dst_address).await {
+                                telio_log_warn!("[DNS] Failed to send handshake packet  : {:?}", e);
+                                return;
+                            };
+                        }
+                    }
+                    // DNS packets
+                    TunnResult::WriteToTunnelV4(packet, _)
+                    | TunnResult::WriteToTunnelV6(packet, _) => {
+                        // !
+                        let _lease = match semaphore.try_acquire() {
+                            Ok(lease) => lease,
+                            Err(_) => {
+                                telio_log_debug!("[DNS] Error semaphore.try_acquire()");
+                                return;
+                            }
+                        };
+
+                        let nameserver = nameserver.clone();
+                        let length = match LocalNameServer::process_packet(
+                            nameserver,
+                            packet,
+                            &mut receiving_buffer,
+                        )
+                        .await
+                        {
+                            Ok(length) => length,
+                            Err(e) => {
+                                telio_log_error!("[DNS] {}", e);
+                                return;
+                            }
+                        };
+
+                        match peer.encapsulate(
+                            receiving_buffer.get(..length).unwrap_or(&[]),
+                            &mut sending_buffer,
+                        ) {
+                            TunnResult::WriteToNetwork(dns) => {
+                                if let Err(e) = socket.send_to(dns, dst_address).await {
+                                    telio_log_warn!(
+                                        "[DNS] Failed to send DNS query response  {:?}",
+                                        e
+                                    )
+                                };
+                            }
+                            TunnResult::Err(e) => {
+                                telio_log_warn!(
+                                    "[DNS] Failed to encapsulate DNS query response  {:?}",
+                                    e
+                                )
+                            }
+                            _ => {}
+                        }
+                    }
+                    _ => {}
+                }
+            });
+        }
+    }
+
+    async fn resolve_dns_request(
+        nameserver: Arc<RwLock<LocalNameServer>>,
+        request_info: &mut RequestInfo,
+    ) -> Result<Vec<u8>, String> {
+        let resolver = Resolver::new();
+        let zones = nameserver.zones().await;
+
+        let dns_request = request_info
+            .udp
+            .dns_request
+            .take()
+            .ok_or_else(|| String::from("Inexistent DNS request"))?;
+        let dns_request = Request::new(dns_request, request_info.dns_source(), Protocol::Udp);
+        zones.lookup(&dns_request, resolver.clone()).await;
+        telio_log_debug!("DNS request: {:?}", &dns_request);
+
+        let dns_response = resolver.0.lock().await;
+        telio_log_debug!("Nameserver response: {:?}", &dns_response);
+        Ok(dns_response.to_vec())
+    }
+
+    async fn process_packet(
+        nameserver: Arc<RwLock<LocalNameServer>>,
+        request_packet: &[u8],
+        response_packet: &mut [u8],
+    ) -> Result<usize, String> {
+        let mut request_info = request_packet
+            .first()
+            .ok_or_else(|| String::from("Empty request packet"))
+            .and_then(|first_byte| match first_byte >> 4 {
+                4 => LocalNameServer::process_ip_packet::<Ipv4Packet>(request_packet),
+                6 => LocalNameServer::process_ip_packet::<Ipv6Packet>(request_packet),
+                _ => Err(String::from("Invalid IP version")),
+            })?;
+
+        let dns_response =
+            LocalNameServer::resolve_dns_request(nameserver, &mut request_info).await?;
+
+        request_info.build_response_packet(&dns_response, response_packet)
+    }
+
+    fn process_ip_packet<'a, P: IpPacket<'a>>(
+        request_packet: &'a [u8],
+    ) -> Result<RequestInfo, String> {
+        let ip = P::try_from(request_packet)
+            .ok_or_else(|| String::from("Failed to build IpPacket from request packet"))?;
+
+        if !ip.check_valid() {
+            return Err(String::from("Invalid IpPacket"));
+        }
+
+        Ok(RequestInfo {
+            ip: ip.ip_request_info(),
+            udp: LocalNameServer::process_udp_packet(&ip)?,
+        })
+    }
+
+    fn process_udp_packet<'a>(ip_request: &impl IpPacket<'a>) -> Result<UdpRequestInfo, String> {
+        let udp_request = UdpPacket::new(ip_request.payload())
+            .ok_or_else(|| String::from("Failed to build UdpPacket from request packet"))?;
+
+        // Validate UDP checksum
+        if ip_request.udp_checksum(&udp_request) != udp_request.get_checksum() {
+            return Err(String::from("Invalid UDP checksum"));
+        }
+
+        // Validate DNS port
+        if udp_request.get_destination() != 53 {
+            return Err(String::from("Invalid DNS port"));
+        }
+
+        let dns_request = MessageRequest::from_bytes(udp_request.payload())
+            .map_err(|_| String::from("Failed to build MessageRequest from request packet"))?;
+
+        Ok(UdpRequestInfo {
+            source_port: udp_request.get_source(),
+            destination_port: udp_request.get_destination(),
+            dns_request: Some(dns_request),
+        })
+    }
+}
+
+enum IpRequestInfo {
+    V4 {
+        source_ip: Ipv4Addr,
+        destination_ip: Ipv4Addr,
+        dscp: u8,
+        ecn: u8,
+        ttl: u8,
+        identification: u16,
+    },
+    V6 {
+        source_ip: Ipv6Addr,
+        destination_ip: Ipv6Addr,
+    },
+}
+
+impl IpRequestInfo {
+    fn source_ip(&self) -> IpAddr {
+        match self {
+            IpRequestInfo::V4 { source_ip, .. } => IpAddr::V4(*source_ip),
+            IpRequestInfo::V6 { source_ip, .. } => IpAddr::V6(*source_ip),
+        }
+    }
+
+    fn compute_udp_checksum(&self, packet: &UdpPacket) -> u16 {
+        match &self {
+            IpRequestInfo::V4 {
+                source_ip,
+                destination_ip,
+                ..
+            } => ipv4_checksum(packet, destination_ip, source_ip),
+            IpRequestInfo::V6 {
+                source_ip,
+                destination_ip,
+                ..
+            } => ipv6_checksum(packet, destination_ip, source_ip),
+        }
+    }
+}
+
+struct UdpRequestInfo {
+    source_port: u16,
+    destination_port: u16,
+    dns_request: Option<MessageRequest>,
+}
+
+struct RequestInfo {
+    ip: IpRequestInfo,
+    udp: UdpRequestInfo,
+}
+
+impl RequestInfo {
+    fn dns_source(&self) -> SocketAddr {
+        SocketAddr::new(self.ip.source_ip(), self.udp.source_port)
+    }
+
+    fn build_response_packet(
+        &self,
+        dns_response: &[u8],
+        response_packet: &mut [u8],
+    ) -> Result<usize, String> {
+        let ip_header_length =
+            self.build_ip_header(UDP_HEADER + dns_response.len(), response_packet)?;
+
+        self.build_payload(ip_header_length, dns_response, response_packet)
+    }
+
+    fn build_ip_header(
+        &self,
+        payload_length: usize,
+        response_packet: &mut [u8],
+    ) -> Result<usize, String> {
+        match &self.ip {
+            IpRequestInfo::V4 {
+                source_ip,
+                destination_ip,
+                dscp,
+                ecn,
+                ttl,
+                identification,
+            } => {
+                let mut ip_response = MutableIpv4Packet::new(response_packet).ok_or_else(|| {
+                    String::from("Failed to build MutableIpv4Packet for response packet")
+                })?;
+
+                ip_response.set_version(4);
+                ip_response.set_header_length((IPV4_HEADER / 4) as u8);
+                ip_response.set_dscp(*dscp);
+                ip_response.set_ecn(*ecn);
+                ip_response.set_total_length((IPV4_HEADER + payload_length) as u16);
+                ip_response.set_flags(2);
+                ip_response.set_identification(*identification);
+                ip_response.set_next_level_protocol(IpNextHeaderProtocols::Udp);
+                ip_response.set_ttl(*ttl);
+                ip_response.set_source(*destination_ip);
+                ip_response.set_destination(*source_ip);
+                ip_response.set_checksum(0);
+                ip_response.set_checksum(checksum(&ip_response.to_immutable()));
+
+                telio_log_debug!("IP response: {:?}", &ip_response);
+                Ok(IPV4_HEADER)
+            }
+            IpRequestInfo::V6 {
+                source_ip,
+                destination_ip,
+            } => {
+                let mut ip_response = MutableIpv6Packet::new(response_packet).ok_or_else(|| {
+                    String::from("Failed to build MutableIpv6Packet for response packet")
+                })?;
+
+                ip_response.set_version(6);
+                ip_response.set_traffic_class(0);
+                ip_response.set_flow_label(0);
+                ip_response.set_payload_length(payload_length as u16);
+                ip_response.set_next_header(IpNextHeaderProtocols::Udp);
+                ip_response.set_hop_limit(255);
+                ip_response.set_source(*destination_ip);
+                ip_response.set_destination(*source_ip);
+
+                telio_log_debug!("IP response: {:?}", &ip_response);
+                Ok(IPV6_HEADER)
+            }
+        }
+    }
+
+    fn build_payload(
+        &self,
+        ihl: usize,
+        dns_response: &[u8],
+        response_packet: &mut [u8],
+    ) -> Result<usize, String> {
+        let length = ihl + UDP_HEADER + dns_response.len();
+        let buffer_slice = response_packet
+            .get_mut(ihl..length)
+            .ok_or_else(|| String::from("Out of bounds on response packet buffer"))?;
+
+        let mut udp_response = MutableUdpPacket::new(buffer_slice)
+            .ok_or_else(|| String::from("Failed to build MutableUdpPacket for response packet"))?;
+
+        udp_response.set_source(self.udp.destination_port);
+        udp_response.set_destination(self.udp.source_port);
+        udp_response.set_length((UDP_HEADER + dns_response.len()) as u16);
+        udp_response.set_payload(dns_response);
+        udp_response.set_checksum(0);
+        udp_response.set_checksum(self.ip.compute_udp_checksum(&udp_response.to_immutable()));
+
+        telio_log_debug!("UDP response: {:?}", &udp_response);
+        Ok(length)
+    }
+}
+
+trait IpPacket<'a>: Sized + Packet {
+    fn try_from(buffer: &'a [u8]) -> Option<Self>;
+    fn ip_request_info(&self) -> IpRequestInfo;
+    fn udp_checksum<'b>(&self, udp_packet: &UdpPacket<'b>) -> u16;
+    fn check_valid(&self) -> bool;
+}
+
+impl<'a> IpPacket<'a> for Ipv4Packet<'a> {
+    fn try_from(buffer: &'a [u8]) -> Option<Self> {
+        Self::new(buffer)
+    }
+
+    fn ip_request_info(&self) -> IpRequestInfo {
+        IpRequestInfo::V4 {
+            source_ip: self.get_source(),
+            destination_ip: self.get_destination(),
+            dscp: self.get_dscp(),
+            ecn: self.get_ecn(),
+            ttl: self.get_ttl(),
+            identification: self.get_identification(),
+        }
+    }
+
+    fn udp_checksum<'b>(&self, udp_packet: &UdpPacket<'b>) -> u16 {
+        ipv4_checksum(udp_packet, &self.get_source(), &self.get_destination())
+    }
+
+    fn check_valid(&self) -> bool {
+        if self.get_version() != 4 {
+            return false; // Non IPv4
+        }
+        if self.get_header_length() < 5 {
+            return false; // IPv4->IHL < 5
+        }
+        if checksum(self) != self.get_checksum() {
+            return false; // Invalid checksum
+        }
+        true
+    }
+}
+
+impl<'a> IpPacket<'a> for Ipv6Packet<'a> {
+    fn try_from(buffer: &'a [u8]) -> Option<Self> {
+        Self::new(buffer)
+    }
+
+    fn ip_request_info(&self) -> IpRequestInfo {
+        IpRequestInfo::V6 {
+            source_ip: self.get_source(),
+            destination_ip: self.get_destination(),
+        }
+    }
+
+    fn udp_checksum<'b>(&self, udp_packet: &UdpPacket<'b>) -> u16 {
+        ipv6_checksum(udp_packet, &self.get_source(), &self.get_destination())
+    }
+
+    fn check_valid(&self) -> bool {
+        if self.get_version() != 6 {
+            return false; // Non IPv6
+        }
+        if self.get_payload_length() as usize != self.payload().len() {
+            return false;
+        }
+        true
     }
 }
 
@@ -111,222 +528,12 @@ impl NameServer for Arc<RwLock<LocalNameServer>> {
     #[allow(unwrap_check)]
     async fn start(&self, peer: Arc<Tunn>, socket: Arc<UdpSocket>, dst_address: SocketAddr) {
         let nameserver = self.clone();
-        self.write().await.task_handle = Some(tokio::spawn(async move {
-            let mut receiving_buffer = vec![0u8; MAX_PACKET];
-            let mut sending_buffer = vec![0u8; MAX_PACKET];
-            let semaphore = Arc::new(Semaphore::new(MAX_CONCURRENT_QUERIES));
-            loop {
-                let bytes_read = match socket.recv(&mut receiving_buffer).await {
-                    Ok(bytes) => bytes,
-                    Err(e) => {
-                        telio_log_error!("[DNS] Failed to read bytes: {:?}", e);
-                        continue;
-                    }
-                };
-
-                loop {
-                    match peer.update_timers(&mut sending_buffer) {
-                        TunnResult::WriteToNetwork(packet) => {
-                            if let Err(e) = socket.send_to(packet, dst_address).await {
-                                telio_log_warn!(
-                                    "[DNS] Failed to send timer update packet : {:?}",
-                                    e
-                                )
-                            };
-                        }
-                        TunnResult::Err(e) => {
-                            telio_log_error!("[DNS] Failed to update Tunn timers : {:?}", e);
-                            break;
-                        }
-                        _ => break,
-                    };
-                }
-
-                let peer = peer.clone();
-                let socket = socket.clone();
-                let nameserver = nameserver.clone();
-                let mut receiving_buffer = receiving_buffer.clone();
-                let mut sending_buffer = sending_buffer.clone();
-                let semaphore = semaphore.clone();
-                tokio::spawn(async move {
-                    match peer.decapsulate(
-                        None,
-                        receiving_buffer.get(..bytes_read).unwrap_or(&[]),
-                        &mut sending_buffer,
-                    ) {
-                        // Handshake packets
-                        TunnResult::WriteToNetwork(packet) => {
-                            if let Err(e) = socket.send_to(packet, dst_address).await {
-                                telio_log_warn!("[DNS] Failed to send handshake packet  : {:?}", e);
-                                return;
-                            };
-                            let mut temporary_buffer = [0u8; MAX_PACKET];
-
-                            while let TunnResult::WriteToNetwork(empty) =
-                                peer.decapsulate(None, &[], &mut temporary_buffer)
-                            {
-                                if let Err(e) = socket.send_to(empty, dst_address).await {
-                                    telio_log_warn!(
-                                        "[DNS] Failed to send handshake packet  : {:?}",
-                                        e
-                                    );
-                                    return;
-                                };
-                            }
-                        }
-                        // DNS packets
-                        TunnResult::WriteToTunnelV4(packet, _) => {
-                            // !
-                            let _lease = match semaphore.try_acquire() {
-                                Ok(lease) => lease,
-                                Err(_) => {
-                                    telio_log_debug!("Error semaphore.try_acquire()");
-                                    return;
-                                }
-                            };
-
-                            let ip_request = match Ipv4Packet::new(packet) {
-                                Some(request) => request,
-                                None => {
-                                    telio_log_debug!("ip_request NULL");
-                                    return;
-                                }
-                            };
-
-                            // Validate IP checksum
-                            if checksum(&ip_request) != ip_request.get_checksum() {
-                                telio_log_debug!("Invalid IP checksum");
-                                return;
-                            }
-
-                            let udp_request = match UdpPacket::new(ip_request.payload()) {
-                                Some(request) => request,
-                                None => {
-                                    telio_log_debug!("udp_request NULL");
-                                    return;
-                                }
-                            };
-
-                            // Validate UDP checksum
-                            let computed_udp_checksum = ipv4_checksum(
-                                &udp_request,
-                                &ip_request.get_source(),
-                                &ip_request.get_destination(),
-                            );
-                            if computed_udp_checksum != udp_request.get_checksum() {
-                                telio_log_debug!("Invalid UDP checksum");
-                                return;
-                            }
-
-                            // Validate DNS port
-                            if udp_request.get_destination() != 53 {
-                                telio_log_debug!("Invalid DNS port");
-                                return;
-                            }
-
-                            let dns_request =
-                                match MessageRequest::from_bytes(udp_request.payload()) {
-                                    Ok(request) => request,
-                                    Err(_) => {
-                                        telio_log_debug!("Error : dns_request");
-                                        return;
-                                    }
-                                };
-
-                            let resolver = Resolver::new();
-                            let zones = nameserver.zones().await;
-                            let dns_request = Request::new(
-                                dns_request,
-                                SocketAddr::new(
-                                    ip_request.get_source().into(),
-                                    udp_request.get_source(),
-                                ),
-                                Protocol::Udp,
-                            );
-                            zones.lookup(&dns_request, resolver.clone()).await;
-
-                            telio_log_debug!("dns request :{:?}", &dns_request);
-
-                            let dns_response = resolver.0.lock().await;
-                            let length = IP_HEADER + UDP_HEADER + dns_response.len();
-
-                            if let Some(mut ip_response) =
-                                MutableIpv4Packet::new(&mut receiving_buffer)
-                            {
-                                ip_response.set_version(4);
-                                ip_response.set_header_length((IP_HEADER / 4) as u8);
-                                ip_response.set_dscp(ip_request.get_dscp());
-                                ip_response.set_ecn(ip_request.get_ecn());
-                                ip_response.set_total_length(length as u16);
-                                ip_response.set_flags(2);
-                                ip_response.set_identification(ip_request.get_identification());
-                                ip_response.set_next_level_protocol(IpNextHeaderProtocols::Udp);
-                                ip_response.set_ttl(ip_request.get_ttl());
-                                ip_response.set_source(ip_request.get_destination());
-                                ip_response.set_destination(ip_request.get_source());
-                                ip_response.set_checksum(0);
-                                ip_response.set_checksum(checksum(&ip_response.to_immutable()));
-
-                                telio_log_debug!("Ip response: {:?}", &ip_response);
-                            } else {
-                                telio_log_debug!("Failed to create mutable IPv4 packet");
-                                return;
-                            }
-
-                            telio_log_debug!("nameserver response: {:?}", &dns_response);
-
-                            if let Some(mut udp_response) = MutableUdpPacket::new(
-                                if let Some(buffer_slice) =
-                                    receiving_buffer.get_mut(IP_HEADER..length)
-                                {
-                                    buffer_slice
-                                } else {
-                                    telio_log_error!("Empty receiving buffer");
-                                    return;
-                                },
-                            ) {
-                                udp_response.set_source(udp_request.get_destination());
-                                udp_response.set_destination(udp_request.get_source());
-                                udp_response.set_length((UDP_HEADER + dns_response.len()) as u16);
-                                udp_response.set_payload(&dns_response);
-                                udp_response.set_checksum(ipv4_checksum(
-                                    &udp_response.to_immutable(),
-                                    &ip_request.get_destination(),
-                                    &ip_request.get_source(),
-                                ));
-
-                                telio_log_debug!("usp response:  : {:?}", &udp_response);
-                            } else {
-                                telio_log_debug!("Failed to create mutable UDP packet");
-                                return;
-                            }
-                            match peer.encapsulate(
-                                receiving_buffer.get(..length).unwrap_or(&[]),
-                                &mut sending_buffer,
-                            ) {
-                                TunnResult::WriteToNetwork(dns) => {
-                                    if let Err(e) = socket.send_to(dns, dst_address).await {
-                                        telio_log_warn!(
-                                            "[DNS] Failed to send DNS query response  {:?}",
-                                            e
-                                        )
-                                    };
-                                }
-                                TunnResult::Err(e) => {
-                                    telio_log_warn!(
-                                        "[DNS] Failed to encapsulate DNS query response  {:?}",
-                                        e
-                                    )
-                                }
-                                _ => {}
-                            }
-                        }
-                        _ => {}
-                    }
-                });
-            }
-        }));
-
+        self.write().await.task_handle = Some(tokio::spawn(LocalNameServer::dns_service(
+            peer,
+            nameserver,
+            socket,
+            dst_address,
+        )));
         telio_log_trace!("start_sucessfull");
     }
 }


### PR DESCRIPTION
### Problem
We need support for IPv6 DNS requests

### Solution
Handle IPv6 packets in a similar way as we handle IPv4 packets


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
