### PR TITLE
Update requirements.txt or nat-lab by enforcing exact version of aiohttp

### DIFF
--- a/nat-lab/requirements.txt
+++ b/nat-lab/requirements.txt
@@ -18,3 +18,7 @@ protobuf == 3.20.3
 
 # Force latest (as of now) stable version to fix CVEs.
 cryptography ~= 41.0.1
+
+
+# transitive dependency lock:
+aiohttp==3.8.6


### PR DESCRIPTION
### Problem
`aiohttp` updated during the weekend and broke all nat-lab pipelines. This forces `aiohttp` version to 3.8.6 in order to unblock the pipelines.

### Solution
*--describe selected solution--*


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
