### PR TITLE
Add support for sed in mac

### DIFF
--- a/linkers/dld
+++ b/linkers/dld
@@ -9,7 +9,12 @@ ARGS=$@
 while (( "$#" )); do
 	if [[ $1 == *"-Wl,--version-script="* ]]; then
 		VERSION=${1#"-Wl,--version-script="}
-		sed -i 's/global:/global:\n    Java*;\n    JNI_OnLoad;\n/' $VERSION
+		SED_ARGS='s/global:/global:\n    Java*;\n    JNI_OnLoad;\n/'
+		if [ "$(uname)" != "Darwin" ]; then
+			sed -i "$SED_ARGS" "$VERSION"
+		else
+			sed -i '' "$SED_ARGS" "$VERSION"
+		fi
 		break
 	fi
 


### PR DESCRIPTION
### Problem
Sed command works a bit differently in mac, hence in its current state it wasn't possible to build shared library for android applications.

### Solution
Add support for sed command in the dld script for mac as well.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
