### PR TITLE
[LLT-4361] build: Bump libtelio-build ref

### DIFF
--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -31,4 +31,4 @@ jobs:
           project-id: ${{ secrets.PROJECT_ID }}
           schedule: ${{ github.event_name == 'schedule' }}
           cancel-outdated-pipelines: ${{ github.ref_name != 'main' }}
-          triggered-ref: v0.2.5
+          triggered-ref: v0.3.0

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,5 +15,5 @@ libtelio-build-pipeline:
 
   trigger:
     project: $LIBTELIO_BUILD_PROJECT_PATH
-    branch: v0.2.5
+    branch: v0.3.0
     strategy: depend


### PR DESCRIPTION
### Problem
apple-tvos build job has been integrated into libtelio-build CI and a new tag has been release, now its reference has to be updated.

### Solution
Bump libtelio-build reference.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
