### PR TITLE
Add xfail mark to flaky test

### DIFF
--- a/nat-lab/tests/test_mesh_plus_vpn.py
+++ b/nat-lab/tests/test_mesh_plus_vpn.py
@@ -535,7 +535,12 @@ async def test_vpn_plus_mesh_over_direct(
             marks=pytest.mark.windows,
         ),
         pytest.param(
-            ConnectionTag.WINDOWS_VM, AdapterType.WireguardGo, marks=pytest.mark.windows
+            ConnectionTag.WINDOWS_VM,
+            AdapterType.WireguardGo,
+            marks=[
+                pytest.mark.windows,
+                pytest.mark.xfail(reason="test is flaky - LLT-4314"),
+            ],
         ),
         pytest.param(
             ConnectionTag.MAC_VM,


### PR DESCRIPTION
### Problem
*test_vpn_plus_mesh_over_different_connection_types[ConnectionTag.WINDOWS_VM-AdapterType.WireguardGo] test is flaky*

### Solution
*Marking it as xfail until it's fixed*


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
