### PR TITLE
Remove assertion which always fails but races with the rest of the test

### DIFF
--- a/nat-lab/tests/test_process.py
+++ b/nat-lab/tests/test_process.py
@@ -120,7 +120,6 @@ async def test_process_run_fail(connection_tag: ConnectionTag, command: list[str
         assert " ".join(command) not in await _get_running_process_list(connection)
 
 
-@pytest.mark.xfail(reason="test is flaky - LLT-4311")
 @pytest.mark.parametrize(
     "connection_tag",
     [
@@ -144,9 +143,8 @@ async def test_process_run_not_found(connection_tag: ConnectionTag):
         )
         command = "non_existing_binary"
         with pytest.raises(ProcessExecError) as e:
-            async with connection.create_process([command]).run() as process:
-                await process.wait_stdin_ready()
-                assert command in await _get_running_process_list(connection)
+            async with connection.create_process([command]).run():
+                await asyncio.sleep(1)
         assert e.value.cmd == [command]
         assert command not in await _get_running_process_list(connection)
 

--- a/nat-lab/tests/test_process.py
+++ b/nat-lab/tests/test_process.py
@@ -143,8 +143,8 @@ async def test_process_run_not_found(connection_tag: ConnectionTag):
         )
         command = "non_existing_binary"
         with pytest.raises(ProcessExecError) as e:
-            async with connection.create_process([command]).run():
-                await asyncio.sleep(1)
+            async with connection.create_process([command]).run() as process:
+                await process.is_done()
         assert e.value.cmd == [command]
         assert command not in await _get_running_process_list(connection)
 

--- a/nat-lab/tests/utils/process/process.py
+++ b/nat-lab/tests/utils/process/process.py
@@ -57,3 +57,7 @@ class Process(ABC):
     @abstractmethod
     def is_executing(self) -> bool:
         pass
+
+    @abstractmethod
+    async def is_done(self) -> None:
+        pass


### PR DESCRIPTION
The assertion which checks if the not existing executable is on the list of running processes, would **always** fails. But it's almost never reached in the test since at almost the same time the subprocess creation is throwing expected exception which most of the time is slightly faster/earlier. This is because we only wait for the stdout ready event which happens before we check the exit code and trigger an exception.

Since the assertion would always fail when reached and is occasionally reached, it is safe to remove it since it is incorrect.

This has been confirmed with additional logging and also by adding a sleep before the `raise` in the `DockerProcess.execute` which causes consistent test failures due to wrong exception being thrown.

Snippet of run with additional logging:

```
1695807387.393364 WAIT STDIN_READY <utils.process.docker_process.DockerProcess object at 0x7f2b8ad00b50>
1695807387.395445 READ LOOP ENTER ['non_existing_binary']
1695807387.3954818 GET PROCESS LIST (process is executing True)
1695807387.3974044 READ LOOP ENTER ['ps', 'aux']
1695807387.4835947 RAISE ['non_existing_binary'] 126
1695807387.5035448 process is executing False
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root           1  0.0  0.0   3924  2944 ?        Ss   Sep26   0:00 bash /opt/bin/client
root          15  0.0  0.0   2484  1280 ?        S    Sep26   0:00 sleep infinity
root       48951  0.0  0.0   8088  4096 ?        Rs   09:36   0:00 ps aux
```

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
