### PR TITLE
LLT-4355: Add tokio::spawn_blocking while searching for igd gateway

### DIFF
--- a/crates/telio-model/src/api_config.rs
+++ b/crates/telio-model/src/api_config.rs
@@ -166,6 +166,8 @@ pub enum EndpointProvider {
 
 /// Endpoint polling interval
 pub const DEFAULT_ENDPOINT_POLL_INTERVAL_SECS: u64 = 25;
+/// IGD search timeout
+pub const DEFAULT_IGD_SEARCH_TIMEOUT_SECS: u64 = 5;
 
 /// Enable meshent direct connection
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
@@ -176,6 +178,8 @@ pub struct FeatureDirect {
     pub providers: Option<HashSet<EndpointProvider>>,
     /// Polling interval for endpoints [default 10s]
     pub endpoint_interval_secs: Option<u64>,
+    /// Timeout interval upnp ge search [default 5s]
+    pub upnp_gw_search_timeout_secs: Option<u64>,
     /// Configuration options for skipping unresponsive peers
     #[serde(default = "FeatureDirect::default_skip_unresponsive_peers")]
     pub skip_unresponsive_peers: Option<FeatureSkipUnresponsivePeers>,
@@ -186,6 +190,7 @@ impl Default for FeatureDirect {
         Self {
             skip_unresponsive_peers: Self::default_skip_unresponsive_peers(),
             providers: Default::default(),
+            upnp_gw_search_timeout_secs: Default::default(),
             endpoint_interval_secs: Default::default(),
         }
     }
@@ -418,6 +423,7 @@ mod tests {
         direct: Some(FeatureDirect {
             providers: None,
             endpoint_interval_secs: Some(10),
+            upnp_gw_search_timeout_secs: None,
             skip_unresponsive_peers: Some(FeatureSkipUnresponsivePeers {
                 no_handshake_threshold_secs: 50,
             }),
@@ -462,6 +468,7 @@ mod tests {
         direct: Some(FeatureDirect {
             providers: None,
             endpoint_interval_secs: None,
+            upnp_gw_search_timeout_secs: None,
             skip_unresponsive_peers: Some(Default::default()),
         }),
         exit_dns: Some(FeatureExitDns {
@@ -496,6 +503,7 @@ mod tests {
                     .collect(),
             ),
             endpoint_interval_secs: Some(30),
+            upnp_gw_search_timeout_secs: None,
             skip_unresponsive_peers: Some(FeatureSkipUnresponsivePeers {
                 no_handshake_threshold_secs: 42,
             }),
@@ -504,6 +512,7 @@ mod tests {
         let partial_features = FeatureDirect {
             providers: Some(vec![EndpointProvider::Local].into_iter().collect()),
             endpoint_interval_secs: None,
+            upnp_gw_search_timeout_secs: None,
             skip_unresponsive_peers: Some(Default::default()),
         };
 

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -66,6 +66,7 @@ use telio_utils::{
 use telio_model::{
     api_config::{
         FeaturePersistentKeepalive, Features, PathType, DEFAULT_ENDPOINT_POLL_INTERVAL_SECS,
+        DEFAULT_IGD_SEARCH_TIMEOUT_SECS,
     },
     config::{Config, Peer, Server as DerpServer},
     event::{Event, Set},
@@ -936,6 +937,9 @@ impl Runtime {
                         maximal: Some(Duration::from_secs(120)),
                     },
                     ping_pong_tracker.clone(),
+                    direct
+                        .upnp_gw_search_timeout_secs
+                        .unwrap_or(DEFAULT_IGD_SEARCH_TIMEOUT_SECS),
                 )?);
                 endpoint_providers.push(ep.clone());
                 Some(ep)
@@ -2103,6 +2107,7 @@ mod tests {
             direct: Some(FeatureDirect {
                 providers: None,
                 endpoint_interval_secs: None,
+                upnp_gw_search_timeout_secs: None,
                 skip_unresponsive_peers: Default::default(),
             }),
             ..Default::default()
@@ -2135,6 +2140,7 @@ mod tests {
             direct: Some(FeatureDirect {
                 providers: Some(HashSet::<telio_model::api_config::EndpointProvider>::new()),
                 endpoint_interval_secs: None,
+                upnp_gw_search_timeout_secs: None,
                 skip_unresponsive_peers: Default::default(),
             }),
             ..Default::default()
@@ -2175,6 +2181,7 @@ mod tests {
             direct: Some(FeatureDirect {
                 providers: Some(providers),
                 endpoint_interval_secs: None,
+                upnp_gw_search_timeout_secs: None,
                 skip_unresponsive_peers: Some(FeatureSkipUnresponsivePeers {
                     no_handshake_threshold_secs: 42,
                 }),


### PR DESCRIPTION
Plus add a variable to set the timeout on upnp igd search.



### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
