### PR TITLE
Add tarpaulin based code coverage job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
   benchmarks:
     needs: trigger
     uses: ./.github/workflows/benchmarks.yml
+  coverage:
+    needs: trigger
+    uses: ./.github/workflows/coverage.yml
 
   check-all-green:
     needs:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,17 @@
+name: Tests
+on: [workflow_call]
+permissions: {}
+
+jobs:
+  coverage-linux:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.6
+      - name: Download tarpaulin
+        run: curl -L 'https://github.com/xd009642/tarpaulin/releases/download/0.27.1/cargo-tarpaulin-x86_64-unknown-linux-musl.tar.gz' | tar xvz
+      - name: Verify download
+        run: echo '564ea439a14eced45cdb3e50b55a463502d9fbfb7722535c5d0390b6577ce343  cargo-tarpaulin' | sha256sum --check --status
+      - name: Run cargo-tarpaulin
+        run: ./cargo-tarpaulin -v --all --out Xml --offline --exclude-files '../3rd-party/*,clis/*'

--- a/crates/telio-sockets/src/protector/linux.rs
+++ b/crates/telio-sockets/src/protector/linux.rs
@@ -75,6 +75,7 @@ mod tests {
 
     use super::*;
 
+    #[cfg(not(tarpaulin))]
     #[rstest]
     #[case(IpAddr::V4(Ipv4Addr::LOCALHOST))]
     #[case(IpAddr::V4(Ipv4Addr::UNSPECIFIED))]


### PR DESCRIPTION
This is a port from previous version of CI and uses the same command as previously.

There might seem to be multiple other and better ways to do it but they are all broken in some ways.

We could use the action https://github.com/actions-rs/tarpaulin but that one is no longer maintained. The last version of tarpaulin it works with is 0.22 from October 2022 and the fix is still not merged in after multiple months: https://github.com/actions-rs/tarpaulin/pull/23 . Additionally there are discussions to deprecate this action: https://github.com/actions-rs/tarpaulin/issues/6

Alternatively we could have used the 'official' docker image of tarpaulin: https://hub.docker.com/r/xd009642/tarpaulin . This will not work since when github action runs in a docker, the container is not started with enough privileges which causes tarpaulin to crash, see as an example of this here:
https://github.com/xd009642/tarpaulin/issues/146

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
