### PR TITLE
Fix test_direct_working_paths

### DIFF
--- a/nat-lab/tests/test_direct_connection.py
+++ b/nat-lab/tests/test_direct_connection.py
@@ -286,7 +286,6 @@ async def new_connections_with_mesh_clients(
     "endpoint_providers, client1_type, client2_type, _reflexive_ip",
     UHP_conn_client_types,
 )
-@pytest.mark.xfail(reason="the test is flaky LLT-4308")
 async def test_direct_working_paths(
     endpoint_providers,
     client1_type,

--- a/nat-lab/tests/utils/router/linux_router.py
+++ b/nat-lab/tests/utils/router/linux_router.py
@@ -19,6 +19,17 @@ FWMARK_VALUE = "11673110"  # LIBTELIO
 ROUTING_PRIORITY = "32111"
 
 
+class AddressError(Exception):
+    address: str
+
+    def __init__(self, address) -> None:
+        self.address = address
+
+
+class AddressTypeError(AddressError):
+    pass
+
+
 class LinuxRouter(Router):
     _connection: Connection
     _interface_name: str
@@ -313,7 +324,7 @@ class LinuxRouter(Router):
         addr_proto = self.check_ip_address(address)
 
         if addr_proto is None:
-            return
+            raise AddressTypeError(address)
 
         iptables_string = ("ip" if addr_proto == IPProto.IPv4 else "ip6") + "tables"
 


### PR DESCRIPTION
### Problem
After migrating to libvirt test_direct_working_paths was failing occasionally, the ping after establishing direct connection fails. Looking at the [logs](https://bucket.digitalarsenal.net/low-level-hacks/vpn/client/libtelio-build/-/jobs/9259504#L1938) we can see that the connections is downgraded to the Relay path after blocking derp relay connection.

It happens mostly with:
```
    (
        STUN_PROVIDER,
        ConnectionTag.DOCKER_SYMMETRIC_CLIENT_1,
        ConnectionTag.DOCKER_OPEN_INTERNET_CLIENT_1,
        DOCKER_OPEN_INTERNET_CLIENT_1_IP,
    ),
    (
        LOCAL_PROVIDER,
        ConnectionTag.DOCKER_SYMMETRIC_CLIENT_1,
        ConnectionTag.DOCKER_OPEN_INTERNET_CLIENT_1,
        DOCKER_OPEN_INTERNET_CLIENT_1_IP,
    ),
    (
        LOCAL_PROVIDER,
        ConnectionTag.DOCKER_CONE_CLIENT_1,
        ConnectionTag.DOCKER_OPEN_INTERNET_CLIENT_1,
        DOCKER_OPEN_INTERNET_CLIENT_1_IP,
    ),
    (
        LOCAL_PROVIDER,
        ConnectionTag.DOCKER_FULLCONE_CLIENT_1,
        ConnectionTag.DOCKER_OPEN_INTERNET_CLIENT_1,
        DOCKER_OPEN_INTERNET_CLIENT_1_IP,
    ),
    (
        LOCAL_PROVIDER,
        ConnectionTag.DOCKER_INTERNAL_SYMMETRIC_CLIENT,
        ConnectionTag.DOCKER_SYMMETRIC_CLIENT_1,
        DOCKER_SYMMETRIC_CLIENT_1_IP,
    )
```

### Solution
Seeing the test duration being approximately 4x times longer in CI than locally, I've tried to reproduce the flakyness downclocking the containers cpu so that it takes approx. the same time as in CI, but I couldn't as the test was still passing. 

I've added a sleep(1) before blocking the derp connection, which seems to work: 432 test runs succeeded ([#1](https://bucket.digitalarsenal.net/low-level-hacks/vpn/client/libtelio-build/-/jobs/9261382), [#2](https://bucket.digitalarsenal.net/low-level-hacks/vpn/client/libtelio-build/-/jobs/9261375), [#3](https://bucket.digitalarsenal.net/low-level-hacks/vpn/client/libtelio-build/-/jobs/9261332)).

This led me to believe that there's a datarace: in spite the node event being reported as using the direct path, the node need a bit more time to completely free itself from the derp relay.

This can show there is some bug on libtelio, however the failure results from blocking derp connection right after nat is traversed, which won't happen on normal usage. This way I conclude that sleep(1) fixes the test, if there's a bug further investigation is needed.

### UPDATE

Logs shown that although the handshake was being done, the RX counters were still zero. After some internal discussions, it was concluded that boringtun is not using the handshake packets to increment the counter, while we rely on this it to avail the connection state.

This PR fixes the bug by using either the time elapsed from the last rx packet or since the handshake, the one that's smaller.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
