### PR TITLE
Fix flaky test_dns_duplicate_requests_on_multiple_forward_servers

### DIFF
--- a/nat-lab/tests/test_dns.py
+++ b/nat-lab/tests/test_dns.py
@@ -741,7 +741,7 @@ async def test_dns_duplicate_requests_on_multiple_forward_servers() -> None:
 
         await client_alpha.enable_magic_dns([FIRST_DNS_SERVER, SECOND_DNS_SERVER])
 
-        await testing.wait_normal(
+        await testing.wait_long(
             connection_alpha.create_process(
                 ["nslookup", "google.com", config.LIBTELIO_DNS_IPV4]
             ).execute()
@@ -749,12 +749,13 @@ async def test_dns_duplicate_requests_on_multiple_forward_servers() -> None:
 
         await asyncio.sleep(1)
 
+        tcpdump_stdout = process.get_stdout()
         results = re.findall(
             r".* IP .* > (?P<dest_ip>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,5}): .* A\?.*",
-            process.get_stdout(),
+            tcpdump_stdout,
         )  # fmt: skip
 
-        assert results
+        assert results, tcpdump_stdout
         assert [result for result in results if FIRST_DNS_SERVER in result]
         assert not ([result for result in results if SECOND_DNS_SERVER in result])
 


### PR DESCRIPTION
This test is the most common failed test in the last night run. In local reproduction it was seen that the nslookup call sometimes takes more time, so a timeout is increased.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
