### PR TITLE
Remove unflaky mark from test_direct_short_connection_loss

### DIFF
--- a/nat-lab/tests/test_direct_connection.py
+++ b/nat-lab/tests/test_direct_connection.py
@@ -450,7 +450,6 @@ async def test_direct_failing_paths(
 
 
 @pytest.mark.asyncio
-@pytest.mark.xfail(reason="test flaky - JIRA issue: LLT-4132")
 @pytest.mark.parametrize(
     "endpoint_providers, client1_type, client2_type, reflexive_ip",
     UHP_conn_client_types,


### PR DESCRIPTION
### Problem
Test was tagged as flaky.

### Solution

Observing the [flakyness report](https://bucket.digitalarsenal.net/low-level-hacks/automation/gitlab/ci-helper-scripts/-/jobs/9166635/artifacts/browse), this test is no longer flaky. 

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
