### PR TITLE
Do not answer to DNS request if forward lookup fails

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,13 +29,14 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.3"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
 dependencies = [
  "cfg-if",
  "once_cell",
  "version_check",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1113,14 +1114,14 @@ checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
 name = "enum-as-inner"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9720bba047d567ffc8a3cba48bf19126600e249ab7f128e9233e6376976a116"
+checksum = "5ffccbb6966c05b32ef8fbac435df276c4ae4d3dc55a8cd0eb9745e6c12f546a"
 dependencies = [
  "heck",
  "proc-macro2 1.0.69",
  "quote 1.0.33",
- "syn 1.0.109",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -1521,6 +1522,89 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hickory-client"
+version = "0.24.0"
+source = "git+https://github.com/NordSecurity/trust-dns.git?tag=v3.0.0#f3583ef082b448e808a492d034a2e30cda53dcdb"
+dependencies = [
+ "cfg-if",
+ "data-encoding",
+ "futures-channel",
+ "futures-util",
+ "hickory-proto",
+ "once_cell",
+ "radix_trie",
+ "rand",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "hickory-proto"
+version = "0.24.0"
+source = "git+https://github.com/NordSecurity/trust-dns.git?tag=v3.0.0#f3583ef082b448e808a492d034a2e30cda53dcdb"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna",
+ "ipnet",
+ "once_cell",
+ "rand",
+ "serde",
+ "thiserror",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.24.0"
+source = "git+https://github.com/NordSecurity/trust-dns.git?tag=v3.0.0#f3583ef082b448e808a492d034a2e30cda53dcdb"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-proto",
+ "ipconfig",
+ "lru-cache",
+ "once_cell",
+ "parking_lot",
+ "rand",
+ "resolv-conf",
+ "serde",
+ "smallvec",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "hickory-server"
+version = "0.24.0"
+source = "git+https://github.com/NordSecurity/trust-dns.git?tag=v3.0.0#f3583ef082b448e808a492d034a2e30cda53dcdb"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "cfg-if",
+ "enum-as-inner",
+ "futures-util",
+ "hickory-proto",
+ "hickory-resolver",
+ "serde",
+ "thiserror",
+ "time",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "histogram"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1638,17 +1722,6 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
-name = "idna"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
-dependencies = [
- "matches",
- "unicode-bidi",
- "unicode-normalization",
-]
 
 [[package]]
 name = "idna"
@@ -1950,12 +2023,6 @@ name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
-
-[[package]]
-name = "matches"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "md5"
@@ -3664,6 +3731,10 @@ dependencies = [
  "base64 0.13.1",
  "boringtun",
  "dns-parser",
+ "hickory-client",
+ "hickory-proto",
+ "hickory-resolver",
+ "hickory-server",
  "ipnetwork",
  "lazy_static",
  "libc",
@@ -3676,10 +3747,6 @@ dependencies = [
  "telio-utils",
  "telio-wg",
  "tokio",
- "trust-dns-client",
- "trust-dns-proto",
- "trust-dns-resolver",
- "trust-dns-server",
  "x25519-dalek 2.0.0",
 ]
 
@@ -4283,92 +4350,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "trust-dns-client"
-version = "0.22.0"
-source = "git+https://github.com/NordSecurity/trust-dns.git?tag=v2.0.0#0be935bf9cda610f096eaa74fc5adb4f3f171297"
-dependencies = [
- "cfg-if",
- "data-encoding",
- "futures-channel",
- "futures-util",
- "lazy_static",
- "radix_trie",
- "rand",
- "thiserror",
- "time",
- "tokio",
- "tracing",
- "trust-dns-proto",
-]
-
-[[package]]
-name = "trust-dns-proto"
-version = "0.22.0"
-source = "git+https://github.com/NordSecurity/trust-dns.git?tag=v2.0.0#0be935bf9cda610f096eaa74fc5adb4f3f171297"
-dependencies = [
- "async-trait",
- "cfg-if",
- "data-encoding",
- "enum-as-inner",
- "futures-channel",
- "futures-io",
- "futures-util",
- "idna 0.2.3",
- "ipnet",
- "lazy_static",
- "rand",
- "serde",
- "smallvec",
- "thiserror",
- "tinyvec",
- "tokio",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "trust-dns-resolver"
-version = "0.22.0"
-source = "git+https://github.com/NordSecurity/trust-dns.git?tag=v2.0.0#0be935bf9cda610f096eaa74fc5adb4f3f171297"
-dependencies = [
- "cfg-if",
- "futures-util",
- "ipconfig",
- "lazy_static",
- "lru-cache",
- "parking_lot",
- "resolv-conf",
- "serde",
- "smallvec",
- "thiserror",
- "tokio",
- "tracing",
- "trust-dns-proto",
-]
-
-[[package]]
-name = "trust-dns-server"
-version = "0.22.1"
-source = "git+https://github.com/NordSecurity/trust-dns.git?tag=v2.0.0#0be935bf9cda610f096eaa74fc5adb4f3f171297"
-dependencies = [
- "async-trait",
- "bytes",
- "cfg-if",
- "enum-as-inner",
- "futures-executor",
- "futures-util",
- "serde",
- "thiserror",
- "time",
- "tokio",
- "toml",
- "tracing",
- "trust-dns-client",
- "trust-dns-proto",
- "trust-dns-resolver",
-]
-
-[[package]]
 name = "try-lock"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4454,7 +4435,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5"
 dependencies = [
  "form_urlencoded",
- "idna 0.4.0",
+ "idna",
  "percent-encoding",
  "serde",
 ]
@@ -4892,6 +4873,26 @@ dependencies = [
  "salsa20",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cd369a67c0edfef15010f980c3cbe45d7f651deac2cd67ce097cd801de16557"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2f140bda219a26ccc0cdb03dba58af72590c53b22642577d88a927bc5c87d6b"
+dependencies = [
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
+ "syn 2.0.38",
 ]
 
 [[package]]

--- a/changelog.md
+++ b/changelog.md
@@ -41,6 +41,7 @@
 * LLT-4376: Add magicdns support for two dns bindings
 * LLT-4515: Add nordvpn app version to moose context
 * LLT-3923: Change DERP and STUN identifiers
+* LLT-4202: Do not answer DNS request if forward lookup fails
 
 <br>
 

--- a/crates/telio-dns/Cargo.toml
+++ b/crates/telio-dns/Cargo.toml
@@ -8,11 +8,10 @@ publish = false
 
 [dependencies]
 rand = "0.8"
-trust-dns-client = { git = "https://github.com/NordSecurity/trust-dns.git", tag = "v2.0.0" }
-trust-dns-proto = { git = "https://github.com/NordSecurity/trust-dns.git", tag = "v2.0.0" }
-trust-dns-resolver = { git = "https://github.com/NordSecurity/trust-dns.git", tag = "v2.0.0" }
-trust-dns-server = { git = "https://github.com/NordSecurity/trust-dns.git", tag = "v2.0.0", features = ["resolver"] }
-
+hickory-client = { git = "https://github.com/NordSecurity/trust-dns.git", tag = "v3.0.0" }
+hickory-proto = { git = "https://github.com/NordSecurity/trust-dns.git", tag = "v3.0.0" }
+hickory-resolver = { git = "https://github.com/NordSecurity/trust-dns.git", tag = "v3.0.0" }
+hickory-server = { git = "https://github.com/NordSecurity/trust-dns.git", tag = "v3.0.0", features = ["resolver"] }
 async-trait.workspace = true
 base64.workspace = true
 boringtun.workspace = true

--- a/crates/telio-dns/src/resolver.rs
+++ b/crates/telio-dns/src/resolver.rs
@@ -1,11 +1,11 @@
-use std::io::{Error as IOError, Result as IOResult};
-use std::sync::Arc;
-use tokio::sync::Mutex;
-use trust_dns_proto::{rr::Record, serialize::binary::BinEncoder};
-use trust_dns_server::{
+use hickory_proto::{rr::Record, serialize::binary::BinEncoder};
+use hickory_server::{
     authority::MessageResponse,
     server::{ResponseHandler, ResponseInfo},
 };
+use std::io::{Error as IOError, Result as IOResult};
+use std::sync::Arc;
+use tokio::sync::Mutex;
 
 #[derive(Clone)]
 /// Resolver converts DNS responses to &[u8].

--- a/crates/telio-dns/tests/nameserver.rs
+++ b/crates/telio-dns/tests/nameserver.rs
@@ -296,6 +296,7 @@ enum DnsTestType {
     CorrectIpv6,
     BadUdpChecksumIpv6,
     BadUdpPortIpv6,
+    NonRespondingForwardServer,
 }
 
 impl DnsTestType {
@@ -433,7 +434,7 @@ async fn dns_request_forward_to_slow_server() {
     // Start a query that will run for several seconds
     tokio::spawn(dns_test_with_server(
         "google.com",
-        DnsTestType::CorrectIpv4,
+        DnsTestType::NonRespondingForwardServer,
         None,
         nameserver.clone(),
     ));
@@ -446,6 +447,21 @@ async fn dns_request_forward_to_slow_server() {
     assert!(timeout(Duration::from_millis(100), nameserver.write())
         .await
         .is_ok());
+}
+
+#[tokio::test]
+async fn dns_request_to_non_responding_forward_server() {
+    let nameserver = LocalNameServer::new(&[IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0))])
+        .await
+        .unwrap();
+
+    dns_test_with_server(
+        "google.com",
+        DnsTestType::NonRespondingForwardServer,
+        None,
+        nameserver.clone(),
+    )
+    .await;
 }
 
 #[tokio::test]

--- a/nat-lab/tests/test_dns.py
+++ b/nat-lab/tests/test_dns.py
@@ -692,13 +692,12 @@ async def test_dns_update(alpha_ip_stack: IPStack) -> None:
         # Don't forward anything yet
         await client_alpha.enable_magic_dns([])
 
-        alpha_response = await testing.wait_normal(
-            connection.create_process(
-                ["nslookup", "google.com", dns_server_address]
-            ).execute()
-        )
-
-        assert "Can't find google.com: No answer" in alpha_response.get_stdout()
+        with pytest.raises(asyncio.TimeoutError):
+            await testing.wait_normal(
+                connection.create_process(
+                    ["nslookup", "google.com", dns_server_address]
+                ).execute()
+            )
 
         # Update forward dns and check if it works now
         await client_alpha.enable_magic_dns(["1.1.1.1"])


### PR DESCRIPTION
### Problem
The initial problem was that if the forward lookup from trust-dns fails, the failure is not indicated to libtelio. Instead the response buffer was filled with an empty lookup response. This, combined with the doubled retry mechanism (OS and trust-dns) produced some issues on IOS.

### Solution
Patched the trust-dns so now it indicates the failure and from libtelio side we try to copy the server behavior and do not respond to this requests.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
