### PR TITLE
Reenable RepeatedActions test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3987,6 +3987,7 @@ dependencies = [
  "hashlink",
  "log",
  "lru_time_cache",
+ "maplit",
  "mockall",
  "parking_lot 0.12.1",
  "proptest",

--- a/crates/telio-utils/Cargo.toml
+++ b/crates/telio-utils/Cargo.toml
@@ -25,6 +25,7 @@ tracing = { version = "0.1.37", features = ["release_max_level_debug"] }
 
 [dev-dependencies]
 lru_time_cache = { version = "0.11.11", features = ["sn_fake_clock"] }
+maplit = "1.0.2"
 mockall = { version = "0.11.3" }
 proptest = "1.2.0"
 proptest-derive = "0.3.0"


### PR DESCRIPTION
### Problem

It was previously disabled due to failing on tarpaulin builds. No more information was available but when run without tarpaulin it also seemingly randomly failed. It turns out that the loop run 4 iterations and the last one was for the 300ms which should have triggered both the 100ms and 150ms action. Since it selected them in a random order, the test failed.

### Solution

This change removes the loop + spawn which only made it less clear what is happening. Instead we explicitly spell out each assertion for each action we expect to happen. The last part where both actions are expected is verified using sets to make sure that the order doesn't matter.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
