### PR TITLE
LLT-4306 Fix infinite loop in STUN handler

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -26,6 +26,7 @@
 * LLT-4266: Add exit node clearing when disabling meshnet
 * LLT-4159: Clarify purpose of hardcoded secrets in repo
 * LLT-3451: Use workspace dependencies
+* LLT-4306: Prevent infinite loop in STUN handler on socket error
 
 <br>
 

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -1106,6 +1106,12 @@ impl Runtime {
             .drop_connected_sockets()
             .await?;
 
+        if let Some(direct) = &self.entities.direct {
+            if let Some(stun) = &direct.stun_endpoint_provider {
+                stun.reconnect().await;
+            }
+        }
+
         self.entities.derp.reconnect().await;
         self.log_nat().await;
         Ok(())

--- a/src/device/wg_controller.rs
+++ b/src/device/wg_controller.rs
@@ -147,6 +147,14 @@ async fn consolidate_wg_peers<
         telio_log_info!("Inserting peer: {:?}", requested_peers.get(key));
         let peer = requested_peers.get(key).ok_or(Error::PeerNotFound)?;
         wireguard_interface.add_peer(peer.peer.clone()).await?;
+
+        if let Some(stun) = stun_ep_provider {
+            if let Some(wg_stun_server) = requested_state.wg_stun_server.as_ref() {
+                if wg_stun_server.public_key == *key {
+                    stun.trigger_endpoint_candidates_discovery().await?;
+                }
+            }
+        }
     }
 
     for key in update_keys {
@@ -164,14 +172,6 @@ async fn consolidate_wg_peers<
             wireguard_interface
                 .add_peer(requested_peer.peer.clone())
                 .await?;
-        }
-
-        if let Some(stun) = stun_ep_provider {
-            if let Some(wg_stun_server) = requested_state.wg_stun_server.as_ref() {
-                if wg_stun_server.public_key == *key {
-                    stun.trigger_endpoint_candidates_discovery().await?;
-                }
-            }
         }
 
         match (


### PR DESCRIPTION
### Problem
An infinite loop was created in our STUN handler because a timeout was set too late. The timeout determines if we should try to start a STUN session or wait, but it was set after trying to start the STUN session. In cases where starting the STUN session failed, the timeout would never be updated, making the code think that we should start a STUN session, even though we just tried, leading to an infinite loop.

### Solution
Add error handling to the affected call site to transition to the right state

### Note
There will be a follow-up PR to add tests for this case. For this PR, there is just manual verification that it solves the issue


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
