### PR TITLE
Natlab police Mark test_client_basic_stun as flaky

### DIFF
--- a/nat-lab/tests/test_client_basic_stun.py
+++ b/nat-lab/tests/test_client_basic_stun.py
@@ -9,7 +9,14 @@ from utils.connection_util import ConnectionTag, new_connection_by_tag
     "connection_tag,public_ip",
     [
         pytest.param(ConnectionTag.DOCKER_CONE_CLIENT_1, "10.0.254.1"),
-        pytest.param(ConnectionTag.WINDOWS_VM, "10.0.254.7", marks=pytest.mark.windows),
+        pytest.param(
+            ConnectionTag.WINDOWS_VM,
+            "10.0.254.7",
+            marks=[
+                pytest.mark.windows,
+                pytest.mark.xfail(reason="test is flaky - LLT-4213"),
+            ],
+        ),
         pytest.param(ConnectionTag.MAC_VM, "10.0.254.7", marks=pytest.mark.mac),
     ],
 )


### PR DESCRIPTION
### Problem
Two pipelines failed recently due test_client_basic_stun timeouts on Windows VMs.

### Solution
In this PR, we mark the test as flaky and create an issue to investigate the timeouts: LLT-4213


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
