### PR TITLE
Fix flaky natlab's tests with tcpdump

### DIFF
--- a/nat-lab/tests/test_direct_connection.py
+++ b/nat-lab/tests/test_direct_connection.py
@@ -612,7 +612,19 @@ async def test_infinite_stun_loop(setup_params: List[SetupParameters]) -> None:
         # 3478 and 3479 are STUN ports in natlab containers
         tcpdump = await exit_stack.enter_async_context(
             alpha_connection.create_process(
-                ["tcpdump", "-i", "any", "(", "port", "3478", "or", "3479", ")"]
+                [
+                    "tcpdump",
+                    "--immediate-mode",
+                    "-l",
+                    "-i",
+                    "any",
+                    "(",
+                    "port",
+                    "3478",
+                    "or",
+                    "3479",
+                    ")",
+                ]
             ).run()
         )
         await asyncio.sleep(5)

--- a/nat-lab/tests/test_dns.py
+++ b/nat-lab/tests/test_dns.py
@@ -735,18 +735,29 @@ async def test_dns_duplicate_requests_on_multiple_forward_servers() -> None:
 
         process = await exit_stack.enter_async_context(
             connection_alpha.create_process(
-                ["tcpdump", "-ni", "eth0", "udp", "and", "port", "53", "-l"]
+                [
+                    "tcpdump",
+                    "--immediate-mode",
+                    "-ni",
+                    "eth0",
+                    "udp",
+                    "and",
+                    "port",
+                    "53",
+                    "-l",
+                ]
             ).run()
         )
+        await asyncio.sleep(1)
 
         await client_alpha.enable_magic_dns([FIRST_DNS_SERVER, SECOND_DNS_SERVER])
+        await asyncio.sleep(1)
 
         await testing.wait_long(
             connection_alpha.create_process(
                 ["nslookup", "google.com", config.LIBTELIO_DNS_IPV4]
             ).execute()
         )
-
         await asyncio.sleep(1)
 
         tcpdump_stdout = process.get_stdout()


### PR DESCRIPTION
### Problem
Couple of tests, which uses `tcpdump`'s stdout, waits predefined amount of time, to check the output. Sometimes it lags, and tests fails (are flaky).

### Solution
Use unbuffered  `tcpdump`'s mode.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
