### PR TITLE
Fix test_dns_duplicate_requests_on_multiple_forward_servers

### DIFF
--- a/nat-lab/tests/test_dns.py
+++ b/nat-lab/tests/test_dns.py
@@ -761,13 +761,11 @@ async def test_dns_duplicate_requests_on_multiple_forward_servers() -> None:
 
         tcpdump_stdout = process.get_stdout()
         results = re.findall(
-            r".* IP .* > (?P<dest_ip>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,5}): .* A\?.*",
+            r".* IP .* > (?P<dest_ip>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\.\d{1,5}: .* A\?.*",
             tcpdump_stdout,
         )  # fmt: skip
 
-        assert results, tcpdump_stdout
-        assert [result for result in results if FIRST_DNS_SERVER in result]
-        assert not ([result for result in results if SECOND_DNS_SERVER in result])
+        assert results in ([FIRST_DNS_SERVER], [SECOND_DNS_SERVER]), tcpdump_stdout
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Seems that sometimes on CI the second server is selected by trust-dns. So instead of expecting that the *first* server is always asked about the A record, we can check that only one server is asked for A.

Before this change, when the test failed the `tcpdump` output was:

```
14:19:02.883980 IP 192.168.101.104.60221 > 1.1.1.1.53: 30843+ A? google.com. (28)
14:19:02.890200 IP 1.1.1.1.53 > 192.168.101.104.60221: 30843 1/0/0 A 142.250.185.78 (44)
14:19:02.890753 IP 192.168.101.104.54107 > 8.8.8.8.53: 3410+ AAAA? google.com. (28)
14:19:02.903749 IP 8.8.8.8.53 > 192.168.101.104.54107: 3410 1/0/0 AAAA 2a00:1450:4001:80b::200e (56)
```

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
