### PR TITLE
Use OS certificates instead of hardcoded mozilla list

### DIFF
--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -31,4 +31,4 @@ jobs:
           project-id: ${{ secrets.PROJECT_ID }}
           schedule: ${{ github.event_name == 'schedule' }}
           cancel-outdated-pipelines: ${{ github.ref_name != 'main' }}
-          triggered-ref: v0.4.8
+          triggered-ref: v0.4.9

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,7 +7,7 @@ libtelio-build-pipeline:
     LIBTELIO_PROJECT_PATH: $CI_PROJECT_PATH
     LIBTELIO_DEFAULT_BRANCH: $CI_DEFAULT_BRANCH
 
-    # Don't checkout libtelio submodule when using GIT_SUBMODULE_STRATEGY.
+    # Don't checkout libtelio submodule when using GIT_SUBMODULE_STRATEGY. 
     # This ensures that all jobs that use `libtelio` submodule are calling
     # `ci/checkout.sh`, which uses `LIBTELIO_COMMIT_SHA` to
     # checkout the correct libtelio REF.
@@ -15,5 +15,5 @@ libtelio-build-pipeline:
 
   trigger:
     project: $LIBTELIO_BUILD_PROJECT_PATH
-    branch: v0.4.8
+    branch: v0.4.9
     strategy: depend

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -479,6 +479,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -635,6 +641,16 @@ dependencies = [
  "is-terminal",
  "lazy_static",
  "windows-sys",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4"
+dependencies = [
+ "bytes",
+ "memchr",
 ]
 
 [[package]]
@@ -1893,6 +1909,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
+name = "jni"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6df18c2e3db7e453d3c6ac5b3e9d5182664d28788126d39b91f2d1e22b017ec"
+dependencies = [
+ "cesu8",
+ "combine",
+ "jni-sys",
+ "log",
+ "thiserror",
+ "walkdir",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
 name = "jobserver"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2255,6 +2291,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2359,6 +2416,12 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "os_str_bytes"
@@ -3100,12 +3163,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "schannel",
+ "security-framework 2.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
 dependencies = [
  "base64 0.21.4",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.1.0"
+source = "git+https://github.com/tomaszklak/rustls-platform-verifier.git?rev=1eeed2dc3a4a7f437220875feb31e50cdec0bf07#1eeed2dc3a4a7f437220875feb31e50cdec0bf07"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-webpki",
+ "security-framework 2.9.2 (git+https://github.com/tomaszklak/rust-security-framework.git?rev=8ad72839ab82c5dcdbadece710f3f813df76b5ce)",
+ "security-framework-sys 2.9.1 (git+https://github.com/tomaszklak/rust-security-framework.git?rev=8ad72839ab82c5dcdbadece710f3f813df76b5ce)",
+ "webpki-roots",
+ "winapi",
 ]
 
 [[package]]
@@ -3184,6 +3278,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3197,6 +3300,51 @@ checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
  "ring",
  "untrusted 0.7.1",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys 2.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.9.2"
+source = "git+https://github.com/tomaszklak/rust-security-framework.git?rev=8ad72839ab82c5dcdbadece710f3f813df76b5ce#8ad72839ab82c5dcdbadece710f3f813df76b5ce"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "num-bigint",
+ "security-framework-sys 2.9.1 (git+https://github.com/tomaszklak/rust-security-framework.git?rev=8ad72839ab82c5dcdbadece710f3f813df76b5ce)",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.9.1"
+source = "git+https://github.com/tomaszklak/rust-security-framework.git?rev=8ad72839ab82c5dcdbadece710f3f813df76b5ce#8ad72839ab82c5dcdbadece710f3f813df76b5ce"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -3724,16 +3872,19 @@ dependencies = [
  "ffi_helpers",
  "futures",
  "ipnetwork",
+ "jni",
  "lazy_static",
  "libc",
  "mockall",
  "modifier",
  "ntest",
  "num_cpus",
+ "once_cell",
  "parking_lot",
  "pretty_assertions",
  "rand",
  "rstest",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "serde_with",
@@ -3958,6 +4109,7 @@ dependencies = [
  "rand_core 0.6.4",
  "rstest",
  "rustls-pemfile",
+ "rustls-platform-verifier",
  "serde",
  "static_assertions",
  "strum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,11 @@ telio-task.workspace = true
 telio-traversal.workspace = true
 telio-utils.workspace = true
 telio-wg.workspace = true
+once_cell.workspace = true
+
+[target.'cfg(target_os = "android")'.dependencies]
+jni = "0.19"
+rustls-platform-verifier = { git = "https://github.com/tomaszklak/rustls-platform-verifier.git", rev = "1eeed2dc3a4a7f437220875feb31e50cdec0bf07" }
 
 [dev-dependencies]
 slog-async = "2.7"

--- a/android/templates/build.gradle
+++ b/android/templates/build.gradle
@@ -1,0 +1,121 @@
+apply plugin: 'com.android.library'
+apply plugin: 'com.jfrog.artifactory'
+apply plugin: 'maven-publish'
+apply plugin: 'kotlin-android'
+apply from: "../init.gradle"
+
+buildscript {
+    repositories {
+        jcenter()
+        google()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:4.1.1'
+        classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.18.2"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.21"
+    }
+}
+
+repositories {
+    google()
+    jcenter()
+    maven { url "https://jitpack.io" }
+    maven { url 'https://maven.google.com' }
+}
+
+def packageName = '$PACKAGE_NAME'
+def packageVersionName = '$VERSION'
+def packageVersionCode = 1
+def repoUrl = System.getenv('ARTIFACTORY_URL')
+def repoUsername = System.getenv('ARTIFACTORY_USERNAME')
+def repoPassword = System.getenv('ARTIFACTORY_PASSWORD')
+
+android {
+    compileSdkVersion 29
+    defaultConfig {
+        minSdkVersion 23
+        targetSdkVersion 29
+        versionCode = packageVersionCode
+        versionName = packageVersionName
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+}
+
+dependencies {
+    implementation "net.java.dev.jna:jna:5.7.0@aar"
+    implementation files('libs/rustls-platform-verifier.jar')
+}
+
+publishing {
+    publications {
+        aar(MavenPublication) {
+            groupId packageName
+            version = packageVersionName
+            artifactId '$ARTIFACT_ID'
+            artifact("build/outputs/aar/$${project.getName()}-release.aar")
+
+            pom.withXml {
+                def dependenciesNode = asNode().appendNode('dependencies')
+
+                configurations.implementation.allDependencies.each {
+                    def dependencyNode = dependenciesNode.appendNode('dependency')
+                    dependencyNode.appendNode('groupId', it.group)
+                    dependencyNode.appendNode('artifactId', it.name)
+                    dependencyNode.appendNode('version', it.version)
+                    dependencyNode.appendNode('type', 'aar') // The only dependency we have is 'jna' with aar artifact type.
+                }
+            }
+        }
+    }
+}
+
+artifactory {
+    contextUrl = repoUrl
+
+    publish {
+        repository {
+            repoKey = packageVersionName.endsWith('SNAPSHOT') ? 'libs-snapshot-local' : 'libs-release-local'
+            username = repoUsername
+            password = repoPassword
+        }
+        defaults {
+            publications('aar')
+            publishArtifacts = true
+        }
+    }
+
+    resolve {
+        repository {
+            repoKey = 'libs-release'
+            username = repoUsername
+            password = repoPassword
+            maven = true
+        }
+    }
+}
+
+task copyLibraries(type: Copy) {
+    from findRustlsPlatformVerifierProject() + '/android/rustls-platform-verifier/build/intermediates/aar_main_jar/release/classes.jar'
+    into 'libs'
+    rename { String fileName ->
+        fileName.replace('classes.jar', 'rustls-platform-verifier.jar')
+    }
+
+ }
+preBuild.dependsOn(copyLibraries)
+
+task buildDependencies {
+    dependsOn gradle.includedBuild('android').task(':rustls-platform-verifier:build')
+}
+copyLibraries.dependsOn(buildDependencies)

--- a/android/templates/init.gradle
+++ b/android/templates/init.gradle
@@ -1,0 +1,12 @@
+ext.findRustlsPlatformVerifierProject = {
+    def cmdProcessBuilder = new ProcessBuilder(new String[] { "/root/.cargo/bin/cargo", "metadata", "--format-version", "1", "--manifest-path", "$PATH_TO_DEPENDENT_CRATE" })
+    def dependencyInfoText = new StringBuffer()
+
+    def cmdProcess = cmdProcessBuilder.start()
+    cmdProcess.consumeProcessOutput(dependencyInfoText, null)
+    cmdProcess.waitFor()
+
+    def dependencyJson = new groovy.json.JsonSlurper().parseText(dependencyInfoText.toString())
+    def manifestPath = file(dependencyJson.packages.find { it.name == "rustls-platform-verifier" }.manifest_path)
+    return manifestPath.parent
+}

--- a/android/templates/settings.gradle
+++ b/android/templates/settings.gradle
@@ -1,0 +1,4 @@
+include ':main'
+apply from: "./init.gradle";
+def verifierProjectPath = findRustlsPlatformVerifierProject()
+includeBuild("${verifierProjectPath}/android/")

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 * LLT-4663: Update zerocopy dependency
 * LLT-4543: Log ffi calls
 * LLT-4310: Change stun client/server to the one, which supports IPv6
+* LLT-4381: Use OS certificates instead of hardcoded mozilla list
 
 ### v4.2.1
 ----

--- a/clis/derpcli/src/conf.rs
+++ b/clis/derpcli/src/conf.rs
@@ -70,8 +70,8 @@ pub struct Config {
     pub send_size_enabled: bool,
     // verbose output
     pub verbose: u64,
-    // CA pem file path
-    pub ca_pem_path: PathBuf,
+    // Instead of using OS certificate store, use the mozzila built in roots
+    pub use_built_in_root_certificates: bool,
     // path to config file used for stress-test
     pub stress_cfg_path: PathBuf,
 }
@@ -244,13 +244,10 @@ impl Config {
                     .short('o'),
             )
             .arg(
-                Arg::new("certificate_authority")
-                    .help("Path to certificate authority pem file")
+                Arg::new("use_built_in_root_certificates")
+                    .help("Instead of using OS certificate store, use the mozzila built in roots")
                     .required(false)
-                    .takes_value(true)
-                    .default_value("")
-                    .long("CA")
-                    .short('C'),
+                    .long("use_built_in_root_certificates"),
             )
             .get_matches();
 
@@ -279,11 +276,6 @@ impl Config {
             .unwrap_or_default()
             .parse::<u16>()
             .unwrap_or_default();
-
-        let ca_pem_path = matches
-            .value_of("certificate_authority")
-            .unwrap_or_default()
-            .to_string();
 
         let stress_cfg_path = matches.value_of("config").unwrap_or_default().to_string();
 
@@ -341,7 +333,7 @@ impl Config {
             send_size_enabled: matches.is_present("size"),
             verbose: matches.occurrences_of("verbose"),
             stress_cfg_path: Path::new(&stress_cfg_path).to_path_buf(),
-            ca_pem_path: Path::new(&ca_pem_path).to_path_buf(),
+            use_built_in_root_certificates: matches.is_present("use_built_in_root_certificates"),
         })
     }
 

--- a/crates/telio-model/src/api_config.rs
+++ b/crates/telio-model/src/api_config.rs
@@ -228,6 +228,9 @@ pub struct FeatureDerp {
     pub derp_keepalive: Option<u32>,
     /// Enable polling of remote peer states to reduce derp traffic
     pub enable_polling: Option<bool>,
+    /// Use Mozilla's root certificates instead of OS ones [default false]
+    #[serde(default)]
+    pub use_built_in_root_certificates: bool,
 }
 
 /// Whether to validate keys
@@ -471,6 +474,7 @@ mod tests {
             tcp_keepalive: Some(1),
             derp_keepalive: Some(2),
             enable_polling: Some(true),
+            use_built_in_root_certificates: false,
         }),
         validate_keys: FeatureValidateKeys(false),
         ipv6: true,

--- a/crates/telio-relay/Cargo.toml
+++ b/crates/telio-relay/Cargo.toml
@@ -13,7 +13,7 @@ rustls-pemfile = "1.0.0"
 tokio-rustls = { version = "0.24.1", features = ["dangerous_configuration"] }
 tokio-util = "0.7.3"
 tokio-stream = "0.1.9"
-webpki-roots = "0.25"
+rustls-platform-verifier = { git = "https://github.com/tomaszklak/rustls-platform-verifier.git", rev = "1eeed2dc3a4a7f437220875feb31e50cdec0bf07" }
 
 async-trait.workspace = true
 bytes.workspace = true
@@ -36,6 +36,7 @@ telio-proto.workspace = true
 telio-sockets.workspace = true
 telio-task.workspace = true
 telio-utils.workspace = true
+webpki-roots = "0.25.2"
 
 [dev-dependencies]
 async-std = { version = "1.5", features = ["attributes"] }

--- a/crates/telio-relay/src/derp/mod.rs
+++ b/crates/telio-relay/src/derp/mod.rs
@@ -15,7 +15,6 @@ use futures::{future::select_all, Future};
 use generic_array::typenum::Unsigned;
 use std::collections::{HashMap, HashSet};
 use std::net::{IpAddr, SocketAddr};
-use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 use telio_crypto::{PublicKey, SecretKey};
@@ -160,14 +159,14 @@ pub struct Config {
     pub allowed_pk: HashSet<PublicKey>,
     /// Timeout used for connecting to derp server
     pub timeout: Duration,
-    /// Path to certificate for tls connections
-    pub ca_pem_path: Option<PathBuf>,
     /// Keepalive values for derp connection
     pub server_keepalives: DerpKeepaliveConfig,
     /// Enable mechanism for turning off keepalive to offline peers
     pub enable_polling: bool,
     /// Derp polling will be done asking status of these meshnet peers
     pub meshnet_peers: Vec<PublicKey>,
+    /// Use Mozilla's root certificates instead of OS ones [default false]
+    pub use_built_in_root_certificates: bool,
 }
 
 impl Default for Config {
@@ -177,13 +176,13 @@ impl Default for Config {
             secret_key: Default::default(),
             allowed_pk: Default::default(),
             servers: Default::default(),
-            ca_pem_path: None,
             server_keepalives: DerpKeepaliveConfig {
                 tcp_keepalive: proto::DERP_TCP_KEEPALIVE_INTERVAL,
                 derp_keepalive: proto::DERP_KEEPALIVE_INTERVAL,
             },
             enable_polling: false,
             meshnet_peers: Default::default(),
+            use_built_in_root_certificates: false,
         }
     }
 }

--- a/deny.toml
+++ b/deny.toml
@@ -56,7 +56,7 @@ skip-tree = []
 unknown-registry = "warn"
 unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-allow-git = []
+allow-git = ["https://github.com/tomaszklak/rustls-platform-verifier.git", "https://github.com/tomaszklak/rust-security-framework.git"]
 
 [sources.allow-org]
 github = ["NordSecurity"]

--- a/ffi/bindings/android/java/com/nordsec/telio/Telio.java
+++ b/ffi/bindings/android/java/com/nordsec/telio/Telio.java
@@ -36,8 +36,8 @@ public class Telio {
     }
   }
 
-  public Telio(String features, ITelioEventCb events, TelioLogLevel level, ITelioLoggerCb logger, ITelioProtectCb protect) {
-    this(libtelioJNI.new_Telio(features, events, level.swigValue(), logger, protect), true);
+  public Telio(String features, ITelioEventCb events, TelioLogLevel level, ITelioLoggerCb logger, ITelioProtectCb protect, java.lang.Object ctx) {
+    this(libtelioJNI.new_Telio(features, events, level.swigValue(), logger, protect, ctx), true);
   }
 
   public static TelioAdapterType getDefaultAdapter() {

--- a/ffi/bindings/android/java/com/nordsec/telio/libtelioJNI.java
+++ b/ffi/bindings/android/java/com/nordsec/telio/libtelioJNI.java
@@ -22,7 +22,7 @@ public class libtelioJNI {
   public final static native int RES_LOCK_ERROR_get();
   public final static native int RES_INVALID_STRING_get();
   public final static native int RES_ALREADY_STARTED_get();
-  public final static native long new_Telio(String jarg1, ITelioEventCb jarg2, int jarg3, ITelioLoggerCb jarg4, ITelioProtectCb jarg5);
+  public final static native long new_Telio(String jarg1, ITelioEventCb jarg2, int jarg3, ITelioLoggerCb jarg4, ITelioProtectCb jarg5, java.lang.Object jarg6);
   public final static native int Telio_getDefaultAdapter();
   public final static native void delete_Telio(long jarg1);
   public final static native int Telio_start(long jarg1, Telio jarg1_, String jarg2, int jarg3);

--- a/ffi/bindings/android/wrap/java_wrap.c
+++ b/ffi/bindings/android/wrap/java_wrap.c
@@ -379,12 +379,14 @@ jint JNI_OnLoad(JavaVM *jvm, void *reserved) {
     return JNI_VERSION_1_6;
 }
 
-SWIGINTERN struct telio *new_telio(char const *features,telio_event_cb events,enum telio_log_level level,telio_logger_cb logger,telio_protect_cb protect){
+SWIGINTERN struct telio *new_telio(char const *features,telio_event_cb events,enum telio_log_level level,telio_logger_cb logger,telio_protect_cb protect,jobject ctx){
         telio *t;
         JNIEnv *env = NULL;
         if ((*jvm)->GetEnv(jvm, (void**)&env, JNI_VERSION_1_6)) {
             exit(1);
         }
+
+        telio_init_cert_store(env, ctx);
 
         enum telio_result result;
         if ((result = telio_new_with_protect(&t, features, events, level, logger, protect)) != TELIO_RES_OK) {
@@ -558,13 +560,14 @@ SWIGEXPORT jint JNICALL Java_com_nordsec_telio_libtelioJNI_RES_1ALREADY_1STARTED
 }
 
 
-SWIGEXPORT jlong JNICALL Java_com_nordsec_telio_libtelioJNI_new_1Telio(JNIEnv *jenv, jclass jcls, jstring jarg1, jobject jarg2, jint jarg3, jobject jarg4, jobject jarg5) {
+SWIGEXPORT jlong JNICALL Java_com_nordsec_telio_libtelioJNI_new_1Telio(JNIEnv *jenv, jclass jcls, jstring jarg1, jobject jarg2, jint jarg3, jobject jarg4, jobject jarg5, jobject jarg6) {
   jlong jresult = 0 ;
   char *arg1 = (char *) 0 ;
   telio_event_cb arg2 ;
   enum telio_log_level arg3 ;
   telio_logger_cb arg4 ;
   telio_protect_cb arg5 ;
+  jobject arg6 ;
   struct telio *result = 0 ;
   
   (void)jenv;
@@ -607,7 +610,8 @@ SWIGEXPORT jlong JNICALL Java_com_nordsec_telio_libtelioJNI_new_1Telio(JNIEnv *j
     };
     arg5 = cb;
   }
-  result = (struct telio *)new_telio((char const *)arg1,arg2,arg3,arg4,arg5);
+  arg6 = jarg6; 
+  result = (struct telio *)new_telio((char const *)arg1,arg2,arg3,arg4,arg5,arg6);
   *(struct telio **)&jresult = result; 
   if (arg1) (*jenv)->ReleaseStringUTFChars(jenv, jarg1, (const char *)arg1);
   return jresult;

--- a/ffi/bindings/linux/go/teliogo.go
+++ b/ffi/bindings/linux/go/teliogo.go
@@ -59,63 +59,63 @@ typedef _gostring_ swig_type_27;
 typedef _gostring_ swig_type_28;
 typedef _gostring_ swig_type_29;
 typedef _gostring_ swig_type_30;
-extern void _wrap_Swig_free_teliogo_9a5d0d120faf5ade(uintptr_t arg1);
-extern uintptr_t _wrap_Swig_malloc_teliogo_9a5d0d120faf5ade(swig_intgo arg1);
-extern swig_intgo _wrap_TELIOADAPTERBORINGTUN_teliogo_9a5d0d120faf5ade(void);
-extern swig_intgo _wrap_TELIOADAPTERLINUXNATIVETUN_teliogo_9a5d0d120faf5ade(void);
-extern swig_intgo _wrap_TELIOADAPTERWIREGUARDGOTUN_teliogo_9a5d0d120faf5ade(void);
-extern swig_intgo _wrap_TELIOADAPTERWINDOWSNATIVETUN_teliogo_9a5d0d120faf5ade(void);
-extern swig_intgo _wrap_TELIOLOGCRITICAL_teliogo_9a5d0d120faf5ade(void);
-extern swig_intgo _wrap_TELIOLOGERROR_teliogo_9a5d0d120faf5ade(void);
-extern swig_intgo _wrap_TELIOLOGWARNING_teliogo_9a5d0d120faf5ade(void);
-extern swig_intgo _wrap_TELIOLOGINFO_teliogo_9a5d0d120faf5ade(void);
-extern swig_intgo _wrap_TELIOLOGDEBUG_teliogo_9a5d0d120faf5ade(void);
-extern swig_intgo _wrap_TELIOLOGTRACE_teliogo_9a5d0d120faf5ade(void);
-extern swig_intgo _wrap_TELIORESOK_teliogo_9a5d0d120faf5ade(void);
-extern swig_intgo _wrap_TELIORESERROR_teliogo_9a5d0d120faf5ade(void);
-extern swig_intgo _wrap_TELIORESINVALIDKEY_teliogo_9a5d0d120faf5ade(void);
-extern swig_intgo _wrap_TELIORESBADCONFIG_teliogo_9a5d0d120faf5ade(void);
-extern swig_intgo _wrap_TELIORESLOCKERROR_teliogo_9a5d0d120faf5ade(void);
-extern swig_intgo _wrap_TELIORESINVALIDSTRING_teliogo_9a5d0d120faf5ade(void);
-extern swig_intgo _wrap_TELIORESALREADYSTARTED_teliogo_9a5d0d120faf5ade(void);
-extern void _wrap_TelioEventCb_Ctx_set_teliogo_9a5d0d120faf5ade(uintptr_t arg1, uintptr_t arg2);
-extern uintptr_t _wrap_TelioEventCb_Ctx_get_teliogo_9a5d0d120faf5ade(uintptr_t arg1);
-extern void _wrap_TelioEventCb_Cb_set_teliogo_9a5d0d120faf5ade(uintptr_t arg1, swig_type_1 arg2);
-extern swig_type_2 _wrap_TelioEventCb_Cb_get_teliogo_9a5d0d120faf5ade(uintptr_t arg1);
-extern uintptr_t _wrap_new_TelioEventCb_teliogo_9a5d0d120faf5ade(void);
-extern void _wrap_delete_TelioEventCb_teliogo_9a5d0d120faf5ade(uintptr_t arg1);
-extern void _wrap_TelioLoggerCb_Ctx_set_teliogo_9a5d0d120faf5ade(uintptr_t arg1, uintptr_t arg2);
-extern uintptr_t _wrap_TelioLoggerCb_Ctx_get_teliogo_9a5d0d120faf5ade(uintptr_t arg1);
-extern void _wrap_TelioLoggerCb_Cb_set_teliogo_9a5d0d120faf5ade(uintptr_t arg1, swig_type_3 arg2);
-extern swig_type_4 _wrap_TelioLoggerCb_Cb_get_teliogo_9a5d0d120faf5ade(uintptr_t arg1);
-extern uintptr_t _wrap_new_TelioLoggerCb_teliogo_9a5d0d120faf5ade(void);
-extern void _wrap_delete_TelioLoggerCb_teliogo_9a5d0d120faf5ade(uintptr_t arg1);
-extern swig_intgo _wrap_Telio_GetDefaultAdapter_teliogo_9a5d0d120faf5ade(void);
-extern uintptr_t _wrap_new_Telio_teliogo_9a5d0d120faf5ade(swig_type_5 arg1, telio_event_cb arg2, swig_intgo arg3, telio_logger_cb arg4);
-extern void _wrap_delete_Telio_teliogo_9a5d0d120faf5ade(uintptr_t arg1);
-extern swig_intgo _wrap_Telio_Start_teliogo_9a5d0d120faf5ade(uintptr_t arg1, swig_type_6 arg2, swig_intgo arg3);
-extern swig_intgo _wrap_Telio_StartNamed_teliogo_9a5d0d120faf5ade(uintptr_t arg1, swig_type_7 arg2, swig_intgo arg3, swig_type_8 arg4);
-extern swig_intgo _wrap_Telio_StartWithTun_teliogo_9a5d0d120faf5ade(uintptr_t arg1, swig_type_9 arg2, swig_intgo arg3, swig_intgo arg4);
-extern swig_intgo _wrap_Telio_EnableMagicDns_teliogo_9a5d0d120faf5ade(uintptr_t arg1, swig_type_10 arg2);
-extern swig_intgo _wrap_Telio_DisableMagicDns_teliogo_9a5d0d120faf5ade(uintptr_t arg1);
-extern swig_intgo _wrap_Telio_Stop_teliogo_9a5d0d120faf5ade(uintptr_t arg1);
-extern swig_type_11 _wrap_Telio_GetAdapterLuid_teliogo_9a5d0d120faf5ade(uintptr_t arg1);
-extern swig_intgo _wrap_Telio_SetPrivateKey_teliogo_9a5d0d120faf5ade(uintptr_t arg1, swig_type_12 arg2);
-extern swig_type_13 _wrap_Telio_GetPrivateKey_teliogo_9a5d0d120faf5ade(uintptr_t arg1);
-extern swig_intgo _wrap_Telio_SetFwmark_teliogo_9a5d0d120faf5ade(uintptr_t arg1, swig_intgo arg2);
-extern swig_intgo _wrap_Telio_NotifyNetworkChange_teliogo_9a5d0d120faf5ade(uintptr_t arg1, swig_type_14 arg2);
-extern swig_intgo _wrap_Telio_ConnectToExitNode_teliogo_9a5d0d120faf5ade(uintptr_t arg1, swig_type_15 arg2, swig_type_16 arg3, swig_type_17 arg4);
-extern swig_intgo _wrap_Telio_ConnectToExitNodeWithId_teliogo_9a5d0d120faf5ade(uintptr_t arg1, swig_type_18 arg2, swig_type_19 arg3, swig_type_20 arg4, swig_type_21 arg5);
-extern swig_intgo _wrap_Telio_DisconnectFromExitNode_teliogo_9a5d0d120faf5ade(uintptr_t arg1, swig_type_22 arg2);
-extern swig_intgo _wrap_Telio_DisconnectFromExitNodes_teliogo_9a5d0d120faf5ade(uintptr_t arg1);
-extern swig_intgo _wrap_Telio_SetMeshnet_teliogo_9a5d0d120faf5ade(uintptr_t arg1, swig_type_23 arg2);
-extern swig_intgo _wrap_Telio_SetMeshnetOff_teliogo_9a5d0d120faf5ade(uintptr_t arg1);
-extern swig_type_24 _wrap_Telio_GenerateSecretKey_teliogo_9a5d0d120faf5ade(uintptr_t arg1);
-extern swig_type_25 _wrap_Telio_GeneratePublicKey_teliogo_9a5d0d120faf5ade(uintptr_t arg1, swig_type_26 arg2);
-extern swig_type_27 _wrap_Telio_GetStatusMap_teliogo_9a5d0d120faf5ade(uintptr_t arg1);
-extern swig_type_28 _wrap_Telio_GetLastError_teliogo_9a5d0d120faf5ade(uintptr_t arg1);
-extern swig_type_29 _wrap_Telio_GetVersionTag_teliogo_9a5d0d120faf5ade(void);
-extern swig_type_30 _wrap_Telio_GetCommitSha_teliogo_9a5d0d120faf5ade(void);
+extern void _wrap_Swig_free_teliogo_979add31dbd463e7(uintptr_t arg1);
+extern uintptr_t _wrap_Swig_malloc_teliogo_979add31dbd463e7(swig_intgo arg1);
+extern swig_intgo _wrap_TELIOADAPTERBORINGTUN_teliogo_979add31dbd463e7(void);
+extern swig_intgo _wrap_TELIOADAPTERLINUXNATIVETUN_teliogo_979add31dbd463e7(void);
+extern swig_intgo _wrap_TELIOADAPTERWIREGUARDGOTUN_teliogo_979add31dbd463e7(void);
+extern swig_intgo _wrap_TELIOADAPTERWINDOWSNATIVETUN_teliogo_979add31dbd463e7(void);
+extern swig_intgo _wrap_TELIOLOGCRITICAL_teliogo_979add31dbd463e7(void);
+extern swig_intgo _wrap_TELIOLOGERROR_teliogo_979add31dbd463e7(void);
+extern swig_intgo _wrap_TELIOLOGWARNING_teliogo_979add31dbd463e7(void);
+extern swig_intgo _wrap_TELIOLOGINFO_teliogo_979add31dbd463e7(void);
+extern swig_intgo _wrap_TELIOLOGDEBUG_teliogo_979add31dbd463e7(void);
+extern swig_intgo _wrap_TELIOLOGTRACE_teliogo_979add31dbd463e7(void);
+extern swig_intgo _wrap_TELIORESOK_teliogo_979add31dbd463e7(void);
+extern swig_intgo _wrap_TELIORESERROR_teliogo_979add31dbd463e7(void);
+extern swig_intgo _wrap_TELIORESINVALIDKEY_teliogo_979add31dbd463e7(void);
+extern swig_intgo _wrap_TELIORESBADCONFIG_teliogo_979add31dbd463e7(void);
+extern swig_intgo _wrap_TELIORESLOCKERROR_teliogo_979add31dbd463e7(void);
+extern swig_intgo _wrap_TELIORESINVALIDSTRING_teliogo_979add31dbd463e7(void);
+extern swig_intgo _wrap_TELIORESALREADYSTARTED_teliogo_979add31dbd463e7(void);
+extern void _wrap_TelioEventCb_Ctx_set_teliogo_979add31dbd463e7(uintptr_t arg1, uintptr_t arg2);
+extern uintptr_t _wrap_TelioEventCb_Ctx_get_teliogo_979add31dbd463e7(uintptr_t arg1);
+extern void _wrap_TelioEventCb_Cb_set_teliogo_979add31dbd463e7(uintptr_t arg1, swig_type_1 arg2);
+extern swig_type_2 _wrap_TelioEventCb_Cb_get_teliogo_979add31dbd463e7(uintptr_t arg1);
+extern uintptr_t _wrap_new_TelioEventCb_teliogo_979add31dbd463e7(void);
+extern void _wrap_delete_TelioEventCb_teliogo_979add31dbd463e7(uintptr_t arg1);
+extern void _wrap_TelioLoggerCb_Ctx_set_teliogo_979add31dbd463e7(uintptr_t arg1, uintptr_t arg2);
+extern uintptr_t _wrap_TelioLoggerCb_Ctx_get_teliogo_979add31dbd463e7(uintptr_t arg1);
+extern void _wrap_TelioLoggerCb_Cb_set_teliogo_979add31dbd463e7(uintptr_t arg1, swig_type_3 arg2);
+extern swig_type_4 _wrap_TelioLoggerCb_Cb_get_teliogo_979add31dbd463e7(uintptr_t arg1);
+extern uintptr_t _wrap_new_TelioLoggerCb_teliogo_979add31dbd463e7(void);
+extern void _wrap_delete_TelioLoggerCb_teliogo_979add31dbd463e7(uintptr_t arg1);
+extern swig_intgo _wrap_Telio_GetDefaultAdapter_teliogo_979add31dbd463e7(void);
+extern uintptr_t _wrap_new_Telio_teliogo_979add31dbd463e7(swig_type_5 arg1, telio_event_cb arg2, swig_intgo arg3, telio_logger_cb arg4);
+extern void _wrap_delete_Telio_teliogo_979add31dbd463e7(uintptr_t arg1);
+extern swig_intgo _wrap_Telio_Start_teliogo_979add31dbd463e7(uintptr_t arg1, swig_type_6 arg2, swig_intgo arg3);
+extern swig_intgo _wrap_Telio_StartNamed_teliogo_979add31dbd463e7(uintptr_t arg1, swig_type_7 arg2, swig_intgo arg3, swig_type_8 arg4);
+extern swig_intgo _wrap_Telio_StartWithTun_teliogo_979add31dbd463e7(uintptr_t arg1, swig_type_9 arg2, swig_intgo arg3, swig_intgo arg4);
+extern swig_intgo _wrap_Telio_EnableMagicDns_teliogo_979add31dbd463e7(uintptr_t arg1, swig_type_10 arg2);
+extern swig_intgo _wrap_Telio_DisableMagicDns_teliogo_979add31dbd463e7(uintptr_t arg1);
+extern swig_intgo _wrap_Telio_Stop_teliogo_979add31dbd463e7(uintptr_t arg1);
+extern swig_type_11 _wrap_Telio_GetAdapterLuid_teliogo_979add31dbd463e7(uintptr_t arg1);
+extern swig_intgo _wrap_Telio_SetPrivateKey_teliogo_979add31dbd463e7(uintptr_t arg1, swig_type_12 arg2);
+extern swig_type_13 _wrap_Telio_GetPrivateKey_teliogo_979add31dbd463e7(uintptr_t arg1);
+extern swig_intgo _wrap_Telio_SetFwmark_teliogo_979add31dbd463e7(uintptr_t arg1, swig_intgo arg2);
+extern swig_intgo _wrap_Telio_NotifyNetworkChange_teliogo_979add31dbd463e7(uintptr_t arg1, swig_type_14 arg2);
+extern swig_intgo _wrap_Telio_ConnectToExitNode_teliogo_979add31dbd463e7(uintptr_t arg1, swig_type_15 arg2, swig_type_16 arg3, swig_type_17 arg4);
+extern swig_intgo _wrap_Telio_ConnectToExitNodeWithId_teliogo_979add31dbd463e7(uintptr_t arg1, swig_type_18 arg2, swig_type_19 arg3, swig_type_20 arg4, swig_type_21 arg5);
+extern swig_intgo _wrap_Telio_DisconnectFromExitNode_teliogo_979add31dbd463e7(uintptr_t arg1, swig_type_22 arg2);
+extern swig_intgo _wrap_Telio_DisconnectFromExitNodes_teliogo_979add31dbd463e7(uintptr_t arg1);
+extern swig_intgo _wrap_Telio_SetMeshnet_teliogo_979add31dbd463e7(uintptr_t arg1, swig_type_23 arg2);
+extern swig_intgo _wrap_Telio_SetMeshnetOff_teliogo_979add31dbd463e7(uintptr_t arg1);
+extern swig_type_24 _wrap_Telio_GenerateSecretKey_teliogo_979add31dbd463e7(uintptr_t arg1);
+extern swig_type_25 _wrap_Telio_GeneratePublicKey_teliogo_979add31dbd463e7(uintptr_t arg1, swig_type_26 arg2);
+extern swig_type_27 _wrap_Telio_GetStatusMap_teliogo_979add31dbd463e7(uintptr_t arg1);
+extern swig_type_28 _wrap_Telio_GetLastError_teliogo_979add31dbd463e7(uintptr_t arg1);
+extern swig_type_29 _wrap_Telio_GetVersionTag_teliogo_979add31dbd463e7(void);
+extern swig_type_30 _wrap_Telio_GetCommitSha_teliogo_979add31dbd463e7(void);
 #undef intgo
 */
 import "C"
@@ -150,41 +150,41 @@ func swigCopyString(s string) string {
 
 func Swig_free(arg1 uintptr) {
 	_swig_i_0 := arg1
-	C._wrap_Swig_free_teliogo_9a5d0d120faf5ade(C.uintptr_t(_swig_i_0))
+	C._wrap_Swig_free_teliogo_979add31dbd463e7(C.uintptr_t(_swig_i_0))
 }
 
 func Swig_malloc(arg1 int) (_swig_ret uintptr) {
 	var swig_r uintptr
 	_swig_i_0 := arg1
-	swig_r = (uintptr)(C._wrap_Swig_malloc_teliogo_9a5d0d120faf5ade(C.swig_intgo(_swig_i_0)))
+	swig_r = (uintptr)(C._wrap_Swig_malloc_teliogo_979add31dbd463e7(C.swig_intgo(_swig_i_0)))
 	return swig_r
 }
 
 type Enum_SS_telio_adapter_type int
 func _swig_getTELIOADAPTERBORINGTUN() (_swig_ret Enum_SS_telio_adapter_type) {
 	var swig_r Enum_SS_telio_adapter_type
-	swig_r = (Enum_SS_telio_adapter_type)(C._wrap_TELIOADAPTERBORINGTUN_teliogo_9a5d0d120faf5ade())
+	swig_r = (Enum_SS_telio_adapter_type)(C._wrap_TELIOADAPTERBORINGTUN_teliogo_979add31dbd463e7())
 	return swig_r
 }
 
 var TELIOADAPTERBORINGTUN Enum_SS_telio_adapter_type = _swig_getTELIOADAPTERBORINGTUN()
 func _swig_getTELIOADAPTERLINUXNATIVETUN() (_swig_ret Enum_SS_telio_adapter_type) {
 	var swig_r Enum_SS_telio_adapter_type
-	swig_r = (Enum_SS_telio_adapter_type)(C._wrap_TELIOADAPTERLINUXNATIVETUN_teliogo_9a5d0d120faf5ade())
+	swig_r = (Enum_SS_telio_adapter_type)(C._wrap_TELIOADAPTERLINUXNATIVETUN_teliogo_979add31dbd463e7())
 	return swig_r
 }
 
 var TELIOADAPTERLINUXNATIVETUN Enum_SS_telio_adapter_type = _swig_getTELIOADAPTERLINUXNATIVETUN()
 func _swig_getTELIOADAPTERWIREGUARDGOTUN() (_swig_ret Enum_SS_telio_adapter_type) {
 	var swig_r Enum_SS_telio_adapter_type
-	swig_r = (Enum_SS_telio_adapter_type)(C._wrap_TELIOADAPTERWIREGUARDGOTUN_teliogo_9a5d0d120faf5ade())
+	swig_r = (Enum_SS_telio_adapter_type)(C._wrap_TELIOADAPTERWIREGUARDGOTUN_teliogo_979add31dbd463e7())
 	return swig_r
 }
 
 var TELIOADAPTERWIREGUARDGOTUN Enum_SS_telio_adapter_type = _swig_getTELIOADAPTERWIREGUARDGOTUN()
 func _swig_getTELIOADAPTERWINDOWSNATIVETUN() (_swig_ret Enum_SS_telio_adapter_type) {
 	var swig_r Enum_SS_telio_adapter_type
-	swig_r = (Enum_SS_telio_adapter_type)(C._wrap_TELIOADAPTERWINDOWSNATIVETUN_teliogo_9a5d0d120faf5ade())
+	swig_r = (Enum_SS_telio_adapter_type)(C._wrap_TELIOADAPTERWINDOWSNATIVETUN_teliogo_979add31dbd463e7())
 	return swig_r
 }
 
@@ -192,42 +192,42 @@ var TELIOADAPTERWINDOWSNATIVETUN Enum_SS_telio_adapter_type = _swig_getTELIOADAP
 type Enum_SS_telio_log_level int
 func _swig_getTELIOLOGCRITICAL() (_swig_ret Enum_SS_telio_log_level) {
 	var swig_r Enum_SS_telio_log_level
-	swig_r = (Enum_SS_telio_log_level)(C._wrap_TELIOLOGCRITICAL_teliogo_9a5d0d120faf5ade())
+	swig_r = (Enum_SS_telio_log_level)(C._wrap_TELIOLOGCRITICAL_teliogo_979add31dbd463e7())
 	return swig_r
 }
 
 var TELIOLOGCRITICAL Enum_SS_telio_log_level = _swig_getTELIOLOGCRITICAL()
 func _swig_getTELIOLOGERROR() (_swig_ret Enum_SS_telio_log_level) {
 	var swig_r Enum_SS_telio_log_level
-	swig_r = (Enum_SS_telio_log_level)(C._wrap_TELIOLOGERROR_teliogo_9a5d0d120faf5ade())
+	swig_r = (Enum_SS_telio_log_level)(C._wrap_TELIOLOGERROR_teliogo_979add31dbd463e7())
 	return swig_r
 }
 
 var TELIOLOGERROR Enum_SS_telio_log_level = _swig_getTELIOLOGERROR()
 func _swig_getTELIOLOGWARNING() (_swig_ret Enum_SS_telio_log_level) {
 	var swig_r Enum_SS_telio_log_level
-	swig_r = (Enum_SS_telio_log_level)(C._wrap_TELIOLOGWARNING_teliogo_9a5d0d120faf5ade())
+	swig_r = (Enum_SS_telio_log_level)(C._wrap_TELIOLOGWARNING_teliogo_979add31dbd463e7())
 	return swig_r
 }
 
 var TELIOLOGWARNING Enum_SS_telio_log_level = _swig_getTELIOLOGWARNING()
 func _swig_getTELIOLOGINFO() (_swig_ret Enum_SS_telio_log_level) {
 	var swig_r Enum_SS_telio_log_level
-	swig_r = (Enum_SS_telio_log_level)(C._wrap_TELIOLOGINFO_teliogo_9a5d0d120faf5ade())
+	swig_r = (Enum_SS_telio_log_level)(C._wrap_TELIOLOGINFO_teliogo_979add31dbd463e7())
 	return swig_r
 }
 
 var TELIOLOGINFO Enum_SS_telio_log_level = _swig_getTELIOLOGINFO()
 func _swig_getTELIOLOGDEBUG() (_swig_ret Enum_SS_telio_log_level) {
 	var swig_r Enum_SS_telio_log_level
-	swig_r = (Enum_SS_telio_log_level)(C._wrap_TELIOLOGDEBUG_teliogo_9a5d0d120faf5ade())
+	swig_r = (Enum_SS_telio_log_level)(C._wrap_TELIOLOGDEBUG_teliogo_979add31dbd463e7())
 	return swig_r
 }
 
 var TELIOLOGDEBUG Enum_SS_telio_log_level = _swig_getTELIOLOGDEBUG()
 func _swig_getTELIOLOGTRACE() (_swig_ret Enum_SS_telio_log_level) {
 	var swig_r Enum_SS_telio_log_level
-	swig_r = (Enum_SS_telio_log_level)(C._wrap_TELIOLOGTRACE_teliogo_9a5d0d120faf5ade())
+	swig_r = (Enum_SS_telio_log_level)(C._wrap_TELIOLOGTRACE_teliogo_979add31dbd463e7())
 	return swig_r
 }
 
@@ -235,49 +235,49 @@ var TELIOLOGTRACE Enum_SS_telio_log_level = _swig_getTELIOLOGTRACE()
 type Enum_SS_telio_result int
 func _swig_getTELIORESOK() (_swig_ret Enum_SS_telio_result) {
 	var swig_r Enum_SS_telio_result
-	swig_r = (Enum_SS_telio_result)(C._wrap_TELIORESOK_teliogo_9a5d0d120faf5ade())
+	swig_r = (Enum_SS_telio_result)(C._wrap_TELIORESOK_teliogo_979add31dbd463e7())
 	return swig_r
 }
 
 var TELIORESOK Enum_SS_telio_result = _swig_getTELIORESOK()
 func _swig_getTELIORESERROR() (_swig_ret Enum_SS_telio_result) {
 	var swig_r Enum_SS_telio_result
-	swig_r = (Enum_SS_telio_result)(C._wrap_TELIORESERROR_teliogo_9a5d0d120faf5ade())
+	swig_r = (Enum_SS_telio_result)(C._wrap_TELIORESERROR_teliogo_979add31dbd463e7())
 	return swig_r
 }
 
 var TELIORESERROR Enum_SS_telio_result = _swig_getTELIORESERROR()
 func _swig_getTELIORESINVALIDKEY() (_swig_ret Enum_SS_telio_result) {
 	var swig_r Enum_SS_telio_result
-	swig_r = (Enum_SS_telio_result)(C._wrap_TELIORESINVALIDKEY_teliogo_9a5d0d120faf5ade())
+	swig_r = (Enum_SS_telio_result)(C._wrap_TELIORESINVALIDKEY_teliogo_979add31dbd463e7())
 	return swig_r
 }
 
 var TELIORESINVALIDKEY Enum_SS_telio_result = _swig_getTELIORESINVALIDKEY()
 func _swig_getTELIORESBADCONFIG() (_swig_ret Enum_SS_telio_result) {
 	var swig_r Enum_SS_telio_result
-	swig_r = (Enum_SS_telio_result)(C._wrap_TELIORESBADCONFIG_teliogo_9a5d0d120faf5ade())
+	swig_r = (Enum_SS_telio_result)(C._wrap_TELIORESBADCONFIG_teliogo_979add31dbd463e7())
 	return swig_r
 }
 
 var TELIORESBADCONFIG Enum_SS_telio_result = _swig_getTELIORESBADCONFIG()
 func _swig_getTELIORESLOCKERROR() (_swig_ret Enum_SS_telio_result) {
 	var swig_r Enum_SS_telio_result
-	swig_r = (Enum_SS_telio_result)(C._wrap_TELIORESLOCKERROR_teliogo_9a5d0d120faf5ade())
+	swig_r = (Enum_SS_telio_result)(C._wrap_TELIORESLOCKERROR_teliogo_979add31dbd463e7())
 	return swig_r
 }
 
 var TELIORESLOCKERROR Enum_SS_telio_result = _swig_getTELIORESLOCKERROR()
 func _swig_getTELIORESINVALIDSTRING() (_swig_ret Enum_SS_telio_result) {
 	var swig_r Enum_SS_telio_result
-	swig_r = (Enum_SS_telio_result)(C._wrap_TELIORESINVALIDSTRING_teliogo_9a5d0d120faf5ade())
+	swig_r = (Enum_SS_telio_result)(C._wrap_TELIORESINVALIDSTRING_teliogo_979add31dbd463e7())
 	return swig_r
 }
 
 var TELIORESINVALIDSTRING Enum_SS_telio_result = _swig_getTELIORESINVALIDSTRING()
 func _swig_getTELIORESALREADYSTARTED() (_swig_ret Enum_SS_telio_result) {
 	var swig_r Enum_SS_telio_result
-	swig_r = (Enum_SS_telio_result)(C._wrap_TELIORESALREADYSTARTED_teliogo_9a5d0d120faf5ade())
+	swig_r = (Enum_SS_telio_result)(C._wrap_TELIORESALREADYSTARTED_teliogo_979add31dbd463e7())
 	return swig_r
 }
 
@@ -294,38 +294,38 @@ func (p SwigcptrTelioEventCb) SwigIsTelioEventCb() {
 func (arg1 SwigcptrTelioEventCb) SetCtx(arg2 uintptr) {
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
-	C._wrap_TelioEventCb_Ctx_set_teliogo_9a5d0d120faf5ade(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1))
+	C._wrap_TelioEventCb_Ctx_set_teliogo_979add31dbd463e7(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1))
 }
 
 func (arg1 SwigcptrTelioEventCb) GetCtx() (_swig_ret uintptr) {
 	var swig_r uintptr
 	_swig_i_0 := arg1
-	swig_r = (uintptr)(C._wrap_TelioEventCb_Ctx_get_teliogo_9a5d0d120faf5ade(C.uintptr_t(_swig_i_0)))
+	swig_r = (uintptr)(C._wrap_TelioEventCb_Ctx_get_teliogo_979add31dbd463e7(C.uintptr_t(_swig_i_0)))
 	return swig_r
 }
 
 func (arg1 SwigcptrTelioEventCb) SetCb(arg2 _swig_fnptr) {
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
-	C._wrap_TelioEventCb_Cb_set_teliogo_9a5d0d120faf5ade(C.uintptr_t(_swig_i_0), C.swig_type_1(_swig_i_1))
+	C._wrap_TelioEventCb_Cb_set_teliogo_979add31dbd463e7(C.uintptr_t(_swig_i_0), C.swig_type_1(_swig_i_1))
 }
 
 func (arg1 SwigcptrTelioEventCb) GetCb() (_swig_ret _swig_fnptr) {
 	var swig_r _swig_fnptr
 	_swig_i_0 := arg1
-	swig_r = (_swig_fnptr)(C._wrap_TelioEventCb_Cb_get_teliogo_9a5d0d120faf5ade(C.uintptr_t(_swig_i_0)))
+	swig_r = (_swig_fnptr)(C._wrap_TelioEventCb_Cb_get_teliogo_979add31dbd463e7(C.uintptr_t(_swig_i_0)))
 	return swig_r
 }
 
 func NewTelioEventCb() (_swig_ret TelioEventCb) {
 	var swig_r TelioEventCb
-	swig_r = (TelioEventCb)(SwigcptrTelioEventCb(C._wrap_new_TelioEventCb_teliogo_9a5d0d120faf5ade()))
+	swig_r = (TelioEventCb)(SwigcptrTelioEventCb(C._wrap_new_TelioEventCb_teliogo_979add31dbd463e7()))
 	return swig_r
 }
 
 func DeleteTelioEventCb(arg1 TelioEventCb) {
 	_swig_i_0 := arg1.Swigcptr()
-	C._wrap_delete_TelioEventCb_teliogo_9a5d0d120faf5ade(C.uintptr_t(_swig_i_0))
+	C._wrap_delete_TelioEventCb_teliogo_979add31dbd463e7(C.uintptr_t(_swig_i_0))
 }
 
 type TelioEventCb interface {
@@ -349,38 +349,38 @@ func (p SwigcptrTelioLoggerCb) SwigIsTelioLoggerCb() {
 func (arg1 SwigcptrTelioLoggerCb) SetCtx(arg2 uintptr) {
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
-	C._wrap_TelioLoggerCb_Ctx_set_teliogo_9a5d0d120faf5ade(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1))
+	C._wrap_TelioLoggerCb_Ctx_set_teliogo_979add31dbd463e7(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1))
 }
 
 func (arg1 SwigcptrTelioLoggerCb) GetCtx() (_swig_ret uintptr) {
 	var swig_r uintptr
 	_swig_i_0 := arg1
-	swig_r = (uintptr)(C._wrap_TelioLoggerCb_Ctx_get_teliogo_9a5d0d120faf5ade(C.uintptr_t(_swig_i_0)))
+	swig_r = (uintptr)(C._wrap_TelioLoggerCb_Ctx_get_teliogo_979add31dbd463e7(C.uintptr_t(_swig_i_0)))
 	return swig_r
 }
 
 func (arg1 SwigcptrTelioLoggerCb) SetCb(arg2 _swig_fnptr) {
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
-	C._wrap_TelioLoggerCb_Cb_set_teliogo_9a5d0d120faf5ade(C.uintptr_t(_swig_i_0), C.swig_type_3(_swig_i_1))
+	C._wrap_TelioLoggerCb_Cb_set_teliogo_979add31dbd463e7(C.uintptr_t(_swig_i_0), C.swig_type_3(_swig_i_1))
 }
 
 func (arg1 SwigcptrTelioLoggerCb) GetCb() (_swig_ret _swig_fnptr) {
 	var swig_r _swig_fnptr
 	_swig_i_0 := arg1
-	swig_r = (_swig_fnptr)(C._wrap_TelioLoggerCb_Cb_get_teliogo_9a5d0d120faf5ade(C.uintptr_t(_swig_i_0)))
+	swig_r = (_swig_fnptr)(C._wrap_TelioLoggerCb_Cb_get_teliogo_979add31dbd463e7(C.uintptr_t(_swig_i_0)))
 	return swig_r
 }
 
 func NewTelioLoggerCb() (_swig_ret TelioLoggerCb) {
 	var swig_r TelioLoggerCb
-	swig_r = (TelioLoggerCb)(SwigcptrTelioLoggerCb(C._wrap_new_TelioLoggerCb_teliogo_9a5d0d120faf5ade()))
+	swig_r = (TelioLoggerCb)(SwigcptrTelioLoggerCb(C._wrap_new_TelioLoggerCb_teliogo_979add31dbd463e7()))
 	return swig_r
 }
 
 func DeleteTelioLoggerCb(arg1 TelioLoggerCb) {
 	_swig_i_0 := arg1.Swigcptr()
-	C._wrap_delete_TelioLoggerCb_teliogo_9a5d0d120faf5ade(C.uintptr_t(_swig_i_0))
+	C._wrap_delete_TelioLoggerCb_teliogo_979add31dbd463e7(C.uintptr_t(_swig_i_0))
 }
 
 type TelioLoggerCb interface {
@@ -449,7 +449,7 @@ func (p SwigcptrTelio) SwigIsTelio() {
 
 func TelioGetDefaultAdapter() (_swig_ret Enum_SS_telio_adapter_type) {
 	var swig_r Enum_SS_telio_adapter_type
-	swig_r = (Enum_SS_telio_adapter_type)(C._wrap_Telio_GetDefaultAdapter_teliogo_9a5d0d120faf5ade())
+	swig_r = (Enum_SS_telio_adapter_type)(C._wrap_Telio_GetDefaultAdapter_teliogo_979add31dbd463e7())
 	return swig_r
 }
 
@@ -477,7 +477,7 @@ func NewTelio(arg1 string, arg2 func(string), arg3 Enum_SS_telio_log_level, arg4
         loggerCallbacks[index] = arg4
         _swig_i_3 = cb
 }
-	swig_r = (Telio)(SwigcptrTelio(C._wrap_new_Telio_teliogo_9a5d0d120faf5ade(*(*C.swig_type_5)(unsafe.Pointer(&_swig_i_0)), C.telio_event_cb(_swig_i_1), C.swig_intgo(_swig_i_2), C.telio_logger_cb(_swig_i_3))))
+	swig_r = (Telio)(SwigcptrTelio(C._wrap_new_Telio_teliogo_979add31dbd463e7(*(*C.swig_type_5)(unsafe.Pointer(&_swig_i_0)), C.telio_event_cb(_swig_i_1), C.swig_intgo(_swig_i_2), C.telio_logger_cb(_swig_i_3))))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg1
 	}
@@ -494,7 +494,7 @@ func NewTelio(arg1 string, arg2 func(string), arg3 Enum_SS_telio_log_level, arg4
 
 func DeleteTelio(arg1 Telio) {
 	_swig_i_0 := arg1.Swigcptr()
-	C._wrap_delete_Telio_teliogo_9a5d0d120faf5ade(C.uintptr_t(_swig_i_0))
+	C._wrap_delete_Telio_teliogo_979add31dbd463e7(C.uintptr_t(_swig_i_0))
 }
 
 func (arg1 SwigcptrTelio) Start(arg2 string, arg3 Enum_SS_telio_adapter_type) (_swig_ret Enum_SS_telio_result) {
@@ -502,7 +502,7 @@ func (arg1 SwigcptrTelio) Start(arg2 string, arg3 Enum_SS_telio_adapter_type) (_
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
 	_swig_i_2 := arg3
-	swig_r = (Enum_SS_telio_result)(C._wrap_Telio_Start_teliogo_9a5d0d120faf5ade(C.uintptr_t(_swig_i_0), *(*C.swig_type_6)(unsafe.Pointer(&_swig_i_1)), C.swig_intgo(_swig_i_2)))
+	swig_r = (Enum_SS_telio_result)(C._wrap_Telio_Start_teliogo_979add31dbd463e7(C.uintptr_t(_swig_i_0), *(*C.swig_type_6)(unsafe.Pointer(&_swig_i_1)), C.swig_intgo(_swig_i_2)))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -515,7 +515,7 @@ func (arg1 SwigcptrTelio) StartNamed(arg2 string, arg3 Enum_SS_telio_adapter_typ
 	_swig_i_1 := arg2
 	_swig_i_2 := arg3
 	_swig_i_3 := arg4
-	swig_r = (Enum_SS_telio_result)(C._wrap_Telio_StartNamed_teliogo_9a5d0d120faf5ade(C.uintptr_t(_swig_i_0), *(*C.swig_type_7)(unsafe.Pointer(&_swig_i_1)), C.swig_intgo(_swig_i_2), *(*C.swig_type_8)(unsafe.Pointer(&_swig_i_3))))
+	swig_r = (Enum_SS_telio_result)(C._wrap_Telio_StartNamed_teliogo_979add31dbd463e7(C.uintptr_t(_swig_i_0), *(*C.swig_type_7)(unsafe.Pointer(&_swig_i_1)), C.swig_intgo(_swig_i_2), *(*C.swig_type_8)(unsafe.Pointer(&_swig_i_3))))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -531,7 +531,7 @@ func (arg1 SwigcptrTelio) StartWithTun(arg2 string, arg3 Enum_SS_telio_adapter_t
 	_swig_i_1 := arg2
 	_swig_i_2 := arg3
 	_swig_i_3 := arg4
-	swig_r = (Enum_SS_telio_result)(C._wrap_Telio_StartWithTun_teliogo_9a5d0d120faf5ade(C.uintptr_t(_swig_i_0), *(*C.swig_type_9)(unsafe.Pointer(&_swig_i_1)), C.swig_intgo(_swig_i_2), C.swig_intgo(_swig_i_3)))
+	swig_r = (Enum_SS_telio_result)(C._wrap_Telio_StartWithTun_teliogo_979add31dbd463e7(C.uintptr_t(_swig_i_0), *(*C.swig_type_9)(unsafe.Pointer(&_swig_i_1)), C.swig_intgo(_swig_i_2), C.swig_intgo(_swig_i_3)))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -542,7 +542,7 @@ func (arg1 SwigcptrTelio) EnableMagicDns(arg2 string) (_swig_ret Enum_SS_telio_r
 	var swig_r Enum_SS_telio_result
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
-	swig_r = (Enum_SS_telio_result)(C._wrap_Telio_EnableMagicDns_teliogo_9a5d0d120faf5ade(C.uintptr_t(_swig_i_0), *(*C.swig_type_10)(unsafe.Pointer(&_swig_i_1))))
+	swig_r = (Enum_SS_telio_result)(C._wrap_Telio_EnableMagicDns_teliogo_979add31dbd463e7(C.uintptr_t(_swig_i_0), *(*C.swig_type_10)(unsafe.Pointer(&_swig_i_1))))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -552,21 +552,21 @@ func (arg1 SwigcptrTelio) EnableMagicDns(arg2 string) (_swig_ret Enum_SS_telio_r
 func (arg1 SwigcptrTelio) DisableMagicDns() (_swig_ret Enum_SS_telio_result) {
 	var swig_r Enum_SS_telio_result
 	_swig_i_0 := arg1
-	swig_r = (Enum_SS_telio_result)(C._wrap_Telio_DisableMagicDns_teliogo_9a5d0d120faf5ade(C.uintptr_t(_swig_i_0)))
+	swig_r = (Enum_SS_telio_result)(C._wrap_Telio_DisableMagicDns_teliogo_979add31dbd463e7(C.uintptr_t(_swig_i_0)))
 	return swig_r
 }
 
 func (arg1 SwigcptrTelio) Stop() (_swig_ret Enum_SS_telio_result) {
 	var swig_r Enum_SS_telio_result
 	_swig_i_0 := arg1
-	swig_r = (Enum_SS_telio_result)(C._wrap_Telio_Stop_teliogo_9a5d0d120faf5ade(C.uintptr_t(_swig_i_0)))
+	swig_r = (Enum_SS_telio_result)(C._wrap_Telio_Stop_teliogo_979add31dbd463e7(C.uintptr_t(_swig_i_0)))
 	return swig_r
 }
 
 func (arg1 SwigcptrTelio) GetAdapterLuid() (_swig_ret uint64) {
 	var swig_r uint64
 	_swig_i_0 := arg1
-	swig_r = (uint64)(C._wrap_Telio_GetAdapterLuid_teliogo_9a5d0d120faf5ade(C.uintptr_t(_swig_i_0)))
+	swig_r = (uint64)(C._wrap_Telio_GetAdapterLuid_teliogo_979add31dbd463e7(C.uintptr_t(_swig_i_0)))
 	return swig_r
 }
 
@@ -574,7 +574,7 @@ func (arg1 SwigcptrTelio) SetPrivateKey(arg2 string) (_swig_ret Enum_SS_telio_re
 	var swig_r Enum_SS_telio_result
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
-	swig_r = (Enum_SS_telio_result)(C._wrap_Telio_SetPrivateKey_teliogo_9a5d0d120faf5ade(C.uintptr_t(_swig_i_0), *(*C.swig_type_12)(unsafe.Pointer(&_swig_i_1))))
+	swig_r = (Enum_SS_telio_result)(C._wrap_Telio_SetPrivateKey_teliogo_979add31dbd463e7(C.uintptr_t(_swig_i_0), *(*C.swig_type_12)(unsafe.Pointer(&_swig_i_1))))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -584,7 +584,7 @@ func (arg1 SwigcptrTelio) SetPrivateKey(arg2 string) (_swig_ret Enum_SS_telio_re
 func (arg1 SwigcptrTelio) GetPrivateKey() (_swig_ret string) {
 	var swig_r string
 	_swig_i_0 := arg1
-	swig_r_p := C._wrap_Telio_GetPrivateKey_teliogo_9a5d0d120faf5ade(C.uintptr_t(_swig_i_0))
+	swig_r_p := C._wrap_Telio_GetPrivateKey_teliogo_979add31dbd463e7(C.uintptr_t(_swig_i_0))
 	swig_r = *(*string)(unsafe.Pointer(&swig_r_p))
 	var swig_r_1 string
  swig_r_1 = swigCopyString(swig_r) 
@@ -595,7 +595,7 @@ func (arg1 SwigcptrTelio) SetFwmark(arg2 uint) (_swig_ret Enum_SS_telio_result) 
 	var swig_r Enum_SS_telio_result
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
-	swig_r = (Enum_SS_telio_result)(C._wrap_Telio_SetFwmark_teliogo_9a5d0d120faf5ade(C.uintptr_t(_swig_i_0), C.swig_intgo(_swig_i_1)))
+	swig_r = (Enum_SS_telio_result)(C._wrap_Telio_SetFwmark_teliogo_979add31dbd463e7(C.uintptr_t(_swig_i_0), C.swig_intgo(_swig_i_1)))
 	return swig_r
 }
 
@@ -603,7 +603,7 @@ func (arg1 SwigcptrTelio) NotifyNetworkChange(arg2 string) (_swig_ret Enum_SS_te
 	var swig_r Enum_SS_telio_result
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
-	swig_r = (Enum_SS_telio_result)(C._wrap_Telio_NotifyNetworkChange_teliogo_9a5d0d120faf5ade(C.uintptr_t(_swig_i_0), *(*C.swig_type_14)(unsafe.Pointer(&_swig_i_1))))
+	swig_r = (Enum_SS_telio_result)(C._wrap_Telio_NotifyNetworkChange_teliogo_979add31dbd463e7(C.uintptr_t(_swig_i_0), *(*C.swig_type_14)(unsafe.Pointer(&_swig_i_1))))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -616,7 +616,7 @@ func (arg1 SwigcptrTelio) ConnectToExitNode(arg2 string, arg3 string, arg4 strin
 	_swig_i_1 := arg2
 	_swig_i_2 := arg3
 	_swig_i_3 := arg4
-	swig_r = (Enum_SS_telio_result)(C._wrap_Telio_ConnectToExitNode_teliogo_9a5d0d120faf5ade(C.uintptr_t(_swig_i_0), *(*C.swig_type_15)(unsafe.Pointer(&_swig_i_1)), *(*C.swig_type_16)(unsafe.Pointer(&_swig_i_2)), *(*C.swig_type_17)(unsafe.Pointer(&_swig_i_3))))
+	swig_r = (Enum_SS_telio_result)(C._wrap_Telio_ConnectToExitNode_teliogo_979add31dbd463e7(C.uintptr_t(_swig_i_0), *(*C.swig_type_15)(unsafe.Pointer(&_swig_i_1)), *(*C.swig_type_16)(unsafe.Pointer(&_swig_i_2)), *(*C.swig_type_17)(unsafe.Pointer(&_swig_i_3))))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -636,7 +636,7 @@ func (arg1 SwigcptrTelio) ConnectToExitNodeWithId(arg2 string, arg3 string, arg4
 	_swig_i_2 := arg3
 	_swig_i_3 := arg4
 	_swig_i_4 := arg5
-	swig_r = (Enum_SS_telio_result)(C._wrap_Telio_ConnectToExitNodeWithId_teliogo_9a5d0d120faf5ade(C.uintptr_t(_swig_i_0), *(*C.swig_type_18)(unsafe.Pointer(&_swig_i_1)), *(*C.swig_type_19)(unsafe.Pointer(&_swig_i_2)), *(*C.swig_type_20)(unsafe.Pointer(&_swig_i_3)), *(*C.swig_type_21)(unsafe.Pointer(&_swig_i_4))))
+	swig_r = (Enum_SS_telio_result)(C._wrap_Telio_ConnectToExitNodeWithId_teliogo_979add31dbd463e7(C.uintptr_t(_swig_i_0), *(*C.swig_type_18)(unsafe.Pointer(&_swig_i_1)), *(*C.swig_type_19)(unsafe.Pointer(&_swig_i_2)), *(*C.swig_type_20)(unsafe.Pointer(&_swig_i_3)), *(*C.swig_type_21)(unsafe.Pointer(&_swig_i_4))))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -656,7 +656,7 @@ func (arg1 SwigcptrTelio) DisconnectFromExitNode(arg2 string) (_swig_ret Enum_SS
 	var swig_r Enum_SS_telio_result
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
-	swig_r = (Enum_SS_telio_result)(C._wrap_Telio_DisconnectFromExitNode_teliogo_9a5d0d120faf5ade(C.uintptr_t(_swig_i_0), *(*C.swig_type_22)(unsafe.Pointer(&_swig_i_1))))
+	swig_r = (Enum_SS_telio_result)(C._wrap_Telio_DisconnectFromExitNode_teliogo_979add31dbd463e7(C.uintptr_t(_swig_i_0), *(*C.swig_type_22)(unsafe.Pointer(&_swig_i_1))))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -666,7 +666,7 @@ func (arg1 SwigcptrTelio) DisconnectFromExitNode(arg2 string) (_swig_ret Enum_SS
 func (arg1 SwigcptrTelio) DisconnectFromExitNodes() (_swig_ret Enum_SS_telio_result) {
 	var swig_r Enum_SS_telio_result
 	_swig_i_0 := arg1
-	swig_r = (Enum_SS_telio_result)(C._wrap_Telio_DisconnectFromExitNodes_teliogo_9a5d0d120faf5ade(C.uintptr_t(_swig_i_0)))
+	swig_r = (Enum_SS_telio_result)(C._wrap_Telio_DisconnectFromExitNodes_teliogo_979add31dbd463e7(C.uintptr_t(_swig_i_0)))
 	return swig_r
 }
 
@@ -674,7 +674,7 @@ func (arg1 SwigcptrTelio) SetMeshnet(arg2 string) (_swig_ret Enum_SS_telio_resul
 	var swig_r Enum_SS_telio_result
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
-	swig_r = (Enum_SS_telio_result)(C._wrap_Telio_SetMeshnet_teliogo_9a5d0d120faf5ade(C.uintptr_t(_swig_i_0), *(*C.swig_type_23)(unsafe.Pointer(&_swig_i_1))))
+	swig_r = (Enum_SS_telio_result)(C._wrap_Telio_SetMeshnet_teliogo_979add31dbd463e7(C.uintptr_t(_swig_i_0), *(*C.swig_type_23)(unsafe.Pointer(&_swig_i_1))))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -684,14 +684,14 @@ func (arg1 SwigcptrTelio) SetMeshnet(arg2 string) (_swig_ret Enum_SS_telio_resul
 func (arg1 SwigcptrTelio) SetMeshnetOff() (_swig_ret Enum_SS_telio_result) {
 	var swig_r Enum_SS_telio_result
 	_swig_i_0 := arg1
-	swig_r = (Enum_SS_telio_result)(C._wrap_Telio_SetMeshnetOff_teliogo_9a5d0d120faf5ade(C.uintptr_t(_swig_i_0)))
+	swig_r = (Enum_SS_telio_result)(C._wrap_Telio_SetMeshnetOff_teliogo_979add31dbd463e7(C.uintptr_t(_swig_i_0)))
 	return swig_r
 }
 
 func (arg1 SwigcptrTelio) GenerateSecretKey() (_swig_ret string) {
 	var swig_r string
 	_swig_i_0 := arg1
-	swig_r_p := C._wrap_Telio_GenerateSecretKey_teliogo_9a5d0d120faf5ade(C.uintptr_t(_swig_i_0))
+	swig_r_p := C._wrap_Telio_GenerateSecretKey_teliogo_979add31dbd463e7(C.uintptr_t(_swig_i_0))
 	swig_r = *(*string)(unsafe.Pointer(&swig_r_p))
 	var swig_r_1 string
  swig_r_1 = swigCopyString(swig_r) 
@@ -702,7 +702,7 @@ func (arg1 SwigcptrTelio) GeneratePublicKey(arg2 string) (_swig_ret string) {
 	var swig_r string
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
-	swig_r_p := C._wrap_Telio_GeneratePublicKey_teliogo_9a5d0d120faf5ade(C.uintptr_t(_swig_i_0), *(*C.swig_type_26)(unsafe.Pointer(&_swig_i_1)))
+	swig_r_p := C._wrap_Telio_GeneratePublicKey_teliogo_979add31dbd463e7(C.uintptr_t(_swig_i_0), *(*C.swig_type_26)(unsafe.Pointer(&_swig_i_1)))
 	swig_r = *(*string)(unsafe.Pointer(&swig_r_p))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
@@ -715,7 +715,7 @@ func (arg1 SwigcptrTelio) GeneratePublicKey(arg2 string) (_swig_ret string) {
 func (arg1 SwigcptrTelio) GetStatusMap() (_swig_ret string) {
 	var swig_r string
 	_swig_i_0 := arg1
-	swig_r_p := C._wrap_Telio_GetStatusMap_teliogo_9a5d0d120faf5ade(C.uintptr_t(_swig_i_0))
+	swig_r_p := C._wrap_Telio_GetStatusMap_teliogo_979add31dbd463e7(C.uintptr_t(_swig_i_0))
 	swig_r = *(*string)(unsafe.Pointer(&swig_r_p))
 	var swig_r_1 string
  swig_r_1 = swigCopyString(swig_r) 
@@ -725,7 +725,7 @@ func (arg1 SwigcptrTelio) GetStatusMap() (_swig_ret string) {
 func (arg1 SwigcptrTelio) GetLastError() (_swig_ret string) {
 	var swig_r string
 	_swig_i_0 := arg1
-	swig_r_p := C._wrap_Telio_GetLastError_teliogo_9a5d0d120faf5ade(C.uintptr_t(_swig_i_0))
+	swig_r_p := C._wrap_Telio_GetLastError_teliogo_979add31dbd463e7(C.uintptr_t(_swig_i_0))
 	swig_r = *(*string)(unsafe.Pointer(&swig_r_p))
 	var swig_r_1 string
  swig_r_1 = swigCopyString(swig_r) 
@@ -734,7 +734,7 @@ func (arg1 SwigcptrTelio) GetLastError() (_swig_ret string) {
 
 func TelioGetVersionTag() (_swig_ret string) {
 	var swig_r string
-	swig_r_p := C._wrap_Telio_GetVersionTag_teliogo_9a5d0d120faf5ade()
+	swig_r_p := C._wrap_Telio_GetVersionTag_teliogo_979add31dbd463e7()
 	swig_r = *(*string)(unsafe.Pointer(&swig_r_p))
 	var swig_r_1 string
  swig_r_1 = swigCopyString(swig_r) 
@@ -743,7 +743,7 @@ func TelioGetVersionTag() (_swig_ret string) {
 
 func TelioGetCommitSha() (_swig_ret string) {
 	var swig_r string
-	swig_r_p := C._wrap_Telio_GetCommitSha_teliogo_9a5d0d120faf5ade()
+	swig_r_p := C._wrap_Telio_GetCommitSha_teliogo_979add31dbd463e7()
 	swig_r = *(*string)(unsafe.Pointer(&swig_r_p))
 	var swig_r_1 string
  swig_r_1 = swigCopyString(swig_r) 

--- a/ffi/bindings/linux/wrap/go_wrap.c
+++ b/ffi/bindings/linux/wrap/go_wrap.c
@@ -241,7 +241,7 @@ SWIGINTERN void delete_telio(struct telio *self){
 extern "C" {
 #endif
 
-void _wrap_Swig_free_teliogo_9a5d0d120faf5ade(void *_swig_go_0) {
+void _wrap_Swig_free_teliogo_979add31dbd463e7(void *_swig_go_0) {
   void *arg1 = (void *) 0 ;
   
   arg1 = *(void **)&_swig_go_0; 
@@ -251,7 +251,7 @@ void _wrap_Swig_free_teliogo_9a5d0d120faf5ade(void *_swig_go_0) {
 }
 
 
-void *_wrap_Swig_malloc_teliogo_9a5d0d120faf5ade(intgo _swig_go_0) {
+void *_wrap_Swig_malloc_teliogo_979add31dbd463e7(intgo _swig_go_0) {
   int arg1 ;
   void *result = 0 ;
   void *_swig_go_result;
@@ -264,7 +264,7 @@ void *_wrap_Swig_malloc_teliogo_9a5d0d120faf5ade(intgo _swig_go_0) {
 }
 
 
-intgo _wrap_TELIOADAPTERBORINGTUN_teliogo_9a5d0d120faf5ade() {
+intgo _wrap_TELIOADAPTERBORINGTUN_teliogo_979add31dbd463e7() {
   enum telio_adapter_type result;
   intgo _swig_go_result;
   
@@ -276,7 +276,7 @@ intgo _wrap_TELIOADAPTERBORINGTUN_teliogo_9a5d0d120faf5ade() {
 }
 
 
-intgo _wrap_TELIOADAPTERLINUXNATIVETUN_teliogo_9a5d0d120faf5ade() {
+intgo _wrap_TELIOADAPTERLINUXNATIVETUN_teliogo_979add31dbd463e7() {
   enum telio_adapter_type result;
   intgo _swig_go_result;
   
@@ -288,7 +288,7 @@ intgo _wrap_TELIOADAPTERLINUXNATIVETUN_teliogo_9a5d0d120faf5ade() {
 }
 
 
-intgo _wrap_TELIOADAPTERWIREGUARDGOTUN_teliogo_9a5d0d120faf5ade() {
+intgo _wrap_TELIOADAPTERWIREGUARDGOTUN_teliogo_979add31dbd463e7() {
   enum telio_adapter_type result;
   intgo _swig_go_result;
   
@@ -300,7 +300,7 @@ intgo _wrap_TELIOADAPTERWIREGUARDGOTUN_teliogo_9a5d0d120faf5ade() {
 }
 
 
-intgo _wrap_TELIOADAPTERWINDOWSNATIVETUN_teliogo_9a5d0d120faf5ade() {
+intgo _wrap_TELIOADAPTERWINDOWSNATIVETUN_teliogo_979add31dbd463e7() {
   enum telio_adapter_type result;
   intgo _swig_go_result;
   
@@ -312,7 +312,7 @@ intgo _wrap_TELIOADAPTERWINDOWSNATIVETUN_teliogo_9a5d0d120faf5ade() {
 }
 
 
-intgo _wrap_TELIOLOGCRITICAL_teliogo_9a5d0d120faf5ade() {
+intgo _wrap_TELIOLOGCRITICAL_teliogo_979add31dbd463e7() {
   enum telio_log_level result;
   intgo _swig_go_result;
   
@@ -324,7 +324,7 @@ intgo _wrap_TELIOLOGCRITICAL_teliogo_9a5d0d120faf5ade() {
 }
 
 
-intgo _wrap_TELIOLOGERROR_teliogo_9a5d0d120faf5ade() {
+intgo _wrap_TELIOLOGERROR_teliogo_979add31dbd463e7() {
   enum telio_log_level result;
   intgo _swig_go_result;
   
@@ -336,7 +336,7 @@ intgo _wrap_TELIOLOGERROR_teliogo_9a5d0d120faf5ade() {
 }
 
 
-intgo _wrap_TELIOLOGWARNING_teliogo_9a5d0d120faf5ade() {
+intgo _wrap_TELIOLOGWARNING_teliogo_979add31dbd463e7() {
   enum telio_log_level result;
   intgo _swig_go_result;
   
@@ -348,7 +348,7 @@ intgo _wrap_TELIOLOGWARNING_teliogo_9a5d0d120faf5ade() {
 }
 
 
-intgo _wrap_TELIOLOGINFO_teliogo_9a5d0d120faf5ade() {
+intgo _wrap_TELIOLOGINFO_teliogo_979add31dbd463e7() {
   enum telio_log_level result;
   intgo _swig_go_result;
   
@@ -360,7 +360,7 @@ intgo _wrap_TELIOLOGINFO_teliogo_9a5d0d120faf5ade() {
 }
 
 
-intgo _wrap_TELIOLOGDEBUG_teliogo_9a5d0d120faf5ade() {
+intgo _wrap_TELIOLOGDEBUG_teliogo_979add31dbd463e7() {
   enum telio_log_level result;
   intgo _swig_go_result;
   
@@ -372,7 +372,7 @@ intgo _wrap_TELIOLOGDEBUG_teliogo_9a5d0d120faf5ade() {
 }
 
 
-intgo _wrap_TELIOLOGTRACE_teliogo_9a5d0d120faf5ade() {
+intgo _wrap_TELIOLOGTRACE_teliogo_979add31dbd463e7() {
   enum telio_log_level result;
   intgo _swig_go_result;
   
@@ -384,7 +384,7 @@ intgo _wrap_TELIOLOGTRACE_teliogo_9a5d0d120faf5ade() {
 }
 
 
-intgo _wrap_TELIORESOK_teliogo_9a5d0d120faf5ade() {
+intgo _wrap_TELIORESOK_teliogo_979add31dbd463e7() {
   enum telio_result result;
   intgo _swig_go_result;
   
@@ -396,7 +396,7 @@ intgo _wrap_TELIORESOK_teliogo_9a5d0d120faf5ade() {
 }
 
 
-intgo _wrap_TELIORESERROR_teliogo_9a5d0d120faf5ade() {
+intgo _wrap_TELIORESERROR_teliogo_979add31dbd463e7() {
   enum telio_result result;
   intgo _swig_go_result;
   
@@ -408,7 +408,7 @@ intgo _wrap_TELIORESERROR_teliogo_9a5d0d120faf5ade() {
 }
 
 
-intgo _wrap_TELIORESINVALIDKEY_teliogo_9a5d0d120faf5ade() {
+intgo _wrap_TELIORESINVALIDKEY_teliogo_979add31dbd463e7() {
   enum telio_result result;
   intgo _swig_go_result;
   
@@ -420,7 +420,7 @@ intgo _wrap_TELIORESINVALIDKEY_teliogo_9a5d0d120faf5ade() {
 }
 
 
-intgo _wrap_TELIORESBADCONFIG_teliogo_9a5d0d120faf5ade() {
+intgo _wrap_TELIORESBADCONFIG_teliogo_979add31dbd463e7() {
   enum telio_result result;
   intgo _swig_go_result;
   
@@ -432,7 +432,7 @@ intgo _wrap_TELIORESBADCONFIG_teliogo_9a5d0d120faf5ade() {
 }
 
 
-intgo _wrap_TELIORESLOCKERROR_teliogo_9a5d0d120faf5ade() {
+intgo _wrap_TELIORESLOCKERROR_teliogo_979add31dbd463e7() {
   enum telio_result result;
   intgo _swig_go_result;
   
@@ -444,7 +444,7 @@ intgo _wrap_TELIORESLOCKERROR_teliogo_9a5d0d120faf5ade() {
 }
 
 
-intgo _wrap_TELIORESINVALIDSTRING_teliogo_9a5d0d120faf5ade() {
+intgo _wrap_TELIORESINVALIDSTRING_teliogo_979add31dbd463e7() {
   enum telio_result result;
   intgo _swig_go_result;
   
@@ -456,7 +456,7 @@ intgo _wrap_TELIORESINVALIDSTRING_teliogo_9a5d0d120faf5ade() {
 }
 
 
-intgo _wrap_TELIORESALREADYSTARTED_teliogo_9a5d0d120faf5ade() {
+intgo _wrap_TELIORESALREADYSTARTED_teliogo_979add31dbd463e7() {
   enum telio_result result;
   intgo _swig_go_result;
   
@@ -468,7 +468,7 @@ intgo _wrap_TELIORESALREADYSTARTED_teliogo_9a5d0d120faf5ade() {
 }
 
 
-void _wrap_TelioEventCb_Ctx_set_teliogo_9a5d0d120faf5ade(struct telio_event_cb *_swig_go_0, void *_swig_go_1) {
+void _wrap_TelioEventCb_Ctx_set_teliogo_979add31dbd463e7(struct telio_event_cb *_swig_go_0, void *_swig_go_1) {
   struct telio_event_cb *arg1 = (struct telio_event_cb *) 0 ;
   void *arg2 = (void *) 0 ;
   
@@ -480,7 +480,7 @@ void _wrap_TelioEventCb_Ctx_set_teliogo_9a5d0d120faf5ade(struct telio_event_cb *
 }
 
 
-void *_wrap_TelioEventCb_Ctx_get_teliogo_9a5d0d120faf5ade(struct telio_event_cb *_swig_go_0) {
+void *_wrap_TelioEventCb_Ctx_get_teliogo_979add31dbd463e7(struct telio_event_cb *_swig_go_0) {
   struct telio_event_cb *arg1 = (struct telio_event_cb *) 0 ;
   void *result = 0 ;
   void *_swig_go_result;
@@ -493,7 +493,7 @@ void *_wrap_TelioEventCb_Ctx_get_teliogo_9a5d0d120faf5ade(struct telio_event_cb 
 }
 
 
-void _wrap_TelioEventCb_Cb_set_teliogo_9a5d0d120faf5ade(struct telio_event_cb *_swig_go_0, void* _swig_go_1) {
+void _wrap_TelioEventCb_Cb_set_teliogo_979add31dbd463e7(struct telio_event_cb *_swig_go_0, void* _swig_go_1) {
   struct telio_event_cb *arg1 = (struct telio_event_cb *) 0 ;
   telio_event_fn arg2 = (telio_event_fn) 0 ;
   
@@ -505,7 +505,7 @@ void _wrap_TelioEventCb_Cb_set_teliogo_9a5d0d120faf5ade(struct telio_event_cb *_
 }
 
 
-void* _wrap_TelioEventCb_Cb_get_teliogo_9a5d0d120faf5ade(struct telio_event_cb *_swig_go_0) {
+void* _wrap_TelioEventCb_Cb_get_teliogo_979add31dbd463e7(struct telio_event_cb *_swig_go_0) {
   struct telio_event_cb *arg1 = (struct telio_event_cb *) 0 ;
   telio_event_fn result;
   void* _swig_go_result;
@@ -518,7 +518,7 @@ void* _wrap_TelioEventCb_Cb_get_teliogo_9a5d0d120faf5ade(struct telio_event_cb *
 }
 
 
-struct telio_event_cb *_wrap_new_TelioEventCb_teliogo_9a5d0d120faf5ade() {
+struct telio_event_cb *_wrap_new_TelioEventCb_teliogo_979add31dbd463e7() {
   struct telio_event_cb *result = 0 ;
   struct telio_event_cb *_swig_go_result;
   
@@ -529,7 +529,7 @@ struct telio_event_cb *_wrap_new_TelioEventCb_teliogo_9a5d0d120faf5ade() {
 }
 
 
-void _wrap_delete_TelioEventCb_teliogo_9a5d0d120faf5ade(struct telio_event_cb *_swig_go_0) {
+void _wrap_delete_TelioEventCb_teliogo_979add31dbd463e7(struct telio_event_cb *_swig_go_0) {
   struct telio_event_cb *arg1 = (struct telio_event_cb *) 0 ;
   
   arg1 = *(struct telio_event_cb **)&_swig_go_0; 
@@ -539,7 +539,7 @@ void _wrap_delete_TelioEventCb_teliogo_9a5d0d120faf5ade(struct telio_event_cb *_
 }
 
 
-void _wrap_TelioLoggerCb_Ctx_set_teliogo_9a5d0d120faf5ade(struct telio_logger_cb *_swig_go_0, void *_swig_go_1) {
+void _wrap_TelioLoggerCb_Ctx_set_teliogo_979add31dbd463e7(struct telio_logger_cb *_swig_go_0, void *_swig_go_1) {
   struct telio_logger_cb *arg1 = (struct telio_logger_cb *) 0 ;
   void *arg2 = (void *) 0 ;
   
@@ -551,7 +551,7 @@ void _wrap_TelioLoggerCb_Ctx_set_teliogo_9a5d0d120faf5ade(struct telio_logger_cb
 }
 
 
-void *_wrap_TelioLoggerCb_Ctx_get_teliogo_9a5d0d120faf5ade(struct telio_logger_cb *_swig_go_0) {
+void *_wrap_TelioLoggerCb_Ctx_get_teliogo_979add31dbd463e7(struct telio_logger_cb *_swig_go_0) {
   struct telio_logger_cb *arg1 = (struct telio_logger_cb *) 0 ;
   void *result = 0 ;
   void *_swig_go_result;
@@ -564,7 +564,7 @@ void *_wrap_TelioLoggerCb_Ctx_get_teliogo_9a5d0d120faf5ade(struct telio_logger_c
 }
 
 
-void _wrap_TelioLoggerCb_Cb_set_teliogo_9a5d0d120faf5ade(struct telio_logger_cb *_swig_go_0, void* _swig_go_1) {
+void _wrap_TelioLoggerCb_Cb_set_teliogo_979add31dbd463e7(struct telio_logger_cb *_swig_go_0, void* _swig_go_1) {
   struct telio_logger_cb *arg1 = (struct telio_logger_cb *) 0 ;
   telio_logger_fn arg2 = (telio_logger_fn) 0 ;
   
@@ -576,7 +576,7 @@ void _wrap_TelioLoggerCb_Cb_set_teliogo_9a5d0d120faf5ade(struct telio_logger_cb 
 }
 
 
-void* _wrap_TelioLoggerCb_Cb_get_teliogo_9a5d0d120faf5ade(struct telio_logger_cb *_swig_go_0) {
+void* _wrap_TelioLoggerCb_Cb_get_teliogo_979add31dbd463e7(struct telio_logger_cb *_swig_go_0) {
   struct telio_logger_cb *arg1 = (struct telio_logger_cb *) 0 ;
   telio_logger_fn result;
   void* _swig_go_result;
@@ -589,7 +589,7 @@ void* _wrap_TelioLoggerCb_Cb_get_teliogo_9a5d0d120faf5ade(struct telio_logger_cb
 }
 
 
-struct telio_logger_cb *_wrap_new_TelioLoggerCb_teliogo_9a5d0d120faf5ade() {
+struct telio_logger_cb *_wrap_new_TelioLoggerCb_teliogo_979add31dbd463e7() {
   struct telio_logger_cb *result = 0 ;
   struct telio_logger_cb *_swig_go_result;
   
@@ -600,7 +600,7 @@ struct telio_logger_cb *_wrap_new_TelioLoggerCb_teliogo_9a5d0d120faf5ade() {
 }
 
 
-void _wrap_delete_TelioLoggerCb_teliogo_9a5d0d120faf5ade(struct telio_logger_cb *_swig_go_0) {
+void _wrap_delete_TelioLoggerCb_teliogo_979add31dbd463e7(struct telio_logger_cb *_swig_go_0) {
   struct telio_logger_cb *arg1 = (struct telio_logger_cb *) 0 ;
   
   arg1 = *(struct telio_logger_cb **)&_swig_go_0; 
@@ -610,7 +610,7 @@ void _wrap_delete_TelioLoggerCb_teliogo_9a5d0d120faf5ade(struct telio_logger_cb 
 }
 
 
-intgo _wrap_Telio_GetDefaultAdapter_teliogo_9a5d0d120faf5ade() {
+intgo _wrap_Telio_GetDefaultAdapter_teliogo_979add31dbd463e7() {
   enum telio_adapter_type result;
   intgo _swig_go_result;
   
@@ -621,7 +621,7 @@ intgo _wrap_Telio_GetDefaultAdapter_teliogo_9a5d0d120faf5ade() {
 }
 
 
-struct telio *_wrap_new_Telio_teliogo_9a5d0d120faf5ade(_gostring_ _swig_go_0, telio_event_cb _swig_go_1, intgo _swig_go_2, telio_logger_cb _swig_go_3) {
+struct telio *_wrap_new_Telio_teliogo_979add31dbd463e7(_gostring_ _swig_go_0, telio_event_cb _swig_go_1, intgo _swig_go_2, telio_logger_cb _swig_go_3) {
   char *arg1 = (char *) 0 ;
   telio_event_cb arg2 ;
   enum telio_log_level arg3 ;
@@ -649,7 +649,7 @@ struct telio *_wrap_new_Telio_teliogo_9a5d0d120faf5ade(_gostring_ _swig_go_0, te
 }
 
 
-void _wrap_delete_Telio_teliogo_9a5d0d120faf5ade(struct telio *_swig_go_0) {
+void _wrap_delete_Telio_teliogo_979add31dbd463e7(struct telio *_swig_go_0) {
   struct telio *arg1 = (struct telio *) 0 ;
   
   arg1 = *(struct telio **)&_swig_go_0; 
@@ -659,7 +659,7 @@ void _wrap_delete_Telio_teliogo_9a5d0d120faf5ade(struct telio *_swig_go_0) {
 }
 
 
-intgo _wrap_Telio_Start_teliogo_9a5d0d120faf5ade(struct telio *_swig_go_0, _gostring_ _swig_go_1, intgo _swig_go_2) {
+intgo _wrap_Telio_Start_teliogo_979add31dbd463e7(struct telio *_swig_go_0, _gostring_ _swig_go_1, intgo _swig_go_2) {
   struct telio *arg1 = (struct telio *) 0 ;
   char *arg2 = (char *) 0 ;
   enum telio_adapter_type arg3 ;
@@ -681,7 +681,7 @@ intgo _wrap_Telio_Start_teliogo_9a5d0d120faf5ade(struct telio *_swig_go_0, _gost
 }
 
 
-intgo _wrap_Telio_StartNamed_teliogo_9a5d0d120faf5ade(struct telio *_swig_go_0, _gostring_ _swig_go_1, intgo _swig_go_2, _gostring_ _swig_go_3) {
+intgo _wrap_Telio_StartNamed_teliogo_979add31dbd463e7(struct telio *_swig_go_0, _gostring_ _swig_go_1, intgo _swig_go_2, _gostring_ _swig_go_3) {
   struct telio *arg1 = (struct telio *) 0 ;
   char *arg2 = (char *) 0 ;
   enum telio_adapter_type arg3 ;
@@ -710,7 +710,7 @@ intgo _wrap_Telio_StartNamed_teliogo_9a5d0d120faf5ade(struct telio *_swig_go_0, 
 }
 
 
-intgo _wrap_Telio_StartWithTun_teliogo_9a5d0d120faf5ade(struct telio *_swig_go_0, _gostring_ _swig_go_1, intgo _swig_go_2, intgo _swig_go_3) {
+intgo _wrap_Telio_StartWithTun_teliogo_979add31dbd463e7(struct telio *_swig_go_0, _gostring_ _swig_go_1, intgo _swig_go_2, intgo _swig_go_3) {
   struct telio *arg1 = (struct telio *) 0 ;
   char *arg2 = (char *) 0 ;
   enum telio_adapter_type arg3 ;
@@ -734,7 +734,7 @@ intgo _wrap_Telio_StartWithTun_teliogo_9a5d0d120faf5ade(struct telio *_swig_go_0
 }
 
 
-intgo _wrap_Telio_EnableMagicDns_teliogo_9a5d0d120faf5ade(struct telio *_swig_go_0, _gostring_ _swig_go_1) {
+intgo _wrap_Telio_EnableMagicDns_teliogo_979add31dbd463e7(struct telio *_swig_go_0, _gostring_ _swig_go_1) {
   struct telio *arg1 = (struct telio *) 0 ;
   char *arg2 = (char *) 0 ;
   enum telio_result result;
@@ -754,7 +754,7 @@ intgo _wrap_Telio_EnableMagicDns_teliogo_9a5d0d120faf5ade(struct telio *_swig_go
 }
 
 
-intgo _wrap_Telio_DisableMagicDns_teliogo_9a5d0d120faf5ade(struct telio *_swig_go_0) {
+intgo _wrap_Telio_DisableMagicDns_teliogo_979add31dbd463e7(struct telio *_swig_go_0) {
   struct telio *arg1 = (struct telio *) 0 ;
   enum telio_result result;
   intgo _swig_go_result;
@@ -767,7 +767,7 @@ intgo _wrap_Telio_DisableMagicDns_teliogo_9a5d0d120faf5ade(struct telio *_swig_g
 }
 
 
-intgo _wrap_Telio_Stop_teliogo_9a5d0d120faf5ade(struct telio *_swig_go_0) {
+intgo _wrap_Telio_Stop_teliogo_979add31dbd463e7(struct telio *_swig_go_0) {
   struct telio *arg1 = (struct telio *) 0 ;
   enum telio_result result;
   intgo _swig_go_result;
@@ -780,7 +780,7 @@ intgo _wrap_Telio_Stop_teliogo_9a5d0d120faf5ade(struct telio *_swig_go_0) {
 }
 
 
-long long _wrap_Telio_GetAdapterLuid_teliogo_9a5d0d120faf5ade(struct telio *_swig_go_0) {
+long long _wrap_Telio_GetAdapterLuid_teliogo_979add31dbd463e7(struct telio *_swig_go_0) {
   struct telio *arg1 = (struct telio *) 0 ;
   unsigned long long result;
   long long _swig_go_result;
@@ -793,7 +793,7 @@ long long _wrap_Telio_GetAdapterLuid_teliogo_9a5d0d120faf5ade(struct telio *_swi
 }
 
 
-intgo _wrap_Telio_SetPrivateKey_teliogo_9a5d0d120faf5ade(struct telio *_swig_go_0, _gostring_ _swig_go_1) {
+intgo _wrap_Telio_SetPrivateKey_teliogo_979add31dbd463e7(struct telio *_swig_go_0, _gostring_ _swig_go_1) {
   struct telio *arg1 = (struct telio *) 0 ;
   char *arg2 = (char *) 0 ;
   enum telio_result result;
@@ -813,7 +813,7 @@ intgo _wrap_Telio_SetPrivateKey_teliogo_9a5d0d120faf5ade(struct telio *_swig_go_
 }
 
 
-_gostring_ _wrap_Telio_GetPrivateKey_teliogo_9a5d0d120faf5ade(struct telio *_swig_go_0) {
+_gostring_ _wrap_Telio_GetPrivateKey_teliogo_979add31dbd463e7(struct telio *_swig_go_0) {
   struct telio *arg1 = (struct telio *) 0 ;
   char *result = 0 ;
   _gostring_ _swig_go_result;
@@ -826,7 +826,7 @@ _gostring_ _wrap_Telio_GetPrivateKey_teliogo_9a5d0d120faf5ade(struct telio *_swi
 }
 
 
-intgo _wrap_Telio_SetFwmark_teliogo_9a5d0d120faf5ade(struct telio *_swig_go_0, intgo _swig_go_1) {
+intgo _wrap_Telio_SetFwmark_teliogo_979add31dbd463e7(struct telio *_swig_go_0, intgo _swig_go_1) {
   struct telio *arg1 = (struct telio *) 0 ;
   unsigned int arg2 ;
   enum telio_result result;
@@ -841,7 +841,7 @@ intgo _wrap_Telio_SetFwmark_teliogo_9a5d0d120faf5ade(struct telio *_swig_go_0, i
 }
 
 
-intgo _wrap_Telio_NotifyNetworkChange_teliogo_9a5d0d120faf5ade(struct telio *_swig_go_0, _gostring_ _swig_go_1) {
+intgo _wrap_Telio_NotifyNetworkChange_teliogo_979add31dbd463e7(struct telio *_swig_go_0, _gostring_ _swig_go_1) {
   struct telio *arg1 = (struct telio *) 0 ;
   char *arg2 = (char *) 0 ;
   enum telio_result result;
@@ -861,7 +861,7 @@ intgo _wrap_Telio_NotifyNetworkChange_teliogo_9a5d0d120faf5ade(struct telio *_sw
 }
 
 
-intgo _wrap_Telio_ConnectToExitNode_teliogo_9a5d0d120faf5ade(struct telio *_swig_go_0, _gostring_ _swig_go_1, _gostring_ _swig_go_2, _gostring_ _swig_go_3) {
+intgo _wrap_Telio_ConnectToExitNode_teliogo_979add31dbd463e7(struct telio *_swig_go_0, _gostring_ _swig_go_1, _gostring_ _swig_go_2, _gostring_ _swig_go_3) {
   struct telio *arg1 = (struct telio *) 0 ;
   char *arg2 = (char *) 0 ;
   char *arg3 = (char *) 0 ;
@@ -895,7 +895,7 @@ intgo _wrap_Telio_ConnectToExitNode_teliogo_9a5d0d120faf5ade(struct telio *_swig
 }
 
 
-intgo _wrap_Telio_ConnectToExitNodeWithId_teliogo_9a5d0d120faf5ade(struct telio *_swig_go_0, _gostring_ _swig_go_1, _gostring_ _swig_go_2, _gostring_ _swig_go_3, _gostring_ _swig_go_4) {
+intgo _wrap_Telio_ConnectToExitNodeWithId_teliogo_979add31dbd463e7(struct telio *_swig_go_0, _gostring_ _swig_go_1, _gostring_ _swig_go_2, _gostring_ _swig_go_3, _gostring_ _swig_go_4) {
   struct telio *arg1 = (struct telio *) 0 ;
   char *arg2 = (char *) 0 ;
   char *arg3 = (char *) 0 ;
@@ -936,7 +936,7 @@ intgo _wrap_Telio_ConnectToExitNodeWithId_teliogo_9a5d0d120faf5ade(struct telio 
 }
 
 
-intgo _wrap_Telio_DisconnectFromExitNode_teliogo_9a5d0d120faf5ade(struct telio *_swig_go_0, _gostring_ _swig_go_1) {
+intgo _wrap_Telio_DisconnectFromExitNode_teliogo_979add31dbd463e7(struct telio *_swig_go_0, _gostring_ _swig_go_1) {
   struct telio *arg1 = (struct telio *) 0 ;
   char *arg2 = (char *) 0 ;
   enum telio_result result;
@@ -956,7 +956,7 @@ intgo _wrap_Telio_DisconnectFromExitNode_teliogo_9a5d0d120faf5ade(struct telio *
 }
 
 
-intgo _wrap_Telio_DisconnectFromExitNodes_teliogo_9a5d0d120faf5ade(struct telio *_swig_go_0) {
+intgo _wrap_Telio_DisconnectFromExitNodes_teliogo_979add31dbd463e7(struct telio *_swig_go_0) {
   struct telio *arg1 = (struct telio *) 0 ;
   enum telio_result result;
   intgo _swig_go_result;
@@ -969,7 +969,7 @@ intgo _wrap_Telio_DisconnectFromExitNodes_teliogo_9a5d0d120faf5ade(struct telio 
 }
 
 
-intgo _wrap_Telio_SetMeshnet_teliogo_9a5d0d120faf5ade(struct telio *_swig_go_0, _gostring_ _swig_go_1) {
+intgo _wrap_Telio_SetMeshnet_teliogo_979add31dbd463e7(struct telio *_swig_go_0, _gostring_ _swig_go_1) {
   struct telio *arg1 = (struct telio *) 0 ;
   char *arg2 = (char *) 0 ;
   enum telio_result result;
@@ -989,7 +989,7 @@ intgo _wrap_Telio_SetMeshnet_teliogo_9a5d0d120faf5ade(struct telio *_swig_go_0, 
 }
 
 
-intgo _wrap_Telio_SetMeshnetOff_teliogo_9a5d0d120faf5ade(struct telio *_swig_go_0) {
+intgo _wrap_Telio_SetMeshnetOff_teliogo_979add31dbd463e7(struct telio *_swig_go_0) {
   struct telio *arg1 = (struct telio *) 0 ;
   enum telio_result result;
   intgo _swig_go_result;
@@ -1002,7 +1002,7 @@ intgo _wrap_Telio_SetMeshnetOff_teliogo_9a5d0d120faf5ade(struct telio *_swig_go_
 }
 
 
-_gostring_ _wrap_Telio_GenerateSecretKey_teliogo_9a5d0d120faf5ade(struct telio *_swig_go_0) {
+_gostring_ _wrap_Telio_GenerateSecretKey_teliogo_979add31dbd463e7(struct telio *_swig_go_0) {
   struct telio *arg1 = (struct telio *) 0 ;
   char *result = 0 ;
   _gostring_ _swig_go_result;
@@ -1016,7 +1016,7 @@ _gostring_ _wrap_Telio_GenerateSecretKey_teliogo_9a5d0d120faf5ade(struct telio *
 }
 
 
-_gostring_ _wrap_Telio_GeneratePublicKey_teliogo_9a5d0d120faf5ade(struct telio *_swig_go_0, _gostring_ _swig_go_1) {
+_gostring_ _wrap_Telio_GeneratePublicKey_teliogo_979add31dbd463e7(struct telio *_swig_go_0, _gostring_ _swig_go_1) {
   struct telio *arg1 = (struct telio *) 0 ;
   char *arg2 = (char *) 0 ;
   char *result = 0 ;
@@ -1037,7 +1037,7 @@ _gostring_ _wrap_Telio_GeneratePublicKey_teliogo_9a5d0d120faf5ade(struct telio *
 }
 
 
-_gostring_ _wrap_Telio_GetStatusMap_teliogo_9a5d0d120faf5ade(struct telio *_swig_go_0) {
+_gostring_ _wrap_Telio_GetStatusMap_teliogo_979add31dbd463e7(struct telio *_swig_go_0) {
   struct telio *arg1 = (struct telio *) 0 ;
   char *result = 0 ;
   _gostring_ _swig_go_result;
@@ -1051,7 +1051,7 @@ _gostring_ _wrap_Telio_GetStatusMap_teliogo_9a5d0d120faf5ade(struct telio *_swig
 }
 
 
-_gostring_ _wrap_Telio_GetLastError_teliogo_9a5d0d120faf5ade(struct telio *_swig_go_0) {
+_gostring_ _wrap_Telio_GetLastError_teliogo_979add31dbd463e7(struct telio *_swig_go_0) {
   struct telio *arg1 = (struct telio *) 0 ;
   char *result = 0 ;
   _gostring_ _swig_go_result;
@@ -1065,7 +1065,7 @@ _gostring_ _wrap_Telio_GetLastError_teliogo_9a5d0d120faf5ade(struct telio *_swig
 }
 
 
-_gostring_ _wrap_Telio_GetVersionTag_teliogo_9a5d0d120faf5ade() {
+_gostring_ _wrap_Telio_GetVersionTag_teliogo_979add31dbd463e7() {
   char *result = 0 ;
   _gostring_ _swig_go_result;
   
@@ -1077,7 +1077,7 @@ _gostring_ _wrap_Telio_GetVersionTag_teliogo_9a5d0d120faf5ade() {
 }
 
 
-_gostring_ _wrap_Telio_GetCommitSha_teliogo_9a5d0d120faf5ade() {
+_gostring_ _wrap_Telio_GetCommitSha_teliogo_979add31dbd463e7() {
   char *result = 0 ;
   _gostring_ _swig_go_result;
   

--- a/ffi/bindings/telio.h
+++ b/ffi/bindings/telio.h
@@ -154,6 +154,18 @@ enum telio_result telio_new(struct telio **dev,
 
 #if defined(__ANDROID__)
 /**
+ * Initialize OS certificate store, should be called only once. Without call to telio_init_cert_store
+ * telio will not be able to verify https certificates in the system certificate store.
+ * # Params
+ * - `env`:    see https://developer.android.com/training/articles/perf-jni#javavm-and-jnienv
+ * - `ctx`:    see https://developer.android.com/reference/android/content/Context
+ */
+enum telio_result telio_init_cert_store(JNIEnv *env,
+                                        jobject ctx);
+#endif
+
+#if defined(__ANDROID__)
+/**
  * Create new telio library instance
  * # Parameters
  * - `events`:     Events callback

--- a/ffi/telio.i
+++ b/ffi/telio.i
@@ -47,7 +47,7 @@ struct telio {};
 
 
 #if defined(__ANDROID__)
-    telio(const char* features, telio_event_cb events, enum telio_log_level level, telio_logger_cb logger, telio_protect_cb protect) {
+    telio(const char* features, telio_event_cb events, enum telio_log_level level, telio_logger_cb logger, telio_protect_cb protect, jobject ctx) {
         telio *t;
         if (TELIO_RES_OK != telio_new_with_protect(&t, features, events, level, logger, protect)) {
             return NULL;

--- a/ffi/teliojava.i
+++ b/ffi/teliojava.i
@@ -21,12 +21,14 @@ static JavaVM *jvm = NULL;
 %extend telio {
 
 #if defined(__ANDROID__)
-    telio(const char* features, telio_event_cb events, enum telio_log_level level, telio_logger_cb logger, telio_protect_cb protect) {
+    telio(const char* features, telio_event_cb events, enum telio_log_level level, telio_logger_cb logger, telio_protect_cb protect, jobject ctx) {
         telio *t;
         JNIEnv *env = NULL;
         if ((*jvm)->GetEnv(jvm, (void**)&env, JNI_VERSION_1_6)) {
             exit(1);
         }
+
+        telio_init_cert_store(env, ctx);
 
         enum telio_result result;
         if ((result = telio_new_with_protect(&t, features, events, level, logger, protect)) != TELIO_RES_OK) {

--- a/linkers/dld
+++ b/linkers/dld
@@ -7,7 +7,7 @@ LINKER=${LINKER#"d-"}
 ARGS=$@
 
 while (( "$#" )); do
-	if [[ $1 == *"-Wl,--version-script="* ]]; then
+	if [[ $1 == *"-Wl,--version-script="* && ! $ARGS =~ -o.*librustls_platform_verifier.* ]]; then
 		VERSION=${1#"-Wl,--version-script="}
 		SED_ARGS='s/global:/global:\n    Java*;\n    JNI_OnLoad;\n/'
 		if [ "$(uname)" != "Darwin" ]; then

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -1335,7 +1335,6 @@ impl Runtime {
                 servers: SortedServers::new(config.derp_servers.clone().unwrap_or_default()),
                 allowed_pk: peers,
                 timeout: Duration::from_secs(10), //TODO: make configurable
-                ca_pem_path: None,
                 server_keepalives: DerpKeepaliveConfig::from(&self.features.derp),
                 enable_polling: self
                     .features
@@ -1349,6 +1348,12 @@ impl Runtime {
                     .as_ref()
                     .map(|peers| peers.iter().map(|peer| peer.public_key).collect())
                     .unwrap_or_default(),
+                use_built_in_root_certificates: self
+                    .features
+                    .derp
+                    .clone()
+                    .unwrap_or_default()
+                    .use_built_in_root_certificates,
             };
 
             // Update configuration for DERP client


### PR DESCRIPTION
### Problem
Libtelio is using hardcoded list of root certificate authorities (from Mozilla) to verify https certificates when connecting to derp. This can cause out of date / insecure / revoked certificates to be used if we don't update the hardcoded list on time.

### Solution
Us operating system, built in mechanisms to validate certificates, since those are automatically (from our pov) updated when needed.

Tested on:

- [x] macos
- [x] ios
- [x] linux
- [x] windows
- [x] android  


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
