### PR TITLE
Update moose, add 'meshnet_enabled' field

### DIFF
--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -29,4 +29,4 @@ jobs:
           project-id: ${{ secrets.PROJECT_ID }}
           token: ${{ secrets.TOKEN }}
           schedule: ${{ github.event_name == 'schedule' }}
-          ref: v0.1.9
+          ref: v0.1.10

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,5 +15,5 @@ libtelio-build-pipeline:
 
   trigger:
     project: $LIBTELIO_BUILD_PROJECT_PATH
-    branch: v0.1.9
+    branch: v0.1.10
     strategy: depend

--- a/changelog.md
+++ b/changelog.md
@@ -16,6 +16,7 @@
 * LLT-3775: Add test for lana validators
 * LLT-4050: Add support for IPv6 packet handling in telio-dns
 * LLT-3875: Don't reconnect to Derp when Multiplexer channel is closed.
+* LLT-4204: Add `meshnet_enabled` field
 
 <br>
 

--- a/crates/telio-lana/Cargo.toml
+++ b/crates/telio-lana/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/NordSecurity/libtelio"
 publish = false
 
 [dependencies]
-log = {version = "0.4.14", features = ["release_max_level_debug"]}
+log = { version = "0.4.14", features = ["release_max_level_debug"]}
 telio-utils = { path = "../telio-utils" }
 thiserror = "1.0.30"
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/telio-lana/src/event_log_file.rs
+++ b/crates/telio-lana/src/event_log_file.rs
@@ -216,16 +216,16 @@ pub mod moose {
     }
 
     #[derive(Debug, Clone, Copy)]
-    pub enum ContextState {
+    pub enum TrackerState {
         Ready,
-        AlreadyInitiated,
+        AlreadyStarted,
         TrackerDeleted,
         AllTrackersDeleted,
-        Deleted,
+        FileDeleted,
     }
 
-    pub trait InitCallback {
-        fn on_init(&self, result_code: &std::result::Result<ContextState, MooseError>);
+    pub trait InitCallback: Send {
+        fn after_init(&self, result: &std::result::Result<TrackerState, MooseError>);
     }
 
     pub trait ErrorCallback {
@@ -269,6 +269,20 @@ pub mod moose {
 
     pub fn moose_deinit() -> std::result::Result<Result, Error> {
         match super::event_log("moose_deinit", None) {
+            Ok(_) => Ok(Result::Success),
+            _ => Err(Error::EventLogError),
+        }
+    }
+
+    #[allow(non_snake_case)]
+    pub fn set_context_application_config_currentState_meshnetEnabled(
+        val: bool,
+    ) -> std::result::Result<Result, Error> {
+        let val = val.to_string();
+        match super::event_log(
+            "set_context_application_config_currentState_meshnetEnabled",
+            Some(vec![val.as_str()]),
+        ) {
             Ok(_) => Ok(Result::Success),
             _ => Err(Error::EventLogError),
         }
@@ -362,14 +376,17 @@ pub mod moose {
     /// Mocked moose function.
     pub fn send_serviceQuality_node_heartbeat(
         connectionDuration: String,
+        derpConnectionDuration: i32,
         heartbeatInterval: i32,
         receivedData: String,
         rtt: String,
         sentData: String,
     ) -> std::result::Result<Result, Error> {
         let heartbeatIntervalString = heartbeatInterval.to_string();
+        let derpConnectionDurationStr = derpConnectionDuration.to_string();
         let args = vec![
             connectionDuration.as_str(),
+            derpConnectionDurationStr.as_str(),
             heartbeatIntervalString.as_str(),
             receivedData.as_str(),
             rtt.as_str(),

--- a/crates/telio-lana/src/lib.rs
+++ b/crates/telio-lana/src/lib.rs
@@ -15,7 +15,7 @@ pub use event_log::*;
 /// App name used to initialize moose with
 pub const LANA_APP_NAME: &str = "libtelio";
 /// Version of the tracker used, should be updated everytime the tracker library is updated
-pub const LANA_MOOSE_VERSION: &str = "0.6.0";
+pub const LANA_MOOSE_VERSION: &str = "0.8.0";
 
 static MOOSE_INITIALIZED: AtomicBool = AtomicBool::new(false);
 const DEFAULT_ORDERING: Ordering = Ordering::SeqCst;

--- a/crates/telio-lana/src/moose_callbacks.rs
+++ b/crates/telio-lana/src/moose_callbacks.rs
@@ -5,7 +5,7 @@ pub use telio_utils::{telio_log_error, telio_log_info, telio_log_warn};
 pub struct MooseCallbacks;
 
 impl moose::InitCallback for MooseCallbacks {
-    fn on_init(&self, result_code: &Result<moose::ContextState, moose::MooseError>) {
+    fn after_init(&self, result_code: &Result<moose::TrackerState, moose::MooseError>) {
         match result_code {
             Ok(res) => telio_log_info!("Moose init success with code {:?}", res),
             Err(err) => telio_log_error!("Moose init failed with code {:?}", err),

--- a/crates/telio-nurse/src/nurse.rs
+++ b/crates/telio-nurse/src/nurse.rs
@@ -181,6 +181,11 @@ impl State {
         // Re-parse the foreign tracker before sending an event, in case it has changed since last time
         init_context_info();
 
+        let _ = lana!(
+            set_context_application_config_currentState_meshnetEnabled,
+            info.meshnet_enabled
+        );
+
         // Send off nominated fingerprint to moose
         let _ = lana!(
             set_context_application_config_currentState_internalMeshnet_fp,
@@ -237,6 +242,7 @@ impl State {
         let _ = lana!(
             send_serviceQuality_node_heartbeat,
             qos_data.connection_duration,
+            0, // TODO(LLT-4205): Derp Connection Duration
             info.heartbeat_interval,
             qos_data.rx,
             qos_data.rtt,


### PR DESCRIPTION
Since version 4.0, we have been sending quality events for both meshnet and VPN. To differentiate whether the library is used solely for VPN or with meshnet, a 'meshnet_enabled' field has been added.

### Problem
It not possible to know from analytics if meshnet is being used.

### Solution
Added 'meshnet_enabled' field.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean
- [x] README.md is updated
- [x] changelog.md is updated