### PR TITLE
Fix clippy allows

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -32,6 +32,7 @@
 * LLT-3914: Add apple tvOS support
 * LLT-4013: Add conntrack rules for icmp
 * LLT-4152: Suspend SessionKeeper and CrossPingCheck for unresponsive peers
+* LLT-4360: Bump rust version to 1.72
 
 <br>
 

--- a/crates/telio-nurse/src/heartbeat.rs
+++ b/crates/telio-nurse/src/heartbeat.rs
@@ -1,6 +1,3 @@
-// We use bitmask with all bits 0. We need to fix
-#![allow(clippy::bad_bit_mask)]
-
 use async_trait::async_trait;
 use bitflags::bitflags;
 use nat_detect::NatType;
@@ -44,7 +41,6 @@ enum RuntimeState {
 
 bitflags! {
     struct MeshConnectionState: u32 {
-        const NONE = 0b00000000;
         const DERP = 0b00000001;
         const WG = 0b00000010;
     }
@@ -74,7 +70,7 @@ struct MeshLink {
 impl Default for MeshLink {
     fn default() -> Self {
         MeshLink {
-            connection_state: MeshConnectionState::NONE,
+            connection_state: MeshConnectionState::empty(),
         }
     }
 }

--- a/crates/telio-relay/src/multiplexer/mod.rs
+++ b/crates/telio-relay/src/multiplexer/mod.rs
@@ -56,12 +56,12 @@ impl Multiplexer {
 
     /// Change the relay, that communicates with lower relay module
     pub async fn change_output(&self, relay: Chan<(PublicKey, PacketRelayed)>) {
-        #[allow(clippy::let_underscore_future)]
         let _ = task_exec!(&self.task, async move |s| {
             s.relay_tx = PollSender::new(relay.tx);
             s.relay_rx = ReceiverStream::new(relay.rx);
             Ok(())
-        });
+        })
+        .await;
     }
 
     /// Change the relay, that communicates with lower relay module

--- a/crates/telio-traversal/src/endpoint_providers/stun.rs
+++ b/crates/telio-traversal/src/endpoint_providers/stun.rs
@@ -62,10 +62,9 @@ impl<Wg: WireGuard> StunEndpointProvider<Wg> {
     }
 
     /// Force STUN endpoint provider to reconnect
-    #[allow(clippy::let_underscore_future)]
     pub async fn reconnect(&self) {
         let _ = task_exec!(&self.task, async move |s| {
-            let _ = s.reconnect();
+            let _ = s.reconnect().await;
             Ok(())
         })
         .await;


### PR DESCRIPTION
### Problem
During the rust version update there were left some clippy allow exceptions. 

### Solution
Fix them.

I also updated the changelog. I forgot to do that in the rust version update PR.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
