### PR TITLE
RemoveUpnp to Default direct features

### DIFF
--- a/nat-lab/tests/test_direct_feature.py
+++ b/nat-lab/tests/test_direct_feature.py
@@ -29,7 +29,7 @@ async def test_default_direct_features() -> None:
         )
 
         started_tasks = alpha_client.get_runtime().get_started_tasks()
-        assert "UpnpEndpointProvider" in started_tasks
+        assert "UpnpEndpointProvider" not in started_tasks
         assert "LocalInterfacesEndpointProvider" in started_tasks
         assert "StunEndpointProvider" in started_tasks
 

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -861,11 +861,10 @@ impl Runtime {
             // Create endpoint providers
             let has_provider = |provider| {
                 // Default is all providers
-                direct
-                    .providers
-                    .as_ref()
-                    .map(|p| p.contains(&provider))
-                    .unwrap_or(true)
+                match direct.providers.as_ref().map(|p| p.contains(&provider)) {
+                    Some(prov) => prov,
+                    None => provider != Upnp,
+                }
             };
 
             use telio_model::api_config::EndpointProvider::*;
@@ -2122,7 +2121,7 @@ mod tests {
 
         let entities = rt.entities.direct.as_ref().unwrap();
 
-        assert!(entities.upnp_endpoint_provider.is_some());
+        assert!(entities.upnp_endpoint_provider.is_none());
         assert!(entities.local_interfaces_endpoint_provider.is_some());
         assert!(entities.stun_endpoint_provider.is_some());
     }


### PR DESCRIPTION
This reverts commit bf7c8e7dff9e098c12c8586cebf6721897886610.


Disable upnp from default direct features  while fixing this issue LLT-4335



### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
