### PR TITLE
LLT-4286: Add logic for ICMP error types in firewall

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -33,6 +33,7 @@
 * LLT-4013: Add conntrack rules for icmp
 * LLT-4152: Suspend SessionKeeper and CrossPingCheck for unresponsive peers
 * LLT-4360: Bump rust version to 1.72
+* LLT-4286: Add icmp error packet handling to firewall
 
 <br>
 


### PR DESCRIPTION
### Problem
A previous PR added logic to the firewall for dealing with ICMP packets. That PR didn't include handling of ICMP error types, in order to keep the PRs simple. This PR handles that.

### Solution
An ICMP error packet contains the original packet as it's body. The ICMP cache key builder will now, when it sees an error type, unpack the body and try to build a cache key from that.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
