### PR TITLE
Suspend CPC and SessionKeeper for unresponsive peers.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3955,6 +3955,7 @@ dependencies = [
  "ntest",
  "parking_lot 0.12.1",
  "rand",
+ "rstest",
  "rupnp",
  "sm",
  "strum",

--- a/changelog.md
+++ b/changelog.md
@@ -31,6 +31,7 @@
 * LLT-4042: IPv6 firewall nat-lab tests.
 * LLT-3914: Add apple tvOS support
 * LLT-4013: Add conntrack rules for icmp
+* LLT-4152: Suspend SessionKeeper and CrossPingCheck for unresponsive peers
 
 <br>
 

--- a/crates/telio-traversal/Cargo.toml
+++ b/crates/telio-traversal/Cargo.toml
@@ -52,6 +52,7 @@ telio-task = { workspace = true, features = ["test-util"] }
 telio-test.workspace = true
 telio-utils = { workspace = true, features = ["mockall"] }
 telio-wg = { workspace = true, features = ["mockall"] }
+rstest.workspace = true
 
 # LLT-3754: get_if_addrs overrides bionic getifaddrs
 [target.'cfg(target_os = "android")'.dependencies]

--- a/crates/telio-traversal/src/last_handshake_time_provider.rs
+++ b/crates/telio-traversal/src/last_handshake_time_provider.rs
@@ -1,0 +1,58 @@
+use std::time::Duration;
+
+use async_trait::async_trait;
+use telio_crypto::PublicKey;
+use telio_wg::{DynamicWg, WireGuard};
+
+pub const MAX_PEER_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(180);
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("Unknown peer: {0}")]
+    UnknownPeer(PublicKey),
+    #[error("Unable to communicate with wireguard: {0}")]
+    UnableToCommunicateWithWG(#[from] telio_wg::Error),
+}
+
+#[cfg_attr(any(test, feature = "mockall"), mockall::automock)]
+#[async_trait]
+pub trait LastHandshakeTimeProvider: Send + Sync {
+    /// Return last handshake time for a peer using given public key
+    async fn last_handshake_time(&self, public_key: &PublicKey) -> Result<Option<Duration>, Error>;
+}
+
+#[async_trait]
+impl LastHandshakeTimeProvider for DynamicWg {
+    async fn last_handshake_time(&self, public_key: &PublicKey) -> Result<Option<Duration>, Error> {
+        let interface = self.get_interface().await?;
+        match interface
+            .peers
+            .get(public_key)
+            .map(|peer| peer.time_since_last_handshake)
+        {
+            Some(t) => Ok(t),
+            None => Err(Error::UnknownPeer(*public_key)),
+        }
+    }
+}
+
+pub async fn is_peer_alive(
+    last_handshake_time_provider: &dyn LastHandshakeTimeProvider,
+    public_key: &PublicKey,
+) -> bool {
+    match last_handshake_time_provider
+        .last_handshake_time(public_key)
+        .await
+    {
+        Ok(Some(time)) => time < MAX_PEER_HANDSHAKE_TIMEOUT,
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+#[async_trait]
+impl<T: LastHandshakeTimeProvider> LastHandshakeTimeProvider for tokio::sync::Mutex<T> {
+    async fn last_handshake_time(&self, public_key: &PublicKey) -> Result<Option<Duration>, Error> {
+        self.lock().await.last_handshake_time(public_key).await
+    }
+}

--- a/crates/telio-traversal/src/lib.rs
+++ b/crates/telio-traversal/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod connectivity_check;
 pub mod endpoint_providers;
 pub mod error;
+pub mod last_handshake_time_provider;
 pub mod ping_pong_handler;
 pub mod session_keeper;
 pub mod upgrade_sync;


### PR DESCRIPTION
### Problem
When peer is not responsive we still send messages to it from CrossPingCheck which causes increased energy usage.

### Solution
Suspend CPC for unresponsive peers.
    
When the last handshake time for a given peer is above 180s we should suspend the CrossPingCheck tasks for that peer.

I've run the whole nat-lab with this feature turned on and it all passed. Separate MR will add nat-lab test(s) with this feature explicitly tested.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
