### PR TITLE
Add tests that verify working ip v4/v6 sockets.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3896,6 +3896,7 @@ dependencies = [
  "objc",
  "objc-foundation",
  "parking_lot 0.12.1",
+ "rstest",
  "socket2 0.5.3",
  "system-configuration",
  "telio-utils",

--- a/crates/telio-lana/Cargo.toml
+++ b/crates/telio-lana/Cargo.toml
@@ -9,9 +9,6 @@ license = "GPL-3.0-only"
 repository = "https://github.com/NordSecurity/libtelio"
 publish = false
 
-[features]
-moose = []
-
 [dependencies]
 log.workspace = true
 serde.workspace = true

--- a/crates/telio-sockets/Cargo.toml
+++ b/crates/telio-sockets/Cargo.toml
@@ -21,6 +21,7 @@ telio-utils.workspace = true
 
 [dev-dependencies]
 mockall.workspace = true
+rstest.workspace = true
 
 [target.'cfg(target_os = "ios")'.dependencies]
 objc = "0.2.7"

--- a/crates/telio-sockets/src/protector/linux.rs
+++ b/crates/telio-sockets/src/protector/linux.rs
@@ -61,3 +61,48 @@ fn set_fwmark(fd: i32, fwmark: u32) -> io::Result<()> {
         _ => Err(io::Error::last_os_error()),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        io::ErrorKind,
+        net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, TcpListener, UdpSocket},
+    };
+
+    use crate::native::AsNativeSocket;
+
+    use rstest::rstest;
+
+    use super::*;
+
+    #[rstest]
+    #[case(IpAddr::V4(Ipv4Addr::LOCALHOST))]
+    #[case(IpAddr::V4(Ipv4Addr::UNSPECIFIED))]
+    #[case(IpAddr::V6(Ipv6Addr::LOCALHOST))]
+    #[case(IpAddr::V6(Ipv6Addr::UNSPECIFIED))]
+    fn test_make_external(#[case] ip_addr: IpAddr) {
+        let protector = NativeProtector::new().unwrap();
+        protector.set_fwmark(11673110);
+        let addr = SocketAddr::new(ip_addr, 0);
+
+        let socket = match UdpSocket::bind(addr) {
+            Ok(socket) => socket,
+            Err(e) if e.kind() == ErrorKind::AddrNotAvailable => {
+                // host has no interface with ipv4/ipv6
+                return;
+            }
+            Err(e) => panic!("Unexpected error: {:?}", e),
+        };
+        assert!(protector.make_external(socket.as_native_socket()).is_ok());
+
+        let socket = match TcpListener::bind(addr) {
+            Ok(socket) => socket,
+            Err(e) if e.kind() == ErrorKind::AddrNotAvailable => {
+                // host has no interface with ipv4/ipv6
+                return;
+            }
+            Err(e) => panic!("Unexpected error: {:?}", e),
+        };
+        assert!(protector.make_external(socket.as_native_socket()).is_ok());
+    }
+}

--- a/crates/telio-sockets/src/protector/windows.rs
+++ b/crates/telio-sockets/src/protector/windows.rs
@@ -468,3 +468,28 @@ pub fn get_default_interface(tunnel_interface: u64) -> Result<Interface> {
 
     Ok(default_interface)
 }
+
+#[cfg(test)]
+mod tests {
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, TcpListener, UdpSocket};
+
+    use crate::native::AsNativeSocket;
+    use rstest::rstest;
+
+    use super::*;
+
+    #[rstest]
+    #[case(IpAddr::V4(Ipv4Addr::LOCALHOST))]
+    #[case(IpAddr::V6(Ipv6Addr::LOCALHOST))]
+    #[tokio::test]
+    async fn test_make_external(#[case] ip_addr: IpAddr) {
+        let protector = NativeProtector::new().unwrap();
+        let addr = SocketAddr::new(ip_addr, 0);
+
+        let socket = std::net::UdpSocket::bind(addr).unwrap();
+        assert!(protector.make_external(socket.as_native_socket()).is_ok());
+
+        let socket = std::net::TcpListener::bind(addr).unwrap();
+        assert!(protector.make_external(socket.as_native_socket()).is_ok());
+    }
+}


### PR DESCRIPTION
### Problem
There was no tests that verify telio-sockets with ipv6.

### Solution
Added tests that verify both ip v4 and v6.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
