### PR TITLE
Natlab police fix flaky tests

### DIFF
--- a/nat-lab/tests/test_lana.py
+++ b/nat-lab/tests/test_lana.py
@@ -718,7 +718,7 @@ async def test_lana_with_disconnected_node() -> None:
 
 @pytest.mark.moose
 @pytest.mark.asyncio
-@pytest.mark.xfail
+@pytest.mark.xfail(reason="test is flaky - LLT-4187")
 async def test_lana_with_second_node_joining_later_meshnet_id_can_change() -> None:
     async with AsyncExitStack() as exit_stack:
         api = API()

--- a/nat-lab/tests/utils/process/docker_process.py
+++ b/nat-lab/tests/utils/process/docker_process.py
@@ -106,7 +106,9 @@ class DockerProcess(Process):
                     continue
                 decodeable_lines = lines[:-1]
 
-            output = b"\x0a".join(decodeable_lines).decode(sys.getfilesystemencoding(), errors='replace')
+            output = b"\x0a".join(decodeable_lines).decode(
+                sys.getfilesystemencoding(), errors="replace"
+            )
 
             if message.stream == 1:
                 self._stdout += output
@@ -119,7 +121,7 @@ class DockerProcess(Process):
 
         for stream_id, buffer in buffers.items():
             if buffer:
-                output = buffer.decode(sys.getfilesystemencoding(), errors='replace')
+                output = buffer.decode(sys.getfilesystemencoding(), errors="replace")
                 if stream_id == 1:
                     self._stdout += output
                     if stdout_callback:

--- a/nat-lab/tests/utils/process/docker_process.py
+++ b/nat-lab/tests/utils/process/docker_process.py
@@ -106,7 +106,7 @@ class DockerProcess(Process):
                     continue
                 decodeable_lines = lines[:-1]
 
-            output = b"\x0a".join(decodeable_lines).decode(sys.getfilesystemencoding())
+            output = b"\x0a".join(decodeable_lines).decode(sys.getfilesystemencoding(), errors='replace')
 
             if message.stream == 1:
                 self._stdout += output
@@ -119,7 +119,7 @@ class DockerProcess(Process):
 
         for stream_id, buffer in buffers.items():
             if buffer:
-                output = buffer.decode(sys.getfilesystemencoding(), errors="ignore")
+                output = buffer.decode(sys.getfilesystemencoding(), errors='replace')
                 if stream_id == 1:
                     self._stdout += output
                     if stdout_callback:


### PR DESCRIPTION
### Problem
`test_event_content_meshnet_node_upgrade_direct` and `test_lana_with_second_node_joining_later_meshnet_id_can_change` are flaky.

### Solution
`test_event_content_meshnet_node_upgrade_direct` failed due to a unhandled utf-8 decode error, which this PR fixes.

`test_lana_with_second_node_joining_later_meshnet_id_can_change` flakyness cause is unknown and might be a caught bug by the test. This PR marks it as flaky.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
