### PR TITLE
add nicknames to features

### DIFF
--- a/crates/telio-model/src/api_config.rs
+++ b/crates/telio-model/src/api_config.rs
@@ -291,6 +291,9 @@ pub struct Features {
     /// IPv6 support
     #[serde(default)]
     pub ipv6: bool,
+    /// Nicknames support
+    #[serde(default)]
+    pub nicknames: bool,
 }
 
 impl FeaturePaths {
@@ -392,7 +395,8 @@ mod tests {
                 "enable_polling": true
             },
             "validate_keys": false,
-            "ipv6": true
+            "ipv6": true,
+            "nicknames": true
         }"#;
 
     static EXPECTED_FEATURES: Lazy<Features> = Lazy::new(|| Features {
@@ -438,6 +442,7 @@ mod tests {
         }),
         validate_keys: FeatureValidateKeys(false),
         ipv6: true,
+        nicknames: true,
     });
 
     static EXPECTED_FEATURES_WITHOUT_TEST_ENV: Lazy<Features> = Lazy::new(|| Features {
@@ -477,6 +482,7 @@ mod tests {
         derp: None,
         validate_keys: Default::default(),
         ipv6: false,
+        nicknames: false,
     });
 
     #[test]
@@ -645,6 +651,7 @@ mod tests {
             derp: None,
             validate_keys: Default::default(),
             ipv6: false,
+            nicknames: false,
         };
 
         let empty_qos_features = Features {
@@ -668,6 +675,7 @@ mod tests {
             derp: None,
             validate_keys: Default::default(),
             ipv6: false,
+            nicknames: false,
         };
 
         let no_qos_features = Features {
@@ -686,6 +694,7 @@ mod tests {
             derp: None,
             validate_keys: Default::default(),
             ipv6: false,
+            nicknames: false,
         };
 
         assert_eq!(from_str::<Features>(full_json).unwrap(), full_features);
@@ -723,6 +732,7 @@ mod tests {
             derp: None,
             validate_keys: Default::default(),
             ipv6: false,
+            nicknames: false,
         };
 
         let empty_features = Features {
@@ -737,6 +747,7 @@ mod tests {
             derp: None,
             validate_keys: Default::default(),
             ipv6: false,
+            nicknames: false,
         };
 
         assert_eq!(from_str::<Features>(full_json).unwrap(), full_features);
@@ -775,6 +786,7 @@ mod tests {
             derp: None,
             validate_keys: Default::default(),
             ipv6: false,
+            nicknames: false,
         };
 
         assert_eq!(Features::default(), expected_defaults);

--- a/nat-lab/tests/telio_features.py
+++ b/nat-lab/tests/telio_features.py
@@ -62,3 +62,4 @@ class TelioFeatures(DataClassJsonMixin):
     lana: Optional[Lana] = None
     nurse: Optional[Nurse] = None
     ipv6: bool = False
+    nicknames: bool = False

--- a/nat-lab/tests/test_dns.py
+++ b/nat-lab/tests/test_dns.py
@@ -799,6 +799,7 @@ async def test_dns_nickname() -> None:
                         ConnectionTag.DOCKER_CONE_CLIENT_1,
                         derp_1_limits=ConnectionLimits(1, 1),
                     ),
+                    features=TelioFeatures(nicknames=True),
                 ),
                 SetupParameters(
                     connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2,
@@ -806,6 +807,7 @@ async def test_dns_nickname() -> None:
                         ConnectionTag.DOCKER_CONE_CLIENT_2,
                         derp_1_limits=ConnectionLimits(1, 1),
                     ),
+                    features=TelioFeatures(nicknames=True),
                 ),
             ],
             provided_api=api,

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -44,6 +44,7 @@ use telio_dns::{DnsResolver, LocalDnsResolver, Records};
 use telio_dns::bind_tun;
 use wg::uapi::{self, PeerState};
 
+use std::collections::HashMap;
 use std::{
     collections::{hash_map::Entry, HashSet},
     future::Future,
@@ -1088,7 +1089,11 @@ impl Runtime {
     async fn upsert_dns_peers(&self) -> Result {
         if let Some(dns) = &self.entities.dns.lock().await.resolver {
             // hostnames have priority over nicknames (override if there's any conflict)
-            let mut peers = self.requested_state.collect_dns_nickname_records();
+            let mut peers: Records = HashMap::new();
+            if self.features.nicknames {
+                peers = self.requested_state.collect_dns_nickname_records();
+            }
+
             peers.extend(self.requested_state.collect_dns_records());
 
             dns.upsert("nord", &peers)

--- a/src/device/wg_controller.rs
+++ b/src/device/wg_controller.rs
@@ -1226,6 +1226,7 @@ mod tests {
                     derp: None,
                     validate_keys: Default::default(),
                     ipv6: false,
+                    nicknames: false,
                 },
             }
         }


### PR DESCRIPTION
### Description
Upserting dns records with nicknames is already implemented, this just adds the capability to turn it on/off via feature config. Default is off.
Note to myself - update feature config page after merge

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
