### PR TITLE
natlab: Fix test teardown

### DIFF
--- a/nat-lab/tests/conftest.py
+++ b/nat-lab/tests/conftest.py
@@ -1,0 +1,40 @@
+import asyncio
+import pytest
+
+
+def _cancel_all_tasks(loop: asyncio.AbstractEventLoop):
+    to_cancel = asyncio.tasks.all_tasks(loop)
+    if not to_cancel:
+        return
+
+    for task in to_cancel:
+        task.cancel()
+
+    loop.run_until_complete(asyncio.tasks.gather(*to_cancel, return_exceptions=True))
+
+    for task in to_cancel:
+        if task.cancelled():
+            continue
+        if task.exception() is not None:
+            loop.call_exception_handler(
+                {
+                    "message": "unhandled exception during asyncio.run() shutdown",
+                    "exception": task.exception(),
+                    "task": task,
+                }
+            )
+
+
+@pytest.fixture(scope="function")
+def event_loop():
+    loop = asyncio.get_event_loop_policy().new_event_loop()
+    try:
+        yield loop
+    finally:
+        try:
+            _cancel_all_tasks(loop)
+            loop.run_until_complete(loop.shutdown_asyncgens())
+            loop.run_until_complete(loop.shutdown_default_executor())
+        finally:
+            asyncio.events.set_event_loop(None)
+            loop.close()

--- a/nat-lab/tests/utils/process/docker_process.py
+++ b/nat-lab/tests/utils/process/docker_process.py
@@ -143,3 +143,6 @@ class DockerProcess(Process):
 
     def get_stderr(self) -> str:
         return self._stderr
+
+    def is_executing(self) -> bool:
+        return self._stream is not None

--- a/nat-lab/tests/utils/process/process.py
+++ b/nat-lab/tests/utils/process/process.py
@@ -53,3 +53,7 @@ class Process(ABC):
     @abstractmethod
     def get_stderr(self) -> str:
         pass
+
+    @abstractmethod
+    def is_executing(self) -> bool:
+        pass


### PR DESCRIPTION
### Problem
Until now, if an exception was thrown during test execution, whether for timing out or any other reason, context managers were not able to properly exit. For instance, when timing out from pytest-timeout, the plugin throws a TimeOutError exception and it doesn't allow the user to catch it. Instead it handles it internally and replaces it by a pytest.fail() call, which in its turn raises a Fail exception.

Our actual implementation doesn't handle every kind of exception, naturally, and in every test whether we have an active ssh or docker connection the teardown needs to be carefully handled so that the cleanup takes place.

There was two main issues:
 - After exception was thrown, event loop would close before cleanup takes place (mainly for docker/ssh connections)
 - Client instance would hangup during teardown, trying to send a `dev stop` to a already closed `tcli` process.

### Solution
 - Adding a custom event loop, where all the tasks are manually cancelled when the test execution is going to stop.
 - Checking if tcli process is active before cleaning up, otherwise the Process concrete class will take care of it during teardown.
  
 PS: This not the ideal solution as the cleanup we design is not really happening, instead we cleanup by killing the processes. Nevertheless, this fixes the actual issue where configuration leftovers are not cleaned from the container, making other tests to fail.

With the ongoing improvement of the framework, we are going to be able to make pytest.fixtures from setup and teardown functions, isolating the setup/teardown phase from the test itself, avoiding these type of issues.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
