### PR TITLE
Changes for running nat-lab from macos host

### DIFF
--- a/ci/build_libtelio.py
+++ b/ci/build_libtelio.py
@@ -204,6 +204,9 @@ LIBTELIO_CONFIG = {
             "aarch64": {
                 "strip_path": "/usr/aarch64-linux-gnu/bin/strip"
             },
+            "arm64": {
+                "strip_path": "/usr/aarch64-linux-gnu/bin/strip"
+            },
             "i686": {
                 "strip_path": "/usr/i686-linux-gnu/bin/strip"
             },

--- a/nat-lab/tests/config.py
+++ b/nat-lab/tests/config.py
@@ -1,7 +1,11 @@
 import os
 import platform
-from python_wireguard import Key  # type: ignore
 from typing import Dict, Union
+
+if platform.system() == "Darwin":
+    import mac_wg as Key
+else:
+    from python_wireguard import Key  # type: ignore
 
 PROJECT_ROOT = os.path.dirname(os.path.realpath(__file__)) + "/../../"
 
@@ -50,9 +54,12 @@ IPERF_BINARY_WINDOWS = "C:/workspace/iperf3/iperf3.exe".replace("/", "\\")
 # since its stable unlike `libtelio/dist`.
 #
 # Libtelio binary path inside Docker containers.
-LIBTELIO_BINARY_PATH_DOCKER = (
-    "/libtelio/dist/linux/release/" + platform.uname().machine + "/"
-)
+if platform.system() == "Darwin":
+    LIBTELIO_BINARY_PATH_DOCKER = "/libtelio/target/aarch64-unknown-linux-gnu/release/"
+else:
+    LIBTELIO_BINARY_PATH_DOCKER = (
+        "/libtelio/dist/linux/release/" + platform.uname().machine + "/"
+    )
 
 # Libtelio binary path inside Windows and Mac VMs
 LIBTELIO_BINARY_PATH_WINDOWS_VM = "C:/workspace/binaries/".replace("/", "\\")

--- a/nat-lab/tests/mac_wg.py
+++ b/nat-lab/tests/mac_wg.py
@@ -1,0 +1,19 @@
+import codecs
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.x25519 import X25519PrivateKey
+
+
+def key_pair():
+    private_key = X25519PrivateKey.generate()
+    bytes_ = private_key.private_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PrivateFormat.Raw,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    sk = codecs.encode(bytes_, "base64").decode("utf8").strip()
+
+    pubkey = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.Raw, format=serialization.PublicFormat.Raw
+    )
+    pk = codecs.encode(pubkey, "base64").decode("utf8").strip()
+    return (sk, pk)

--- a/nat-lab/tests/mesh_api.py
+++ b/nat-lab/tests/mesh_api.py
@@ -1,13 +1,18 @@
 import os
+import platform
 import pprint
 import random
 import time
 import uuid
 from config import DERP_SERVERS, LIBTELIO_IPV6_WG_SUBNET, WG_SERVERS
 from ipaddress import ip_address
-from python_wireguard import Key  # type: ignore
 from typing import Dict, Any, List, Tuple, Optional
 from utils.router import IPStack, IPProto, get_ip_address_type
+
+if platform.system() == "Darwin":
+    import mac_wg as Key
+else:
+    from python_wireguard import Key  # type: ignore
 
 Meshmap = Dict[str, Any]
 

--- a/nat-lab/tests/test_mesh_api.py
+++ b/nat-lab/tests/test_mesh_api.py
@@ -1,7 +1,12 @@
 import mesh_api
+import platform
 import pytest
 from mesh_api import Node, API
-from python_wireguard import Key  # type: ignore
+
+if platform.system() == "Darwin":
+    import mac_wg as Key
+else:
+    from python_wireguard import Key  # type: ignore
 
 
 class TestNode:

--- a/nat-lab/tests/test_verify_pk_on_packets.py
+++ b/nat-lab/tests/test_verify_pk_on_packets.py
@@ -1,12 +1,17 @@
 import asyncio
+import platform
 import pytest
 import telio
 from contextlib import AsyncExitStack
 from mesh_api import API
-from python_wireguard import Key  # type: ignore
 from typing import Optional
 from utils import testing
 from utils.connection_util import ConnectionTag, new_connection_by_tag
+
+if platform.system() == "Darwin":
+    import mac_wg as Key
+else:
+    from python_wireguard import Key  # type: ignore
 
 
 async def check_fake_derp_connection(client: telio.Client) -> Optional[telio.Client]:

--- a/nat-lab/tests/utils/connection_tracker.py
+++ b/nat-lab/tests/utils/connection_tracker.py
@@ -1,4 +1,5 @@
 import asyncio
+import platform
 import re
 import time
 from contextlib import asynccontextmanager
@@ -107,12 +108,16 @@ class ConnectionTracker:
             self._events.append(connection)
 
     async def execute(self) -> None:
+        if platform.system() == "Darwin":
+            return None
         if not self._config:
             return
 
         await self._process.execute(stdout_callback=self.on_stdout)
 
     def get_out_of_limits(self) -> Optional[Dict[str, int]]:
+        if platform.system() == "Darwin":
+            return None
         if not self._config:
             return None
 


### PR DESCRIPTION
Changes:

1. python-wireguard hardcodes opening of `*.so` file which obviously fails on macos. To fix that alternative, pure python implementation of the key derivation is provided.
2. `conntrack` cli is not available on macos, so on macos conntrack python wrapper always return no out of limits
3. the official architecture name of arm on macos is `arm64` but the corresponding name in the rust world is `aarch64` so some translation is added.

This results in most of the tests passing, example end result:
`47 failed, 177 passed, 1 skipped, 181 deselected, 15 xfailed, 36 xpassed`

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
