### PR TITLE
Correct the git commit guidelines link in dod

### DIFF
--- a/dod.yml
+++ b/dod.yml
@@ -1,5 +1,5 @@
 dod:
-  - 'Commit history is clean ([requirements](../../blob/main/docs/git_commit_messages_requirements.md))'
+  - 'Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))'
   - 'README.md is updated'
   - 'changelog.md is updated'
   - 'Functionality is covered by unit or integration tests'


### PR DESCRIPTION
Before this change the rendered link was:
https://github.com/NordSecurity/blob/main/docs/git_commit_messages_requirements.md
but should be:
https://github.com/NordSecurity/libtelio/blob/main/docs/git_commit_messages_requirements.md


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
