### PR TITLE
Bump libtelio-build version

### DIFF
--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -31,4 +31,4 @@ jobs:
           project-id: ${{ secrets.PROJECT_ID }}
           schedule: ${{ github.event_name == 'schedule' }}
           cancel-outdated-pipelines: ${{ github.ref_name != 'main' }}
-          triggered-ref: v0.4.0
+          triggered-ref: v0.4.2

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,5 +15,5 @@ libtelio-build-pipeline:
 
   trigger:
     project: $LIBTELIO_BUILD_PROJECT_PATH
-    branch: v0.4.0
+    branch: v0.4.2
     strategy: depend


### PR DESCRIPTION
This mainly fixes releases being placed in the wrong repository

### Problem
Currently our releases land in the wrong repo. This updates libtelio-build reference to the one which contain the fix for it.



### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
