### PR TITLE
LLT-4306: Add regression test for STUN infinite loop

### DIFF
--- a/nat-lab/tests/utils/router/mac_router.py
+++ b/nat-lab/tests/utils/router/mac_router.py
@@ -147,3 +147,9 @@ class MacRouter(Router):
         self, address: str  # pylint: disable=unused-argument
     ) -> AsyncIterator:
         yield
+
+    @asynccontextmanager
+    async def break_udp_conn_to_host(
+        self, address: str  # pylint: disable=unused-argument
+    ) -> AsyncIterator:
+        yield

--- a/nat-lab/tests/utils/router/router.py
+++ b/nat-lab/tests/utils/router/router.py
@@ -87,6 +87,11 @@ class Router(ABC):
     async def break_tcp_conn_to_host(self, address: str) -> AsyncIterator:
         yield
 
+    @abstractmethod
+    @asynccontextmanager
+    async def break_udp_conn_to_host(self, address: str) -> AsyncIterator:
+        yield
+
     @property
     def ip_stack(self) -> IPStack:
         return self._ip_stack

--- a/nat-lab/tests/utils/router/windows_router.py
+++ b/nat-lab/tests/utils/router/windows_router.py
@@ -188,3 +188,9 @@ class WindowsRouter(Router):
         self, address: str  # pylint: disable=unused-argument
     ) -> AsyncIterator:
         yield
+
+    @asynccontextmanager
+    async def break_udp_conn_to_host(
+        self, address: str  # pylint: disable=unused-argument
+    ) -> AsyncIterator:
+        yield


### PR DESCRIPTION
### Problem
There was a bug in our STUN handler that would cause an infinite loop in some scenarios recently. We prioritized getting a fix out, leaving the task of adding a regression test for later. This is that regression test.

The bug was triggered when there was a socket error to the STUN server after already establishing a STUN session.

### Solution
1. Establish direct connection between two nodes
2. Break UDP connection to derp servers to make STUN unreachable
3. Verify that there aren't many STUN requests being made

To fail the test, comment out line `558` in `stun.rs` and run the test. 


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
