### PR TITLE
Llt 3950 wg stun ipv6 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4791,7 +4791,7 @@ dependencies = [
 [[package]]
 name = "wireguard-nt"
 version = "1.0.0"
-source = "git+https://github.com/NordSecurity/wireguard-nt-rust-wrapper?tag=v1.0.2#977a54e4decc8ecd886c0fc1eda58f253ffdc5dc"
+source = "git+https://github.com/NordSecurity/wireguard-nt-rust-wrapper?tag=v1.0.3#38b6a4223abe1117335efa440ca33361b8e74e8b"
 dependencies = [
  "bitflags 1.3.2",
  "ipnet",

--- a/changelog.md
+++ b/changelog.md
@@ -44,6 +44,8 @@
 * LLT-4202: Do not answer DNS request if forward lookup fails
 * LLT-4427: Fix issue with malformed disconnect event
 * LLT-4280: Implement TCP connection reset upon VPN server change for boringtun adapter
+* LLT-4124: Add IPv6 feature flag
+* LLT-3950: Enable IPv6 for wg-stun.
 
 <br>
 
@@ -62,7 +64,6 @@
 * LLT-3849: Fix and adjust test for `telio-task` drop
 * LLT-3592: Bind Ipv6 sockets on macOs
 * LLT-3626: Implement IPv6 support in telio-firewall
-* LLT-4124: Add IPv6 feature flag
 
 <br>
 

--- a/crates/telio-traversal/src/endpoint_providers/mod.rs
+++ b/crates/telio-traversal/src/endpoint_providers/mod.rs
@@ -69,6 +69,8 @@ pub enum Error {
     /// Stun peer is missconfigured (no allowed_ip or endpoint)
     #[error("Stun peer is misconfigured")]
     BadStunPeer,
+    #[error("Stun endpoint provider not configured")]
+    StunNotConfigured,
     #[error("Encryption failed: {0}")]
     EncryptionFailed(#[from] encryption::Error),
     #[error("Cannot find endpoint in local cache")]

--- a/crates/telio-wg/Cargo.toml
+++ b/crates/telio-wg/Cargo.toml
@@ -52,6 +52,6 @@ ipnet.workspace = true
 sha2.workspace = true
 winapi = { workspace = true, features = ["nldef"] }
 
-wireguard-nt = { git = "https://github.com/NordSecurity/wireguard-nt-rust-wrapper", tag = "v1.0.2" }
+wireguard-nt = { git = "https://github.com/NordSecurity/wireguard-nt-rust-wrapper", tag = "v1.0.3" }
 
 wg-go-rust-wrapper = { path = "../../wireguard-go-rust-wrapper" }

--- a/nat-lab/tests/test_events.py
+++ b/nat-lab/tests/test_events.py
@@ -495,16 +495,7 @@ async def test_event_content_exit_through_peer(
                 features=TelioFeatures(direct=Direct(providers=["stun"])),
             ),
             "10.0.254.7",
-            marks=[
-                pytest.mark.windows,
-                pytest.mark.skip(
-                    reason=(
-                        "The currently used wireguard-nt implementation for Windows"
-                        " doesn't work well with IPv6 - should be unskipped when that"
-                        " will be fixed"
-                    )
-                ),
-            ],
+            marks=pytest.mark.windows,
         ),
         pytest.param(
             SetupParameters(

--- a/nat-lab/tests/test_events.py
+++ b/nat-lab/tests/test_events.py
@@ -495,7 +495,16 @@ async def test_event_content_exit_through_peer(
                 features=TelioFeatures(direct=Direct(providers=["stun"])),
             ),
             "10.0.254.7",
-            marks=pytest.mark.windows,
+            marks=[
+                pytest.mark.windows,
+                pytest.mark.skip(
+                    reason=(
+                        "The currently used wireguard-nt implementation for Windows"
+                        " doesn't work well with IPv6 - should be unskipped when that"
+                        " will be fixed"
+                    )
+                ),
+            ],
         ),
         pytest.param(
             SetupParameters(


### PR DESCRIPTION
### Problem
Our wg-stun implementation does not support IPv6.

### Solution
Add support for IPv6 in the wg-stun implementation, bump libtelio-build to version which uses Nordderper supporting that feature as well.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
