### PR TITLE
Resolve LLT-4102: Remove natlab test order and improve stability

### DIFF
--- a/nat-lab/bin/derp-server
+++ b/nat-lab/bin/derp-server
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -e
+
+/usr/bin/nordderper &
+
+sleep infinity

--- a/nat-lab/conftest.py
+++ b/nat-lab/conftest.py
@@ -1,15 +1,18 @@
 import os
 
 
-def pytest_runtest_setup():
-    os.system("docker exec nat-lab-vpn-01-1 bash -c 'wg setconf wg0 /wg0.conf'")
-    os.system("docker exec nat-lab-vpn-02-1 bash -c 'wg setconf wg0 /wg0.conf'")
-    os.system(
-        "docker exec -d nat-lab-derp-01-1 bash -c 'pkill nordderper ; nordderper'"
-    )
-    os.system(
-        "docker exec -d nat-lab-derp-02-1 bash -c 'pkill nordderper ; nordderper'"
-    )
-    os.system(
-        "docker exec -d nat-lab-derp-03-1 bash -c 'pkill nordderper ; nordderper'"
-    )
+def pytest_runtest_setup(item):
+    if any(mark for mark in item.iter_markers() if mark.name == "vpn"):
+        os.system("docker exec nat-lab-vpn-01-1 bash -c 'wg setconf wg0 /wg0.conf'")
+        os.system("docker exec nat-lab-vpn-02-1 bash -c 'wg setconf wg0 /wg0.conf'")
+
+    if any(mark for mark in item.iter_markers() if mark.name == "derp"):
+        os.system(
+            "docker exec -d nat-lab-derp-01-1 bash -c 'pkill nordderper ; nordderper'"
+        )
+        os.system(
+            "docker exec -d nat-lab-derp-02-1 bash -c 'pkill nordderper ; nordderper'"
+        )
+        os.system(
+            "docker exec -d nat-lab-derp-03-1 bash -c 'pkill nordderper ; nordderper'"
+        )

--- a/nat-lab/conftest.py
+++ b/nat-lab/conftest.py
@@ -1,25 +1,15 @@
-import pytest
+import os
 
 
-def pytest_collection_modifyitems(items):
-    # Separate test execution into layers based on platform. The biggest reason
-    # for this is to separate `linux_native` tests. If the tests are running
-    # normally, they are interleaved, e.g.:
-    # Test1-BoringTun, Test1-LinuxNative, Test2-BoringTun, Test2-LinuxNative.
-    # For whatever reason, `linux_native` tests that connect to VPN server take
-    # 30 seconds to run, if they are executed after the same BoringTun test.
-    # Given 4 tests like that, interleaving increases test execution time by 2 minutes.
-
-    for item in items:
-        order_index = 1
-        for mark in item.iter_markers():
-            if mark.name == "linux_native":
-                order_index = 0
-            elif mark.name == "windows":
-                order_index = 2
-            elif mark.name == "mac":
-                order_index = 3
-            elif mark.name == "long":
-                order_index = 4
-
-        item.add_marker(pytest.mark.order(order_index))
+def pytest_runtest_setup():
+    os.system("docker exec nat-lab-vpn-01-1 bash -c 'wg setconf wg0 /wg0.conf'")
+    os.system("docker exec nat-lab-vpn-02-1 bash -c 'wg setconf wg0 /wg0.conf'")
+    os.system(
+        "docker exec -d nat-lab-derp-01-1 bash -c 'pkill nordderper ; nordderper'"
+    )
+    os.system(
+        "docker exec -d nat-lab-derp-02-1 bash -c 'pkill nordderper ; nordderper'"
+    )
+    os.system(
+        "docker exec -d nat-lab-derp-03-1 bash -c 'pkill nordderper ; nordderper'"
+    )

--- a/nat-lab/docker-compose.yml
+++ b/nat-lab/docker-compose.yml
@@ -47,7 +47,7 @@ services:
   derp-01:
     hostname: derp-01
     image: nat-lab:base
-    entrypoint: /usr/bin/nordderper
+    entrypoint: /opt/bin/derp-server
     networks:
       internet:
         ipv4_address: 10.0.10.1
@@ -57,7 +57,7 @@ services:
   derp-02:
     hostname: derp-02
     image: nat-lab:base
-    entrypoint: /usr/bin/nordderper
+    entrypoint: /opt/bin/derp-server
     networks:
       internet:
         ipv4_address: 10.0.10.2
@@ -67,7 +67,7 @@ services:
   derp-03:
     hostname: derp-03
     image: nat-lab:base
-    entrypoint: /usr/bin/nordderper
+    entrypoint: /opt/bin/derp-server
     networks:
       internet:
         ipv4_address: 10.0.10.3

--- a/nat-lab/pyproject.toml
+++ b/nat-lab/pyproject.toml
@@ -68,4 +68,6 @@ markers = [
     "linux_native: tests that use linux native WG implementation",
     "long: tests that take a lot of time to run",
     "moose: test that requires build with full moose",
+    "derp: test that uses derp connection",
+    "vpn: test that uses vpn connection",
 ]

--- a/nat-lab/tests/test_connection_states.py
+++ b/nat-lab/tests/test_connection_states.py
@@ -14,6 +14,7 @@ from utils.ping import Ping
 
 
 @pytest.mark.asyncio
+@pytest.mark.derp
 @pytest.mark.parametrize(
     "alpha_connection_tag, adapter_type",
     [

--- a/nat-lab/tests/test_derp_client_message_forward.py
+++ b/nat-lab/tests/test_derp_client_message_forward.py
@@ -10,6 +10,7 @@ TESTING_STRING = "testing"
 
 
 @pytest.mark.asyncio
+@pytest.mark.derp
 @pytest.mark.parametrize(
     "connection_tag",
     [

--- a/nat-lab/tests/test_derp_connect.py
+++ b/nat-lab/tests/test_derp_connect.py
@@ -16,6 +16,7 @@ DERP3_IP = str(DERP_TERTIARY["ipv4"])
 
 
 @pytest.mark.asyncio
+@pytest.mark.derp
 # test client reconnection
 async def test_derp_reconnect_2clients() -> None:
     # TODO test tcp keepalive
@@ -109,6 +110,7 @@ async def test_derp_reconnect_2clients() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.derp
 # test client reconnection
 async def test_derp_reconnect_3clients() -> None:
     # TODO test tcp keepalive
@@ -287,6 +289,7 @@ async def test_derp_reconnect_3clients() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.derp
 # test client reconnection
 async def test_derp_restart() -> None:
     async with AsyncExitStack() as exit_stack:
@@ -509,6 +512,7 @@ async def test_derp_restart() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.derp
 async def test_derp_server_list_exhaustion() -> None:
     async with AsyncExitStack() as exit_stack:
         api = API()

--- a/nat-lab/tests/test_direct_connection.py
+++ b/nat-lab/tests/test_direct_connection.py
@@ -240,6 +240,7 @@ async def new_connections_with_mesh_clients(
 
 
 @pytest.mark.asyncio
+@pytest.mark.derp
 @pytest.mark.parametrize(
     "endpoint_providers, client1_type, client2_type, _reflexive_ip",
     UHP_conn_client_types,
@@ -298,6 +299,7 @@ async def test_direct_working_paths(
 
 
 @pytest.mark.asyncio
+@pytest.mark.derp
 @pytest.mark.parametrize(
     "endpoint_providers, client1_type, client2_type",
     [
@@ -418,6 +420,7 @@ async def test_direct_failing_paths(
 
 
 @pytest.mark.asyncio
+@pytest.mark.derp
 @pytest.mark.xfail(reason="test flaky - JIRA issue: LLT-4132")
 @pytest.mark.parametrize(
     "endpoint_providers, client1_type, client2_type, reflexive_ip",
@@ -491,6 +494,7 @@ async def test_direct_short_connection_loss(
 
 
 @pytest.mark.asyncio
+@pytest.mark.derp
 @pytest.mark.long
 @pytest.mark.parametrize(
     "endpoint_providers, client1_type, client2_type, reflexive_ip",
@@ -572,6 +576,7 @@ async def test_direct_connection_loss_for_infinity(
 
 @pytest.mark.timeout(90)
 @pytest.mark.asyncio
+@pytest.mark.derp
 @pytest.mark.xfail(reason="test is flaky - LLT-4115")
 @pytest.mark.parametrize(
     "alpha_connection_tag, beta_connection_tag, ep1, ep2",

--- a/nat-lab/tests/test_direct_feature.py
+++ b/nat-lab/tests/test_direct_feature.py
@@ -10,6 +10,7 @@ EMPTY_PROVIDER = [""]
 
 
 @pytest.mark.asyncio
+@pytest.mark.derp
 async def test_default_direct_features() -> None:
     async with AsyncExitStack() as exit_stack:
         api = API()
@@ -35,6 +36,7 @@ async def test_default_direct_features() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.derp
 async def test_enable_all_direct_features() -> None:
     async with AsyncExitStack() as exit_stack:
         api = API()
@@ -62,6 +64,7 @@ async def test_enable_all_direct_features() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.derp
 async def test_check_features_with_empty_direct_providers() -> None:
     async with AsyncExitStack() as exit_stack:
         api = API()

--- a/nat-lab/tests/test_dns.py
+++ b/nat-lab/tests/test_dns.py
@@ -20,6 +20,7 @@ DNS_SERVER_ADDRESS = config.LIBTELIO_DNS_IP
 
 
 @pytest.mark.asyncio
+@pytest.mark.derp
 async def test_dns() -> None:
     async with AsyncExitStack() as exit_stack:
         api = API()
@@ -143,6 +144,7 @@ async def test_dns() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.derp
 async def test_dns_port() -> None:
     async with AsyncExitStack() as exit_stack:
         api = API()
@@ -264,6 +266,8 @@ async def test_dns_port() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.derp
+@pytest.mark.vpn
 async def test_vpn_dns() -> None:
     async with AsyncExitStack() as exit_stack:
         api = API()
@@ -342,6 +346,7 @@ async def test_vpn_dns() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.derp
 async def test_dns_after_mesh_off() -> None:
     async with AsyncExitStack() as exit_stack:
         api = API()
@@ -413,6 +418,7 @@ async def test_dns_after_mesh_off() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.derp
 @pytest.mark.long
 @pytest.mark.timeout(60 * 5 + 60)
 @pytest.mark.parametrize(
@@ -538,6 +544,7 @@ async def test_dns_stability(
 
 
 @pytest.mark.asyncio
+@pytest.mark.derp
 async def test_set_meshmap_dns_update() -> None:
     async with AsyncExitStack() as exit_stack:
         api = API()
@@ -585,6 +592,8 @@ async def test_set_meshmap_dns_update() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.derp
+@pytest.mark.vpn
 async def test_dns_update() -> None:
     async with AsyncExitStack() as exit_stack:
         api = API()
@@ -644,6 +653,7 @@ async def test_dns_update() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.derp
 async def test_dns_duplicate_requests_on_multiple_forward_servers() -> None:
     async with AsyncExitStack() as exit_stack:
         api = API()
@@ -694,6 +704,7 @@ async def test_dns_duplicate_requests_on_multiple_forward_servers() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.derp
 async def test_dns_aaaa_records() -> None:
     async with AsyncExitStack() as exit_stack:
         api = API()

--- a/nat-lab/tests/test_dns_through_exit.py
+++ b/nat-lab/tests/test_dns_through_exit.py
@@ -16,6 +16,7 @@ from utils.connection_util import (
 
 
 @pytest.mark.asyncio
+@pytest.mark.derp
 @pytest.mark.parametrize(
     "alpha_connection_tag,alpha_adapter_type",
     [

--- a/nat-lab/tests/test_events.py
+++ b/nat-lab/tests/test_events.py
@@ -17,6 +17,7 @@ from utils.ping import Ping
 
 
 @pytest.mark.asyncio
+@pytest.mark.derp
 @pytest.mark.parametrize(
     "alpha_connection_tag,adapter_type",
     [
@@ -152,6 +153,8 @@ async def test_event_content_meshnet(
 
 
 @pytest.mark.asyncio
+@pytest.mark.derp
+@pytest.mark.vpn
 @pytest.mark.parametrize(
     "alpha_connection_tag,adapter_type,public_ip",
     [
@@ -282,6 +285,7 @@ async def test_event_content_vpn_connection(
 
 
 @pytest.mark.asyncio
+@pytest.mark.derp
 @pytest.mark.parametrize(
     "alpha_connection_tag,adapter_type",
     [
@@ -415,6 +419,7 @@ async def test_event_content_exit_through_peer(
 
 
 @pytest.mark.asyncio
+@pytest.mark.derp
 @pytest.mark.timeout(90)
 @pytest.mark.parametrize(
     "alpha_connection_tag,adapter_type,alpha_public_ip",

--- a/nat-lab/tests/test_fire_connecting_event.py
+++ b/nat-lab/tests/test_fire_connecting_event.py
@@ -15,6 +15,7 @@ from utils.ping import Ping
 
 
 @pytest.mark.asyncio
+@pytest.mark.derp
 @pytest.mark.long
 @pytest.mark.timeout(180 + 60)
 @pytest.mark.parametrize(

--- a/nat-lab/tests/test_lana.py
+++ b/nat-lab/tests/test_lana.py
@@ -238,6 +238,7 @@ async def run_default_scenario(
 
 
 @pytest.mark.moose
+@pytest.mark.derp
 @pytest.mark.asyncio
 async def test_lana_with_same_meshnet() -> None:
     async with AsyncExitStack() as exit_stack:
@@ -314,6 +315,7 @@ async def test_lana_with_same_meshnet() -> None:
 
 
 @pytest.mark.moose
+@pytest.mark.derp
 @pytest.mark.asyncio
 async def test_lana_with_external_node() -> None:
     async with AsyncExitStack() as exit_stack:
@@ -405,6 +407,7 @@ async def test_lana_with_external_node() -> None:
 
 
 @pytest.mark.moose
+@pytest.mark.derp
 @pytest.mark.asyncio
 async def test_lana_all_external() -> None:
     async with AsyncExitStack() as exit_stack:
@@ -483,6 +486,8 @@ async def test_lana_all_external() -> None:
 
 
 @pytest.mark.moose
+@pytest.mark.derp
+@pytest.mark.vpn
 @pytest.mark.asyncio
 async def test_lana_with_vpn_connections() -> None:
     async with AsyncExitStack() as exit_stack:
@@ -568,6 +573,7 @@ async def test_lana_with_vpn_connections() -> None:
 
 
 @pytest.mark.moose
+@pytest.mark.derp
 @pytest.mark.asyncio
 async def test_lana_with_disconnected_node() -> None:
     async with AsyncExitStack() as exit_stack:
@@ -717,6 +723,7 @@ async def test_lana_with_disconnected_node() -> None:
 
 
 @pytest.mark.moose
+@pytest.mark.derp
 @pytest.mark.asyncio
 async def test_lana_with_second_node_joining_later_meshnet_id_can_change() -> None:
     async with AsyncExitStack() as exit_stack:
@@ -808,6 +815,7 @@ async def test_lana_with_second_node_joining_later_meshnet_id_can_change() -> No
 
 
 @pytest.mark.moose
+@pytest.mark.derp
 @pytest.mark.asyncio
 async def test_lana_same_meshnet_id_is_reported_after_a_restart():
     async with AsyncExitStack() as exit_stack:
@@ -860,6 +868,7 @@ async def test_lana_same_meshnet_id_is_reported_after_a_restart():
 
 
 @pytest.mark.moose
+@pytest.mark.derp
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "initial_heartbeat_interval", [pytest.param(5), pytest.param(None)]

--- a/nat-lab/tests/test_mesh_exit_through_peer.py
+++ b/nat-lab/tests/test_mesh_exit_through_peer.py
@@ -16,6 +16,7 @@ from utils.ping import Ping
 
 
 @pytest.mark.asyncio
+@pytest.mark.derp
 @pytest.mark.parametrize(
     "alpha_connection_tag,adapter_type",
     [

--- a/nat-lab/tests/test_mesh_firewall.py
+++ b/nat-lab/tests/test_mesh_firewall.py
@@ -16,6 +16,7 @@ from utils.ping import Ping
 
 
 @pytest.mark.asyncio
+@pytest.mark.derp
 async def test_mesh_firewall_successful_passthrough() -> None:
     async with AsyncExitStack() as exit_stack:
         api = API()
@@ -86,6 +87,7 @@ async def test_mesh_firewall_successful_passthrough() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.derp
 async def test_mesh_firewall_reject_packet() -> None:
     async with AsyncExitStack() as exit_stack:
         api = API()
@@ -153,6 +155,7 @@ async def test_mesh_firewall_reject_packet() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.derp
 async def test_blocking_incoming_connections_from_exit_node() -> None:
     # This tests recreates LLT-3449
     async with AsyncExitStack() as exit_stack:
@@ -323,6 +326,7 @@ async def test_blocking_incoming_connections_from_exit_node() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.derp
 @pytest.mark.parametrize(
     "allow_incoming_connections,allow_peer_send_file,port,successful",
     [
@@ -477,6 +481,7 @@ async def test_mesh_firewall_file_share_port(
 
 
 @pytest.mark.asyncio
+@pytest.mark.derp
 @pytest.mark.parametrize(
     "alpha_adapter_type, beta_adapter_type",
     [
@@ -617,6 +622,7 @@ async def test_mesh_firewall_tcp_stuck_in_last_ack_state_conn_kill_from_server_s
 
 
 @pytest.mark.asyncio
+@pytest.mark.derp
 @pytest.mark.parametrize(
     "alpha_adapter_type, beta_adapter_type",
     [

--- a/nat-lab/tests/test_mesh_plus_vpn.py
+++ b/nat-lab/tests/test_mesh_plus_vpn.py
@@ -17,6 +17,8 @@ from utils.ping import Ping
 
 
 @pytest.mark.asyncio
+@pytest.mark.derp
+@pytest.mark.vpn
 @pytest.mark.parametrize(
     "alpha_connection_tag,adapter_type",
     [
@@ -125,6 +127,8 @@ async def test_mesh_plus_vpn_one_peer(
 
 
 @pytest.mark.asyncio
+@pytest.mark.derp
+@pytest.mark.vpn
 @pytest.mark.parametrize(
     "alpha_connection_tag,adapter_type",
     [
@@ -250,6 +254,8 @@ async def test_mesh_plus_vpn_both_peers(
 
 
 @pytest.mark.asyncio
+@pytest.mark.derp
+@pytest.mark.vpn
 @pytest.mark.parametrize(
     "alpha_connection_tag,adapter_type,public_ip",
     [
@@ -370,6 +376,8 @@ async def test_vpn_plus_mesh(
 
 
 @pytest.mark.asyncio
+@pytest.mark.derp
+@pytest.mark.vpn
 @pytest.mark.timeout(150)
 @pytest.mark.parametrize(
     "alpha_connection_tag,adapter_type",
@@ -513,6 +521,8 @@ async def test_vpn_plus_mesh_over_direct(
 
 
 @pytest.mark.asyncio
+@pytest.mark.derp
+@pytest.mark.vpn
 @pytest.mark.timeout(150)
 @pytest.mark.parametrize(
     "alpha_connection_tag,adapter_type",

--- a/nat-lab/tests/test_mesh_remove_node.py
+++ b/nat-lab/tests/test_mesh_remove_node.py
@@ -15,6 +15,7 @@ from utils.ping import Ping
 
 
 @pytest.mark.asyncio
+@pytest.mark.derp
 @pytest.mark.parametrize(
     "alpha_connection_tag,adapter_type",
     [

--- a/nat-lab/tests/test_network_switch.py
+++ b/nat-lab/tests/test_network_switch.py
@@ -59,6 +59,7 @@ async def test_network_switcher(
 
 
 @pytest.mark.asyncio
+@pytest.mark.derp
 @pytest.mark.xfail(reason="the test is flaky - JIRA issue: LLT-4105")
 @pytest.mark.parametrize(
     "alpha_connection_tag, adapter_type",
@@ -133,6 +134,7 @@ async def test_mesh_network_switch(
 
 
 @pytest.mark.asyncio
+@pytest.mark.vpn
 @pytest.mark.parametrize(
     "connection_tag, adapter_type",
     [
@@ -213,6 +215,7 @@ async def test_vpn_network_switch(
 
 
 @pytest.mark.asyncio
+@pytest.mark.derp
 @pytest.mark.xfail(
     reason=(
         "Flaky: Running tests in specific order, might change the"

--- a/nat-lab/tests/test_node_state_flickering.py
+++ b/nat-lab/tests/test_node_state_flickering.py
@@ -13,6 +13,7 @@ from utils.connection_util import (
 
 
 @pytest.mark.asyncio
+@pytest.mark.derp
 @pytest.mark.timeout(180)
 @pytest.mark.long
 @pytest.mark.parametrize(

--- a/nat-lab/tests/test_pinger.py
+++ b/nat-lab/tests/test_pinger.py
@@ -5,7 +5,7 @@ import socket
 import struct
 import telio
 from contextlib import AsyncExitStack
-from mesh_api import DERP_SERVERS, API
+from mesh_api import API
 from protobuf.pinger_pb2 import Pinger
 from utils import testing
 from utils.asyncio_util import run_async_context
@@ -49,6 +49,7 @@ async def send_ping_pong(ping_type) -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.derp
 async def test_ping_pong() -> None:
     async with AsyncExitStack() as exit_stack:
         api = API()
@@ -60,9 +61,7 @@ async def test_ping_pong() -> None:
         )
 
         client_alpha = await exit_stack.enter_async_context(
-            telio.Client(connection_alpha, alpha).run_meshnet(
-                api.get_meshmap(alpha.id, DERP_SERVERS)
-            )
+            telio.Client(connection_alpha, alpha).run_meshnet(api.get_meshmap(alpha.id))
         )
 
         pinger_event = client_alpha.wait_for_output("Pinger")
@@ -85,6 +84,7 @@ async def test_ping_pong() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.derp
 async def test_send_malform_pinger_packet() -> None:
     async with AsyncExitStack() as exit_stack:
         api = API()
@@ -96,9 +96,7 @@ async def test_send_malform_pinger_packet() -> None:
         )
 
         client_alpha = await exit_stack.enter_async_context(
-            telio.Client(connection_alpha, alpha).run_meshnet(
-                api.get_meshmap(alpha.id, DERP_SERVERS)
-            )
+            telio.Client(connection_alpha, alpha).run_meshnet(api.get_meshmap(alpha.id))
         )
 
         unexpected_packet_event = client_alpha.wait_for_output("Unexpected packet: ")

--- a/nat-lab/tests/test_reconnections.py
+++ b/nat-lab/tests/test_reconnections.py
@@ -15,6 +15,7 @@ from utils.ping import Ping
 
 
 @pytest.mark.asyncio
+@pytest.mark.derp
 @pytest.mark.parametrize(
     "alpha_connection_tag,adapter_type,",
     [

--- a/nat-lab/tests/test_tcli.py
+++ b/nat-lab/tests/test_tcli.py
@@ -13,6 +13,7 @@ from utils.connection_util import (
 
 
 @pytest.mark.asyncio
+@pytest.mark.derp
 @pytest.mark.parametrize(
     "alpha_connection_tag,adapter_type",
     [

--- a/nat-lab/tests/test_telio_tasks.py
+++ b/nat-lab/tests/test_telio_tasks.py
@@ -8,6 +8,7 @@ from utils.connection_util import ConnectionTag, new_connection_by_tag
 
 
 @pytest.mark.asyncio
+@pytest.mark.derp
 async def test_telio_tasks_with_all_features() -> None:
     async with AsyncExitStack() as exit_stack:
         api = API()

--- a/nat-lab/tests/test_upnp_connection.py
+++ b/nat-lab/tests/test_upnp_connection.py
@@ -14,6 +14,7 @@ UPNP_PROVIDER = ["upnp"]
 
 
 @pytest.mark.asyncio
+@pytest.mark.derp
 async def test_upnp_route_removed() -> None:
     async with AsyncExitStack() as exit_stack:
         api = API()

--- a/nat-lab/tests/test_verify_pk_on_packets.py
+++ b/nat-lab/tests/test_verify_pk_on_packets.py
@@ -23,7 +23,8 @@ async def check_fake_derp_connection(client: telio.Client) -> Optional[telio.Cli
 
 
 @pytest.mark.asyncio
-@pytest.mark.xfail(reason="the test is flaky - JIRA issue: LLT-3078")
+@pytest.mark.derp
+@pytest.mark.skip(reason="test doesnt work at all - JIRA issue: LLT-3078")
 async def test_verify_pk_on_packets() -> None:
     async with AsyncExitStack() as exit_stack:
         api = API()

--- a/nat-lab/tests/test_vpn.py
+++ b/nat-lab/tests/test_vpn.py
@@ -49,6 +49,7 @@ async def _connect_vpn(
 
 
 @pytest.mark.asyncio
+@pytest.mark.vpn
 @pytest.mark.parametrize(
     "alpha_connection_tag,adapter_type,public_ip",
     [
@@ -123,6 +124,7 @@ async def test_vpn_connection(
 
 
 @pytest.mark.asyncio
+@pytest.mark.vpn
 @pytest.mark.parametrize(
     "alpha_connection_tag,adapter_type,public_ip",
     [


### PR DESCRIPTION
### Problem
- Some of test when run after some specific test, will run slower, make connections harder, causing tests to be flaky. Custom order in `conftest.py` was attempt of a workaround, which doesn't always help.
- Bug itself is know, but it is in Boringtun and only affects our natlab specific case (LLT-4112), because of that, it is very low priority.

### Solution
- Reset vpn/derp servers, but without actually needing to restart docker containers.

**P.S.** This actually improve test speed quite abit. For example:
Running `pytest test/test_vpn.py` with custom order, takes 100~ seconds, but with current solution it takes 80~

**P.S.S.** This might also have side effect of improving stability for tests.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
