### PR TITLE
Add test that verifies succesful reconnection with skip_unresponsive_peers feature

### DIFF
--- a/nat-lab/tests/telio_features.py
+++ b/nat-lab/tests/telio_features.py
@@ -11,9 +11,18 @@ class ExitDns(DataClassJsonMixin):
 
 @dataclass_json
 @dataclass
+class SkipUnresponsivePeers(DataClassJsonMixin):
+    no_handshake_threshold_secs: int = 180
+
+
+@dataclass_json
+@dataclass
 class Direct(DataClassJsonMixin):
     providers: Optional[List[str]] = None
     endpoint_interval_secs: Optional[int] = 5
+    skip_unresponsive_peers: Optional[SkipUnresponsivePeers] = SkipUnresponsivePeers(
+        no_handshake_threshold_secs=180
+    )
 
 
 @dataclass_json

--- a/nat-lab/tests/test_telio_tasks.py
+++ b/nat-lab/tests/test_telio_tasks.py
@@ -3,7 +3,15 @@ import pytest
 from contextlib import AsyncExitStack
 from mesh_api import API
 from telio import Client
-from telio_features import TelioFeatures, Direct, Lana, Nurse, Qos, ExitDns
+from telio_features import (
+    TelioFeatures,
+    Direct,
+    Lana,
+    Nurse,
+    Qos,
+    ExitDns,
+    SkipUnresponsivePeers,
+)
 from utils.connection_util import ConnectionTag, new_connection_by_tag
 
 
@@ -21,7 +29,12 @@ async def test_telio_tasks_with_all_features() -> None:
                 alpha,
                 telio_features=TelioFeatures(
                     exit_dns=ExitDns(auto_switch_dns_ips=True),
-                    direct=Direct(providers=["stun", "local"]),
+                    direct=Direct(
+                        providers=["stun", "local"],
+                        skip_unresponsive_peers=SkipUnresponsivePeers(
+                            no_handshake_threshold_secs=150
+                        ),
+                    ),
                     lana=Lana(prod=False, event_path="/some_path"),
                     nurse=Nurse(
                         fingerprint="alpha",
@@ -34,6 +47,6 @@ async def test_telio_tasks_with_all_features() -> None:
                 ),
             ).run_meshnet(api.get_meshmap(alpha.id))
         )
-        # le wait some seconds for everything to start
+        # let's wait some seconds for everything to start
         await asyncio.sleep(5)
         await client_alpha.stop_device()


### PR DESCRIPTION
In the test we wait for cross ping check to stop sending CMM due to the detection of peer as unresponsive and only after that we reenable the peer and check that direct connection is reestablished.

As discussed in previous PR, feature flag is moved under the direct feature and turned on by default: https://github.com/NordSecurity/libtelio/pull/160#discussion_r1357869247

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
