### PR TITLE
Fix test building inside of the telio-sockets crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3896,7 +3896,7 @@ dependencies = [
  "objc",
  "objc-foundation",
  "parking_lot 0.12.1",
- "socket2 0.4.9",
+ "socket2 0.5.3",
  "system-configuration",
  "telio-utils",
  "thiserror",

--- a/crates/telio-sockets/Cargo.toml
+++ b/crates/telio-sockets/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/NordSecurity/libtelio"
 publish = false
 
 [dependencies]
-socket2 = "0.4.7"
+socket2 = "0.5"
 
 boringtun.workspace = true
 futures.workspace = true


### PR DESCRIPTION
Before this change, when building this crate from `crates/telio-sockets` directory the compilation would fail. Because cargo would select socket2 in the 0.4.x version which lacks functions used in this crate. When build from top level libtelio directory cargo would select newer version 0.5.x which would work correctly. Which is why bumping to 0.5.x is safe since it is eitherway the only version that compiles and one which is selected when whole libtelio is being built.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
