### PR TITLE
Natlab police: update flaky tests marks

### DIFF
--- a/nat-lab/tests/test_connection_states.py
+++ b/nat-lab/tests/test_connection_states.py
@@ -31,10 +31,7 @@ from utils.ping import Ping
         pytest.param(
             ConnectionTag.WINDOWS_VM,
             telio.AdapterType.WireguardGo,
-            marks=[
-                pytest.mark.windows,
-                pytest.mark.xfail(reason="test is flaky - Jira issue: LLT-4064"),
-            ],
+            marks=pytest.mark.windows,
         ),
         pytest.param(
             ConnectionTag.MAC_VM, telio.AdapterType.Default, marks=pytest.mark.mac

--- a/nat-lab/tests/test_mesh_plus_vpn.py
+++ b/nat-lab/tests/test_mesh_plus_vpn.py
@@ -29,10 +29,18 @@ from utils.ping import Ping
         pytest.param(
             ConnectionTag.WINDOWS_VM,
             AdapterType.WindowsNativeWg,
-            marks=pytest.mark.windows,
+            marks=[
+                pytest.mark.windows,
+                pytest.mark.xfail(reason="Test is flaky - LLT-4357"),
+            ],
         ),
         pytest.param(
-            ConnectionTag.WINDOWS_VM, AdapterType.WireguardGo, marks=pytest.mark.windows
+            ConnectionTag.WINDOWS_VM,
+            AdapterType.WireguardGo,
+            marks=[
+                pytest.mark.windows,
+                pytest.mark.xfail(reason="Test is flaky - LLT-4357"),
+            ],
         ),
         pytest.param(ConnectionTag.MAC_VM, AdapterType.Default, marks=pytest.mark.mac),
     ],
@@ -140,7 +148,12 @@ async def test_mesh_plus_vpn_one_peer(
             marks=pytest.mark.windows,
         ),
         pytest.param(
-            ConnectionTag.WINDOWS_VM, AdapterType.WireguardGo, marks=pytest.mark.windows
+            ConnectionTag.WINDOWS_VM,
+            AdapterType.WireguardGo,
+            marks=[
+                pytest.mark.windows,
+                pytest.mark.xfail(reason="Test is flaky - LLT-4357"),
+            ],
         ),
         pytest.param(ConnectionTag.MAC_VM, AdapterType.Default, marks=pytest.mark.mac),
     ],
@@ -560,10 +573,7 @@ async def test_vpn_plus_mesh_over_direct(
         pytest.param(
             ConnectionTag.MAC_VM,
             AdapterType.Default,
-            marks=[
-                pytest.mark.mac,
-                pytest.mark.xfail(reason="test is flaky - LLT-4116"),
-            ],
+            marks=pytest.mark.mac,
         ),
     ],
 )

--- a/nat-lab/tests/test_network_switch.py
+++ b/nat-lab/tests/test_network_switch.py
@@ -30,10 +30,7 @@ from utils.ping import Ping
             ConnectionTag.MAC_VM,
             "10.0.254.7",
             "10.0.254.8",
-            marks=[
-                pytest.mark.mac,
-                pytest.mark.xfail(reason="the test is flaky - JIRA issue: LLT-2393"),
-            ],
+            marks=pytest.mark.mac,
         ),
     ],
 )


### PR DESCRIPTION
### Problem
Some tests were passing while marked as flaky and there are some new tests which need to be marked as flaky.

### Solution
Update `python.xfail` marks in our natlab tests

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
