### PR TITLE
Restore derp server preparation before test

### DIFF
--- a/nat-lab/conftest.py
+++ b/nat-lab/conftest.py
@@ -1,6 +1,7 @@
-import natlab
+import os
 
 
 def pytest_runtest_setup(item):
     if any(mark for mark in item.iter_markers() if mark.name == "derp"):
-        natlab.quick_restart_container(["derp"])
+        for derp in ["nat-lab-derp-01-1", "nat-lab-derp-02-1", "nat-lab-derp-03-1"]:
+            os.system(f"docker exec -d {derp} bash -c 'pkill nordderper ; nordderper'")


### PR DESCRIPTION
### Problem
Restarting servers was not the best solution, since some tests might fail because service might not be started.

### Solution
Temp solution (doesnt fix root cause): but restating process itself, leaves all the tcp connections between servers itself and etc.. Doing this kinda dirty, restores connections faster and etc.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
