### PR TITLE
Mark direct test xfail

### DIFF
--- a/nat-lab/tests/test_direct_connection.py
+++ b/nat-lab/tests/test_direct_connection.py
@@ -286,6 +286,7 @@ async def new_connections_with_mesh_clients(
     "endpoint_providers, client1_type, client2_type, _reflexive_ip",
     UHP_conn_client_types,
 )
+@pytest.mark.xfail(reason="the test is flaky LLT-4308")
 async def test_direct_working_paths(
     endpoint_providers,
     client1_type,


### PR DESCRIPTION
### Problem
Direct working path is failing on natlab nightly, hence being marked xfail.

### Solution
*--describe selected solution--*


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
