### PR TITLE
Wait some time before getting process list in test_process_run_not_found

### DIFF
--- a/nat-lab/tests/test_process.py
+++ b/nat-lab/tests/test_process.py
@@ -120,7 +120,6 @@ async def test_process_run_fail(connection_tag: ConnectionTag, command: list[str
         assert " ".join(command) not in await _get_running_process_list(connection)
 
 
-@pytest.mark.xfail(reason="test is flaky - LLT-4311")
 @pytest.mark.parametrize(
     "connection_tag",
     [
@@ -148,6 +147,7 @@ async def test_process_run_not_found(connection_tag: ConnectionTag):
                 await process.wait_stdin_ready()
                 assert command in await _get_running_process_list(connection)
         assert e.value.cmd == [command]
+        await asyncio.sleep(1)
         assert command not in await _get_running_process_list(connection)
 
 


### PR DESCRIPTION
### Problem

Sometimes process list seems to contain processes that have already ended. This causes `test_process_run_not_found` to fail sometimes.

### Solution

To account for above behaviour we wait 1 second before getting process list. This is not a 100% reliable solution but I'm not sure if there is a better one. Alternatively we could just remove the check of process listing since we already know that executing not existing process has failed via the exception. For now let's keep it this way, especially since few other similar tests are already performing sleep before getting the process list.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
