### PR TITLE
Add magicdns support for two dns bindings

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -38,6 +38,7 @@
 * LLT-3951: IPv6 analytics.
 * LLT-4409: Wait for listen port only if meshnet is enabled
 * LLT-4375: Add meshmap config support for custom peer names
+* LLT-4376: Add magicdns support for two dns bindings
 
 <br>
 

--- a/crates/telio-model/src/lib.rs
+++ b/crates/telio-model/src/lib.rs
@@ -4,6 +4,7 @@ pub mod api_config;
 pub mod config;
 pub mod event;
 pub mod mesh;
+pub mod validation;
 
 pub use std::collections::HashMap;
 pub use std::net::SocketAddr;

--- a/crates/telio-model/src/validation.rs
+++ b/crates/telio-model/src/validation.rs
@@ -1,0 +1,44 @@
+//! Config validation checks
+
+use telio_utils::telio_log_debug;
+
+/// Nickname validation checks (RFC #009)
+pub fn validate_nickname(name: &str) -> bool {
+    if name.len() > 25 {
+        telio_log_debug!("Nickname is too long");
+        return false;
+    }
+    if name.is_empty() {
+        telio_log_debug!("Nickname is empty");
+        return false;
+    }
+    if name.contains(' ') {
+        telio_log_debug!("Nickname contains spaces");
+        return false;
+    }
+    if name.contains("--") {
+        telio_log_debug!("Nickname contains double hyphens");
+        return false;
+    }
+    if name.ends_with('-') {
+        telio_log_debug!("Nickname ends with a hyphen");
+        return false;
+    }
+    if name.ends_with(".nord") {
+        telio_log_debug!("Nickname ends with \'.nord\'");
+        return false;
+    }
+    if name.ends_with('.') {
+        telio_log_debug!("Nickname ends with \'.\'");
+        return false;
+    }
+    if name.starts_with('-') {
+        telio_log_debug!("Nickname starts with a hyphen");
+        return false;
+    }
+    if !name.eq(name.to_lowercase().as_str()) {
+        telio_log_debug!("Nickname is not in lowercase");
+        return false;
+    }
+    true
+}

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -1008,12 +1008,12 @@ mod tests {
 
         let cfg = "a".repeat(MAX_CONFIG_LENGTH);
         assert_eq!(
-            telio_set_meshnet(&telio_dev, cfg.as_bytes().as_ptr() as *const i8),
+            telio_set_meshnet(&telio_dev, cfg.as_bytes().as_ptr() as *const c_char),
             TELIO_RES_BAD_CONFIG
         );
         let cfg = "a".repeat(MAX_CONFIG_LENGTH + 1);
         assert_eq!(
-            telio_set_meshnet(&telio_dev, cfg.as_bytes().as_ptr() as *const i8),
+            telio_set_meshnet(&telio_dev, cfg.as_bytes().as_ptr() as *const c_char),
             TELIO_RES_INVALID_STRING
         );
         Ok(())


### PR DESCRIPTION
### Problem
As we start allowing users to rename peer, magic DNS needs to support both the “official” name and these custom names.

### Solution
Parse nickname records and add them to dns resolver so that we can properly resolve both “official” and custom names.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
