### PR TITLE
[LLT-3875] Fix derp disconnections

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,7 @@
 * LLT-3869: Turn off relayed traffic to offline peers
 * LLT-3775: Add test for lana validators
 * LLT-4050: Add support for IPv6 packet handling in telio-dns
+* LLT-3875: Don't reconnect to Derp when Multiplexer channel is closed.
 
 <br>
 

--- a/nat-lab/tests/test_events.py
+++ b/nat-lab/tests/test_events.py
@@ -486,8 +486,7 @@ async def test_event_content_meshnet_node_upgrade_direct(
                 ConnectionTag.DOCKER_CONE_CLIENT_2,
                 generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_2,
-                    # TODO: Change back derp limits max value to 2, when issue LLT-3875 is fixed
-                    derp_1_limits=ConnectionLimits(2, None),
+                    derp_1_limits=ConnectionLimits(2, 2),
                 ),
             )
         )

--- a/nat-lab/tests/test_fire_connecting_event.py
+++ b/nat-lab/tests/test_fire_connecting_event.py
@@ -41,8 +41,7 @@ async def test_fire_connecting_event(
                 ConnectionTag.DOCKER_CONE_CLIENT_2,
                 generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_2,
-                    # TODO: Change back derp limits max value to 1, when issue LLT-3875 is fixed
-                    derp_1_limits=ConnectionLimits(1, None),
+                    derp_1_limits=ConnectionLimits(1, 1),
                 ),
             )
         )

--- a/nat-lab/tests/test_lana.py
+++ b/nat-lab/tests/test_lana.py
@@ -111,8 +111,7 @@ async def run_default_scenario(
             ConnectionTag.DOCKER_CONE_CLIENT_1,
             generate_connection_tracker_config(
                 ConnectionTag.DOCKER_CONE_CLIENT_1,
-                # TODO: Change back derp limits max value to 1, when issue LLT-3875 is fixed
-                derp_1_limits=ConnectionLimits(1, None),
+                derp_1_limits=ConnectionLimits(1, 1),
                 vpn_1_limits=ConnectionLimits(1 if alpha_has_vpn_connection else 0, 1),
             ),
         )
@@ -122,8 +121,7 @@ async def run_default_scenario(
             ConnectionTag.DOCKER_CONE_CLIENT_2,
             generate_connection_tracker_config(
                 ConnectionTag.DOCKER_CONE_CLIENT_2,
-                # TODO: Change back derp limits max value to 1, when issue LLT-3875 is fixed
-                derp_1_limits=ConnectionLimits(1, None),
+                derp_1_limits=ConnectionLimits(1, 1),
                 vpn_1_limits=ConnectionLimits(1 if beta_has_vpn_connection else 0, 1),
             ),
         )
@@ -133,8 +131,7 @@ async def run_default_scenario(
             ConnectionTag.DOCKER_SYMMETRIC_CLIENT_1,
             generate_connection_tracker_config(
                 ConnectionTag.DOCKER_SYMMETRIC_CLIENT_1,
-                # TODO: Change back derp limits max value to 1, when issue LLT-3875 is fixed
-                derp_1_limits=ConnectionLimits(1, None),
+                derp_1_limits=ConnectionLimits(1, 1),
                 vpn_1_limits=ConnectionLimits(1 if gamma_has_vpn_connection else 0, 1),
             ),
         )
@@ -587,8 +584,7 @@ async def test_lana_with_disconnected_node() -> None:
                 ConnectionTag.DOCKER_CONE_CLIENT_2,
                 generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_2,
-                    # TODO: Change back derp limits max value to 1, when issue LLT-3875 is fixed
-                    derp_1_limits=ConnectionLimits(1, None),
+                    derp_1_limits=ConnectionLimits(1, 1),
                 ),
             )
         )

--- a/nat-lab/tests/test_reconnections.py
+++ b/nat-lab/tests/test_reconnections.py
@@ -51,8 +51,7 @@ async def test_mesh_reconnect(
                 alpha_connection_tag,
                 generate_connection_tracker_config(
                     alpha_connection_tag,
-                    # TODO: Change back derp limits max value to 1, when issue LLT-3875 is fixed
-                    derp_1_limits=ConnectionLimits(1, None),
+                    derp_1_limits=ConnectionLimits(2, 2),
                 ),
             )
         )


### PR DESCRIPTION
### Problem
Telio sometimes tries to reconnect with Derp server when already stopped

### Solution
Ensure that Derp doesn't try to reconnect when the Multiplexer channel is closed


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
