### PR TITLE
Add nagger job using the latest (2.0) version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
   coverage:
     needs: trigger
     uses: ./.github/workflows/coverage.yml
+  nagger:
+    needs: trigger
+    uses: ./.github/workflows/nagger.yml
 
   check-all-green:
     needs:

--- a/.github/workflows/nagger.yml
+++ b/.github/workflows/nagger.yml
@@ -1,0 +1,12 @@
+name: Nagger
+on: [workflow_call]
+permissions: {}
+
+jobs:
+  nagger:
+    runs-on: ubuntu-22.04
+    container: ghcr.io/nordsecurity/nagger:v2.0.0
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
+      - run: RUSTFLAGS="-Dwarnings" DYLINT_LIBRARY_PATH=${NAGGER_PATH} cargo dylint --workspace --all


### PR DESCRIPTION
### Problem
Nagger is not run on github for libtelio

### Solution
Use the latest nagger version available on github.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
