### PR TITLE
Bump telio-bulid to v0.3.2

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,5 +15,5 @@ libtelio-build-pipeline:
 
   trigger:
     project: $LIBTELIO_BUILD_PROJECT_PATH
-    branch: v0.3.2
+    branch: v0.3.3
     strategy: depend


### PR DESCRIPTION
### Problem
Release pipelines still use rust in version 1.68.0. This updates release pipelines to the new version 1.72.0

### Solution
Bump telio-bulid to v0.3.2


### :ballot_box_with_check: Definition of Done checklist
- [ ] Commit history is clean ([requirements](../../blob/main/docs/git_commit_messages_requirements.md))
- [ ] README.md is updated
- [ ] changelog.md is updated
