### PR TITLE
When disabling meshnet, don't wait for wg listen port

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -36,6 +36,7 @@
 * LLT-4286: Add icmp error packet handling to firewall
 * LLT-4432: Use forked system-configuration crate to prevent iOS linking errors
 * LLT-3951: IPv6 analytics.
+* LLT-4409: Wait for listen port only if meshnet is enabled
 
 <br>
 


### PR DESCRIPTION
Before this change, failing call to wait_for_listen_port could make the disabling of meshnet (set_config with None) fail. There is no reason for that so the call to wait_for_listen_port is moved to the part executed only when the meshnet is enabled.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
