### PR TITLE
LLT-4106: Skip ticks on analytics interval after telio was paused

### DIFF
--- a/crates/telio-nurse/src/heartbeat.rs
+++ b/crates/telio-nurse/src/heartbeat.rs
@@ -356,6 +356,7 @@ impl Analytics {
             // This way, the interval between events will be constant.
             Instant::now() + config.collect_interval - config.collect_answer_timeout
         };
+
         let mut interval: Interval = interval_at(start_time, config.collect_interval);
         interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
@@ -906,14 +907,11 @@ impl Analytics {
 
 #[cfg(test)]
 mod tests {
-    use telio_model::{
-        event::EventMsg,
-        mesh::{ExitNode, Node},
-    };
+    use telio_model::mesh::Node;
     use telio_sockets::{native::NativeSocket, Protector, SocketPool};
-    use telio_task::io::{mc_chan::Tx, McChan};
+    use telio_task::{io::McChan, Task};
     use telio_utils::sync::mpsc::Receiver;
-    use tokio::task::yield_now;
+    use tokio::time::timeout;
 
     use super::*;
 
@@ -945,14 +943,19 @@ mod tests {
         analytics: Analytics,
     }
 
-    fn setup() -> State {
+    fn setup(collect_interval: Option<Duration>) -> State {
         let sk = SecretKey::gen();
         let pk = sk.public();
         let meshnet_id = Uuid::new_v4();
-        let config = HeartbeatConfig::default();
+        let mut config = HeartbeatConfig::default();
+        let channel = Chan::new(1);
+        if let Some(interval) = collect_interval {
+            config.collect_interval = interval;
+        }
+
         let analytics_channel = Chan::new(1);
         let io = Io {
-            chan: Chan::new(1),
+            chan: channel,
             derp_event_channel: McChan::new(1).rx,
             wg_event_channel: McChan::new(1).rx,
             config_update_channel: McChan::new(1).rx,
@@ -1022,7 +1025,7 @@ mod tests {
             mut analytics_channel,
             mut analytics,
             ..
-        } = setup();
+        } = setup(None);
 
         analytics.handle_aggregation().await;
 
@@ -1037,7 +1040,7 @@ mod tests {
             mut analytics,
             meshnet_id,
             ..
-        } = setup();
+        } = setup(None);
 
         let peer_sk_1 = SecretKey::gen();
         let peer_sk_2 = SecretKey::gen();
@@ -1063,7 +1066,7 @@ mod tests {
             mut analytics_channel,
             mut analytics,
             ..
-        } = setup();
+        } = setup(None);
         let peer_sk_1 = SecretKey::gen();
         let peer_sk_2 = SecretKey::gen();
 
@@ -1092,7 +1095,7 @@ mod tests {
             mut analytics_channel,
             mut analytics,
             meshnet_id,
-        } = setup();
+        } = setup(None);
 
         let peer_sk = SecretKey::gen();
 
@@ -1124,7 +1127,7 @@ mod tests {
             mut analytics_channel,
             mut analytics,
             ..
-        } = setup();
+        } = setup(None);
 
         let vpn_pk = SecretKey::gen().public();
 
@@ -1166,7 +1169,7 @@ mod tests {
             mut analytics_channel,
             mut analytics,
             ..
-        } = setup();
+        } = setup(None);
 
         let vpn_pk = SecretKey::gen().public();
 
@@ -1200,5 +1203,44 @@ mod tests {
 
         assert_eq!(true, meshnet_enabled);
         assert_eq!("vpn:7600617f9f9db5691a8c2768bd9d8110:2", external_links);
+    }
+
+    #[tokio::test]
+    // After a pause libtelio should send only one analytic even
+    // if it missed more than one analytic interval.
+    async fn test_send_analytics_report_once_on_skipped_ticks() {
+        let State {
+            mut analytics_channel,
+            mut analytics,
+            ..
+        } = setup(Some(Duration::from_secs(5)));
+
+        // Reset analytic timer 25s in the past
+        analytics
+            .task_interval
+            .reset_at(Instant::now() - Duration::from_secs(25));
+
+        // Set analytic collect interval 200 ms
+        analytics.config.collect_answer_timeout = Duration::from_millis(200);
+
+        let rt = Task::start(analytics);
+
+        // Should succeed to get one analytic meesage
+        assert_eq!(
+            true,
+            timeout(Duration::from_secs(1), analytics_channel.recv())
+                .await
+                .is_ok()
+        );
+
+        // Should timeout trying to get second analytic message
+        assert_eq!(
+            false,
+            timeout(Duration::from_secs(1), analytics_channel.recv())
+                .await
+                .is_ok()
+        );
+
+        rt.stop().await;
     }
 }

--- a/crates/telio-nurse/src/qos.rs
+++ b/crates/telio-nurse/src/qos.rs
@@ -397,8 +397,8 @@ mod tests {
 
         let histogram = default_histogram();
 
-        let a_node = dummy_node(&a_public_key, &histogram, 100);
-        let b_node = dummy_node(&b_public_key, &histogram, 200);
+        let a_node = dummy_node(&a_public_key, &histogram, Duration::from_secs(100));
+        let b_node = dummy_node(&b_public_key, &histogram, Duration::from_secs(200));
 
         let mut hashmap = HashMap::new();
         hashmap.insert(a_public_key.clone(), a_node);
@@ -438,12 +438,16 @@ mod tests {
         a
     }
 
-    fn dummy_node(public_key: &PublicKey, histogram: &Histogram, connected_time: u64) -> NodeInfo {
+    fn dummy_node(
+        public_key: &PublicKey,
+        histogram: &Histogram,
+        connected_time: Duration,
+    ) -> NodeInfo {
         NodeInfo {
             public_key: public_key.clone(),
             peer_state: PeerState::Disconnected,
             last_event: Instant::now(),
-            last_state_change: Instant::now(),
+            last_wg_event: Instant::now(),
             connected_time,
             endpoint: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
             rtt_histogram: histogram.clone(),

--- a/crates/telio-nurse/src/qos.rs
+++ b/crates/telio-nurse/src/qos.rs
@@ -5,7 +5,7 @@ use std::collections::{BTreeSet, HashMap};
 use std::net::IpAddr;
 use std::time::Instant;
 
-use tokio::time::{interval_at, Interval};
+use tokio::time::{interval_at, Duration, Interval};
 
 use telio_crypto::PublicKey;
 use telio_task::{io::mc_chan, Runtime, RuntimeExt, WaitResponse};
@@ -32,8 +32,8 @@ pub struct NodeInfo {
     pub last_event: Instant,
 
     // Connection duration
-    pub last_state_change: Instant,
-    pub connected_time: u64,
+    pub last_wg_event: Instant,
+    pub connected_time: Duration,
 
     // RTT
     pub endpoint: IpAddr,
@@ -71,23 +71,15 @@ impl NodeInfo {
         };
     }
 
-    fn update_connection_duration(&mut self, event: &AnalyticsEvent) {
-        if self.peer_state != event.peer_state {
-            // Connected -> Disconnected
-            if self.peer_state == PeerState::Connected {
-                // Connected time
-                let duration = event
-                    .timestamp
-                    .checked_duration_since(self.last_state_change);
-                telio_log_debug!("adding {:?} to connected_time", duration);
-                self.connected_time += duration
-                    .map(|duration| duration.as_secs())
-                    .unwrap_or_default();
-            }
-
-            self.peer_state = event.peer_state;
-            self.last_state_change = event.timestamp;
+    fn update_connection_duration(&mut self, event: &AnalyticsEvent, pause: bool) {
+        if self.peer_state == PeerState::Connected && !pause {
+            // Connected time
+            let duration = event.timestamp.checked_duration_since(self.last_wg_event);
+            self.connected_time += duration.unwrap_or_default();
         }
+
+        self.peer_state = event.peer_state;
+        self.last_wg_event = event.timestamp;
     }
 }
 
@@ -97,8 +89,8 @@ impl From<AnalyticsEvent> for NodeInfo {
             public_key: event.public_key,
             peer_state: event.peer_state,
             last_event: event.timestamp,
-            last_state_change: event.timestamp,
-            connected_time: 0,
+            last_wg_event: event.timestamp,
+            connected_time: Duration::default(),
             endpoint: event.endpoint.ip(),
             rtt_histogram: Histogram::new(),
             last_tx_bytes: 0,
@@ -264,21 +256,9 @@ impl Analytics {
                 ));
                 output.rx.push(',');
 
-                // Connection duration
-                let mut total_connected_time = node.connected_time;
-                if node.peer_state == PeerState::Connected {
-                    let duration = Instant::now().checked_duration_since(node.last_state_change);
-                    telio_log_debug!(
-                        "connected at the collection interval, adding: {:?}",
-                        duration
-                    );
-                    total_connected_time += duration
-                        .map(|duration| duration.as_secs())
-                        .unwrap_or_default();
-                }
                 output
                     .connection_duration
-                    .push_str(&total_connected_time.to_string());
+                    .push_str(&node.connected_time.as_secs().to_string());
                 output.connection_duration.push(';');
             } else {
                 output.rtt.push_str(&Analytics::empty_data(buckets));
@@ -311,10 +291,7 @@ impl Analytics {
             node.rtt_histogram = Histogram::new();
             node.tx_histogram = Histogram::new();
             node.rx_histogram = Histogram::new();
-
-            // Even if the state doesn't really change, reset connection duration info
-            node.last_state_change = Instant::now();
-            node.connected_time = 0;
+            node.connected_time = Duration::default();
         }
     }
 
@@ -323,8 +300,10 @@ impl Analytics {
         self.nodes
             .entry(event.public_key)
             .and_modify(|n| {
+                // Check if peer was not paused
+                let pause: bool = (event.timestamp - n.last_event).as_secs() > 10;
                 // Update current state
-                n.update_connection_duration(&event);
+                n.update_connection_duration(&event, pause);
 
                 // Update rtt info
                 n.endpoint = event.endpoint.ip();


### PR DESCRIPTION
After a few analytic interval long pause, telio sends analytic data one after another to catch up. Setting the tick to skip the missed ticks.




### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
