### PR TITLE
[nl-police] Mark flaky tests

### DIFF
--- a/nat-lab/tests/test_direct_connection.py
+++ b/nat-lab/tests/test_direct_connection.py
@@ -585,6 +585,7 @@ async def test_direct_connection_endpoint_gone(
 
 @pytest.mark.asyncio
 # Regression test for LLT-4306
+@pytest.mark.xfail(reason="Test is flaky - JIRA issue LLT-4555")
 @pytest.mark.parametrize(
     "setup_params",
     [

--- a/nat-lab/tests/test_dns.py
+++ b/nat-lab/tests/test_dns.py
@@ -712,7 +712,6 @@ async def test_dns_update(alpha_ip_stack: IPStack) -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.xfail(reason="Test is flaky - JIRA issue LLT-4563")
 async def test_dns_duplicate_requests_on_multiple_forward_servers() -> None:
     async with AsyncExitStack() as exit_stack:
         FIRST_DNS_SERVER = "8.8.8.8"

--- a/nat-lab/tests/test_dns.py
+++ b/nat-lab/tests/test_dns.py
@@ -712,6 +712,7 @@ async def test_dns_update(alpha_ip_stack: IPStack) -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.xfail(reason="Test is flaky - JIRA issue LLT-4563")
 async def test_dns_duplicate_requests_on_multiple_forward_servers() -> None:
     async with AsyncExitStack() as exit_stack:
         FIRST_DNS_SERVER = "8.8.8.8"

--- a/nat-lab/tests/test_events.py
+++ b/nat-lab/tests/test_events.py
@@ -348,7 +348,10 @@ async def test_event_content_vpn_connection(
                     derp_1_limits=ConnectionLimits(1, 1),
                 ),
             ),
-            marks=pytest.mark.windows,
+            marks=[
+                pytest.mark.windows,
+                pytest.mark.xfail(reason="Test is flaky - see JIRA issue LLT-4559"),
+            ],
         ),
         pytest.param(
             SetupParameters(
@@ -359,7 +362,10 @@ async def test_event_content_vpn_connection(
                     derp_1_limits=ConnectionLimits(1, 1),
                 ),
             ),
-            marks=pytest.mark.windows,
+            marks=[
+                pytest.mark.windows,
+                pytest.mark.xfail(reason="Test is flaky - see JIRA issue LLT-4559"),
+            ],
         ),
         pytest.param(
             SetupParameters(
@@ -470,6 +476,7 @@ async def test_event_content_exit_through_peer(
                 features=TelioFeatures(direct=Direct(providers=["stun"])),
             ),
             "10.0.254.1",
+            marks=pytest.mark.flaky("Test is flaky - JIRA issue LLT-4558"),
         ),
         pytest.param(
             SetupParameters(

--- a/nat-lab/tests/test_events.py
+++ b/nat-lab/tests/test_events.py
@@ -476,7 +476,7 @@ async def test_event_content_exit_through_peer(
                 features=TelioFeatures(direct=Direct(providers=["stun"])),
             ),
             "10.0.254.1",
-            marks=pytest.mark.flaky("Test is flaky - JIRA issue LLT-4558"),
+            marks=pytest.mark.xfail(reason="Test is flaky - JIRA issue LLT-4558"),
         ),
         pytest.param(
             SetupParameters(

--- a/nat-lab/tests/test_mesh_firewall.py
+++ b/nat-lab/tests/test_mesh_firewall.py
@@ -522,6 +522,7 @@ async def test_mesh_firewall_file_share_port(
 
 
 @pytest.mark.asyncio
+@pytest.mark.xfail(reason="test flaky - JIRA issue: LLT-4553")
 @pytest.mark.parametrize(
     "alpha_ip_stack,beta_ip_stack",
     [
@@ -667,6 +668,7 @@ async def test_mesh_firewall_tcp_stuck_in_last_ack_state_conn_kill_from_server_s
 
 
 @pytest.mark.asyncio
+@pytest.mark.xfail(reason="test flaky - JIRA issue: LLT-4553")
 @pytest.mark.parametrize(
     "alpha_ip_stack,beta_ip_stack",
     [

--- a/nat-lab/tests/test_mesh_plus_vpn.py
+++ b/nat-lab/tests/test_mesh_plus_vpn.py
@@ -533,7 +533,7 @@ async def test_vpn_plus_mesh_over_direct(
 
 @pytest.mark.asyncio
 @pytest.mark.timeout(150)
-@pytest.mark.xfail("Test is flaky - JIRA issue LLT-4560")
+@pytest.mark.xfail(reason="Test is flaky - JIRA issue LLT-4560")
 @pytest.mark.parametrize(
     "alpha_setup_params",
     [

--- a/nat-lab/tests/test_mesh_plus_vpn.py
+++ b/nat-lab/tests/test_mesh_plus_vpn.py
@@ -533,6 +533,7 @@ async def test_vpn_plus_mesh_over_direct(
 
 @pytest.mark.asyncio
 @pytest.mark.timeout(150)
+@pytest.mark.xfail("Test is flaky - JIRA issue LLT-4560")
 @pytest.mark.parametrize(
     "alpha_setup_params",
     [

--- a/nat-lab/tests/test_vpn.py
+++ b/nat-lab/tests/test_vpn.py
@@ -78,7 +78,10 @@ async def _connect_vpn(
                 is_meshnet=False,
             ),
             "10.0.254.7",
-            marks=pytest.mark.windows,
+            marks=[
+                pytest.mark.windows,
+                pytest.mark.xfail(reason="Test flaky: JIRA issue LLT-4554"),
+            ],
         ),
         pytest.param(
             SetupParameters(
@@ -92,7 +95,10 @@ async def _connect_vpn(
                 is_meshnet=False,
             ),
             "10.0.254.7",
-            marks=pytest.mark.windows,
+            marks=[
+                pytest.mark.windows,
+                pytest.mark.xfail(reason="Test flaky: JIRA issue LLT-4554"),
+            ],
         ),
         pytest.param(
             SetupParameters(
@@ -184,7 +190,10 @@ async def test_vpn_connection(
                 is_meshnet=False,
             ),
             "10.0.254.7",
-            marks=pytest.mark.windows,
+            marks=[
+                pytest.mark.windows,
+                pytest.mark.xfail(reason="Test is flaky - JIRA issue: LLT-4554"),
+            ],
         ),
         pytest.param(
             SetupParameters(


### PR DESCRIPTION
### Problem
There are a lot of tests which are failing, which makes CI quite unreliable.

### Solution
 This PR marks with `xfail` those of them which are failing more often, or the way in which they failed is alarming.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
