### PR TITLE
[LLT-4432] Fix iOS linking issue

### DIFF
--- a/.cargo/config_apple_tvos
+++ b/.cargo/config_apple_tvos
@@ -11,8 +11,6 @@ parking_lot_core_0_8_6 = { git = 'https://github.com/nordsecurity/parking_lot.gi
 nix = { git = 'https://github.com/nordsecurity/nix.git', branch = 'add_apple_tvos_support_0_26_4' }
 block = { git = 'https://github.com/nordsecurity/rust-block.git', branch = 'add_apple_tvos_support' }
 objc = { git = 'https://github.com/nordsecurity/rust-objc.git', branch = 'add_apple_tvos_support' }
-system-configuration = { git = 'https://github.com/nordsecurity/system-configuration-rs.git', branch = 'add_apple_tvos_support' }
-system-configuration-sys = { git = 'https://github.com/nordsecurity/system-configuration-rs.git', branch = 'add_apple_tvos_support' }
 libc = { git = 'https://github.com/nordsecurity/libc.git', branch = 'add_apple_tvos_support' }
 
 [patch.'https://github.com/NordSecurity/boringtun.git']

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2887,7 +2887,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "system-configuration",
+ "system-configuration 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -3543,7 +3543,17 @@ checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
- "system-configuration-sys",
+ "system-configuration-sys 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "git+https://github.com/NordSecurity/system-configuration-rs.git#39f80cdfa4785b785f368354d6946111b7774e00"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys 0.5.0 (git+https://github.com/NordSecurity/system-configuration-rs.git)",
 ]
 
 [[package]]
@@ -3551,6 +3561,15 @@ name = "system-configuration-sys"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "git+https://github.com/NordSecurity/system-configuration-rs.git#39f80cdfa4785b785f368354d6946111b7774e00"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3886,7 +3905,7 @@ dependencies = [
  "parking_lot",
  "rstest",
  "socket2 0.5.4",
- "system-configuration",
+ "system-configuration 0.5.1 (git+https://github.com/NordSecurity/system-configuration-rs.git)",
  "telio-utils",
  "thiserror",
  "tokio",

--- a/changelog.md
+++ b/changelog.md
@@ -34,6 +34,7 @@
 * LLT-4152: Suspend SessionKeeper and CrossPingCheck for unresponsive peers
 * LLT-4360: Bump rust version to 1.72
 * LLT-4286: Add icmp error packet handling to firewall
+* LLT-4432: Use forked system-configuration crate to prevent iOS linking errors
 
 <br>
 

--- a/crates/telio-sockets/Cargo.toml
+++ b/crates/telio-sockets/Cargo.toml
@@ -31,8 +31,18 @@ version-compare = "0.1"
 [target.'cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))'.dependencies]
 debug_panic = "0.2.1"
 nix = "0.26.2"
-system-configuration = "0.5.0"
+system-configuration = { git = 'https://github.com/NordSecurity/system-configuration-rs.git' }
 
 [target.'cfg(windows)'.dependencies]
-winapi = { workspace = true, features = ["ntdef", "winerror", "iptypes", "iphlpapi", "impl-default"] }
-windows = { version = "0.34.0", features = ["alloc", "Win32_Networking_WinSock", "Win32_NetworkManagement_IpHelper"] }
+winapi = { workspace = true, features = [
+    "ntdef",
+    "winerror",
+    "iptypes",
+    "iphlpapi",
+    "impl-default",
+] }
+windows = { version = "0.34.0", features = [
+    "alloc",
+    "Win32_Networking_WinSock",
+    "Win32_NetworkManagement_IpHelper",
+] }


### PR DESCRIPTION
### Problem
There are “undefined refernce to kSCNetworkInterfaceTypeIrDA” errors when one tries to build iOS application with libtelio v4.1.1

### Solution
We need to use a bit modified version (our fork) of `system-configuration` crate


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
