### PR TITLE
[LLT-4179] Add test for stun with no WG peer

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -20,6 +20,7 @@
 * LLT-4128: Add integration tests for IPv6 MagicDNS service
 * LLT-3316: Improve usage of peer-reflexive endpoints
 * LLT-4246: Add self nordname as well as self IP address to the DNS records
+* LLT-4179: Fix issue where first WG-STUN request would fail due to missing WG-STUN peer
 
 <br>
 


### PR DESCRIPTION
### Problem
The problem with failing STUN session was already fixed in https://github.com/NordSecurity/libtelio/pull/115, but the task demands also some test for the correct behavior. 

### Solution
Because the session fail was caused by starting STUN session when the corresponding WG peer was not ready, this commit adds a test to check if STUN endpoint provider correctly waits until the desired WG peer appears.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
