### PR TITLE
LLT-3451: Use workspace dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,15 +361,6 @@ checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
 name = "block-buffer"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
@@ -1047,7 +1038,7 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
+ "block-buffer",
  "crypto-common",
 ]
 
@@ -2242,32 +2233,11 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
-dependencies = [
- "num_enum_derive 0.5.11",
-]
-
-[[package]]
-name = "num_enum"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a015b430d3c108a207fd776d2e2196aaf8b1cf8cf93253e3a097ff3085076a1"
 dependencies = [
- "num_enum_derive 0.6.1",
-]
-
-[[package]]
-name = "num_enum_derive"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2 1.0.66",
- "quote 1.0.33",
- "syn 1.0.109",
+ "num_enum_derive",
 ]
 
 [[package]]
@@ -3276,19 +3246,6 @@ checksum = "cc30b1e1e8c40c121ca33b86c23308a090d19974ef001b4bf6e61fd1a0fb095c"
 
 [[package]]
 name = "sha2"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if",
- "cpufeatures",
- "digest 0.9.0",
- "opaque-debug",
-]
-
-[[package]]
-name = "sha2"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
@@ -3645,7 +3602,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "sha2 0.9.9",
+ "sha2",
  "shellwords",
  "telio",
  "telio-crypto",
@@ -3795,7 +3752,7 @@ dependencies = [
  "itertools",
  "log",
  "modifier",
- "num_enum 0.6.1",
+ "num_enum",
  "once_cell",
  "pretty_assertions",
  "serde",
@@ -3901,7 +3858,7 @@ dependencies = [
  "libc",
  "log",
  "ntest",
- "num_enum 0.5.11",
+ "num_enum",
  "rand",
  "rand_core 0.6.4",
  "rstest",
@@ -4048,7 +4005,7 @@ dependencies = [
  "pretty_assertions",
  "serde",
  "serde_json",
- "sha2 0.10.7",
+ "sha2",
  "slog",
  "slog-stdlog",
  "telio-crypto",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,69 +17,71 @@ crate-type = ["staticlib", "cdylib", "lib"]
 pretend_to_be_macos = ["telio-model/pretend_to_be_macos"]
 
 [dependencies]
-anyhow = "1.0.64"
-base64 = "0.13.0"
 cfg-if = "1.0.0"
-crypto_box = { version = "0.8.2", features = ["std"] }
 ffi_helpers = "0.3.0"
-futures = "0.3"
-ipnetwork = "0.18"
-lazy_static = "1.4.0"
-libc = "0.2.99"
-log = {version = "0.4.14", features = ["release_max_level_debug"]}
-modifier = "0.1.0"
 num_cpus = "1.15.0"
-parking_lot = "0.12"
-serde = { version = "1.0", features = ["derive"] }
-serde_with = "1.10"
-serde_json = "1.0"
-thiserror = "1.0"
-tokio = { version = ">=1.22", features = ["full"] }
-async-trait = "0.1.51"
-uuid =  { version = "1.1.2", features = ["v4"] }
 wasm-bindgen = "=0.2.83" # Only for compatability with moose wasm version
 
-telio-crypto = { version = "0.1.0", path = "./crates/telio-crypto" }
-telio-dns = { version = "0.1.0", path = "./crates/telio-dns" }
-telio-proto = { version = "0.1.0", path = "./crates/telio-proto" }
-telio-proxy = { version = "0.1.0", path = "./crates/telio-proxy" }
-telio-nurse = { version = "0.1.0", path = "./crates/telio-nurse" }
-telio-relay = { version = "0.1.0", path = "./crates/telio-relay" }
-telio-traversal = { path = "./crates/telio-traversal" }
-telio-sockets = { version = "0.1.0", path = "./crates/telio-sockets" }
-telio-task = { version = "0.1.0", path = "./crates/telio-task" }
-telio-wg = { version = "0.1.0", path = "./crates/telio-wg" }
-telio-model = { version = "0.1.0", path = "./crates/telio-model" }
-telio-nat-detect = { version = "0.1.0", path = "./crates/telio-nat-detect" }
-telio-utils = { version = "0.1.0", path = "./crates/telio-utils" }
-telio-lana = { version = "0.1.0", path = "./crates/telio-lana" }
-telio-firewall = { version = "0.1.0", path = "./crates/telio-firewall" }
-tracing = { version = "0.1.37", features = ["release_max_level_debug"] }
+anyhow.workspace = true
+async-trait.workspace = true
+base64.workspace = true
+crypto_box.workspace = true
+futures.workspace = true
+ipnetwork.workspace = true
+lazy_static.workspace = true
+libc.workspace = true
+log.workspace = true
+modifier.workspace = true
+parking_lot.workspace = true
+serde.workspace = true
+serde_with.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+tokio = { workspace = true, features = ["full"] }
+tracing.workspace = true
+uuid.workspace = true
+
+telio-crypto.workspace = true
+telio-dns.workspace = true
+telio-firewall.workspace = true
+telio-lana.workspace = true
+telio-model.workspace = true
+telio-nat-detect.workspace = true
+telio-nurse.workspace = true
+telio-proto.workspace = true
+telio-proxy.workspace = true
+telio-relay.workspace = true
+telio-sockets.workspace = true
+telio-task.workspace = true
+telio-traversal.workspace = true
+telio-utils.workspace = true
+telio-wg.workspace = true
 
 [dev-dependencies]
-mockall = "0.11.3"
-ntest = "0.7"
-pretty_assertions = "0.7.2"
 slog-async = "2.7"
 slog-term = "2.8"
-tokio = { version = ">=1.22", features = ["test-util"] }
 
-telio-test = { version = "1.0.0", path = "./crates/telio-test" }
-telio-wg = { features = ["mockall", "test-adapter"], path = "./crates/telio-wg" }
-telio-dns = { features = ["mockall"], path = "./crates/telio-dns" }
-telio-firewall = { features = ["mockall"], path = "./crates/telio-firewall" }
-telio-proxy = { features = ["mockall"], path = "./crates/telio-proxy" }
-telio-traversal = { features = ["mockall"], path = "./crates/telio-traversal" }
+mockall.workspace = true
+ntest.workspace = true
+pretty_assertions.workspace = true
+tokio = { workspace = true, features = ["test-util"] }
+
+telio-dns = { workspace = true, features = ["mockall"] }
+telio-firewall = { workspace = true, features = ["mockall"] }
+telio-proxy = { workspace = true, features = ["mockall"] }
+telio-test.workspace = true
+telio-traversal = { workspace = true, features = ["mockall"] }
+telio-wg = { workspace = true, features = ["mockall", "test-adapter"] }
 
 [build-dependencies]
-anyhow = "1"
-cc = "1.0"
+anyhow.workspace = true
+cc.workspace = true
+
+[target.'cfg(windows)'.dependencies]
+winapi = { workspace = true, features = ["ntdef", "winerror"] }
 
 [target.'cfg(windows)'.build-dependencies]
 winres = "0.1"
-
-[target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3.9", features = ["netioapi", "ntdef", "winerror", "ws2def"] }
 
 [workspace]
 resolver = "2"
@@ -90,3 +92,74 @@ members = [
 exclude = [
 	"wireguard-go-rust-wrapper"
 ]
+
+[workspace.dependencies]
+anyhow = "1"
+async-trait = "0.1.51"
+base64 = "0.13.0"
+bytes = "1"
+cc = "1.0"
+clap = { version = "3.1", features = ["derive"] }
+crypto_box = { version = "0.8.2", features = ["std"] }
+env_logger = "0.9.0"
+futures = "0.3"
+hashlink = "0.8.3"
+hex = "0.4.3"
+httparse = "1.8.0"
+ipnet = "2.3"
+ipnetwork = "0.18"
+itertools = "0.10"
+lazy_static = "1.4.0"
+libc = "0.2.112"
+log = {version = "0.4.14", features = ["release_max_level_debug"]}
+maplit = "1"
+mockall = "0.11.3"
+modifier = "0.1.0"
+nat-detect = "0.1.7"
+ntest = "0.7"
+num_enum = "0.6.1"
+once_cell = "1"
+parking_lot = "0.12"
+pnet_packet = "0.28.0"
+pretty_assertions = "0.7.2"
+proptest = "1.2.0"
+proptest-derive = "0.3.0"
+protobuf-codegen-pure = "2"
+rand = "0.8"
+rstest = "0.11.0"
+rupnp = "1.1.0"
+rustc-hash = "1"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+serde_with = "1.10"
+sha2 = "0.10.6"
+slog = "2.7"
+sn_fake_clock = "0.4"
+strum = { version = "0.24.0", features = ["derive"] }
+surge-ping = { version = "0.8.0" }
+thiserror = "1.0"
+time = { version = "0.3.9", features = ["formatting"] }
+tokio = ">=1.22"
+tracing = { version = "0.1.37", features = ["release_max_level_debug"] }
+url = "2.2.2"
+uuid = { version = "1.1.2", features = ["v4"] }
+winapi = { version = "0.3", features = ["netioapi", "ws2def"] }
+
+boringtun = { git = "https://github.com/NordSecurity/boringtun.git", tag = "v1.1.1" }
+
+telio-crypto = { version = "0.1.0", path = "./crates/telio-crypto" }
+telio-dns = { version = "0.1.0", path = "./crates/telio-dns" }
+telio-firewall = { version = "0.1.0", path = "./crates/telio-firewall" }
+telio-lana = { version = "0.1.0", path = "./crates/telio-lana" }
+telio-model = { version = "0.1.0", path = "./crates/telio-model" }
+telio-nat-detect = { version = "0.1.0", path = "./crates/telio-nat-detect" }
+telio-nurse = { version = "0.1.0", path = "./crates/telio-nurse" }
+telio-proto = { version = "0.1.0", path = "./crates/telio-proto" }
+telio-proxy = { version = "0.1.0", path = "./crates/telio-proxy" }
+telio-relay = { version = "0.1.0", path = "./crates/telio-relay" }
+telio-sockets = { version = "0.1.0", path = "./crates/telio-sockets" }
+telio-task = { version = "0.1.0", path = "./crates/telio-task" }
+telio-test = { version = "1.0.0", path = "./crates/telio-test" }
+telio-traversal = { version = "0.1.0",  path = "./crates/telio-traversal" }
+telio-utils = { version = "0.1.0", path = "./crates/telio-utils" }
+telio-wg = { version = "0.1.0", path = "./crates/telio-wg" }

--- a/changelog.md
+++ b/changelog.md
@@ -25,6 +25,7 @@
 * LLT-4136: Migrate Natlab VMs to use libvirt
 * LLT-4266: Add exit node clearing when disabling meshnet
 * LLT-4159: Clarify purpose of hardcoded secrets in repo
+* LLT-3451: Use workspace dependencies
 
 <br>
 

--- a/clis/derpcli/Cargo.toml
+++ b/clis/derpcli/Cargo.toml
@@ -7,9 +7,20 @@ license = "GPL-3.0-only"
 repository = "https://github.com/NordSecurity/libtelio"
 
 [dependencies]
-anyhow = "1"
-crypto_box = { version = "0.8.2", features = ["std"] }
-tokio = { version = ">=1.22", features = [
+atomic-counter = "1.0.1"
+ctrlc = "3.2.2"
+
+anyhow.workspace = true
+base64.workspace = true
+clap.workspace = true
+crypto_box.workspace = true
+futures.workspace = true
+parking_lot.workspace = true
+rand.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+time = { workspace = true, features = ["macros", "local-offset"] }
+tokio = { workspace = true, features = [
     "io-util",
     "net",
     "sync",
@@ -18,25 +29,11 @@ tokio = { version = ">=1.22", features = [
     "io-std",
     "time",
 ] }
-clap = { version = "3.1", features = ["derive"] }
-base64 = "0.13.0"
-url = "2.2.2"
-parking_lot = "0.12"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-ctrlc = "3.2.2"
-futures = "0.3.23"
-rand = "0.8"
-atomic-counter = "1.0.1"
-time = { version = "0.3.9", features = [
-    "macros",
-    "local-offset",
-    "formatting",
-] }
+url.workspace = true
 
-telio-crypto = { path = "../../crates/telio-crypto" }
-telio-relay = { path = "../../crates/telio-relay" }
-telio-sockets = { path = "../../crates/telio-sockets" }
+telio-crypto.workspace = true
+telio-relay.workspace = true
+telio-sockets.workspace = true
 
 [dev-dependencies]
-rstest = "0.11.0"
+rstest.workspace = true

--- a/clis/interderpcli/Cargo.toml
+++ b/clis/interderpcli/Cargo.toml
@@ -7,26 +7,24 @@ license = "GPL-3.0-only"
 repository = "https://github.com/NordSecurity/libtelio"
 
 [dependencies]
-crypto_box = { version = "0.8.2", features = ["std"] }
-tokio = { version = ">=1.22", features = ["io-util", "net", "sync", "macros", "rt-multi-thread", "io-std", "time"] }
-env_logger = "0.9.0"
-base64 = "0.13.0"
-url = "2.2.2"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-futures = "0.3.23"
 clap = { version = "4.3.3", features = ["derive"] }
 ring = "0.16"
 
+anyhow.workspace = true
+base64.workspace = true
+crypto_box.workspace = true
+env_logger.workspace = true
+futures.workspace = true
+itertools.workspace = true
+log.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tokio = { workspace = true, features = ["io-util", "net", "sync", "macros", "rt-multi-thread", "io-std", "time"] }
+url.workspace = true
 
-
-telio-crypto = { path = "../../crates/telio-crypto" }
-telio-relay = { path = "../../crates/telio-relay" }
-telio-sockets = { path = "../../crates/telio-sockets" }
-log = "0.4.17"
-anyhow = "1.0.69"
-itertools = "0.10.5"
+telio-crypto.workspace = true
+telio-relay.workspace = true
+telio-sockets.workspace = true
 
 [dev-dependencies]
-tokio = { version = ">=1.22", features = ["macros", "rt-multi-thread", "io-std"] }
-env_logger = "0.9.0"
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "io-std"] }

--- a/clis/tcli/Cargo.toml
+++ b/clis/tcli/Cargo.toml
@@ -6,40 +6,41 @@ license = "GPL-3.0-only"
 repository = "https://github.com/NordSecurity/libtelio"
 
 [dependencies]
-anyhow = "1"
-base64 = "0.13"
-clap = { version = "3.1", features = ["derive"] }
-crypto_box = { version = "0.8.2", features = ["std"] }
 dirs = "4.0.0"
-hex = "0.4.3"
-ipnetwork = "0.18"
-parking_lot = "0.12"
-rand = { version = "0.8.4", features = ["std", "std_rng"] }
+flexi_logger = "0.22.0"
+regex = "1.5.5"
 reqwest = { version = "0.11.16", default-features = false, features = [
     "json",
     "blocking",
     "rustls-tls",
 ] }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-serde_with = "1.10.0"
-sha2 = "0.9.8"
-shellwords = "1.1.0"
-thiserror = "1.0"
-tokio = { version = ">=1.22", features = ["full"] }
-regex = "1.5.5"
-log = { version = "0.4.14", features = ["release_max_level_debug"] }
-flexi_logger = "0.22.0"
 rustyline = "11.0.0"
+shellwords = "1.1.0"
+
+anyhow.workspace = true
+base64.workspace = true
+clap.workspace = true
+crypto_box.workspace = true
+hex.workspace = true
+ipnetwork.workspace = true
+log.workspace = true
+parking_lot.workspace = true
+rand = { workspace = true, features = ["std", "std_rng"] }
+serde.workspace = true
+serde_json.workspace = true
+serde_with.workspace = true
+sha2.workspace = true
+thiserror.workspace = true
+tokio = { workspace = true, features = ["full"] }
 
 telio = { path = "../.." }
-telio-crypto = { path = "../../crates/telio-crypto" }
-telio-utils = { path = "../../crates/telio-utils" }
-telio-model = { path = "../../crates/telio-model" }
-telio-wg = { path = "../../crates/telio-wg" }
-telio-proto = { path = "../../crates/telio-proto" }
-telio-traversal = { path = "../../crates/telio-traversal" }
-telio-task = { path = "../../crates/telio-task" }
-telio-relay = { path = "../../crates/telio-relay" }
-telio-sockets = { path = "../../crates/telio-sockets" }
-telio-nat-detect = { version = "0.1.0", path = "../../crates/telio-nat-detect" }
+telio-crypto.workspace = true
+telio-model.workspace = true
+telio-nat-detect.workspace = true
+telio-proto.workspace = true
+telio-relay.workspace = true
+telio-sockets.workspace = true
+telio-task.workspace = true
+telio-traversal.workspace = true
+telio-utils.workspace = true
+telio-wg.workspace = true

--- a/crates/telio-crypto/Cargo.toml
+++ b/crates/telio-crypto/Cargo.toml
@@ -7,16 +7,16 @@ repository = "https://github.com/NordSecurity/libtelio"
 publish = false
 
 [dependencies]
-base64 = "0.13.0"
-crypto_box = { version = "0.8.2", features = ["std"] }
-hex = "0.4.3"
-log = {version = "0.4.14", features = ["release_max_level_debug"]}
-rand = { version = "0.8.4", features = ["std", "std_rng"] }
-serde = { version = "1.0", features = ["derive"] }
-serde_with = "1.10"
-thiserror = "1.0"
+base64.workspace = true
+crypto_box.workspace = true
+hex.workspace = true
+log.workspace = true
+rand = { workspace = true, features = ["std", "std_rng"] }
+serde.workspace = true
+serde_with.workspace = true
+thiserror.workspace = true
 
-telio-utils = { path = "../telio-utils" }
+telio-utils.workspace = true
 
 [dev-dependencies]
 bstr = "0.2"

--- a/crates/telio-dns/Cargo.toml
+++ b/crates/telio-dns/Cargo.toml
@@ -7,26 +7,28 @@ repository = "https://github.com/NordSecurity/libtelio"
 publish = false
 
 [dependencies]
-base64 = "0.13.0"
-boringtun = { git = "https://github.com/NordSecurity/boringtun.git", tag = "v1.1.1" }
-pnet_packet = "0.28.0"
-tokio = { version = ">=1.22", features = ["rt", "net", "sync", "macros"] }
 trust-dns-client = { git = "https://github.com/NordSecurity/trust-dns.git", tag = "v2.0.0" }
 trust-dns-proto = { git = "https://github.com/NordSecurity/trust-dns.git", tag = "v2.0.0" }
 trust-dns-resolver = { git = "https://github.com/NordSecurity/trust-dns.git", tag = "v2.0.0" }
 trust-dns-server = { git = "https://github.com/NordSecurity/trust-dns.git", tag = "v2.0.0", features = ["resolver"] }
-async-trait = "0.1.51"
-lazy_static = "1.4.0"
-log = {version = "0.4.14", features = ["release_max_level_debug"]}
-libc = "0.2.99"
-ipnetwork = "0.18"
-mockall = { version = "0.11.3", optional = true }
 
-telio-crypto = { path = "../telio-crypto" }
-telio-utils = { path = "../telio-utils" }
-telio-wg = { path = "../telio-wg" }
-telio-model = { path = "../telio-model" }
+async-trait.workspace = true
+base64.workspace = true
+boringtun.workspace = true
+ipnetwork.workspace = true
+lazy_static.workspace = true
+libc.workspace = true
+log.workspace = true
+mockall = { workspace = true, optional = true }
+pnet_packet.workspace = true
+tokio = { workspace = true, features = ["rt", "net", "sync", "macros"] }
+
+telio-crypto.workspace = true
+telio-model.workspace = true
+telio-utils.workspace = true
+telio-wg.workspace = true
 
 [dev-dependencies]
 dns-parser = "0.8.0"
-mockall = "0.11.3"
+
+mockall.workspace = true

--- a/crates/telio-firewall/Cargo.toml
+++ b/crates/telio-firewall/Cargo.toml
@@ -6,26 +6,29 @@ license = "GPL-3.0-only"
 repository = "https://github.com/NordSecurity/libtelio"
 publish = false
 
-[dependencies]
-log = {version = "0.4.14", features = ["release_max_level_debug"]}
-pnet_packet = "0.28.0"
-mockall = { version = "0.11.3", optional = true }
-telio-crypto = { path = "../telio-crypto" }
-telio-utils = { path = "../telio-utils" }
-rustc-hash = "1.1.0"
-hashlink = "0.8.3"
-
-[dev-dependencies]
-mockall = "0.11.3"
-criterion = "0.3"
-rand = "0.8.5"
-sn_fake_clock = "0.4"
-proptest-derive = "0.3.0"
-proptest = "1.2.0"
-telio-utils = { path = "../telio-utils", features = ["sn_fake_clock"] }
-
 [features]
 test_utils = [] # For use in benchmarks to avoid duplication of the 'setup' code needed to create buffers with valid packets
+
+[dependencies]
+hashlink.workspace = true
+log.workspace = true
+mockall = { workspace = true, optional = true }
+pnet_packet.workspace = true
+rustc-hash.workspace = true
+
+telio-crypto.workspace = true
+telio-utils.workspace = true
+
+[dev-dependencies]
+criterion = "0.3"
+
+mockall.workspace = true
+proptest.workspace = true
+proptest-derive.workspace = true
+rand.workspace = true
+sn_fake_clock.workspace = true
+
+telio-utils = { workspace = true, features = ["sn_fake_clock"] }
 
 [[bench]]
 name = "firewall_bench"

--- a/crates/telio-lana/Cargo.toml
+++ b/crates/telio-lana/Cargo.toml
@@ -9,19 +9,20 @@ license = "GPL-3.0-only"
 repository = "https://github.com/NordSecurity/libtelio"
 publish = false
 
+[features]
+moose = []
+
 [dependencies]
-log = { version = "0.4.14", features = ["release_max_level_debug"]}
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-telio-utils = { path = "../telio-utils" }
-thiserror = "1.0.30"
-time = { version = "0.3.9", features = ["formatting"] }
+log.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+time.workspace = true
+
+telio-utils.workspace = true
 
 [dev-dependencies]
 serial_test = "0.8.0"
 
 [build-dependencies]
-anyhow = "1"
-
-[features]
-moose = []
+anyhow.workspace = true

--- a/crates/telio-model/Cargo.toml
+++ b/crates/telio-model/Cargo.toml
@@ -11,21 +11,21 @@ publish = false
 pretend_to_be_macos = []
 
 [dependencies]
-log = { version = "0.4.14", features = ["release_max_level_debug"] }
-serde = { version = "1.0", features = ["derive"] }
-serde_with = "1.10"
-serde_json = "1.0"
-strum = { version = "0.24.0", features = ["derive"] }
 strum_macros = "0.24"
-ipnetwork = "0.18"
-modifier = "0.1.0"
-num_enum = "0.6.1"
-itertools = "0.10"
 
-telio-crypto = { version = "0.1.0", path = "../telio-crypto" }
-telio-utils = { version = "0.1.0", path = "../telio-utils" }
+ipnetwork.workspace = true
+itertools.workspace = true
+log.workspace = true
+modifier.workspace = true
+num_enum.workspace = true
+serde.workspace = true
+serde_with.workspace = true
+serde_json.workspace = true
+strum.workspace = true
 
+telio-crypto.workspace = true
+telio-utils.workspace = true
 
 [dev-dependencies]
-pretty_assertions = "0.7.2"
-once_cell = "1"
+once_cell.workspace = true
+pretty_assertions.workspace = true

--- a/crates/telio-nat-detect/Cargo.toml
+++ b/crates/telio-nat-detect/Cargo.toml
@@ -7,6 +7,6 @@ repository = "https://github.com/NordSecurity/libtelio"
 publish = false
 
 [dependencies]
-tokio = { version = ">=1.22", features = ["full"] }
-nat-detect = "0.1.7"
-log = {version = "0.4.14", features = ["release_max_level_debug"]}
+log.workspace = true
+nat-detect.workspace = true
+tokio = { workspace = true, features = ["full"] }

--- a/crates/telio-nurse/Cargo.toml
+++ b/crates/telio-nurse/Cargo.toml
@@ -7,36 +7,36 @@ repository = "https://github.com/NordSecurity/libtelio"
 publish = false
 
 [dependencies]
-futures = "0.3.13"
-tokio = { version = ">=1.22", features = ["net", "sync"] }
-slog = "2.7"
-async-trait = "0.1.51"
-thiserror = "1.0"
-log = "0.4.14"
-crypto_box = { version = "0.8.2", features = ["std"] }
 bitflags = { version = "1.3.2" }
-uuid =  { version = "1.1.2", features = ["v4"] }
-surge-ping = { version = "0.8.0" }
-rand = "0.8.5"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
 histogram = "0.6.9"
-nat-detect = "0.1.7"
-
 md5 = "0.7.0"
 
-telio-task = { path = "../telio-task" }
-telio-relay = { path = "../telio-relay" }
-telio-crypto = { path = "../telio-crypto" }
-telio-lana = { path =  "../telio-lana" }
-telio-model = { path = "../telio-model" }
-telio-nat-detect = { path = "../telio-nat-detect" }
-telio-proto = { path = "../telio-proto"}
-telio-utils = { path = "../telio-utils" }
-telio-wg = { path = "../telio-wg" }
+async-trait.workspace = true
+crypto_box.workspace = true
+futures.workspace = true
+log.workspace = true
+nat-detect.workspace = true
+rand.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+slog.workspace = true
+surge-ping.workspace = true
+thiserror.workspace = true
+tokio = { workspace = true, features = ["net", "sync"] }
+uuid.workspace = true
+
+telio-crypto.workspace = true
+telio-lana.workspace = true
+telio-model.workspace = true
+telio-nat-detect.workspace = true
+telio-proto.workspace = true
+telio-relay.workspace = true
+telio-task.workspace = true
+telio-utils.workspace = true
+telio-wg.workspace = true
 
 [dev-dependencies]
-telio-sockets = { path = "../telio-sockets" }
+telio-sockets.workspace = true
 
 [build-dependencies]
-protobuf-codegen-pure = "2.27.1"
+protobuf-codegen-pure.workspace = true

--- a/crates/telio-proto/Cargo.toml
+++ b/crates/telio-proto/Cargo.toml
@@ -7,17 +7,16 @@ repository = "https://github.com/NordSecurity/libtelio"
 publish = false
 
 [dependencies]
-bytes = "1"
 protobuf = "2"
-log = { version = "0.4.14", features = ["release_max_level_debug"] }
-strum = { version = "0.24.0", features = ["derive"] }
-thiserror = "1.0"
 
-telio-crypto = { path = "../telio-crypto" }
-telio-utils = { path = "../telio-utils" }
-telio-model = { path = "../telio-model" }
+bytes.workspace = true
+log.workspace = true
+strum.workspace = true
+thiserror.workspace = true
+
+telio-crypto.workspace = true
+telio-model.workspace = true
+telio-utils.workspace = true
 
 [build-dependencies]
-protobuf-codegen-pure = "2"
-
-[dev-dependencies]
+protobuf-codegen-pure.workspace = true

--- a/crates/telio-proxy/Cargo.toml
+++ b/crates/telio-proxy/Cargo.toml
@@ -7,23 +7,25 @@ repository = "https://github.com/NordSecurity/libtelio"
 publish = false
 
 [dependencies]
-crypto_box = { version = "0.8.2", features = ["std"] }
-futures = "0.3.13"
-tokio = { version = ">=1.22", features = ["net", "sync"] }
-slog = "2.7"
-async-trait = "0.1.51"
-thiserror = "1.0"
-telio-task = { path = "../telio-task"}
-telio-crypto = { path = "../telio-crypto" }
-telio-utils = { path = "../telio-utils" }
-telio-model = { path = "../telio-model" }
-telio-sockets = { path = "../telio-sockets" }
-log = {version = "0.4.14", features = ["release_max_level_debug"]}
-telio-proto = { path = "../telio-proto" }
-mockall = { version = "0.11.3", optional = true }
+async-trait.workspace = true
+crypto_box.workspace = true
+futures.workspace = true
+log.workspace = true
+mockall = { workspace = true, optional = true }
+slog.workspace = true
+thiserror.workspace = true
+tokio = { workspace = true, features = ["net", "sync"] }
+
+telio-crypto.workspace = true
+telio-model.workspace = true
+telio-proto.workspace = true
+telio-sockets.workspace = true
+telio-task.workspace = true
+telio-utils.workspace = true
 
 [dev-dependencies]
-telio-test = { version = "1.0.0", path = "../telio-test" }
-telio-task = { features = ["test-util"], path = "../telio-task" }
-tokio = { version = ">=1.22", features = ["macros", "rt-multi-thread", "time"] }
-mockall = "0.11.3"
+mockall.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
+
+telio-task = { workspace = true, features = ["test-util"] }
+telio-test.workspace = true

--- a/crates/telio-relay/Cargo.toml
+++ b/crates/telio-relay/Cargo.toml
@@ -7,50 +7,53 @@ repository = "https://github.com/NordSecurity/libtelio"
 publish = false
 
 [dependencies]
-crypto_box = { version = "0.8.2", features = ["std"] }
-futures = "0.3.21"
+generic-array = "0.14.5"
 rand_core = { version = "0.6.3", features = ["getrandom"] }
-rand = "0.8.5"
-httparse = "1.4.1"
-bytes = "1"
-num_enum = "0.5.4"
 rustls-pemfile = "1.0.0"
-strum = { version = "0.24.0", features = ["derive"] }
-thiserror = "1.0.30"
 tokio-rustls = { version = "0.24.1", features = ["dangerous_configuration"] }
 tokio-util = "0.7.3"
 tokio-stream = "0.1.9"
 webpki-roots = "0.25"
-tokio = { version = ">=1.22", features = ["io-util", "net", "sync"] }
-url = "2.2.2"
-log = { version = "0.4.14", features = ["release_max_level_debug"] }
-libc = "0.2.99"
-async-trait = "0.1.51"
-serde = { version = "1.0", features = ["derive"] }
-generic-array = "0.14.5"
 
-telio-crypto = { path = "../telio-crypto" }
-telio-utils = { path = "../telio-utils" }
-telio-proto = { path = "../telio-proto" }
-telio-task = { path = "../telio-task" }
-telio-sockets = { path = "../telio-sockets" }
-telio-model = { path = "../telio-model" }
+async-trait.workspace = true
+bytes.workspace = true
+crypto_box.workspace = true
+futures.workspace = true
+httparse.workspace = true
+libc.workspace = true
+log.workspace = true
+num_enum.workspace = true
+rand.workspace = true
+serde.workspace = true
+strum.workspace = true
+thiserror.workspace = true
+tokio = { workspace = true, features = ["io-util", "net", "sync"] }
+url.workspace = true
 
-[target.'cfg(windows)'.dependencies]
-static_assertions = "1.1.0"
+telio-crypto.workspace = true
+telio-model.workspace = true
+telio-proto.workspace = true
+telio-sockets.workspace = true
+telio-task.workspace = true
+telio-utils.workspace = true
 
 [dev-dependencies]
 async-std = { version = "1.5", features = ["attributes"] }
-env_logger = "0.9.0"
-hex = "0.4.3"
-ntest = "0.7"
-rstest = "0.11.0"
-telio-test = { version = "1.0.0", path = "../telio-test" }
-telio-task = { features = ["test-util"], path = "../telio-task" }
-tokio = { version = ">=1.22", features = [
+
+env_logger.workspace = true
+hex.workspace = true
+ntest.workspace = true
+rstest.workspace = true
+tokio = { workspace = true, features = [
     "macros",
     "rt-multi-thread",
     "io-std",
     "time",
     "test-util",
 ] }
+
+telio-task = { workspace = true, features = ["test-util"] }
+telio-test.workspace = true
+
+[target.'cfg(windows)'.dependencies]
+static_assertions = "1.1.0"

--- a/crates/telio-sockets/Cargo.toml
+++ b/crates/telio-sockets/Cargo.toml
@@ -7,17 +7,20 @@ repository = "https://github.com/NordSecurity/libtelio"
 publish = false
 
 [dependencies]
-futures = "0.3"
-libc = "0.2.112"
-parking_lot = "0.12"
-tokio = { version = ">=1.22", features = ["full"] }
 socket2 = "0.4.7"
-log = { version = "0.4.14", features = ["release_max_level_debug"]}
-thiserror = "1.0.30"
 
-telio-utils = { path = "../telio-utils" }
+boringtun.workspace = true
+futures.workspace = true
+libc.workspace = true
+log.workspace = true
+parking_lot.workspace = true
+thiserror.workspace = true
+tokio = { workspace = true, features = ["full"] }
 
-boringtun = { git = "https://github.com/NordSecurity/boringtun.git", tag = "v1.1.1" }
+telio-utils.workspace = true
+
+[dev-dependencies]
+mockall.workspace = true
 
 [target.'cfg(target_os = "ios")'.dependencies]
 objc = "0.2.7"
@@ -25,13 +28,10 @@ objc-foundation = "0.1.1"
 version-compare = "0.1"
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
-system-configuration = "0.5.0"
-nix = "0.26.2"
 debug_panic = "0.2.1"
+nix = "0.26.2"
+system-configuration = "0.5.0"
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3.9", features = ["netioapi", "ntdef", "winerror", "ws2def", "iptypes", "iphlpapi", "impl-default"] }
+winapi = { workspace = true, features = ["ntdef", "winerror", "iptypes", "iphlpapi", "impl-default"] }
 windows = { version = "0.34.0", features = ["alloc", "Win32_Networking_WinSock", "Win32_NetworkManagement_IpHelper"] }
-
-[dev-dependencies]
-mockall = "0.11.3"

--- a/crates/telio-task/Cargo.toml
+++ b/crates/telio-task/Cargo.toml
@@ -12,10 +12,10 @@ default = []
 test-util = []
 
 [dependencies]
-telio-utils = { path = "../telio-utils" }
+async-trait.workspace = true
+futures.workspace = true
+log.workspace = true
+thiserror.workspace = true
+tokio = { workspace = true, features = ["full"] }
 
-async-trait = "0.1.51"
-futures = "0.3"
-log = {version = "0.4.14", features = ["release_max_level_debug"]}
-thiserror = "1.0.32"
-tokio = { version = ">=1.22", features = ["full"] }
+telio-utils.workspace = true

--- a/crates/telio-traversal/Cargo.toml
+++ b/crates/telio-traversal/Cargo.toml
@@ -7,54 +7,55 @@ repository = "https://github.com/NordSecurity/libtelio"
 publish = false
 
 [dependencies]
-boringtun = { git = "https://github.com/NordSecurity/boringtun.git", tag = "v1.1.1" }
-telio-crypto = { path = "../telio-crypto" }
-telio-task = { path = "../telio-task" }
-telio-proto = { path = "../telio-proto" }
-telio-utils = { path = "../telio-utils" }
-telio-sockets = { path = "../telio-sockets" }
-telio-model = { path = "../telio-model" }
-telio-wg = { path = "../telio-wg" }
-
-async-trait = "0.1.56"
-base64 = "0.13.0"
 bytecodec = "0.4.15"
 enum-map = "2.5.0"
-if-addrs = "0.7.0"
-ipnet = "2.3.1"
-log = { version = "0.4.17", features = ["release_max_level_debug"] }
-rand = "0.8.4"
-stun_codec = "0.1.13"
-thiserror = "1.0.30"
-tokio = { version = ">=1.22", features = ["full"] }
-futures = "0.3.21"
-surge-ping = { version = "0.8.0" }
-sm = "0.9.0"
-strum = { version = "0.24.0", features = ["derive"] }
-mockall = { version = "0.11.3", optional = true }
-
-# This is for Upnp
-lazy_static = "1.4.0"
 http = "0.2.8"
-httparse = "1.8.0"
+if-addrs = "0.7.0"
 igd = "0.12.1"
-parking_lot = "0.12"
+sm = "0.9.0"
+stun_codec = "0.1.13"
 
-[target.'cfg(not(target_os = "android"))'.dependencies]
-rupnp = "1.1.0"
+async-trait.workspace = true
+base64.workspace = true
+boringtun.workspace = true
+futures.workspace = true
+httparse.workspace = true
+ipnet.workspace = true
+lazy_static.workspace = true
+log.workspace = true
+mockall = { workspace = true, optional = true }
+parking_lot.workspace = true
+rand.workspace = true
+strum.workspace = true
+surge-ping.workspace = true
+thiserror.workspace = true
+tokio = { workspace = true, features = ["full"] }
 
-# LLT-3754: get_if_addrs overrides bionic getifaddrs
-[target.'cfg(target_os = "android")'.dependencies]
-rupnp = { version = "1.1.0", default-features = false }
+telio-crypto.workspace = true
+telio-model.workspace = true
+telio-proto.workspace = true
+telio-sockets.workspace = true
+telio-task.workspace = true
+telio-utils.workspace = true
+telio-wg.workspace = true
 
 [dev-dependencies]
 assert_matches = "1.5.0"
-ntest = "0.7"
-maplit = "1"
-mockall = "0.11.3"
-env_logger = "0.9.0"
-tokio = { version = ">=1.22", features = ["test-util"] }
-telio-wg = { features = ["mockall"], path = "../telio-wg" }
-telio-task = { features = ["test-util"], path = "../telio-task" }
-telio-test = { path = "../telio-test" }
-telio-utils = { features = ["mockall"], path = "../telio-utils" }
+
+env_logger.workspace = true
+maplit.workspace = true
+mockall.workspace = true
+ntest.workspace = true
+tokio = { workspace = true, features = ["test-util"] }
+
+telio-task = { workspace = true, features = ["test-util"] }
+telio-test.workspace = true
+telio-utils = { workspace = true, features = ["mockall"] }
+telio-wg = { workspace = true, features = ["mockall"] }
+
+# LLT-3754: get_if_addrs overrides bionic getifaddrs
+[target.'cfg(target_os = "android")'.dependencies]
+rupnp = { workspace = true, default-features = false }
+
+[target.'cfg(not(target_os = "android"))'.dependencies]
+rupnp.workspace = true

--- a/crates/telio-utils/Cargo.toml
+++ b/crates/telio-utils/Cargo.toml
@@ -10,25 +10,26 @@ publish = false
 sn_fake_clock = ["dep:sn_fake_clock"]
 
 [dependencies]
-futures = "0.3.21"
-hashlink = "0.8.3"
-log = {version = "0.4.14", features = ["release_max_level_debug"]}
-mockall = { version = "0.11.3", optional = true }
-parking_lot = "0.12"
-rustc-hash = "1"
-serde = { version = "1", features = ["derive"] }
-sn_fake_clock = { version = "0.4", optional = true }
-thiserror = "1.0.30"
-tokio = { version = ">=1.22", features = ["time"] }
-tracing = { version = "0.1.37", features = ["release_max_level_debug"] }
-
+futures.workspace = true
+hashlink.workspace = true
+log.workspace = true
+mockall = { workspace = true, optional = true }
+parking_lot.workspace = true
+rustc-hash.workspace = true
+serde.workspace = true
+sn_fake_clock = { workspace = true, optional = true }
+thiserror.workspace = true
+tokio = { workspace = true, features = ["time"] }
+tracing.workspace = true
 
 [dev-dependencies]
 lru_time_cache = { version = "0.11.11", features = ["sn_fake_clock"] }
-maplit = "1.0.2"
-mockall = { version = "0.11.3" }
-proptest = "1.2.0"
-proptest-derive = "0.3.0"
-rand = "0.8.5"
-telio-test = { version = "1.0.0", path = "../telio-test" }
-tokio = { version = ">=1.22", features = ["time", "rt", "macros", "test-util"] }
+
+maplit.workspace = true
+mockall.workspace = true
+proptest.workspace = true
+proptest-derive.workspace = true
+rand.workspace = true
+tokio = { workspace = true, features = ["time", "rt", "macros", "test-util"] }
+
+telio-test.workspace = true

--- a/crates/telio-wg/Cargo.toml
+++ b/crates/telio-wg/Cargo.toml
@@ -6,50 +6,52 @@ license = "GPL-3.0-only"
 repository = "https://github.com/NordSecurity/libtelio"
 publish = false
 
-[target.'cfg(windows)'.dependencies]
-ipnet = "2.3"
-sha2 = "0.10.6"
-wireguard-nt = { git = "https://github.com/NordSecurity/wireguard-nt-rust-wrapper", tag = "v1.0.2" }
-winapi = { version = "0.3", features = ["ws2def", "netioapi", "nldef"] }
-wg-go-rust-wrapper = { path = "../../wireguard-go-rust-wrapper" }
-
-[dependencies]
-boringtun = { git = "https://github.com/NordSecurity/boringtun.git", tag = "v1.1.1" }
-futures = "0.3"
-hex = "0.4.3"
-ipnetwork = "0.18"
-lazy_static = "1.4.0"
-libc = "0.2.99"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-log = {version = "0.4.14", features = ["release_max_level_debug"]}
-slog = "2.7"
-slog-stdlog = "4.1.0"
-thiserror = "1.0"
-tokio = { version = ">=1.22", features = ["full"] }
-async-trait = "0.1.51"
-mockall = { version = "0.11.3", optional = true }
-telio-crypto = { path = "../telio-crypto" }
-telio-model = { path = "../telio-model" }
-telio-sockets = { path = "../telio-sockets" }
-telio-task = { path = "../telio-task" }
-telio-utils = { path = "../telio-utils" }
-wireguard-uapi = { version = "2.0.4", features = ["xplatform"]}
-
-
-[dev-dependencies]
-mockall = "0.11.3"
-ntest = "0.7"
-pretty_assertions = "0.7.2"
-tokio = { version = ">=1.22", features = ["test-util"] }
-
-telio-firewall = { path = "../telio-firewall" }
-telio-task = { features = ["test-util"], path = "../telio-task" }
-telio-test = { version = "1.0.0", path = "../telio-test" }
-hex = "0.4.3"
-
-[build-dependencies]
-cc = "1.0"
-
 [features]
 test-adapter = []
+
+[dependencies]
+slog-stdlog = "4.1.0"
+wireguard-uapi = { version = "2.0.4", features = ["xplatform"]}
+
+async-trait.workspace = true
+boringtun.workspace = true
+futures.workspace = true
+hex.workspace = true
+ipnetwork.workspace = true
+lazy_static.workspace = true
+libc.workspace = true
+log.workspace = true
+mockall = { workspace = true, optional = true }
+serde.workspace = true
+serde_json.workspace = true
+slog.workspace = true
+thiserror.workspace = true
+tokio = { workspace = true, features = ["full"] }
+
+telio-crypto.workspace = true
+telio-model.workspace = true
+telio-sockets.workspace = true
+telio-task.workspace = true
+telio-utils.workspace = true
+
+[dev-dependencies]
+mockall.workspace = true
+ntest.workspace = true
+pretty_assertions.workspace = true
+tokio = { workspace = true, features = ["test-util"] }
+
+telio-firewall.workspace = true
+telio-task = { workspace = true, features = ["test-util"] }
+telio-test.workspace = true
+
+[build-dependencies]
+cc.workspace = true
+
+[target.'cfg(windows)'.dependencies]
+ipnet.workspace = true
+sha2.workspace = true
+winapi = { workspace = true, features = ["nldef"] }
+
+wireguard-nt = { git = "https://github.com/NordSecurity/wireguard-nt-rust-wrapper", tag = "v1.0.2" }
+
+wg-go-rust-wrapper = { path = "../../wireguard-go-rust-wrapper" }

--- a/docs/cargo_dependency_ordering.md
+++ b/docs/cargo_dependency_ordering.md
@@ -1,0 +1,69 @@
+# Cargo dependency ordering
+
+To make out Cargo files more predictable and easier to read, please follow these guidelines.
+
+## Section ordering
+
+1. features
+2. dependencies
+3. dev-dependencies
+4. build-dependencies
+5. Platfrom-specific dependencies (within each of these, follow points 1-4)
+
+## Dependency grouping
+
+In each of the sections mentioned in the previous part, the dependencies should be ordered as such:
+
+1. Cargo dependencies that are not marked as workspace dependencies
+2. Workspace dependencies
+3. Git dependencies
+4. Internal crates
+
+## Other considerations
+
+Each group of dependencies after following the above points should have its dependencies ordered in alphabetical order.
+
+# Example
+
+```toml
+[features]
+test-util = []
+
+[dependencies]
+cfg-if = "1.0.0"
+num_cpus = "1.15.0"
+
+anyhow.workspace = true
+futures.workspace = true
+modifier.workspace = true
+serde.workspace = true
+uuid.workspace = true
+
+trust-dns-client = { git = "https://github.com/NordSecurity/trust-dns.git", tag = "v2.0.0" }
+trust-dns-server = { git = "https://github.com/NordSecurity/trust-dns.git", tag = "v2.0.0", features = ["resolver"] }
+
+telio-crypto.workspace = true
+telio-firewall.workspace = true
+telio-sockets.workspace = true
+telio-wg.workspace = true
+
+[dev-dependencies]
+dns-parser = "0.8.0"
+
+mockall.workspace = true
+
+[build-dependencies]
+cc = "1"
+
+[target.'cfg(target_os = "android")'.dependencies]
+rupnp = { version = "1.1.0", default-features = false }
+
+[target.'cfg(not(target_os = "android"))'.dependencies]
+rupnp.workspace = true
+
+[target.'cfg(windows)'.dependencies]
+winapi = { workspace = true, features = ["ntdef", "winerror"] }
+
+[target.'cfg(windows)'.build-dependencies]
+winres = "0.1"
+```

--- a/wireguard-go-rust-wrapper/Cargo.toml
+++ b/wireguard-go-rust-wrapper/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/NordSecurity/libtelio"
 publish = false
 
 [dependencies]
-libc = "0.2.99"
+libc = "0.2.112"
 
 [build-dependencies]
 cc = "1.0"


### PR DESCRIPTION
### Problem
There are a lot of dependencies that are shared between our crates, making it easy to miss something when updating those shared dependencies. Also, our dependencies were not very well organized everywhere.

### Solution
In this PR, workspace dependencies are used for any dependency that's used at least twice, with the exception of our fuzzer crates and `wireguard-go-rust-wrapper`. The dependencies are now also reorganized, where the sections are ordered `dependencies, dev-dependencies, build-dependencies`, with platform-specific dependencies coming after that, with their internal ordering the same. Within each dependency section, the dependencies are now group as `non-workspace deps, workspace deps, git deps, internal crates`, and each such group has been alphabetized.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
