### PR TITLE
lana: Add moose init callback validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3243,6 +3243,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial_test"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eec42e7232e5ca56aa59d63af3c7f991fe71ee6a3ddd2d3480834cf3902b007"
+dependencies = [
+ "futures",
+ "lazy_static",
+ "log",
+ "parking_lot 0.12.1",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1b95bb2f4f624565e8fe8140c789af7e2082c0e0561b5a82a1b678baa9703dc"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
+ "rustversion",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "sha1"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3755,6 +3781,7 @@ dependencies = [
  "log",
  "serde",
  "serde_json",
+ "serial_test",
  "telio-utils",
  "thiserror",
  "time",

--- a/changelog.md
+++ b/changelog.md
@@ -21,6 +21,7 @@
 * LLT-3316: Improve usage of peer-reflexive endpoints
 * LLT-4246: Add self nordname as well as self IP address to the DNS records
 * LLT-4179: Fix issue where first WG-STUN request would fail due to missing WG-STUN peer
+* LLT-4233: Add moose init callback validation
 
 <br>
 

--- a/crates/telio-lana/Cargo.toml
+++ b/crates/telio-lana/Cargo.toml
@@ -11,11 +11,14 @@ publish = false
 
 [dependencies]
 log = { version = "0.4.14", features = ["release_max_level_debug"]}
-telio-utils = { path = "../telio-utils" }
-thiserror = "1.0.30"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+telio-utils = { path = "../telio-utils" }
+thiserror = "1.0.30"
 time = { version = "0.3.9", features = ["formatting"] }
+
+[dev-dependencies]
+serial_test = "0.8.0"
 
 [build-dependencies]
 anyhow = "1"

--- a/crates/telio-lana/src/event_log_file.rs
+++ b/crates/telio-lana/src/event_log_file.rs
@@ -229,7 +229,7 @@ pub mod moose {
             match state {
                 TrackerState::Ready => Result::Success,
                 TrackerState::AlreadyStarted => Result::AlreadyInitiated,
-                _ => unreachable!("All other cases are not covered by Result enum"),
+                _ => unimplemented!("All other cases are not covered by Result enum"),
             }
         }
     }

--- a/crates/telio-lana/src/event_log_file.rs
+++ b/crates/telio-lana/src/event_log_file.rs
@@ -224,6 +224,25 @@ pub mod moose {
         FileDeleted,
     }
 
+    impl From<TrackerState> for Result {
+        fn from(state: TrackerState) -> Result {
+            match state {
+                TrackerState::Ready => Result::Success,
+                TrackerState::AlreadyStarted => Result::AlreadyInitiated,
+                _ => unreachable!("All other cases are not covered by Result enum"),
+            }
+        }
+    }
+
+    impl From<MooseError> for Error {
+        fn from(moose_error: MooseError) -> Error {
+            match moose_error {
+                MooseError::NotInitiated => Error::NotInitiatedError,
+                _ => Error::EventLogError,
+            }
+        }
+    }
+
     pub trait InitCallback: Send {
         fn after_init(&self, result: &std::result::Result<TrackerState, MooseError>);
     }
@@ -252,7 +271,7 @@ pub mod moose {
         init_cb: Box<(dyn InitCallback + 'static)>,
         error_cb: Box<(dyn ErrorCallback + Sync + std::marker::Send + 'static)>,
     ) -> std::result::Result<Result, Error> {
-        match super::event_log(
+        let result = match super::event_log(
             "init",
             Some(vec![
                 event_path.as_str(),
@@ -262,8 +281,15 @@ pub mod moose {
                 prod.to_string().as_str(),
             ]),
         ) {
-            Ok(_) => Ok(Result::Success),
-            _ => Err(Error::EventLogError),
+            Ok(_) => Ok(TrackerState::Ready),
+            _ => Err(MooseError::NotInitiated),
+        };
+
+        init_cb.after_init(&result);
+
+        match result {
+            Ok(r) => Ok(Result::from(r)),
+            Err(e) => Err(Error::from(e)),
         }
     }
 

--- a/crates/telio-lana/src/moose_callbacks.rs
+++ b/crates/telio-lana/src/moose_callbacks.rs
@@ -1,19 +1,34 @@
 pub use crate::event_log::*;
+use std::sync::mpsc::SyncSender;
 pub use telio_utils::{telio_log_error, telio_log_info, telio_log_warn};
 
-/// Struct for Moose callbacks
-pub struct MooseCallbacks;
+/// Struct for moose::InitCallback
+pub struct MooseInitCallback {
+    /// Channel tx half to send init result
+    pub init_success_tx: SyncSender<bool>,
+}
 
-impl moose::InitCallback for MooseCallbacks {
+/// Struct for moose::ErrorCallback
+pub struct MooseErrorCallback;
+
+impl moose::InitCallback for MooseInitCallback {
     fn after_init(&self, result_code: &Result<moose::TrackerState, moose::MooseError>) {
-        match result_code {
-            Ok(res) => telio_log_info!("Moose init success with code {:?}", res),
-            Err(err) => telio_log_error!("Moose init failed with code {:?}", err),
-        }
+        let success = match result_code {
+            Ok(res) => {
+                telio_log_info!("[Moose] Init callback success: {:?}", res);
+                true
+            }
+            Err(err) => {
+                telio_log_warn!("[Moose] Init callback error: {:?}", err);
+                false
+            }
+        };
+        #[allow(mpsc_blocking_send)]
+        let _ = self.init_success_tx.send(success);
     }
 }
 
-impl moose::ErrorCallback for MooseCallbacks {
+impl moose::ErrorCallback for MooseErrorCallback {
     fn on_error(
         &self,
         error_level: moose::MooseErrorLevel,
@@ -22,10 +37,10 @@ impl moose::ErrorCallback for MooseCallbacks {
     ) {
         match error_level {
             moose::MooseErrorLevel::Warning => {
-                telio_log_warn!("Moose error {:?}: {}", error_code, msg)
+                telio_log_warn!("[Moose] Error callback {:?}: {:?}", error_code, msg)
             }
             moose::MooseErrorLevel::Error => {
-                telio_log_error!("Moose error {:?}: {}", error_code, msg)
+                telio_log_warn!("[Moose] Error callback {:?}: {:?}", error_code, msg)
             }
         }
     }

--- a/crates/telio-lana/src/moose_callbacks.rs
+++ b/crates/telio-lana/src/moose_callbacks.rs
@@ -1,4 +1,7 @@
-pub use crate::event_log::*;
+pub use crate::event_log::moose::{ErrorCallback, MooseError, MooseErrorLevel, TrackerState};
+
+pub use crate::event_log::moose::InitCallback;
+
 use std::sync::mpsc::SyncSender;
 pub use telio_utils::{telio_log_error, telio_log_info, telio_log_warn};
 
@@ -11,8 +14,8 @@ pub struct MooseInitCallback {
 /// Struct for moose::ErrorCallback
 pub struct MooseErrorCallback;
 
-impl moose::InitCallback for MooseInitCallback {
-    fn after_init(&self, result_code: &Result<moose::TrackerState, moose::MooseError>) {
+impl InitCallback for MooseInitCallback {
+    fn after_init(&self, result_code: &Result<TrackerState, MooseError>) {
         let success = match result_code {
             Ok(res) => {
                 telio_log_info!("[Moose] Init callback success: {:?}", res);
@@ -28,18 +31,13 @@ impl moose::InitCallback for MooseInitCallback {
     }
 }
 
-impl moose::ErrorCallback for MooseErrorCallback {
-    fn on_error(
-        &self,
-        error_level: moose::MooseErrorLevel,
-        error_code: moose::MooseError,
-        msg: &str,
-    ) {
+impl ErrorCallback for MooseErrorCallback {
+    fn on_error(&self, error_level: MooseErrorLevel, error_code: MooseError, msg: &str) {
         match error_level {
-            moose::MooseErrorLevel::Warning => {
+            MooseErrorLevel::Warning => {
                 telio_log_warn!("[Moose] Error callback {:?}: {:?}", error_code, msg)
             }
-            moose::MooseErrorLevel::Error => {
+            MooseErrorLevel::Error => {
                 telio_log_warn!("[Moose] Error callback {:?}: {:?}", error_code, msg)
             }
         }

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -57,7 +57,7 @@ use cfg_if::cfg_if;
 use telio_utils::{
     commit_sha,
     exponential_backoff::ExponentialBackoffBounds,
-    telio_log_debug, telio_log_info, telio_log_warn,
+    telio_log_debug, telio_log_error, telio_log_info, telio_log_warn,
     tokio::{Monitor, ThreadTracker},
     version_tag,
 };
@@ -349,7 +349,9 @@ impl Device {
         telio_log_info!("libtelio is starting up with features : {:?}", features);
 
         if let Some(lana) = &features.lana {
-            init_lana(lana.event_path.clone(), version_tag.to_string(), lana.prod)?;
+            if init_lana(lana.event_path.clone(), version_tag.to_string(), lana.prod).is_err() {
+                telio_log_error!("Failed to initialize lana")
+            }
         }
 
         let thread_tracker = Arc::new(parking_lot::Mutex::new(ThreadTracker::default()));


### PR DESCRIPTION
### Problem
Libtelio updated moose to a new async version which report’s it’s errors not by return but by callback.
One of the callbacks, `moose::InitCallback`, should be waited for and in case of error, analytics should be disabled entirely.

### Solution
Wait for `moose::InitCallback` value with a 2s timeout and in case there's an error, lana initialization fails with just an error message, continuing libtelio startup.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
