### PR TITLE
Add xfail mark to test_vpn_plus_mesh_over_direct

### DIFF
--- a/nat-lab/tests/test_mesh_plus_vpn.py
+++ b/nat-lab/tests/test_mesh_plus_vpn.py
@@ -386,7 +386,12 @@ async def test_vpn_plus_mesh(
             marks=pytest.mark.windows,
         ),
         pytest.param(
-            ConnectionTag.WINDOWS_VM, AdapterType.WireguardGo, marks=pytest.mark.windows
+            ConnectionTag.WINDOWS_VM,
+            AdapterType.WireguardGo,
+            marks=[
+                pytest.mark.windows,
+                pytest.mark.xfail(reason="Test is flaky - LLT-4313"),
+            ],
         ),
         pytest.param(ConnectionTag.MAC_VM, AdapterType.Default, marks=pytest.mark.mac),
     ],


### PR DESCRIPTION
### Problem
*test_vpn_plus_mesh_over_direct[ConnectionTag.WINDOWS_VM-AdapterType.WireguardGo] is flaky*

### Solution
*Marked test_vpn_plus_mesh_over_direct[ConnectionTag.WINDOWS_VM-AdapterType.WireguardGo] as xfail until it's properly fixed*


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
