### PR TITLE
LLT-4502: Perform connection state tracking in telio firewall for each peer separately

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -46,6 +46,7 @@
 * LLT-4280: Implement TCP and UDP connection reset upon VPN server change for boringtun adapter
 * LLT-4124: Add IPv6 feature flag
 * LLT-3950: Enable IPv6 for wg-stun.
+* LLT-4502: Implement ICMP, UDP and TCP conntrack tracking for each peer separately
 
 <br>
 


### PR DESCRIPTION
### Problem
The TCP connection can be dropped by spoofing ICMP error packets. It's because the peer public key is not matched to the TCP connection conntrack thus allowing different peers to affect the connection

### Solution
This PR adds a validation of the peer's public key before any action on the TCP connection is done 


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
