### PR TITLE
LLT-4006: Restrict nat-lab containers capabilities

### DIFF
--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -31,4 +31,4 @@ jobs:
           project-id: ${{ secrets.PROJECT_ID }}
           schedule: ${{ github.event_name == 'schedule' }}
           cancel-outdated-pipelines: ${{ github.ref_name != 'main' }}
-          triggered-ref: v0.4.5
+          triggered-ref: v0.4.6

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,5 +15,5 @@ libtelio-build-pipeline:
 
   trigger:
     project: $LIBTELIO_BUILD_PROJECT_PATH
-    branch: v0.4.5
+    branch: v0.4.6
     strategy: depend

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+### UNRELEASED
+----
+* LLT-4006: Restrict nat-lab containers capabilities
+
+<br>
+
 ### v4.2.0
 ### **Space-cakes**
 ---

--- a/nat-lab/bin/client
+++ b/nat-lab/bin/client
@@ -2,17 +2,6 @@
 
 set -e
 
-# Disable return path filter. It blocks inbound traffic when using fwmark routing policy.
-# net.ipv4.conf.all.rp_filter.src_valid_mark=1 is supposed to fix this, but it doesn't
-# seem to work. So for now disable return path filter outright.
-sysctl -w net.ipv4.conf.all.rp_filter=0
-sysctl -w net.ipv4.conf.eth0.rp_filter=0
-
-# Enable IPv6, by default, docker has this set to '1'
-sysctl -w net.ipv6.conf.all.disable_ipv6=0
-sysctl -w net.ipv6.conf.default.disable_ipv6=0
-sysctl -w net.ipv6.conf.all.forwarding=1
-
 # Add conntrack states to iptables, since running dockers on ubuntu
 # conntrack doesn't find flow entries by default somehow. Works when running dockers on debian tho.
 # ref: https://serverfault.com/a/978715

--- a/nat-lab/bin/cone-gw
+++ b/nat-lab/bin/cone-gw
@@ -2,8 +2,6 @@
 
 set -e
 
-echo 1 > /proc/sys/net/ipv4/ip_forward
-
 # Acquire public IP address
 public_itf=$(ip route show | awk '/10.0.0.0\/16.*dev [a-z0-0]+/ {print $3}')
 

--- a/nat-lab/bin/fullcone-gw
+++ b/nat-lab/bin/fullcone-gw
@@ -2,8 +2,6 @@
 
 set -ex
 
-echo 1 > /proc/sys/net/ipv4/ip_forward
-
 pushd /opt/iptables
 make install
 popd

--- a/nat-lab/bin/internal-symmetric-gw
+++ b/nat-lab/bin/internal-symmetric-gw
@@ -2,8 +2,6 @@
 
 set -e
 
-echo 1 > /proc/sys/net/ipv4/ip_forward
-
 # Configure standard FW
 iptables -t filter -A INPUT -i lo -j ACCEPT
 iptables -t filter -A INPUT -m state --state RELATED,ESTABLISHED -j ACCEPT

--- a/nat-lab/bin/symmetric-gw
+++ b/nat-lab/bin/symmetric-gw
@@ -2,8 +2,6 @@
 
 set -e
 
-echo 1 > /proc/sys/net/ipv4/ip_forward
-
 public_itf=$(ip route show | awk '/10.0.0.0\/16.*dev [a-z0-0]+/ {print $3}')
 private_itf=$(ip route show | awk '/192.168.*\/24.*dev [a-z0-0]+/ {print $3}')
 

--- a/nat-lab/bin/upnp-gw
+++ b/nat-lab/bin/upnp-gw
@@ -4,14 +4,11 @@ set -e
 
 upnpd eth0 eth1
 
-echo 1 > /proc/sys/net/ipv4/ip_forward
-
 # Acquire public IP address
 public_itf=$(ip route show | awk '/10.0.0.0\/16.*dev [a-z0-0]+/ {print $3}')
 
 # Configure standart linux NAT, this will be port restricted cone NAT
 iptables -t nat -A POSTROUTING -o $public_itf -j MASQUERADE
-
 
 sleep infinity
 

--- a/nat-lab/bin/vpn-server
+++ b/nat-lab/bin/vpn-server
@@ -2,13 +2,6 @@
 
 set -euxo pipefail
 
-# Enable IPv6, by default, docker has this set to '1'
-sysctl -w net.ipv6.conf.all.disable_ipv6=0
-sysctl -w net.ipv6.conf.default.disable_ipv6=0
-sysctl -w net.ipv6.conf.all.forwarding=1
-
-echo 1 > /proc/sys/net/ipv4/ip_forward
-
 # Configure standart linux NAT, this will be port restricted cone NAT
 iptables -t nat -A POSTROUTING -s 100.64.0.0/10 ! -o wg0 -j MASQUERADE
 

--- a/nat-lab/docker-compose.yml
+++ b/nat-lab/docker-compose.yml
@@ -11,29 +11,12 @@ services:
     profiles:
       - base
 
-  # Create gateway for first cone network
-  cone-gw-01: &common-gw
-    hostname: cone-gw-01
-    image: nat-lab:base
-    entrypoint: /opt/bin/cone-gw
-    cap_drop:
-      - ALL
-    cap_add:
-      - NET_ADMIN
-      - NET_RAW
-    sysctls:
-      - net.ipv4.ip_forward=1
-    security_opt:
-      - no-new-privileges:true
-    networks:
-      internet:
-        ipv4_address: 10.0.254.1
-        priority: 1000
-      cone-net-01:
-        ipv4_address: 192.168.101.254
-        priority: 900
-  # Create one client for cone network, this client will use
-  # the above gateway as its route to the "internet"
+
+  ###########################################################
+  #                         CLIENTS                         #
+  ###########################################################
+  # Clients for cone network, they'll use cone gateways
+  # as their route to the open internet
   cone-client-01: &common-client
     hostname: cone-client-01
     image: nat-lab:base
@@ -74,8 +57,164 @@ services:
       - "derp-00:10.0.10.245"
     volumes:
       - ../:/libtelio
+  cone-client-02:
+    hostname: cone-client-02
+    <<: *common-client
+    networks:
+      cone-net-02:
+        ipv4_address: 192.168.102.54
+    environment:
+      CLIENT_GATEWAY_PRIMARY: 192.168.102.254
+  # Client that shares two cone networks on different interfaces
+  shared-client-01:
+    hostname: shared-client-01
+    <<: *common-client
+    networks:
+      cone-net-01:
+        ipv4_address: 192.168.101.67
+      cone-net-05:
+        ipv4_address: 192.168.113.67
+    environment:
+      CLIENT_GATEWAY_PRIMARY: 192.168.101.254
+      CLIENT_GATEWAY_SECONDARY: 192.168.113.254
 
-  # Create gateway for second cone network
+  # Open internet clients used in cryptography tests
+  open-internet-client-01:
+    hostname: open-client-01
+    <<: *common-client
+    networks:
+      internet:
+        ipv4_address: 10.0.11.2
+    environment:
+      CLIENT_GATEWAY_PRIMARY: none
+  open-internet-client-02:
+    hostname: open-client-02
+    <<: *common-client
+    networks:
+      internet:
+        ipv4_address: 10.0.11.3
+    environment:
+      CLIENT_GATEWAY_PRIMARY: none
+  # Open internet client used on ipv6 tests
+  open-internet-client-dual-stack:
+    hostname: open-client-dual-stack
+    <<: *common-client
+    networks:
+      internet:
+        ipv4_address: 10.0.11.4
+        ipv6_address: 2001:db8:85a4::dead:beef:ceed
+    environment:
+      CLIENT_GATEWAY_PRIMARY: none
+    extra_hosts:
+      - "photo-album:2001:db8:85a4::adda:edde:5"
+      - "derp-01:10.0.10.1"
+      - "derp-02:10.0.10.2"
+      - "derp-03:10.0.10.3"
+      - "derp-00:10.0.10.245"
+
+  fullcone-client-01:
+    hostname: fullcone-client-01
+    <<: *common-client
+    networks:
+      fullcone-net-01:
+        ipv4_address: 192.168.109.88
+    environment:
+      CLIENT_GATEWAY_PRIMARY: 192.168.109.254
+  fullcone-client-02:
+    hostname: fullcone-client-02
+    <<: *common-client
+    networks:
+      fullcone-net-02:
+        ipv4_address: 192.168.106.88
+    environment:
+      CLIENT_GATEWAY_PRIMARY: 192.168.106.254
+
+  upnp-client-01:
+    hostname: upnp-client-01
+    <<: *common-client
+    networks:
+      upnp-net-01:
+        ipv4_address: 192.168.105.88
+    environment:
+      CLIENT_GATEWAY_PRIMARY: 192.168.105.254
+  upnp-client-02:
+    hostname: upnp-client-02
+    <<: *common-client
+    networks:
+      upnp-net-02:
+        ipv4_address: 192.168.112.88
+    environment:
+      CLIENT_GATEWAY_PRIMARY: 192.168.112.254
+
+  symmetric-client-01:
+    hostname: symmetric-client-01
+    <<: *common-client
+    networks:
+      hsymmetric-net-01:
+        ipv4_address: 192.168.103.88
+    environment:
+      CLIENT_GATEWAY_PRIMARY: 192.168.103.254
+  symmetric-client-02:
+    hostname: symmetric-client-02
+    <<: *common-client
+    networks:
+      hsymmetric-net-02:
+        ipv4_address: 192.168.104.88
+    environment:
+      CLIENT_GATEWAY_PRIMARY: 192.168.104.254
+  internal-symmetric-client-01:
+    hostname: internal-symmetric-client-01
+    <<: *common-client
+    environment:
+      CLIENT_GATEWAY_PRIMARY: 192.168.114.254
+      INTERMEDIATE_NETWORK: 192.168.103.0/24
+    networks:
+      hsymmetric-internal-net-01:
+        ipv4_address: 192.168.114.88
+
+  udp-block-client-01:
+    hostname: udp-block-client-01
+    <<: *common-client
+    networks:
+      udp-block-net-01:
+        ipv4_address: 192.168.110.100
+    environment:
+      CLIENT_GATEWAY_PRIMARY: 192.168.110.254
+  udp-block-client-02:
+    hostname: udp-block-client-02
+    <<: *common-client
+    networks:
+      udp-block-net-02:
+        ipv4_address: 192.168.111.100
+    environment:
+      CLIENT_GATEWAY_PRIMARY: 192.168.111.254
+
+
+  ###########################################################
+  #                        GATEWAYS                         #
+  ###########################################################
+  # Gateways acting like VM network routers, intended to route VM traffic through
+  # docker network.
+  cone-gw-01: &common-gw
+    hostname: cone-gw-01
+    image: nat-lab:base
+    entrypoint: /opt/bin/cone-gw
+    cap_drop:
+      - ALL
+    cap_add:
+      - NET_ADMIN
+      - NET_RAW
+    sysctls:
+      - net.ipv4.ip_forward=1
+    security_opt:
+      - no-new-privileges:true
+    networks:
+      internet:
+        ipv4_address: 10.0.254.1
+        priority: 1000
+      cone-net-01:
+        ipv4_address: 192.168.101.254
+        priority: 900
   cone-gw-02:
     hostname: cone-gw-02
     <<: *common-gw
@@ -85,72 +224,149 @@ services:
         priority: 1000
       cone-net-02:
         ipv4_address: 192.168.102.254
+        priority: 90
+  cone-gw-03:
+    hostname: cone-gw-03
+    <<: *common-gw
+    networks:
+      internet:
+        ipv4_address: 10.0.254.7
+        priority: 1000
+      cone-net-03:
+        ipv4_address: 192.168.107.254
         priority: 900
-  # Create one client for cone network, this client will use
-  # the above gateway as its route to the "internet"
-  cone-client-02:
-    hostname: cone-client-02
-    <<: *common-client
+  cone-gw-04:
+    hostname: cone-gw-04
+    <<: *common-gw
     networks:
-      cone-net-02:
-        ipv4_address: 192.168.102.54
+      internet:
+        ipv4_address: 10.0.254.8
+        priority: 1000
+      cone-net-04:
+        ipv4_address: 192.168.108.254
+        priority: 900
+  cone-gw-05:
+    hostname: cone-gw-05
+    <<: *common-gw
+    networks:
+      internet:
+        ipv4_address: 10.0.254.13
+        priority: 1000
+      cone-net-05:
+        ipv4_address: 192.168.113.254
+        priority: 900
+
+  fullcone-gw-01:
+    hostname: fullcone-gw-01
+    <<: *common-gw
+    entrypoint: /opt/bin/fullcone-gw
+    networks:
+      internet:
+        ipv4_address: 10.0.254.9
+        priority: 1000
+      fullcone-net-01:
+        ipv4_address: 192.168.109.254
+        priority: 900
+  fullcone-gw-02:
+    hostname: fullcone-gw-02
+    <<: *common-gw
+    entrypoint: /opt/bin/fullcone-gw
+    networks:
+      internet:
+        ipv4_address: 10.0.254.6
+        priority: 1000
+      fullcone-net-02:
+        ipv4_address: 192.168.106.254
+        priority: 900
+
+  symmetric-gw-01:
+    hostname: symmetric-gw-01
+    <<: *common-gw
+    entrypoint: /opt/bin/symmetric-gw
+    networks:
+      internet:
+        ipv4_address: 10.0.254.3
+        priority: 1000
+      hsymmetric-net-01:
+        ipv4_address: 192.168.103.254
+        priority: 900
+  symmetric-gw-02:
+    hostname: symmetric-gw-02
+    <<: *common-gw
+    entrypoint: /opt/bin/symmetric-gw
+    networks:
+      internet:
+        ipv4_address: 10.0.254.4
+        priority: 1000
+      hsymmetric-net-02:
+        ipv4_address: 192.168.104.254
+        priority: 900
+  internal-symmetric-gw-01:
+    hostname: internal-symmetric-gw-01
+    <<: *common-gw
+    entrypoint: /opt/bin/internal-symmetric-gw
     environment:
-      CLIENT_GATEWAY_PRIMARY: 192.168.102.254
-
-  # Just some publicly-routable service over TCP. To access
-  # it just simply run `curl photo-album`
-  photo-album:
-    hostname: photo-album
-    image: nat-lab:base
-    entrypoint: "/usr/bin/python3 -m http.server --bind :: --directory /srv/www 80"
-    cap_drop:
-      - ALL
-    security_opt:
-      - no-new-privileges:true
+      CLIENT_GATEWAY_SECONDARY: 192.168.103.254
     networks:
-      internet:
-        ipv4_address: 10.0.80.80
-        ipv6_address: 2001:db8:85a4::adda:edde:5
+      hsymmetric-net-01:
+        ipv4_address: 192.168.103.44
+      hsymmetric-internal-net-01:
+        ipv4_address: 192.168.114.254
     volumes:
-      - type: bind
-        source: ./data/photo.png
-        target: /srv/www/photo.png
-        read_only: true
+      - ../:/libtelio
 
-  # Just some publicly-routable UDP server. To access
-  # it just simply run `nc -u udp-server 2000`
-  udp-server:
-    hostname: udp-server
-    image: nat-lab:base
-    entrypoint: "/usr/bin/nc -unkl46 2000"
+  upnp-gw-01:
+    hostname: upnp-gw-01
+    <<: *common-gw
+    entrypoint: /opt/bin/upnp-gw
     networks:
       internet:
-        ipv4_address: 10.0.80.81
-        ipv6_address: 2001:db8:85a4::adda:edde:6
-
-  # Plain STUN server. This can be used for doing some simple testing,
-  # but note that for libtelio, we are not using plaintext STUN.
-  stun-01:
-    hostname: stun-01
-    image: nat-lab:base
-    entrypoint: /opt/bin/stun-server
-    cap_drop:
-      - ALL
-    cap_add:
-      - NET_ADMIN
-    security_opt:
-      - no-new-privileges:true
+        ipv4_address: 10.0.254.5
+        priority: 1000
+      upnp-net-01:
+        ipv4_address: 192.168.105.254
+        priority: 900
+  upnp-gw-02:
+    hostname: upnp-gw-02
+    <<: *common-gw
+    entrypoint: /opt/bin/upnp-gw
     networks:
       internet:
-        # This container requires two IP addresses to operate,
-        # therefore it takes the specified IP address and an
-        # IP address + 1. The logic for this is inside bin/stun-server.
-        ipv4_address: 10.0.1.1
-    logging:
-      options:
-        max-size: 50m
+        ipv4_address: 10.0.254.12
+        priority: 1000
+      upnp-net-02:
+        ipv4_address: 192.168.112.254
+        priority: 900
 
-  # Run three DERP servers configured to run in a cluster
+  # Gateways which block udp traffic
+  udp-block-gw-01:
+    hostname: udp-block-gw-01
+    <<: *common-gw
+    entrypoint: /opt/bin/udp-block-gw
+    networks:
+      internet:
+        ipv4_address: 10.0.254.10
+        priority: 1000
+      udp-block-net-01:
+        ipv4_address: 192.168.110.254
+        priority: 900
+  udp-block-gw-02:
+    hostname: udp-block-gw-02
+    <<: *common-gw
+    entrypoint: /opt/bin/udp-block-gw
+    networks:
+      internet:
+        ipv4_address: 10.0.254.11
+        priority: 1000
+      udp-block-net-02:
+        ipv4_address: 192.168.111.254
+        priority: 900
+
+
+  ###########################################################
+  #                       MISC SERVERS                      #
+  ###########################################################
+  # Three DERP servers configured to run in a cluster
   derp-01: &common-derp
     hostname: derp-01
     image: nat-lab:base
@@ -181,6 +397,28 @@ services:
         ipv4_address: 10.0.10.3
     volumes:
       - ./data/nordderper/config3.yml:/etc/nordderper/config.yml
+
+  # Plain STUN server. This can be used for doing some simple testing,
+  # but note that for libtelio, we are not using plaintext STUN.
+  stun-01:
+    hostname: stun-01
+    image: nat-lab:base
+    entrypoint: /opt/bin/stun-server
+    cap_drop:
+      - ALL
+    cap_add:
+      - NET_ADMIN
+    security_opt:
+      - no-new-privileges:true
+    networks:
+      internet:
+        # This container requires two IP addresses to operate,
+        # therefore it takes the specified IP address and an
+        # IP address + 1. The logic for this is inside bin/stun-server.
+        ipv4_address: 10.0.1.1
+    logging:
+      options:
+        max-size: 50m
 
   # Two VPN servers
   vpn-01: &common-vpn
@@ -213,285 +451,41 @@ services:
       internet:
         ipv4_address: 10.0.100.2
 
-  # Create one open internet client for
-  # cryptography tests
-  open-internet-client-01:
-    hostname: open-client-01
-    <<: *common-client
+  # Just some publicly-routable service over TCP. To access
+  # it just simply run `curl photo-album`
+  photo-album:
+    hostname: photo-album
+    image: nat-lab:base
+    entrypoint: "/usr/bin/python3 -m http.server --bind :: --directory /srv/www 80"
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
     networks:
       internet:
-        ipv4_address: 10.0.11.2
-    environment:
-      CLIENT_GATEWAY_PRIMARY: none
-
-  # Create one open internet client for
-  # cryptography tests
-  open-internet-client-02:
-    hostname: open-client-02
-    <<: *common-client
-    networks:
-      internet:
-        ipv4_address: 10.0.11.3
-    environment:
-      CLIENT_GATEWAY_PRIMARY: none
-
-  # Create one open internet client for
-  # cryptography tests
-  open-internet-client-dual-stack:
-    hostname: open-client-dual-stack
-    <<: *common-client
-    networks:
-      internet:
-        ipv4_address: 10.0.11.4
-        ipv6_address: 2001:db8:85a4::dead:beef:ceed
-    environment:
-      CLIENT_GATEWAY_PRIMARY: none
-    extra_hosts:
-      - "photo-album:2001:db8:85a4::adda:edde:5"
-      - "derp-01:10.0.10.1"
-      - "derp-02:10.0.10.2"
-      - "derp-03:10.0.10.3"
-      - "derp-00:10.0.10.245"
-
-  symmetric-gw-01:
-    hostname: symmetric-gw-01
-    <<: *common-gw
-    entrypoint: /opt/bin/symmetric-gw
-    networks:
-      internet:
-        ipv4_address: 10.0.254.3
-        priority: 1000
-      hsymmetric-net-01:
-        ipv4_address: 192.168.103.254
-        priority: 900
-
-  symmetric-client-01:
-    hostname: symmetric-client-01
-    <<: *common-client
-    networks:
-      hsymmetric-net-01:
-        ipv4_address: 192.168.103.88
-    environment:
-      CLIENT_GATEWAY_PRIMARY: 192.168.103.254
-
-  symmetric-gw-02:
-    hostname: symmetric-gw-02
-    <<: *common-gw
-    entrypoint: /opt/bin/symmetric-gw
-    networks:
-      internet:
-        ipv4_address: 10.0.254.4
-        priority: 1000
-      hsymmetric-net-02:
-        ipv4_address: 192.168.104.254
-        priority: 900
-
-  symmetric-client-02:
-    hostname: symmetric-client-02
-    <<: *common-client
-    networks:
-      hsymmetric-net-02:
-        ipv4_address: 192.168.104.88
-    environment:
-      CLIENT_GATEWAY_PRIMARY: 192.168.104.254
-
-  fullcone-gw-01:
-    hostname: fullcone-gw-01
-    <<: *common-gw
-    entrypoint: /opt/bin/fullcone-gw
-    networks:
-      internet:
-        ipv4_address: 10.0.254.9
-        priority: 1000
-      fullcone-net-01:
-        ipv4_address: 192.168.109.254
-        priority: 900
-
-  fullcone-client-01:
-    hostname: fullcone-client-01
-    <<: *common-client
-    networks:
-      fullcone-net-01:
-        ipv4_address: 192.168.109.88
-    environment:
-      CLIENT_GATEWAY_PRIMARY: 192.168.109.254
-
-  fullcone-gw-02:
-    hostname: fullcone-gw-02
-    <<: *common-gw
-    entrypoint: /opt/bin/fullcone-gw
-    networks:
-      internet:
-        ipv4_address: 10.0.254.6
-        priority: 1000
-      fullcone-net-02:
-        ipv4_address: 192.168.106.254
-        priority: 900
-
-  fullcone-client-02:
-    hostname: fullcone-client-02
-    <<: *common-client
-    networks:
-      fullcone-net-02:
-        ipv4_address: 192.168.106.88
-    environment:
-      CLIENT_GATEWAY_PRIMARY: 192.168.106.254
-
-  upnp-gw-01:
-    hostname: upnp-gw-01
-    <<: *common-gw
-    entrypoint: /opt/bin/upnp-gw
-    networks:
-      internet:
-        ipv4_address: 10.0.254.5
-        priority: 1000
-      upnp-net-01:
-        ipv4_address: 192.168.105.254
-        priority: 900
-
-  upnp-client-01:
-    hostname: upnp-client-01
-    <<: *common-client
-    networks:
-      upnp-net-01:
-        ipv4_address: 192.168.105.88
-    environment:
-      CLIENT_GATEWAY_PRIMARY: 192.168.105.254
-
-  shared-client-01:
-    hostname: shared-client-01
-    <<: *common-client
-    networks:
-      cone-net-01:
-        ipv4_address: 192.168.101.67
-      cone-net-05:
-        ipv4_address: 192.168.113.67
-    environment:
-      CLIENT_GATEWAY_PRIMARY: 192.168.101.254
-      CLIENT_GATEWAY_SECONDARY: 192.168.113.254
-
-  udp-block-client-01:
-    hostname: udp-block-client-01
-    <<: *common-client
-    networks:
-      udp-block-net-01:
-        ipv4_address: 192.168.110.100
-    environment:
-      CLIENT_GATEWAY_PRIMARY: 192.168.110.254
-
-  # Create gateway which block all udp traffic
-  udp-block-gw-01:
-    hostname: udp-block-gw-01
-    <<: *common-gw
-    entrypoint: /opt/bin/udp-block-gw
-    networks:
-      internet:
-        ipv4_address: 10.0.254.10
-        priority: 1000
-      udp-block-net-01:
-        ipv4_address: 192.168.110.254
-        priority: 900
-
-  udp-block-client-02:
-    hostname: udp-block-client-02
-    <<: *common-client
-    networks:
-      udp-block-net-02:
-        ipv4_address: 192.168.111.100
-    environment:
-      CLIENT_GATEWAY_PRIMARY: 192.168.111.254
-
-  # Create gateway which block all udp traffic
-  udp-block-gw-02:
-    hostname: udp-block-gw-02
-    <<: *common-gw
-    entrypoint: /opt/bin/udp-block-gw
-    networks:
-      internet:
-        ipv4_address: 10.0.254.11
-        priority: 1000
-      udp-block-net-02:
-        ipv4_address: 192.168.111.254
-        priority: 900
-
-  # These gateways are dedicated for VM network routing. VM traffic is gonna be routed into
-  # docker network through these gateways.
-  cone-gw-03:
-    hostname: cone-gw-03
-    <<: *common-gw
-    networks:
-      internet:
-        ipv4_address: 10.0.254.7
-        priority: 1000
-      cone-net-03:
-        ipv4_address: 192.168.107.254
-        priority: 900
-  cone-gw-04:
-    hostname: cone-gw-04
-    <<: *common-gw
-    networks:
-      internet:
-        ipv4_address: 10.0.254.8
-        priority: 1000
-      cone-net-04:
-        ipv4_address: 192.168.108.254
-        priority: 900
-
-  upnp-gw-02:
-    hostname: upnp-gw-02
-    <<: *common-gw
-    entrypoint: /opt/bin/upnp-gw
-    networks:
-      internet:
-        ipv4_address: 10.0.254.12
-        priority: 1000
-      upnp-net-02:
-        ipv4_address: 192.168.112.254
-        priority: 900
-
-  upnp-client-02:
-    hostname: upnp-client-02
-    <<: *common-client
-    networks:
-      upnp-net-02:
-        ipv4_address: 192.168.112.88
-    environment:
-      CLIENT_GATEWAY_PRIMARY: 192.168.112.254
-
-  cone-gw-05:
-    hostname: cone-gw-05
-    <<: *common-gw
-    networks:
-      internet:
-        ipv4_address: 10.0.254.13
-        priority: 1000
-      cone-net-05:
-        ipv4_address: 192.168.113.254
-        priority: 900
-
-  internal-symmetric-gw-01:
-    hostname: internal-symmetric-gw-01
-    <<: *common-gw
-    entrypoint: /opt/bin/internal-symmetric-gw
-    environment:
-      CLIENT_GATEWAY_SECONDARY: 192.168.103.254
-    networks:
-      hsymmetric-net-01:
-        ipv4_address: 192.168.103.44
-      hsymmetric-internal-net-01:
-        ipv4_address: 192.168.114.254
+        ipv4_address: 10.0.80.80
+        ipv6_address: 2001:db8:85a4::adda:edde:5
     volumes:
-      - ../:/libtelio
+      - type: bind
+        source: ./data/photo.png
+        target: /srv/www/photo.png
+        read_only: true
 
-  internal-symmetric-client-01:
-    hostname: internal-symmetric-client-01
-    <<: *common-client
-    environment:
-      CLIENT_GATEWAY_PRIMARY: 192.168.114.254
-      INTERMEDIATE_NETWORK: 192.168.103.0/24
+  # Just some publicly-routable UDP server. To access
+  # it just simply run `nc -u udp-server 2000`
+  udp-server:
+    hostname: udp-server
+    image: nat-lab:base
+    entrypoint: "/usr/bin/nc -unkl46 2000"
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
     networks:
-      hsymmetric-internal-net-01:
-        ipv4_address: 192.168.114.88
+      internet:
+        ipv4_address: 10.0.80.81
+        ipv6_address: 2001:db8:85a4::adda:edde:6
+
 
 networks:
   # Network representing public internet,
@@ -508,8 +502,8 @@ networks:
         - subnet: 10.0.0.0/16
         - subnet: 2001:db8:85a4::/48
 
-  # Define two separate networks for use with cone NATs
-  # gateways on these networks must implement restricted-cone NAT.
+  # Networks for use with cone NATs.
+  # Gateways on these networks must implement restricted-cone NAT.
   cone-net-01:
     driver: bridge
     ipam:
@@ -522,33 +516,56 @@ networks:
       driver: default
       config:
         - subnet: 192.168.102.0/24
+  cone-net-03:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: 192.168.107.0/24
+  cone-net-04:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: 192.168.108.0/24
+  cone-net-05:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: 192.168.113.0/24
 
-  # Define separate network for use with symmetric NATs
-  # gateways on these networks must implement symmetric NAT.
-  # name starts with letter H prefix, because docker doesn't let name to start with letter S, idk why
+  # Network for use with symmetric NATs.
+  # Gateways on these networks must implement symmetric NAT.
+  # Name starts with letter 'H' prefix because for some reason docker doesn't let name
+  # to start with letter 'S'.
   hsymmetric-net-01:
     driver: bridge
     ipam:
       driver: default
       config:
         - subnet: 192.168.103.0/24
-
   hsymmetric-net-02:
     driver: bridge
     ipam:
       driver: default
       config:
         - subnet: 192.168.104.0/24
+  hsymmetric-internal-net-01:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: 192.168.114.0/24
 
-  # Define separate network for use with full-cone NATs
-  # gateways on these networks must implement full-cone NAT.
+  # Define separate network to use with full-cone NATs.
+  # Gateways on these networks must implement full-cone NAT.
   fullcone-net-01:
     driver: bridge
     ipam:
       driver: default
       config:
         - subnet: 192.168.109.0/24
-
   fullcone-net-02:
     driver: bridge
     ipam:
@@ -562,35 +579,6 @@ networks:
       driver: default
       config:
         - subnet: 192.168.105.0/24
-
-  udp-block-net-01:
-    driver: bridge
-    ipam:
-      driver: default
-      config:
-        - subnet: 192.168.110.0/24
-
-  udp-block-net-02:
-    driver: bridge
-    ipam:
-      driver: default
-      config:
-        - subnet: 192.168.111.0/24
-
-  cone-net-03:
-    driver: bridge
-    ipam:
-      driver: default
-      config:
-        - subnet: 192.168.107.0/24
-
-  cone-net-04:
-    driver: bridge
-    ipam:
-      driver: default
-      config:
-        - subnet: 192.168.108.0/24
-
   upnp-net-02:
     driver: bridge
     ipam:
@@ -598,16 +586,15 @@ networks:
       config:
         - subnet: 192.168.112.0/24
 
-  cone-net-05:
+  udp-block-net-01:
     driver: bridge
     ipam:
       driver: default
       config:
-        - subnet: 192.168.113.0/24
-
-  hsymmetric-internal-net-01:
+        - subnet: 192.168.110.0/24
+  udp-block-net-02:
     driver: bridge
     ipam:
       driver: default
       config:
-        - subnet: 192.168.114.0/24
+        - subnet: 192.168.111.0/24

--- a/nat-lab/docker-compose.yml
+++ b/nat-lab/docker-compose.yml
@@ -11,12 +11,102 @@ services:
     profiles:
       - base
 
+  # Create gateway for first cone network
+  cone-gw-01: &common-gw
+    hostname: cone-gw-01
+    image: nat-lab:base
+    entrypoint: /opt/bin/cone-gw
+    cap_drop:
+      - ALL
+    cap_add:
+      - NET_ADMIN
+      - NET_RAW
+    sysctls:
+      - net.ipv4.ip_forward=1
+    security_opt:
+      - no-new-privileges:true
+    networks:
+      internet:
+        ipv4_address: 10.0.254.1
+        priority: 1000
+      cone-net-01:
+        ipv4_address: 192.168.101.254
+        priority: 900
+  # Create one client for cone network, this client will use
+  # the above gateway as its route to the "internet"
+  cone-client-01: &common-client
+    hostname: cone-client-01
+    image: nat-lab:base
+    entrypoint: /opt/bin/client
+    devices:
+      - "/dev/net/tun"
+    cap_drop:
+      - ALL
+    cap_add:
+      - NET_RAW
+      - NET_ADMIN
+      - NET_BIND_SERVICE
+      - SETUID
+      - SETGID
+    sysctls:
+      # Disable return path filter. It blocks inbound traffic when using fwmark routing policy.
+      # net.ipv4.conf.all.rp_filter.src_valid_mark=1 is supposed to fix this, but it doesn't
+      # seem to work. So for now disable return path filter outright.
+      - net.ipv4.conf.all.rp_filter=0
+      - net.ipv4.conf.eth0.rp_filter=0
+      # Enable IPv6, by default, docker has this set to '1'
+      - net.ipv6.conf.all.disable_ipv6=0
+      - net.ipv6.conf.default.disable_ipv6=0
+      - net.ipv6.conf.all.forwarding=1
+    security_opt:
+      - no-new-privileges:true
+    networks:
+      cone-net-01:
+        ipv4_address: 192.168.101.104
+    environment:
+      CLIENT_GATEWAY_PRIMARY: 192.168.101.254
+    extra_hosts:
+      - "photo-album:10.0.80.80"
+      - "stun-01:10.0.1.1"
+      - "derp-01:10.0.10.1"
+      - "derp-02:10.0.10.2"
+      - "derp-03:10.0.10.3"
+      - "derp-00:10.0.10.245"
+    volumes:
+      - ../:/libtelio
+
+  # Create gateway for second cone network
+  cone-gw-02:
+    hostname: cone-gw-02
+    <<: *common-gw
+    networks:
+      internet:
+        ipv4_address: 10.0.254.2
+        priority: 1000
+      cone-net-02:
+        ipv4_address: 192.168.102.254
+        priority: 900
+  # Create one client for cone network, this client will use
+  # the above gateway as its route to the "internet"
+  cone-client-02:
+    hostname: cone-client-02
+    <<: *common-client
+    networks:
+      cone-net-02:
+        ipv4_address: 192.168.102.54
+    environment:
+      CLIENT_GATEWAY_PRIMARY: 192.168.102.254
+
   # Just some publicly-routable service over TCP. To access
   # it just simply run `curl photo-album`
   photo-album:
     hostname: photo-album
     image: nat-lab:base
     entrypoint: "/usr/bin/python3 -m http.server --bind :: --directory /srv/www 80"
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
     networks:
       internet:
         ipv4_address: 10.0.80.80
@@ -44,7 +134,12 @@ services:
     hostname: stun-01
     image: nat-lab:base
     entrypoint: /opt/bin/stun-server
-    privileged: true
+    cap_drop:
+      - ALL
+    cap_add:
+      - NET_ADMIN
+    security_opt:
+      - no-new-privileges:true
     networks:
       internet:
         # This container requires two IP addresses to operate,
@@ -55,11 +150,15 @@ services:
       options:
         max-size: 50m
 
-  # Run two DERP servers configured to run in a cluster
-  derp-01:
+  # Run three DERP servers configured to run in a cluster
+  derp-01: &common-derp
     hostname: derp-01
     image: nat-lab:base
     entrypoint: /opt/bin/derp-server
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
     networks:
       internet:
         ipv4_address: 10.0.10.1
@@ -68,111 +167,79 @@ services:
     working_dir: /etc/nordderper
   derp-02:
     hostname: derp-02
-    image: nat-lab:base
-    entrypoint: /opt/bin/derp-server
+    <<: *common-derp
     networks:
       internet:
         ipv4_address: 10.0.10.2
     volumes:
       - ./data/nordderper/config2.yml:/etc/nordderper/config.yml
-    working_dir: /etc/nordderper
   derp-03:
     hostname: derp-03
-    image: nat-lab:base
-    entrypoint: /opt/bin/derp-server
+    <<: *common-derp
     networks:
       internet:
         ipv4_address: 10.0.10.3
     volumes:
       - ./data/nordderper/config3.yml:/etc/nordderper/config.yml
-    working_dir: /etc/nordderper
 
   # Two VPN servers
-  vpn-01:
+  vpn-01: &common-vpn
     hostname: vpn-01
     image: nat-lab:base
     entrypoint: /opt/bin/vpn-server
+    cap_drop:
+      - ALL
+    cap_add:
+      - NET_ADMIN
+      - NET_RAW
+    sysctls:
+      - net.ipv6.conf.all.disable_ipv6=0
+      - net.ipv6.conf.default.disable_ipv6=0
+      - net.ipv6.conf.all.forwarding=1
+      - net.ipv4.ip_forward=1
+    security_opt:
+      - no-new-privileges:true
     networks:
       internet:
         ipv4_address: 10.0.100.1
     environment:
       CLIENT_GATEWAY_PRIMARY: none
-    privileged: true
     volumes:
       - ../:/libtelio
   vpn-02:
     hostname: vpn-02
-    image: nat-lab:base
-    entrypoint: /opt/bin/vpn-server
+    <<: *common-vpn
     networks:
       internet:
         ipv4_address: 10.0.100.2
-    environment:
-      CLIENT_GATEWAY_PRIMARY: none
-    privileged: true
-    volumes:
-      - ../:/libtelio
-
-  # Create gateway for first cone network
-  cone-gw-01:
-    hostname: cone-gw-01
-    image: nat-lab:base
-    entrypoint: /opt/bin/cone-gw
-    privileged: true
-    networks:
-      internet:
-        ipv4_address: 10.0.254.1
-        priority: 1000
-      cone-net-01:
-        ipv4_address: 192.168.101.254
-        priority: 900
 
   # Create one open internet client for
   # cryptography tests
   open-internet-client-01:
     hostname: open-client-01
-    image: nat-lab:base
-    entrypoint: /opt/bin/client
-    privileged: true
+    <<: *common-client
     networks:
       internet:
         ipv4_address: 10.0.11.2
     environment:
       CLIENT_GATEWAY_PRIMARY: none
-    extra_hosts:
-      - "derp-01:10.0.10.1"
-      - "derp-02:10.0.10.2"
-      - "derp-03:10.0.10.3"
-      - "derp-00:10.0.10.245"
-    volumes:
-      - ../:/libtelio
+
   # Create one open internet client for
   # cryptography tests
   open-internet-client-02:
     hostname: open-client-02
-    image: nat-lab:base
-    entrypoint: /opt/bin/client
-    privileged: true
+    <<: *common-client
     networks:
       internet:
         ipv4_address: 10.0.11.3
     environment:
       CLIENT_GATEWAY_PRIMARY: none
-    extra_hosts:
-      - "derp-01:10.0.10.1"
-      - "derp-02:10.0.10.2"
-      - "derp-03:10.0.10.3"
-      - "derp-00:10.0.10.245"
-    volumes:
-      - ../:/libtelio
 
   # Create one open internet client for
   # cryptography tests
   open-internet-client-dual-stack:
     hostname: open-client-dual-stack
-    image: nat-lab:base
-    entrypoint: /opt/bin/client
-    privileged: true
+    <<: *common-client
     networks:
       internet:
         ipv4_address: 10.0.11.4
@@ -185,73 +252,11 @@ services:
       - "derp-02:10.0.10.2"
       - "derp-03:10.0.10.3"
       - "derp-00:10.0.10.245"
-    volumes:
-      - ../:/libtelio
-
-  # Create one client for cone network, this client will use
-  # the above gateway as its route to the "internet"
-  cone-client-01:
-    hostname: cone-client-01
-    image: nat-lab:base
-    entrypoint: /opt/bin/client
-    privileged: true
-    networks:
-      cone-net-01:
-        ipv4_address: 192.168.101.104
-    environment:
-      CLIENT_GATEWAY_PRIMARY: 192.168.101.254
-    extra_hosts:
-      - "photo-album:10.0.80.80"
-      - "stun-01:10.0.1.1"
-      - "stun-02:10.0.1.245"
-      - "derp-01:10.0.10.1"
-      - "derp-02:10.0.10.2"
-      - "derp-03:10.0.10.3"
-      - "derp-00:10.0.10.245"
-    volumes:
-      - ../:/libtelio
-
-  # Create gateway for second cone network
-  cone-gw-02:
-    hostname: cone-gw-02
-    image: nat-lab:base
-    entrypoint: /opt/bin/cone-gw
-    privileged: true
-    networks:
-      internet:
-        ipv4_address: 10.0.254.2
-        priority: 1000
-      cone-net-02:
-        ipv4_address: 192.168.102.254
-        priority: 900
-  # Create one client for cone network, this client will use
-  # the above gateway as its route to the "internet"
-  cone-client-02:
-    hostname: cone-client-02
-    image: nat-lab:base
-    entrypoint: /opt/bin/client
-    privileged: true
-    networks:
-      cone-net-02:
-        ipv4_address: 192.168.102.54
-    environment:
-      CLIENT_GATEWAY_PRIMARY: 192.168.102.254
-    extra_hosts:
-      - "photo-album:10.0.80.80"
-      - "stun-01:10.0.1.1"
-      - "stun-02:10.0.1.245"
-      - "derp-01:10.0.10.1"
-      - "derp-02:10.0.10.2"
-      - "derp-03:10.0.10.3"
-      - "derp-00:10.0.10.245"
-    volumes:
-      - ../:/libtelio
 
   symmetric-gw-01:
     hostname: symmetric-gw-01
-    image: nat-lab:base
+    <<: *common-gw
     entrypoint: /opt/bin/symmetric-gw
-    privileged: true
     networks:
       internet:
         ipv4_address: 10.0.254.3
@@ -262,30 +267,17 @@ services:
 
   symmetric-client-01:
     hostname: symmetric-client-01
-    image: nat-lab:base
-    entrypoint: /opt/bin/client
-    privileged: true
+    <<: *common-client
     networks:
       hsymmetric-net-01:
         ipv4_address: 192.168.103.88
     environment:
       CLIENT_GATEWAY_PRIMARY: 192.168.103.254
-    extra_hosts:
-      - "photo-album:10.0.80.80"
-      - "stun-01:10.0.1.1"
-      - "stun-02:10.0.1.245"
-      - "derp-01:10.0.10.1"
-      - "derp-02:10.0.10.2"
-      - "derp-03:10.0.10.3"
-      - "derp-00:10.0.10.245"
-    volumes:
-      - ../:/libtelio
 
   symmetric-gw-02:
     hostname: symmetric-gw-02
-    image: nat-lab:base
+    <<: *common-gw
     entrypoint: /opt/bin/symmetric-gw
-    privileged: true
     networks:
       internet:
         ipv4_address: 10.0.254.4
@@ -296,32 +288,17 @@ services:
 
   symmetric-client-02:
     hostname: symmetric-client-02
-    image: nat-lab:base
-    entrypoint: /opt/bin/client
-    privileged: true
+    <<: *common-client
     networks:
       hsymmetric-net-02:
         ipv4_address: 192.168.104.88
     environment:
       CLIENT_GATEWAY_PRIMARY: 192.168.104.254
-    extra_hosts:
-      - "photo-album:10.0.80.80"
-      - "stun-01:10.0.1.1"
-      - "stun-02:10.0.1.245"
-      - "derp-01:10.0.10.1"
-      - "derp-02:10.0.10.2"
-      - "derp-03:10.0.10.3"
-      - "derp-00:10.0.10.245"
-    volumes:
-      - ../:/libtelio
 
   fullcone-gw-01:
     hostname: fullcone-gw-01
-    image: nat-lab:base
+    <<: *common-gw
     entrypoint: /opt/bin/fullcone-gw
-    privileged: true
-    cap_add:
-      - ALL
     networks:
       internet:
         ipv4_address: 10.0.254.9
@@ -332,32 +309,17 @@ services:
 
   fullcone-client-01:
     hostname: fullcone-client-01
-    image: nat-lab:base
-    entrypoint: /opt/bin/client
-    privileged: true
+    <<: *common-client
     networks:
       fullcone-net-01:
         ipv4_address: 192.168.109.88
     environment:
       CLIENT_GATEWAY_PRIMARY: 192.168.109.254
-    extra_hosts:
-      - "photo-album:10.0.80.80"
-      - "stun-01:10.0.1.1"
-      - "stun-02:10.0.1.245"
-      - "derp-01:10.0.10.1"
-      - "derp-02:10.0.10.2"
-      - "derp-03:10.0.10.3"
-      - "derp-00:10.0.10.245"
-    volumes:
-      - ../:/libtelio
 
   fullcone-gw-02:
     hostname: fullcone-gw-02
-    image: nat-lab:base
+    <<: *common-gw
     entrypoint: /opt/bin/fullcone-gw
-    privileged: true
-    cap_add:
-      - ALL
     networks:
       internet:
         ipv4_address: 10.0.254.6
@@ -368,30 +330,17 @@ services:
 
   fullcone-client-02:
     hostname: fullcone-client-02
-    image: nat-lab:base
-    entrypoint: /opt/bin/client
-    privileged: true
+    <<: *common-client
     networks:
       fullcone-net-02:
         ipv4_address: 192.168.106.88
     environment:
       CLIENT_GATEWAY_PRIMARY: 192.168.106.254
-    extra_hosts:
-      - "photo-album:10.0.80.80"
-      - "stun-01:10.0.1.1"
-      - "stun-02:10.0.1.245"
-      - "derp-01:10.0.10.1"
-      - "derp-02:10.0.10.2"
-      - "derp-03:10.0.10.3"
-      - "derp-00:10.0.10.245"
-    volumes:
-      - ../:/libtelio
 
   upnp-gw-01:
     hostname: upnp-gw-01
-    image: nat-lab:base
+    <<: *common-gw
     entrypoint: /opt/bin/upnp-gw
-    privileged: true
     networks:
       internet:
         ipv4_address: 10.0.254.5
@@ -402,30 +351,16 @@ services:
 
   upnp-client-01:
     hostname: upnp-client-01
-    image: nat-lab:base
-    entrypoint: /opt/bin/client
-    privileged: true
+    <<: *common-client
     networks:
       upnp-net-01:
         ipv4_address: 192.168.105.88
     environment:
       CLIENT_GATEWAY_PRIMARY: 192.168.105.254
-    extra_hosts:
-      - "photo-album:10.0.80.80"
-      - "stun-01:10.0.1.1"
-      - "stun-02:10.0.1.245"
-      - "derp-01:10.0.10.1"
-      - "derp-02:10.0.10.2"
-      - "derp-03:10.0.10.3"
-      - "derp-00:10.0.10.245"
-    volumes:
-      - ../:/libtelio
 
   shared-client-01:
     hostname: shared-client-01
-    image: nat-lab:base
-    entrypoint: /opt/bin/client
-    privileged: true
+    <<: *common-client
     networks:
       cone-net-01:
         ipv4_address: 192.168.101.67
@@ -434,44 +369,21 @@ services:
     environment:
       CLIENT_GATEWAY_PRIMARY: 192.168.101.254
       CLIENT_GATEWAY_SECONDARY: 192.168.113.254
-    extra_hosts:
-      - "photo-album:10.0.80.80"
-      - "stun-01:10.0.1.1"
-      - "stun-02:10.0.1.245"
-      - "derp-01:10.0.10.1"
-      - "derp-02:10.0.10.2"
-      - "derp-03:10.0.10.3"
-      - "derp-00:10.0.10.245"
-    volumes:
-      - ../:/libtelio
 
   udp-block-client-01:
     hostname: udp-block-client-01
-    image: nat-lab:base
-    entrypoint: /opt/bin/client
-    privileged: true
+    <<: *common-client
     networks:
       udp-block-net-01:
         ipv4_address: 192.168.110.100
     environment:
       CLIENT_GATEWAY_PRIMARY: 192.168.110.254
-    extra_hosts:
-      - "photo-album:10.0.80.80"
-      - "stun-01:10.0.1.1"
-      - "stun-02:10.0.1.245"
-      - "derp-01:10.0.10.1"
-      - "derp-02:10.0.10.2"
-      - "derp-03:10.0.10.3"
-      - "derp-00:10.0.10.245"
-    volumes:
-      - ../:/libtelio
 
   # Create gateway which block all udp traffic
   udp-block-gw-01:
     hostname: udp-block-gw-01
-    image: nat-lab:base
+    <<: *common-gw
     entrypoint: /opt/bin/udp-block-gw
-    privileged: true
     networks:
       internet:
         ipv4_address: 10.0.254.10
@@ -482,31 +394,18 @@ services:
 
   udp-block-client-02:
     hostname: udp-block-client-02
-    image: nat-lab:base
-    entrypoint: /opt/bin/client
-    privileged: true
+    <<: *common-client
     networks:
       udp-block-net-02:
         ipv4_address: 192.168.111.100
     environment:
       CLIENT_GATEWAY_PRIMARY: 192.168.111.254
-    extra_hosts:
-      - "photo-album:10.0.80.80"
-      - "stun-01:10.0.1.1"
-      - "stun-02:10.0.1.245"
-      - "derp-01:10.0.10.1"
-      - "derp-02:10.0.10.2"
-      - "derp-03:10.0.10.3"
-      - "derp-00:10.0.10.245"
-    volumes:
-      - ../:/libtelio
 
   # Create gateway which block all udp traffic
   udp-block-gw-02:
     hostname: udp-block-gw-02
-    image: nat-lab:base
+    <<: *common-gw
     entrypoint: /opt/bin/udp-block-gw
-    privileged: true
     networks:
       internet:
         ipv4_address: 10.0.254.11
@@ -519,9 +418,7 @@ services:
   # docker network through these gateways.
   cone-gw-03:
     hostname: cone-gw-03
-    image: nat-lab:base
-    entrypoint: /opt/bin/cone-gw
-    privileged: true
+    <<: *common-gw
     networks:
       internet:
         ipv4_address: 10.0.254.7
@@ -531,9 +428,7 @@ services:
         priority: 900
   cone-gw-04:
     hostname: cone-gw-04
-    image: nat-lab:base
-    entrypoint: /opt/bin/cone-gw
-    privileged: true
+    <<: *common-gw
     networks:
       internet:
         ipv4_address: 10.0.254.8
@@ -544,9 +439,8 @@ services:
 
   upnp-gw-02:
     hostname: upnp-gw-02
-    image: nat-lab:base
+    <<: *common-gw
     entrypoint: /opt/bin/upnp-gw
-    privileged: true
     networks:
       internet:
         ipv4_address: 10.0.254.12
@@ -557,30 +451,16 @@ services:
 
   upnp-client-02:
     hostname: upnp-client-02
-    image: nat-lab:base
-    entrypoint: /opt/bin/client
-    privileged: true
+    <<: *common-client
     networks:
       upnp-net-02:
         ipv4_address: 192.168.112.88
     environment:
       CLIENT_GATEWAY_PRIMARY: 192.168.112.254
-    extra_hosts:
-      - "photo-album:10.0.80.80"
-      - "stun-01:10.0.1.1"
-      - "stun-02:10.0.1.245"
-      - "derp-01:10.0.10.1"
-      - "derp-02:10.0.10.2"
-      - "derp-03:10.0.10.3"
-      - "derp-00:10.0.10.245"
-    volumes:
-      - ../:/libtelio
 
   cone-gw-05:
     hostname: cone-gw-05
-    image: nat-lab:base
-    entrypoint: /opt/bin/cone-gw
-    privileged: true
+    <<: *common-gw
     networks:
       internet:
         ipv4_address: 10.0.254.13
@@ -591,9 +471,8 @@ services:
 
   internal-symmetric-gw-01:
     hostname: internal-symmetric-gw-01
-    image: nat-lab:base
+    <<: *common-gw
     entrypoint: /opt/bin/internal-symmetric-gw
-    privileged: true
     environment:
       CLIENT_GATEWAY_SECONDARY: 192.168.103.254
     networks:
@@ -606,26 +485,13 @@ services:
 
   internal-symmetric-client-01:
     hostname: internal-symmetric-client-01
-    image: nat-lab:base
-    entrypoint: /opt/bin/client
-    privileged: true
+    <<: *common-client
     environment:
       CLIENT_GATEWAY_PRIMARY: 192.168.114.254
       INTERMEDIATE_NETWORK: 192.168.103.0/24
     networks:
       hsymmetric-internal-net-01:
         ipv4_address: 192.168.114.88
-    volumes:
-      - ../:/libtelio
-    extra_hosts:
-      - "photo-album:10.0.80.80"
-      - "stun-01:10.0.1.1"
-      - "stun-02:10.0.1.245"
-      - "derp-01:10.0.10.1"
-      - "derp-02:10.0.10.2"
-      - "derp-03:10.0.10.3"
-      - "derp-00:10.0.10.245"
-
 
 networks:
   # Network representing public internet,

--- a/nat-lab/tests/utils/vm/windows_vm_util.py
+++ b/nat-lab/tests/utils/vm/windows_vm_util.py
@@ -37,7 +37,6 @@ async def new_connection() -> AsyncIterator[Connection]:
         connection = SshConnection(ssh_connection, TargetOS.Windows)
 
         await _copy_binaries(ssh_connection, connection)
-        await _disable_firewall(connection)
 
         async def on_stdout(stdout: str) -> None:
             print(stdout)
@@ -55,12 +54,6 @@ async def new_connection() -> AsyncIterator[Connection]:
             yield connection
         finally:
             pass
-
-
-async def _disable_firewall(connection: Connection):
-    await connection.create_process(
-        ["netsh", "advfirewall", "set", "allprofiles", "state", "off"]
-    ).execute()
 
 
 async def _copy_binaries(

--- a/nat-lab/tests/utils/vm/windows_vm_util.py
+++ b/nat-lab/tests/utils/vm/windows_vm_util.py
@@ -38,18 +38,6 @@ async def new_connection() -> AsyncIterator[Connection]:
 
         await _copy_binaries(ssh_connection, connection)
 
-        async def on_stdout(stdout: str) -> None:
-            print(stdout)
-
-        await connection.create_process(["route", "print"]).execute(
-            stdout_callback=on_stdout,
-            stderr_callback=on_stdout,
-        )
-        await connection.create_process(["ipconfig/all"]).execute(
-            stdout_callback=on_stdout,
-            stderr_callback=on_stdout,
-        )
-
         try:
             yield connection
         finally:


### PR DESCRIPTION
### Problem
At the moment nat-lab docker containers are being ran with root privileges, thus have all the kernel capabilities enabled, which is unsafe and not necessary. 

### Solution
This PR restricts these containers capabilities, following the least privilege principle, and also adds other unrelated changes:
- Remove Windows VM firewall disablement for every test (done now during VM startup).
- Remove previously added windows VM debug logs which are no longer needed.
- Add custom peer names integration test that asserts the nodes can have their nicknames changed/removed.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
