### PR TITLE
Add a reminder about tests in DoD

### DIFF
--- a/dod.yml
+++ b/dod.yml
@@ -2,3 +2,4 @@ dod:
   - 'Commit history is clean ([requirements](../../blob/main/docs/git_commit_messages_requirements.md))'
   - 'README.md is updated'
   - 'changelog.md is updated'
+  - 'Functionality is covered by unit or integration tests'


### PR DESCRIPTION
During one of the libtelio team retro's, a wish was expressed to add more attention to tests. E.g. every new functionality should be covered by tests. This PR adds a reminder in Definition of Done checks to write those tests.

### Problem
*--describe problem being solved--*

### Solution
*--describe selected solution--*


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
