### PR TITLE
Add self host and ip to DNS records

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,7 @@
 * LLT-3875: Don't reconnect to Derp when Multiplexer channel is closed.
 * LLT-4204: Add `meshnet_enabled` field
 * LLT-4128: Add integration tests for IPv6 MagicDNS service
+* LLT-4246: Add self nordname as well as self IP address to the DNS records
 
 <br>
 

--- a/nat-lab/tests/test_dns.py
+++ b/nat-lab/tests/test_dns.py
@@ -129,6 +129,15 @@ async def test_dns(dns_server_address: str) -> None:
         for ip in alpha.ip_addresses:
             assert ip in beta_response.get_stdout()
 
+        # Testing if instance can get the IP of self from DNS. See LLT-4246 for more details.
+        alpha_response = await testing.wait_long(
+            connection_alpha.create_process(
+                ["nslookup", "alpha.nord", dns_server_address]
+            ).execute()
+        )
+        for ip in alpha.ip_addresses:
+            assert ip in alpha_response.get_stdout()
+
         # Now we disable magic dns
         await client_alpha.disable_magic_dns()
         await client_beta.disable_magic_dns()

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -669,7 +669,14 @@ impl RequestedState {
         self.meshnet_config
             .clone()
             .map_or(Vec::new(), |cfg| {
-                cfg.peers.map_or(Vec::new(), |peers| peers)
+                [
+                    cfg.peers.map_or(Vec::new(), |peers| peers),
+                    vec![Peer {
+                        base: cfg.this,
+                        ..Default::default()
+                    }],
+                ]
+                .concat()
             })
             .iter()
             .filter_map(|v| {


### PR DESCRIPTION
### Problem
*MagicDNS does not include self-domain in the `.nord` authority zone*

### Solution
*Add self nordname as well as self IP address to the DNS records*


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
