### PR TITLE
fix debug assert of bad type

### DIFF
--- a/crates/telio-dns/src/forward.rs
+++ b/crates/telio-dns/src/forward.rs
@@ -203,7 +203,7 @@ impl Authority for ForwardAuthority {
                     negative_ttl: _,
                     response_code,
                     trusted: _,
-                } => LookupError::from(*response_code),
+                } => LookupError::ResponseCode(*response_code),
                 _ => LookupError::from(ResponseCode::Unknown(0)),
             })
     }


### PR DESCRIPTION
### Problem
Debug build of telio asserts when NoError is returned after no name was found from dns query

### Solution
Remove the assert, because there is no underlying issue here.


### :ballot_box_with_check: Definition of Done checklist
- [ ] Commit history is clean ([requirements](../../blob/main/docs/git_commit_messages_requirements.md))
- [ ] README.md is updated
- [ ] changelog.md is updated
