### PR TITLE
Migrate natlab VMs to libvirt

### DIFF
--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -31,4 +31,4 @@ jobs:
           project-id: ${{ secrets.PROJECT_ID }}
           schedule: ${{ github.event_name == 'schedule' }}
           cancel-outdated-pipelines: ${{ github.ref_name != 'main' }}
-          triggered-ref: v0.1.12
+          triggered-ref: LLT-4136_migrate-natlab-to-libvirt

--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -31,4 +31,4 @@ jobs:
           project-id: ${{ secrets.PROJECT_ID }}
           schedule: ${{ github.event_name == 'schedule' }}
           cancel-outdated-pipelines: ${{ github.ref_name != 'main' }}
-          triggered-ref: LLT-4136_migrate-natlab-to-libvirt
+          triggered-ref: v0.2.1

--- a/changelog.md
+++ b/changelog.md
@@ -22,6 +22,7 @@
 * LLT-4246: Add self nordname as well as self IP address to the DNS records
 * LLT-4179: Fix issue where first WG-STUN request would fail due to missing WG-STUN peer
 * LLT-4233: Add moose init callback validation
+* LLT-4136: Migrate Natlab VMs to use libvirt
 
 <br>
 

--- a/nat-lab/tests/config.py
+++ b/nat-lab/tests/config.py
@@ -18,17 +18,25 @@ MAC_VM_IP = "10.55.0.12"
 LINUX_VM_PRIMARY_GATEWAY = "10.55.0.10"
 LINUX_VM_SECONDARY_GATEWAY = "10.66.0.10"
 
+PRIMARY_VM_NETWORK_PREFIX = "10.55.0"
+SECONDARY_VM_NETWORK_PREFIX = "10.66.0"
+
+# https://vagrant-libvirt.github.io/vagrant-libvirt/configuration.html#management-network
+LIBVIRT_MANAGEMENT_NETWORK_PREFIX = "192.168.121"
+
 # Same as defined in `libtelio/nat-lab/docker-compose.yml`, 10.0.0.0/16
 DOCKER_NETWORK_IP = "10.0.0.0"
 DOCKER_NETWORK_MASK = "255.255.0.0"
 STUN_SERVER = "10.0.1.1"
 
 # Same as defined in `libtelio/nat-lab/provision_windows.ps1`
-STUN_BINARY_PATH_WINDOWS = "C:/workspace/stunserver/release/stunclient.exe"
-STUN_BINARY_PATH_MAC = "/Users/vagrant/stunserver/stunclient"
+STUN_BINARY_PATH_WINDOWS = "C:/workspace/stunserver/release/stunclient.exe".replace(
+    "/", "\\"
+)
+STUN_BINARY_PATH_MAC = "/var/root/stunserver/stunclient"
 
-IPERF_BINARY_MAC = "/Users/vagrant/iperf3/iperf3"
-IPERF_BINARY_WINDOWS = "C:\\workspace\\iperf3\\iperf3.exe"
+IPERF_BINARY_MAC = "/var/root/iperf3/iperf3"
+IPERF_BINARY_WINDOWS = "C:/workspace/iperf3/iperf3.exe".replace("/", "\\")
 
 # JIRA issue: LLT-1664
 # The directories between host and Docker container are shared via
@@ -46,7 +54,8 @@ LIBTELIO_BINARY_PATH_DOCKER = (
 )
 
 # Libtelio binary path inside Windows and Mac VMs
-LIBTELIO_BINARY_PATH_VM = "/workspace/binaries/"
+LIBTELIO_BINARY_PATH_WINDOWS_VM = "C:/workspace/binaries/".replace("/", "\\")
+LIBTELIO_BINARY_PATH_MAC_VM = "/var/root/workspace/binaries/"
 
 LIBTELIO_DNS_IPV4 = "100.64.0.2"
 LIBTELIO_DNS_IPV6 = "fc74:656c:696f::2"

--- a/nat-lab/tests/test_process.py
+++ b/nat-lab/tests/test_process.py
@@ -89,7 +89,7 @@ async def test_process_run_success(
 
 
 @pytest.mark.parametrize(
-    "connection_tag,ping_command",
+    "connection_tag,command",
     [
         pytest.param(
             ConnectionTag.DOCKER_CONE_CLIENT_1,
@@ -107,17 +107,17 @@ async def test_process_run_success(
         ),
     ],
 )
-async def test_process_run_fail(connection_tag: ConnectionTag, ping_command: list[str]):
+async def test_process_run_fail(connection_tag: ConnectionTag, command: list[str]):
     async with AsyncExitStack() as exit_stack:
         connection = await exit_stack.enter_async_context(
             new_connection_by_tag(connection_tag)
         )
         with pytest.raises(ProcessExecError) as e:
-            async with connection.create_process(ping_command).run():
+            async with connection.create_process(command).run():
                 await asyncio.sleep(1)
-        assert e.value.cmd == ping_command
+        assert e.value.cmd == command
         assert e.value.returncode == 77
-        assert " ".join(ping_command) not in await _get_running_process_list(connection)
+        assert " ".join(command) not in await _get_running_process_list(connection)
 
 
 @pytest.mark.parametrize(

--- a/nat-lab/tests/utils/connection_util.py
+++ b/nat-lab/tests/utils/connection_util.py
@@ -183,14 +183,14 @@ async def new_connection_raw(tag: ConnectionTag) -> AsyncIterator[Connection]:
         assert False, f"tag {tag} not supported"
 
 
-def create_network_switcher(
+async def create_network_switcher(
     tag: ConnectionTag, connection: Connection
 ) -> Optional[NetworkSwitcher]:
     if tag in DOCKER_SERVICE_IDS:
         return NetworkSwitcherDocker(connection)
 
     if tag == ConnectionTag.WINDOWS_VM:
-        return NetworkSwitcherWindows(connection)
+        return await NetworkSwitcherWindows.create(connection)
 
     if tag == ConnectionTag.MAC_VM:
         return NetworkSwitcherMac(connection)
@@ -208,7 +208,7 @@ async def new_connection_manager_by_tag(
     ]
 ]:
     async with new_connection_raw(tag) as connection:
-        network_switcher = create_network_switcher(tag, connection)
+        network_switcher = await create_network_switcher(tag, connection)
         if network_switcher:
             await network_switcher.switch_to_primary_network()
         if tag in DOCKER_GW_MAP:

--- a/nat-lab/tests/utils/connection_util.py
+++ b/nat-lab/tests/utils/connection_util.py
@@ -154,8 +154,13 @@ def get_libtelio_binary_path(path: str, connection: Connection) -> str:
     target_os = connection.target_os
     if target_os == TargetOS.Linux:
         return config.LIBTELIO_BINARY_PATH_DOCKER + path
-    if target_os in [TargetOS.Windows, TargetOS.Mac]:
-        return config.LIBTELIO_BINARY_PATH_VM + path
+
+    if target_os == TargetOS.Windows:
+        return config.LIBTELIO_BINARY_PATH_WINDOWS_VM + path
+
+    if target_os == TargetOS.Mac:
+        return config.LIBTELIO_BINARY_PATH_MAC_VM + path
+
     assert False, f"target_os not supported '{target_os}'"
 
 

--- a/nat-lab/tests/utils/network_switcher/network_switcher_windows.py
+++ b/nat-lab/tests/utils/network_switcher/network_switcher_windows.py
@@ -1,16 +1,68 @@
 import config
+import re
 from .network_switcher import NetworkSwitcher
+from dataclasses import dataclass
+from typing import List, Optional
 from utils.connection import Connection
 from utils.process import ProcessExecError
 
-VAGRANT_DEFAULT_IF = "Ethernet"  # 10.0.2.0/24
-PRIMARY_IF = "Ethernet 2"  # 10.55.0.11
-SECONDARY_IF = "Ethernet 3"  # 10.66.0.11
+
+@dataclass
+class Interface:
+    def __init__(self, name: str, ipv4: str) -> None:
+        self.name = name
+        self.ipv4 = ipv4
+
+
+class ConfiguredInterfaces:
+    def __init__(self, default: str, primary: str, secondary: str) -> None:
+        self.default = default
+        self.primary = primary
+        self.secondary = secondary
+
+    @staticmethod
+    async def find(connection: Connection) -> "ConfiguredInterfaces":
+        interfaces = await ConfiguredInterfaces.get_network_interfaces(connection)
+
+        def find_interface(prefix: str) -> str:
+            for interface in interfaces:
+                if interface.ipv4.startswith(prefix):
+                    return interface.name
+            assert False, f"interface not found with prefix `{prefix}`, {interfaces}"
+
+        return ConfiguredInterfaces(
+            find_interface(config.LIBVIRT_MANAGEMENT_NETWORK_PREFIX),
+            find_interface(config.PRIMARY_VM_NETWORK_PREFIX),
+            find_interface(config.SECONDARY_VM_NETWORK_PREFIX),
+        )
+
+    @staticmethod
+    async def get_network_interfaces(connection: Connection) -> List[Interface]:
+        process = await connection.create_process(
+            ["netsh", "interface", "ipv4", "show", "addresses"]
+        ).execute()
+
+        matches = re.findall(
+            r"Configuration for interface \"(.*)\"[\s\S]*?IP Address:\s*([\d.]*)",
+            process.get_stdout(),
+        )
+
+        result: List[Interface] = []
+        for match in matches:
+            result.append(Interface(match[0], match[1]))
+
+        return result
 
 
 class NetworkSwitcherWindows(NetworkSwitcher):
     def __init__(self, connection: Connection) -> None:
         self._connection = connection
+        self._interfaces: Optional[ConfiguredInterfaces] = None
+
+    async def get_interfaces(self) -> ConfiguredInterfaces:
+        if not self._interfaces:
+            self._interfaces = await ConfiguredInterfaces.find(self._connection)
+        return self._interfaces
 
     async def switch_to_primary_network(self) -> None:
         await self._delete_existing_route()
@@ -23,7 +75,7 @@ class NetworkSwitcherWindows(NetworkSwitcher):
                 "add",
                 "route",
                 "0.0.0.0/0",
-                PRIMARY_IF,
+                (await self.get_interfaces()).primary,
                 f"nexthop={config.LINUX_VM_PRIMARY_GATEWAY}",
             ]
         ).execute()
@@ -39,7 +91,7 @@ class NetworkSwitcherWindows(NetworkSwitcher):
                 "add",
                 "route",
                 "0.0.0.0/0",
-                SECONDARY_IF,
+                (await self.get_interfaces()).secondary,
                 f"nexthop={config.LINUX_VM_SECONDARY_GATEWAY}",
             ]
         ).execute()
@@ -49,9 +101,10 @@ class NetworkSwitcherWindows(NetworkSwitcher):
         # it possible to have multiple default routes at the same time: first default route
         # for LAN network, and second default route for VPN network.
 
-        await self._delete_route(VAGRANT_DEFAULT_IF)
-        await self._delete_route(PRIMARY_IF)
-        await self._delete_route(SECONDARY_IF)
+        interfaces = await self.get_interfaces()
+        await self._delete_route(interfaces.default)
+        await self._delete_route(interfaces.primary)
+        await self._delete_route(interfaces.secondary)
 
     async def _delete_route(self, interface_name: str) -> None:
         try:

--- a/nat-lab/tests/utils/vm/mac_vm_util.py
+++ b/nat-lab/tests/utils/vm/mac_vm_util.py
@@ -7,7 +7,7 @@ from typing import AsyncIterator
 from utils.connection import Connection, SshConnection, TargetOS
 from utils.process import ProcessExecError
 
-VM_TCLI_DIR = config.LIBTELIO_BINARY_PATH_VM
+VM_TCLI_DIR = config.LIBTELIO_BINARY_PATH_MAC_VM
 FILES_COPIED = False
 
 

--- a/nat-lab/tests/utils/vm/windows_vm_util.py
+++ b/nat-lab/tests/utils/vm/windows_vm_util.py
@@ -1,13 +1,13 @@
 import asyncssh
 import config
 import subprocess
-from config import get_root_path
+from config import get_root_path, LIBTELIO_BINARY_PATH_WINDOWS_VM
 from contextlib import asynccontextmanager
 from typing import AsyncIterator
 from utils.connection import Connection, SshConnection, TargetOS
 from utils.process import ProcessExecError
 
-VM_TCLI_DIR = "C:\\workspace\\binaries"
+VM_TCLI_DIR = LIBTELIO_BINARY_PATH_WINDOWS_VM
 FILES_COPIED = False
 
 

--- a/release.py
+++ b/release.py
@@ -24,8 +24,10 @@ def check_project_root_directory():
     with open("Cargo.toml") as f:
         content = f.read()
 
-    if not re.search(r"^\[package\]", content, re.MULTILINE) or not re.search(r'name\s*=\s*"telio"', content):
-        print("This does not appear to be a \"libtelio\" repo.")
+    if not re.search(r"^\[package\]", content, re.MULTILINE) or not re.search(
+        r'name\s*=\s*"telio"', content
+    ):
+        print('This does not appear to be a "libtelio" repo.')
         sys.exit(1)
 
 
@@ -44,34 +46,28 @@ def get_default_branch():
     if not default_branch:
         print("Failed to retrieve default branch.")
         sys.exit(1)
-    
+
     return default_branch
 
 
 def check_git_tree(branch):
-    current_branch = (
-        subprocess.run(
-            "git rev-parse --abbrev-ref HEAD",
-            capture_output=True,
-            text=True,
-            shell=True,
-        )
-        .stdout.strip()
-    )
+    current_branch = subprocess.run(
+        "git rev-parse --abbrev-ref HEAD",
+        capture_output=True,
+        text=True,
+        shell=True,
+    ).stdout.strip()
 
     if current_branch != branch:
         print("Git tree is not on the default branch.")
         sys.exit(1)
 
-    git_status = (
-        subprocess.run(
-            "git status --short",
-            capture_output=True,
-            text=True,
-            shell=True,
-        )
-        .stdout.strip()
-    )
+    git_status = subprocess.run(
+        "git status --short",
+        capture_output=True,
+        text=True,
+        shell=True,
+    ).stdout.strip()
 
     if git_status:
         print("Git tree is dirty.")
@@ -119,13 +115,17 @@ def check_cargo_tools(install_missing_tools):
             else:
                 print("$ cargo install cargo-edit")
         else:
-            print("Required tool 'cargo-edit' not found. Use --install-missing-tools to install.")
+            print(
+                "Required tool 'cargo-edit' not found. Use --install-missing-tools to install."
+            )
             sys.exit(1)
 
 
 def validate_tag_format(tag):
     if not re.match(r"^v[0-9]+\.[0-9]+\.[0-9]+$", tag):
-        print("Invalid tag format. Expected format: 'vMAJOR.MINOR.BUGFIX', e.g. 'v4.12.3'.")
+        print(
+            "Invalid tag format. Expected format: 'vMAJOR.MINOR.BUGFIX', e.g. 'v4.12.3'."
+        )
         sys.exit(1)
 
 
@@ -145,7 +145,9 @@ def update_changelog(tag):
         with open(changelog_file, "w") as f:
             f.write(content)
     else:
-        print("$ substitute \"### UNRELEASED\" --> \"### {}\" in ./changelog.md".format(tag))
+        print(
+            '$ substitute "### UNRELEASED" --> "### {}" in ./changelog.md'.format(tag)
+        )
 
 
 def update_cargo_toml(tag):
@@ -164,13 +166,32 @@ def commit_and_push(tag, push, remote, branch):
 
 def main():
     parser = argparse.ArgumentParser(description="Libtelio release helper script")
-    parser.add_argument("--dry-run", action="store_true", help="Run in dry-run mode, only prints commands")
-    parser.add_argument("--install-missing-tools", action="store_true", help="Install missing tools (e.g., 'cargo-edit')")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Run in dry-run mode, only prints commands",
+    )
+    parser.add_argument(
+        "--install-missing-tools",
+        action="store_true",
+        help="Install missing tools (e.g., 'cargo-edit')",
+    )
     parser.add_argument("--tag", help="Version to release (mandatory)")
-    parser.add_argument("--push", action="store_true", help="Push changes to the remote repository")
-    parser.add_argument("--changelog", action="store_true", help="Make changes to './changelog.md'")
-    parser.add_argument("--remote", default="origin", help="Remote name for git push (default: 'origin')")
-    parser.add_argument("--branch", help="Remote name for git push (default repo branch will be used, if not supplied)")
+    parser.add_argument(
+        "--push", action="store_true", help="Push changes to the remote repository"
+    )
+    parser.add_argument(
+        "--changelog", action="store_true", help="Make changes to './changelog.md'"
+    )
+    parser.add_argument(
+        "--remote",
+        default="origin",
+        help="Remote name for git push (default: 'origin')",
+    )
+    parser.add_argument(
+        "--branch",
+        help="Remote name for git push (default repo branch will be used, if not supplied)",
+    )
     args = parser.parse_args()
 
     if not args.tag:
@@ -187,7 +208,7 @@ def main():
         branch = get_default_branch()
     else:
         branch = args.branch
-        
+
     check_git_tree(branch)
     check_existing_tag(args.tag)
     check_cargo_tools(args.install_missing_tools)


### PR DESCRIPTION
MacOS VM has been updated to Catalina (previously Big-Sierra). Catalina
has different directory structure, and `/workspace` is not writeable.
Instead, copy the requires files to `/var/root/workspace`.

For some reason with libvirt Windows network interface names are not
consistent across different machines, i.e. the names are different when
running on my computer and when running on CI. Add some code to detect
the names of interfaces by their IP address.

`test_process_run_fail` was failing because of different error messgage
from ping. Rewrite the test to use `bash -c exit 77`.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
