### PR TITLE
LLT-3913: Deduplicate IPs of external meshent peers

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@
 * LLT-3629: Add IPv6 support to nat-lab
 * LLT-4119: Fix multiple bugs in telio-firewall. Mainly whitelist vpn server
 * LLT-4166: Bump tokio-rustls version
+* LLT-3913: Deduplicate IPs of external wireguard peers
 
 <br>
 


### PR DESCRIPTION
### Problem
Wireguard mandates that every connected peer has a unique IP address. So far we haven't validated that that is the case in our meshnet config. 

### Solution
We have two types of peers, internal and external. Internal peers will never have IP collisions with each other, but external peers might have collisions with internal and/or external peers. Added here is a deduplication step where overlapping IPs are removed from external peers. If two or more external peers have the same IP, only the first one specified in the config will keep the IP.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
