### PR TITLE
[LLT-4427] Fix exit node events

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -42,6 +42,7 @@
 * LLT-4515: Add nordvpn app version to moose context
 * LLT-3923: Change DERP and STUN identifiers
 * LLT-4202: Do not answer DNS request if forward lookup fails
+* LLT-4427: Fix issue with malformed disconnect event
 
 <br>
 

--- a/nat-lab/tests/telio.py
+++ b/nat-lab/tests/telio.py
@@ -286,6 +286,12 @@ class Runtime:
         self._peer_state_events.append(peer)
 
     def _handle_node_event(self, line) -> bool:
+        def _check_node_event(node_event: PeerInfo):
+            assert node_event.is_exit or (
+                "0.0.0.0/0" not in node_event.allowed_ips
+                and "::/0" not in node_event.allowed_ips
+            )
+
         if not line.startswith("event node: "):
             return False
         tokens = line.split("event node: ")
@@ -296,6 +302,7 @@ class Runtime:
                 "{" + result.group(1).replace("\\", "") + "}"
             )
             assert isinstance(node_state, PeerInfo)
+            _check_node_event(node_state)
             self.set_peer(node_state)
             return True
         return False

--- a/nat-lab/tests/test_mesh_exit_through_peer.py
+++ b/nat-lab/tests/test_mesh_exit_through_peer.py
@@ -163,7 +163,10 @@ async def test_mesh_exit_through_peer(
         # and also all other events future, then checking which occurred first.
         disconnect_task = asyncio.create_task(
             client_alpha.wait_for_event_peer(
-                beta.public_key, [State.Disconnected], list(telio.PathType)
+                beta.public_key,
+                [State.Disconnected],
+                list(telio.PathType),
+                is_exit=True,
             )
         )
         # Using a list of all State variants except for Disconnect just in case new variants are added in the future.

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -1497,7 +1497,7 @@ impl Runtime {
             .meshnet_config
             .as_ref()
             .and_then(|config| config.peers.clone())
-            .and_then(|config_peers| {
+            .and_then(|config_peers: Vec<Peer>| {
                 config_peers
                     .iter()
                     .cloned()
@@ -1562,12 +1562,10 @@ impl Runtime {
                     identifier: meshnet_peer.base.identifier,
                     public_key: meshnet_peer.base.public_key,
                     state: state.unwrap_or_else(|| peer.state()),
-                    is_exit: self
-                        .requested_state
-                        .exit_node
-                        .as_ref()
-                        .filter(|node| node.public_key == peer.public_key)
-                        .is_some(),
+                    is_exit: peer
+                        .allowed_ips
+                        .iter()
+                        .any(|network| network.ip().is_unspecified()),
                     is_vpn: false,
                     ip_addresses: meshnet_peer.base.ip_addresses.unwrap_or_default(),
                     allowed_ips: peer.allowed_ips.clone(),


### PR DESCRIPTION
Make sure that exit node events are marked as exit node ones.

### Problem
When a node stops begin exit node, an event is presented 

### Solution
Just base "is_exit" field in event on the ip_addresses, not the existence of the ExitNode in the requested state.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
