### PR TITLE
[LLT-4124] Add IPv6 feature

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -56,6 +56,7 @@
 * LLT-3849: Fix and adjust test for `telio-task` drop
 * LLT-3592: Bind Ipv6 sockets on macOs
 * LLT-3626: Implement IPv6 support in telio-firewall
+* LLT-4124: Add IPv6 feature flag
 
 <br>
 

--- a/crates/telio-firewall/benches/firewall_bench.rs
+++ b/crates/telio-firewall/benches/firewall_bench.rs
@@ -90,7 +90,7 @@ pub fn firewall_tcp_inbound_benchmarks(c: &mut Criterion) {
                     BenchmarkId::from_parameter(parameter.clone()),
                     &parameter,
                     |b, param| {
-                        let firewall = StatefullFirewall::new();
+                        let firewall = StatefullFirewall::new(true);
                         for _ in 0..param.peers {
                             let public_key = SecretKey::gen().public();
                             firewall.add_to_peer_whitelist(public_key);
@@ -127,7 +127,7 @@ pub fn firewall_tcp_inbound_benchmarks(c: &mut Criterion) {
                     BenchmarkId::from_parameter(parameter.clone()),
                     &parameter,
                     |b, param| {
-                        let firewall = StatefullFirewall::new();
+                        let firewall = StatefullFirewall::new(true);
                         let mut peers = vec![];
                         for _ in 0..param.peers {
                             let public_key = SecretKey::gen().public();
@@ -162,7 +162,7 @@ pub fn firewall_tcp_inbound_benchmarks(c: &mut Criterion) {
                     BenchmarkId::from_parameter(parameter.clone()),
                     &parameter,
                     |b, param| {
-                        let firewall = StatefullFirewall::new();
+                        let firewall = StatefullFirewall::new(true);
                         let mut peers_and_packets = vec![];
                         let port_base = 1111;
                         for i in 0..param.peers {
@@ -215,7 +215,7 @@ pub fn firewall_tcp_outbound_benchmarks(c: &mut Criterion) {
                     BenchmarkId::from_parameter(parameter.clone()),
                     &parameter,
                     |b, param| {
-                        let firewall = StatefullFirewall::new();
+                        let firewall = StatefullFirewall::new(true);
                         for _ in 0..param.peers {
                             let public_key = SecretKey::gen().public();
                             firewall.add_to_peer_whitelist(public_key);
@@ -257,7 +257,7 @@ pub fn firewall_tcp_outbound_benchmarks(c: &mut Criterion) {
                     BenchmarkId::from_parameter(parameter.clone()),
                     &parameter,
                     |b, param| {
-                        let firewall = StatefullFirewall::new();
+                        let firewall = StatefullFirewall::new(true);
                         for _ in 0..param.peers {
                             let public_key = SecretKey::gen().public();
                             firewall.add_to_peer_whitelist(public_key);
@@ -292,7 +292,7 @@ pub fn firewall_tcp_outbound_benchmarks(c: &mut Criterion) {
                     BenchmarkId::from_parameter(parameter.clone()),
                     &parameter,
                     |b, param| {
-                        let firewall = StatefullFirewall::new();
+                        let firewall = StatefullFirewall::new(true);
                         let mut peers = vec![];
                         for _ in 0..param.peers {
                             let public_key = SecretKey::gen().public();
@@ -332,7 +332,7 @@ pub fn firewall_udp_inbound_benchmarks(c: &mut Criterion) {
                     BenchmarkId::from_parameter(parameter.clone()),
                     &parameter,
                     |b, param| {
-                        let firewall = StatefullFirewall::new();
+                        let firewall = StatefullFirewall::new(true);
                         for _ in 0..param.peers {
                             let public_key = SecretKey::gen().public();
                             firewall.add_to_peer_whitelist(public_key);
@@ -369,7 +369,7 @@ pub fn firewall_udp_inbound_benchmarks(c: &mut Criterion) {
                     BenchmarkId::from_parameter(parameter.clone()),
                     &parameter,
                     |b, param| {
-                        let firewall = StatefullFirewall::new();
+                        let firewall = StatefullFirewall::new(true);
                         let mut peers = vec![];
                         for _ in 0..param.peers {
                             let public_key = SecretKey::gen().public();
@@ -404,7 +404,7 @@ pub fn firewall_udp_inbound_benchmarks(c: &mut Criterion) {
                     BenchmarkId::from_parameter(parameter.clone()),
                     &parameter,
                     |b, param| {
-                        let firewall = StatefullFirewall::new();
+                        let firewall = StatefullFirewall::new(true);
                         let mut peers_and_packets = vec![];
                         let port_base = 42;
                         for i in 0..param.peers {
@@ -453,7 +453,7 @@ pub fn firewall_udp_outbound_benchmarks(c: &mut Criterion) {
                     BenchmarkId::from_parameter(parameter.clone()),
                     &parameter,
                     |b, param| {
-                        let firewall = StatefullFirewall::new();
+                        let firewall = StatefullFirewall::new(true);
                         let mut peers = vec![];
                         for _ in 0..param.peers {
                             let public_key = SecretKey::gen().public();
@@ -487,7 +487,7 @@ pub fn firewall_udp_outbound_benchmarks(c: &mut Criterion) {
                     BenchmarkId::from_parameter(parameter.clone()),
                     &parameter,
                     |b, param| {
-                        let firewall = StatefullFirewall::new();
+                        let firewall = StatefullFirewall::new(true);
                         let mut peers = vec![];
                         for _ in 0..param.peers {
                             let public_key = SecretKey::gen().public();

--- a/crates/telio-model/src/api_config.rs
+++ b/crates/telio-model/src/api_config.rs
@@ -288,6 +288,9 @@ pub struct Features {
     /// Flag to specify if keys should be validated
     #[serde(default)]
     pub validate_keys: FeatureValidateKeys,
+    /// IPv6 support
+    #[serde(default)]
+    pub ipv6: bool,
 }
 
 impl FeaturePaths {
@@ -388,7 +391,8 @@ mod tests {
                 "derp_keepalive": 2,
                 "enable_polling": true
             },
-            "validate_keys": false
+            "validate_keys": false,
+            "ipv6": true
         }"#;
 
     static EXPECTED_FEATURES: Lazy<Features> = Lazy::new(|| Features {
@@ -433,6 +437,7 @@ mod tests {
             enable_polling: Some(true),
         }),
         validate_keys: FeatureValidateKeys(false),
+        ipv6: true,
     });
 
     static EXPECTED_FEATURES_WITHOUT_TEST_ENV: Lazy<Features> = Lazy::new(|| Features {
@@ -471,6 +476,7 @@ mod tests {
         is_test_env: None,
         derp: None,
         validate_keys: Default::default(),
+        ipv6: false,
     });
 
     #[test]
@@ -638,6 +644,7 @@ mod tests {
             exit_dns: None,
             derp: None,
             validate_keys: Default::default(),
+            ipv6: false,
         };
 
         let empty_qos_features = Features {
@@ -660,6 +667,7 @@ mod tests {
             exit_dns: None,
             derp: None,
             validate_keys: Default::default(),
+            ipv6: false,
         };
 
         let no_qos_features = Features {
@@ -677,6 +685,7 @@ mod tests {
             exit_dns: None,
             derp: None,
             validate_keys: Default::default(),
+            ipv6: false,
         };
 
         assert_eq!(from_str::<Features>(full_json).unwrap(), full_features);
@@ -713,6 +722,7 @@ mod tests {
             }),
             derp: None,
             validate_keys: Default::default(),
+            ipv6: false,
         };
 
         let empty_features = Features {
@@ -726,6 +736,7 @@ mod tests {
             }),
             derp: None,
             validate_keys: Default::default(),
+            ipv6: false,
         };
 
         assert_eq!(from_str::<Features>(full_json).unwrap(), full_features);
@@ -763,6 +774,7 @@ mod tests {
             direct: None,
             derp: None,
             validate_keys: Default::default(),
+            ipv6: false,
         };
 
         assert_eq!(Features::default(), expected_defaults);

--- a/crates/telio-model/src/mesh.rs
+++ b/crates/telio-model/src/mesh.rs
@@ -3,9 +3,8 @@
 use super::EndpointMap as RelayEndpointMap;
 
 use crate::api_config::PathType;
-use ipnetwork::IpNetworkError;
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, convert::TryFrom, net::IpAddr};
+use std::{collections::HashMap, net::IpAddr};
 use telio_crypto::PublicKey;
 
 use super::config::{Config, Peer, PeerBase};
@@ -100,27 +99,6 @@ pub struct Map {
     pub allowed_ips: Vec<IpNetwork>,
     /// Hash map of all the nodes in the network mesh
     pub nodes: HashMap<PublicKey, Node>,
-}
-
-impl TryFrom<&ExitNode> for Node {
-    type Error = IpNetworkError;
-
-    fn try_from(other: &ExitNode) -> Result<Self, IpNetworkError> {
-        let address_v4 = "0.0.0.0/0".parse()?;
-        let address_v6 = "::/0".parse()?;
-        Ok(Self {
-            public_key: other.public_key,
-            is_exit: true,
-            is_vpn: other.endpoint.is_some(),
-            allowed_ips: other
-                .allowed_ips
-                .as_ref()
-                .cloned()
-                .unwrap_or_else(|| vec![address_v4, address_v6]),
-            endpoint: other.endpoint,
-            ..Default::default()
-        })
-    }
 }
 
 impl From<&PeerBase> for Node {

--- a/crates/telio-nurse/src/qos.rs
+++ b/crates/telio-nurse/src/qos.rs
@@ -499,7 +499,7 @@ mod tests {
             last_event: Instant::now(),
             last_wg_event: Instant::now(),
             connected_time,
-            endpoint: DualTarget::new((Some(Ipv4Addr::new(127, 0, 0, 1)), None)).unwrap(),
+            endpoint: DualTarget::new((Some(Ipv4Addr::new(127, 0, 0, 1)), None), true).unwrap(),
             rtt_histogram: histogram.clone(),
             rtt_loss_histogram: histogram.clone(),
             rtt6_histogram: histogram.clone(),

--- a/crates/telio-wg/src/wg.rs
+++ b/crates/telio-wg/src/wg.rs
@@ -160,7 +160,7 @@ impl DynamicWg {
     ///         fn set_tunnel_interface(&self, interface: u64);
     ///         }
     ///     }
-    ///     let firewall = Arc::new(StatefullFirewall::new());
+    ///     let firewall = Arc::new(StatefullFirewall::new(true));
     ///     let firewall_filter_inbound_packets = {
     ///         let fw = firewall.clone();
     ///         move |peer: &[u8; 32], packet: &[u8]| fw.process_inbound_packet(peer, packet)
@@ -693,7 +693,9 @@ impl State {
                         }
                     }
 
-                    let endpoint = match dual_target::DualTarget::new(target) {
+                    // I see no reason to filter the IPv6 in analytics if we already
+                    // have it in the allowed IPs, so just set ipv6 usage to true
+                    let endpoint = match dual_target::DualTarget::new(target, true) {
                         Ok(dt) => dt,
                         Err(_) => continue,
                     };

--- a/nat-lab/tests/telio.py
+++ b/nat-lab/tests/telio.py
@@ -17,7 +17,7 @@ from utils.connection import Connection, TargetOS
 from utils.connection_util import get_libtelio_binary_path
 from utils.output_notifier import OutputNotifier
 from utils.process import Process
-from utils.router import Router, new_router
+from utils.router import Router, new_router, IPStack
 
 
 # Equivalent of `libtelio/telio-wg/src/uapi.rs`
@@ -396,6 +396,7 @@ class Client:
         node: Node,
         adapter_type: AdapterType = AdapterType.Default,
         telio_features: TelioFeatures = TelioFeatures(),
+        force_ipv6_feature: bool = False,
     ) -> None:
         self._router: Optional[Router] = None
         self._events: Optional[Events] = None
@@ -408,6 +409,13 @@ class Client:
         self._adapter_type = adapter_type
         self._telio_features = telio_features
         self._quit = False
+
+        # Automatically enables IPv6 feature when the IPv6 stack is enabled
+        if (
+            self._node.ip_stack in (IPStack.IPv4v6, IPStack.IPv6)
+            and not force_ipv6_feature
+        ):
+            self._telio_features.ipv6 = True
 
     @asynccontextmanager
     async def run(

--- a/nat-lab/tests/telio_features.py
+++ b/nat-lab/tests/telio_features.py
@@ -61,3 +61,4 @@ class TelioFeatures(DataClassJsonMixin):
     direct: Optional[Direct] = None
     lana: Optional[Lana] = None
     nurse: Optional[Nurse] = None
+    ipv6: bool = False

--- a/nat-lab/tests/test_dns.py
+++ b/nat-lab/tests/test_dns.py
@@ -4,7 +4,7 @@ import pytest
 import re
 from contextlib import AsyncExitStack
 from helpers import SetupParameters, setup_api, setup_environment, setup_mesh_nodes
-from telio import AdapterType
+from telio import AdapterType, TelioFeatures
 from utils import testing
 from utils.connection_tracker import ConnectionLimits
 from utils.connection_util import ConnectionTag, generate_connection_tracker_config
@@ -404,6 +404,7 @@ async def test_dns_after_mesh_off(alpha_ip_stack: IPStack) -> None:
                             ConnectionTag.DOCKER_CONE_CLIENT_1
                         ),
                         derp_servers=[],
+                        features=TelioFeatures(ipv6=True),
                     )
                 ],
                 provided_api=api,


### PR DESCRIPTION
### Problem
There is no feature flag for the introduced IPv6 changes which are meant to be disabled by default, but which should be tested with all of the new changes.

### Solution
Add IPv6 feature flag, so we will be able to use battle-tested IPv4 implementation on production, but also a possibility to test our new changes with newly introduced IPv6 support.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
