### PR TITLE
LLT-3951 IPv6 analytics

### DIFF
--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -31,4 +31,4 @@ jobs:
           project-id: ${{ secrets.PROJECT_ID }}
           schedule: ${{ github.event_name == 'schedule' }}
           cancel-outdated-pipelines: ${{ github.ref_name != 'main' }}
-          triggered-ref: v0.3.3
+          triggered-ref: v0.3.5

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,5 +15,5 @@ libtelio-build-pipeline:
 
   trigger:
     project: $LIBTELIO_BUILD_PROJECT_PATH
-    branch: v0.3.3
+    branch: v0.3.5
     strategy: depend

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3770,6 +3770,7 @@ dependencies = [
  "strum_macros",
  "telio-crypto",
  "telio-utils",
+ "thiserror",
 ]
 
 [[package]]

--- a/changelog.md
+++ b/changelog.md
@@ -35,6 +35,7 @@
 * LLT-4360: Bump rust version to 1.72
 * LLT-4286: Add icmp error packet handling to firewall
 * LLT-4432: Use forked system-configuration crate to prevent iOS linking errors
+* LLT-3951: IPv6 analytics.
 
 <br>
 

--- a/crates/telio-lana/src/event_log_file.rs
+++ b/crates/telio-lana/src/event_log_file.rs
@@ -399,6 +399,7 @@ pub mod moose {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     #[allow(non_snake_case)]
     /// Mocked moose function.
     pub fn send_serviceQuality_node_heartbeat(
@@ -407,6 +408,9 @@ pub mod moose {
         heartbeatInterval: i32,
         receivedData: String,
         rtt: String,
+        rtt6: String,
+        rtt6_loss: String,
+        rtt_loss: String,
         sentData: String,
     ) -> std::result::Result<Result, Error> {
         let heartbeatIntervalString = heartbeatInterval.to_string();
@@ -417,6 +421,9 @@ pub mod moose {
             heartbeatIntervalString.as_str(),
             receivedData.as_str(),
             rtt.as_str(),
+            rtt6.as_str(),
+            rtt6_loss.as_str(),
+            rtt_loss.as_str(),
             sentData.as_str(),
         ];
 

--- a/crates/telio-lana/src/lib.rs
+++ b/crates/telio-lana/src/lib.rs
@@ -23,7 +23,7 @@ pub use event_log::*;
 /// App name used to initialize moose with
 pub const LANA_APP_NAME: &str = "libtelio";
 /// Version of the tracker used, should be updated everytime the tracker library is updated
-pub const LANA_MOOSE_VERSION: &str = "0.8.0";
+pub const LANA_MOOSE_VERSION: &str = "0.10.1";
 /// Timeout for moose to send init error, if any, through callback
 pub const LANA_MOOSE_MAX_INIT_TIME: u8 = 2;
 

--- a/crates/telio-model/Cargo.toml
+++ b/crates/telio-model/Cargo.toml
@@ -22,6 +22,7 @@ serde.workspace = true
 serde_with.workspace = true
 serde_json.workspace = true
 strum.workspace = true
+thiserror.workspace = true
 
 telio-crypto.workspace = true
 telio-utils.workspace = true

--- a/crates/telio-model/src/event.rs
+++ b/crates/telio-model/src/event.rs
@@ -207,6 +207,7 @@ mod tests {
     use crate::config::{RelayState, Server};
 
     use super::super::mesh::*;
+    use super::Error as EventError;
     use super::*;
     use telio_crypto::{PublicKey, KEY_SIZE};
 
@@ -276,7 +277,7 @@ mod tests {
             r#"}}"#
         ));
 
-        let err_event = Event::new::<Error>()
+        let err_event = Event::new::<EventError>()
             .set(EventMsg::from("big_error"))
             .set(ErrorCode::Unknown)
             .set(ErrorLevel::Severe);

--- a/crates/telio-model/src/mesh.rs
+++ b/crates/telio-model/src/mesh.rs
@@ -13,6 +13,26 @@ use super::config::{Config, Peer, PeerBase};
 pub use ipnetwork::IpNetwork;
 pub use std::net::{Ipv4Addr, SocketAddr};
 
+/// Possible errors from node
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// No IPs are assigned to node
+    #[error("Node does not have IP addresses assigned")]
+    NoIPsFound,
+}
+
+/// Stack in-use by node
+#[derive(Clone, Default, PartialEq, Eq)]
+pub enum IpStack {
+    /// Node can be reached only through IPv4 address
+    #[default]
+    IPv4,
+    /// Node can be reached only through IPv6 address
+    IPv6,
+    /// Node can be reached through IPv4 or IPv6 addresses
+    IPv4v6,
+}
+
 /// Description of a Node
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize)]
 pub struct Node {
@@ -170,5 +190,25 @@ impl From<&Config> for Map {
                 })
                 .unwrap_or_default(),
         }
+    }
+}
+
+/// Returns IP stack used in node
+pub fn get_ip_stack(ip_addresses: &[IpAddr]) -> Result<IpStack, Error> {
+    let (mut v4, mut v6) = (false, false);
+
+    for addr in ip_addresses.iter() {
+        if addr.is_ipv4() {
+            v4 = true;
+        } else {
+            v6 = true;
+        }
+    }
+
+    match (v4, v6) {
+        (false, false) => Err(Error::NoIPsFound),
+        (true, false) => Ok(IpStack::IPv4),
+        (false, true) => Ok(IpStack::IPv6),
+        (true, true) => Ok(IpStack::IPv4v6),
     }
 }

--- a/crates/telio-nurse/src/data.rs
+++ b/crates/telio-nurse/src/data.rs
@@ -1,6 +1,9 @@
 use std::collections::{BTreeSet, HashMap};
 use telio_crypto::PublicKey;
-use telio_model::config::Config;
+use telio_model::{
+    config::Config,
+    mesh::{get_ip_stack, IpStack},
+};
 
 /// Information about a heartbeat, for analytics.
 #[derive(Default)]
@@ -43,11 +46,17 @@ pub struct MeshConfigUpdateEvent {
     pub enabled: bool,
     /// All the nodes (public_key, is_local) from the config passed to telio library.
     pub nodes: HashMap<PublicKey, bool>,
+    /// IP stack after config update event
+    pub ip_stack: Option<IpStack>,
 }
 
 impl From<&Option<Config>> for MeshConfigUpdateEvent {
     fn from(config: &Option<Config>) -> Self {
-        let enabled = config.is_some();
+        let (mut enabled, mut ip_stack) = (false, None);
+        if let Some(c) = config {
+            enabled = true;
+            ip_stack = get_ip_stack(c.this.ip_addresses.as_ref().map_or(&[], |v| v)).ok();
+        }
         let nodes = config
             .as_ref()
             .and_then(|c| c.peers.as_ref())
@@ -58,6 +67,10 @@ impl From<&Option<Config>> for MeshConfigUpdateEvent {
                     .collect()
             })
             .unwrap_or_default();
-        Self { enabled, nodes }
+        Self {
+            enabled,
+            nodes,
+            ip_stack,
+        }
     }
 }

--- a/crates/telio-nurse/src/heartbeat.rs
+++ b/crates/telio-nurse/src/heartbeat.rs
@@ -41,8 +41,10 @@ enum RuntimeState {
 
 bitflags! {
     struct MeshConnectionState: u32 {
-        const DERP = 0b00000001;
-        const WG = 0b00000010;
+        const DERP  = 0b00000001;
+        const WG    = 0b00000010;
+        const IPV4  = 0b00000100;
+        const IPV6  = 0b00001000;
     }
 }
 

--- a/crates/telio-nurse/src/heartbeat.rs
+++ b/crates/telio-nurse/src/heartbeat.rs
@@ -13,7 +13,10 @@ use std::{
 };
 use telio_crypto::{PublicKey, SecretKey};
 use telio_model::config::{RelayState, Server};
-use telio_model::{event::Event, mesh::NodeState};
+use telio_model::{
+    event::Event,
+    mesh::{get_ip_stack, IpStack, NodeState},
+};
 use telio_nat_detect::nat_detection::{retrieve_single_nat, NatData};
 use telio_proto::{HeartbeatMessage, HeartbeatNatType, HeartbeatStatus, HeartbeatType};
 use telio_relay::DerpRelay;
@@ -41,10 +44,12 @@ enum RuntimeState {
 
 bitflags! {
     struct MeshConnectionState: u32 {
-        const DERP  = 0b00000001;
-        const WG    = 0b00000010;
-        const IPV4  = 0b00000100;
-        const IPV6  = 0b00001000;
+        const DERP      = 0b00000001;
+        const WG        = 0b00000010;
+        const IPV4      = 0b00000100;
+        const IPV6      = 0b00001000;
+        const IPV4V6    = Self::IPV4.bits
+                        | Self::IPV6.bits;
     }
 }
 
@@ -245,6 +250,9 @@ pub struct Analytics {
 
     /// DERP Server instance
     derp: Arc<DerpRelay>,
+
+    /// Our current IP stack
+    ip_stack: Option<IpStack>,
 }
 
 #[async_trait]
@@ -382,6 +390,7 @@ impl Analytics {
             derp_connection: false,
             meshnet_enabled: false,
             derp: derp_server,
+            ip_stack: None,
         }
     }
 
@@ -420,6 +429,24 @@ impl Analytics {
                     .connection_state
                     .set(MeshConnectionState::WG, node.state == NodeState::Connected);
 
+                if let (Some(our_stack), Ok(nodes_stack)) =
+                    (self.ip_stack.clone(), get_ip_stack(&node.ip_addresses))
+                {
+                    mesh_link.connection_state.set(
+                        match (our_stack, nodes_stack) {
+                            (IpStack::IPv4, IpStack::IPv4) => MeshConnectionState::IPV4,
+                            (IpStack::IPv4v6, IpStack::IPv4) => MeshConnectionState::IPV4,
+                            (IpStack::IPv4, IpStack::IPv4v6) => MeshConnectionState::IPV4,
+                            (IpStack::IPv6, IpStack::IPv6) => MeshConnectionState::IPV6,
+                            (IpStack::IPv4v6, IpStack::IPv6) => MeshConnectionState::IPV6,
+                            (IpStack::IPv6, IpStack::IPv4v6) => MeshConnectionState::IPV6,
+                            (IpStack::IPv4v6, IpStack::IPv4v6) => MeshConnectionState::IPV4V6,
+                            _ => MeshConnectionState::empty(),
+                        },
+                        true,
+                    );
+                }
+
                 let node_info = if node.is_vpn {
                     NodeInfo::Vpn {
                         mesh_link,
@@ -449,6 +476,7 @@ impl Analytics {
         if self.state == RuntimeState::Monitoring {
             self.meshnet_enabled = event.enabled;
             self.config_nodes = event.nodes;
+            self.ip_stack = event.ip_stack;
             // Add self to config nodes
             self.config_nodes.insert(self.public_key, true);
         } else {
@@ -989,6 +1017,7 @@ mod tests {
                 .into_iter()
                 .map(|sk| (sk.public(), is_local))
                 .collect(),
+            ip_stack: None,
         };
         analytics
             .handle_config_update_event(mesh_config_update_event)

--- a/crates/telio-nurse/src/nurse.rs
+++ b/crates/telio-nurse/src/nurse.rs
@@ -246,6 +246,9 @@ impl State {
             info.heartbeat_interval,
             qos_data.rx,
             qos_data.rtt,
+            qos_data.rtt6,
+            qos_data.rtt6_loss,
+            qos_data.rtt_loss,
             qos_data.tx
         );
     }

--- a/crates/telio-nurse/src/rtt/ping.rs
+++ b/crates/telio-nurse/src/rtt/ping.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use std::{convert::TryInto, net::IpAddr};
 use surge_ping::{Client, Config, PingIdentifier, PingSequence, ICMP};
+use telio_utils::{telio_log_debug, telio_log_error, DualTarget};
 
 use crate::qos::NodeInfo;
 
@@ -12,6 +13,19 @@ pub struct Ping {
     client_v4: Arc<Client>,
     client_v6: Arc<Client>,
     no_of_tries: u32,
+}
+
+#[derive(Debug, Clone)]
+struct PingResults {
+    successful_pings: u32,
+    unsuccessful_pings: u32,
+    avg_rtt: Option<Duration>,
+}
+
+#[derive(Debug)]
+struct DualPingResults {
+    v4: Option<PingResults>,
+    v6: Option<PingResults>,
 }
 
 impl Ping {
@@ -36,39 +50,100 @@ impl Ping {
     ///
     /// * `node` - `NodeInfo` instance to get endpoint to ping and to store RTT information.
     pub async fn perform(&self, node: &mut NodeInfo) {
-        let avg = self.perform_average_rtt(node.endpoint).await;
+        // TODO this needs some refinement
+        let dpr = self.perform_average_rtt(&node.endpoint).await;
 
-        if let Some(avg) = avg {
-            let u64_avg = avg.as_millis().try_into().unwrap_or(0u64);
+        telio_log_debug!(
+            "Ping results: {:?}, no_of_tries: {:?}",
+            dpr,
+            self.no_of_tries
+        );
+
+        if let Some(results_v4) = dpr.v4 {
+            let u64_avg = results_v4
+                .avg_rtt
+                .map_or(Duration::from_millis(0), |a| a)
+                .as_millis()
+                .try_into()
+                .unwrap_or(0u64);
             let _ = node.rtt_histogram.increment(u64_avg);
+            let _ = node
+                .rtt_loss_histogram
+                .increment((100 * results_v4.unsuccessful_pings / self.no_of_tries) as u64);
+        }
+
+        if let Some(results_v6) = dpr.v6 {
+            let u64_avg = results_v6
+                .avg_rtt
+                .map_or(Duration::from_millis(0), |a| a)
+                .as_millis()
+                .try_into()
+                .unwrap_or(0u64);
+            let _ = node.rtt6_histogram.increment(u64_avg);
+            let _ = node
+                .rtt6_loss_histogram
+                .increment((100 * results_v6.unsuccessful_pings / self.no_of_tries) as u64);
         }
     }
 
-    async fn perform_average_rtt(&self, node: IpAddr) -> Option<Duration> {
-        let client = match node {
-            IpAddr::V4(_) => self.client_v4.clone(),
-            IpAddr::V6(_) => self.client_v6.clone(),
+    async fn perform_average_rtt(&self, target: &DualTarget) -> DualPingResults {
+        let mut dpresults = DualPingResults { v4: None, v6: None };
+
+        let ping_action = |client: Arc<Client>, host| async move {
+            let mut results = PingResults {
+                successful_pings: 0,
+                unsuccessful_pings: 0,
+                avg_rtt: None,
+            };
+            let mut pinger = client.pinger(host, PingIdentifier(rand::random())).await;
+            let payload = [0; 56];
+            pinger.timeout(Self::PING_TIMEOUT);
+
+            let mut sum = Duration::default();
+
+            for i in 0..self.no_of_tries {
+                if let Ok((_, duration)) = pinger
+                    .ping(PingSequence(i.try_into().unwrap_or(0)), &payload)
+                    .await
+                {
+                    sum = sum.saturating_add(duration);
+                    results.successful_pings += 1;
+                } else {
+                    results.unsuccessful_pings += 1;
+                }
+            }
+
+            results.avg_rtt = sum.checked_div(results.successful_pings);
+            results
         };
 
-        let mut pinger = client.pinger(node, PingIdentifier(rand::random())).await;
-        let payload = [0; 56];
-        pinger.timeout(Self::PING_TIMEOUT);
+        match target.get_targets() {
+            Ok(t) => {
+                match t.0 {
+                    IpAddr::V4(_) => {
+                        dpresults.v4 = Some(ping_action(self.client_v4.clone(), t.0).await);
+                    }
+                    IpAddr::V6(_) => {
+                        dpresults.v6 = Some(ping_action(self.client_v6.clone(), t.0).await);
+                    }
+                }
 
-        let mut sum = Duration::default();
-        let mut successful_pings = 0;
-
-        for i in 0..self.no_of_tries {
-            if let Ok((_, duration)) = pinger
-                .ping(PingSequence(i.try_into().unwrap_or(0)), &payload)
-                .await
-            {
-                sum = sum.saturating_add(duration);
-                successful_pings += 1;
-            } else {
-                // TODO: Log error
+                if let Some(secondary) = t.1 {
+                    match secondary {
+                        IpAddr::V4(_) => {
+                            dpresults.v4 = Some(ping_action(self.client_v4.clone(), t.0).await);
+                        }
+                        IpAddr::V6(_) => {
+                            dpresults.v6 = Some(ping_action(self.client_v6.clone(), t.0).await);
+                        }
+                    }
+                }
+            }
+            Err(_) => {
+                telio_log_error!("No target to ping");
             }
         }
 
-        sum.checked_div(successful_pings)
+        dpresults
     }
 }

--- a/crates/telio-utils/src/dual_target.rs
+++ b/crates/telio-utils/src/dual_target.rs
@@ -1,0 +1,84 @@
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+/// Possible [DualTarget] errors.
+#[derive(thiserror::Error, Debug)]
+pub enum DualTargetError {
+    /// Target error
+    #[error("No IP target provided")]
+    NoTarget,
+}
+
+/// Result for [DualTarget] constructor
+pub type Result<T> = std::result::Result<T, DualTargetError>;
+
+/// Target input with IPv4 and IPv6 addresses
+pub type Target = (Option<Ipv4Addr>, Option<Ipv6Addr>);
+
+/// DualTarget wrapper
+#[derive(Clone, Copy)]
+pub struct DualTarget {
+    target: Target,
+}
+
+impl DualTarget {
+    /// [DualTarget] constructor
+    pub fn new(target: Target) -> Result<Self> {
+        if target.0.is_none() && target.1.is_none() {
+            return Err(DualTargetError::NoTarget);
+        }
+
+        Ok(DualTarget { target })
+    }
+
+    /// Get target IPs
+    pub fn get_targets(self) -> Result<(IpAddr, Option<IpAddr>)> {
+        if let (Some(ip4), Some(ip6)) = (self.target.0, self.target.1) {
+            // IPv6 target is preffered, because we can be sure, that address is unique
+            Ok((IpAddr::V6(ip6), Some(IpAddr::V4(ip4))))
+        } else if let (Some(ip4), None) = (self.target.0, self.target.1) {
+            Ok((IpAddr::V4(ip4), None))
+        } else if let (None, Some(ip6)) = (self.target.0, self.target.1) {
+            Ok((IpAddr::V6(ip6), None))
+        } else {
+            Err(DualTargetError::NoTarget)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+    #[test]
+    fn test_dual_target() {
+        assert!(DualTarget::new((None, None)).is_err());
+
+        assert_eq!(
+            (
+                IpAddr::V6(Ipv6Addr::LOCALHOST),
+                Some(IpAddr::V4(Ipv4Addr::LOCALHOST))
+            ),
+            DualTarget::new((Some(Ipv4Addr::LOCALHOST), Some(Ipv6Addr::LOCALHOST)))
+                .unwrap()
+                .get_targets()
+                .unwrap()
+        );
+
+        assert_eq!(
+            (IpAddr::V4(Ipv4Addr::LOCALHOST), None),
+            DualTarget::new((Some(Ipv4Addr::LOCALHOST), None))
+                .unwrap()
+                .get_targets()
+                .unwrap()
+        );
+
+        assert_eq!(
+            (IpAddr::V6(Ipv6Addr::LOCALHOST), None),
+            DualTarget::new((None, Some(Ipv6Addr::LOCALHOST)))
+                .unwrap()
+                .get_targets()
+                .unwrap()
+        );
+    }
+}

--- a/crates/telio-utils/src/dual_target.rs
+++ b/crates/telio-utils/src/dual_target.rs
@@ -15,7 +15,7 @@ pub type Result<T> = std::result::Result<T, DualTargetError>;
 pub type Target = (Option<Ipv4Addr>, Option<Ipv6Addr>);
 
 /// DualTarget wrapper
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct DualTarget {
     target: Target,
 }

--- a/crates/telio-utils/src/lib.rs
+++ b/crates/telio-utils/src/lib.rs
@@ -16,6 +16,10 @@ pub use sleep::*;
 pub mod repeated_actions;
 pub use repeated_actions::*;
 
+/// Dual stack IP target helper
+pub mod dual_target;
+pub use dual_target::*;
+
 /// Exponential backoff helper
 pub mod exponential_backoff;
 

--- a/crates/telio-wg/src/uapi.rs
+++ b/crates/telio-wg/src/uapi.rs
@@ -4,7 +4,7 @@ use ipnetwork::{IpNetwork, IpNetworkError};
 use serde::{Deserialize, Serialize};
 use telio_crypto::{KeyDecodeError, PublicKey, SecretKey};
 use telio_model::mesh::{Node, NodeState};
-use telio_utils::telio_log_warn;
+use telio_utils::{telio_log_warn, DualTarget};
 use wireguard_uapi::{get, xplatform::set};
 
 use std::{
@@ -237,8 +237,8 @@ pub struct Event {
 pub struct AnalyticsEvent {
     /// Public key of the Peer
     pub public_key: PublicKey,
-    /// IP address and port number of the socket
-    pub endpoint: SocketAddr,
+    /// Mesh's IP target of peer
+    pub endpoint: DualTarget,
     /// Number of transmitted bytes
     pub tx_bytes: u64,
     /// Number of recieved bytes

--- a/nat-lab/tests/utils/analytics/event_loader.py
+++ b/nat-lab/tests/utils/analytics/event_loader.py
@@ -48,6 +48,9 @@ class Event(DataClassJsonMixin):
     )
     received_data: str = field(metadata=json_config(field_name="body_received_data"))
     rtt: str = field(metadata=json_config(field_name="body_rtt"))
+    rtt_loss: str = field(metadata=json_config(field_name="body_rtt_loss"))
+    rtt6: str = field(metadata=json_config(field_name="body_rtt6"))
+    rtt6_loss: str = field(metadata=json_config(field_name="body_rtt6_loss"))
     sent_data: str = field(metadata=json_config(field_name="body_sent_data"))
     nat_type: str = field(
         metadata=json_config(

--- a/src/device/wg_controller.rs
+++ b/src/device/wg_controller.rs
@@ -16,10 +16,12 @@ use telio_proxy::Proxy;
 use telio_traversal::endpoint_providers::stun::StunEndpointProvider;
 use telio_traversal::endpoint_providers::EndpointProvider;
 use telio_traversal::{
-    cross_ping_check::CrossPingCheckTrait, SessionKeeperTrait, Target as SessionKeeperTarget,
-    UpgradeSyncTrait, WireGuardEndpointCandidateChangeEvent,
+    cross_ping_check::CrossPingCheckTrait, SessionKeeperTrait, UpgradeSyncTrait,
+    WireGuardEndpointCandidateChangeEvent,
 };
-use telio_utils::{telio_log_debug, telio_log_info, telio_log_warn};
+use telio_utils::{
+    dual_target::Target as SessionKeeperTarget, telio_log_debug, telio_log_info, telio_log_warn,
+};
 use telio_wg::{uapi::Peer, WireGuard};
 use thiserror::Error as TError;
 use tokio::sync::Mutex;


### PR DESCRIPTION
### Problem
We need to collect analytics on IPv6 usage. But current WG implementations does not distinguish data between IP protocols.

### Solution
The following solution is being used:

- Add IPv4/IPv6 flags/bits in connectivity matrix.
- Add `rtt6` collection, using `ICMPv6` protocol. Additionally, to get a more clear picture of IP protocol health, `rtt_loss` / `rtt6_loss`  which collects percentages of lost `ICMP` / `ICMPv6` packets.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests 
