### PR TITLE
Natlab police: unmark passing tests

### DIFF
--- a/nat-lab/tests/test_network_switch.py
+++ b/nat-lab/tests/test_network_switch.py
@@ -59,7 +59,6 @@ async def test_network_switcher(
 
 
 @pytest.mark.asyncio
-@pytest.mark.xfail(reason="the test is flaky - JIRA issue: LLT-4105")
 @pytest.mark.parametrize(
     "alpha_connection_tag, adapter_type",
     [

--- a/nat-lab/tests/test_reconnections.py
+++ b/nat-lab/tests/test_reconnections.py
@@ -15,7 +15,6 @@ from utils.ping import Ping
 
 
 @pytest.mark.asyncio
-@pytest.mark.xfail(reason="test is flaky - Jira issue: LLT-4161")
 @pytest.mark.parametrize(
     "alpha_connection_tag,adapter_type,",
     [


### PR DESCRIPTION
### Problem
Tests test_mesh_network_switch and test_mesh_reconnect are passing constantly, so they shouldn't be marked as flaky.

### Solution
Remove their flaky marks.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
