### PR TITLE
LLT-4584: Add timestamps to the tcli `events` output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3652,6 +3652,7 @@ dependencies = [
  "telio-utils",
  "telio-wg",
  "thiserror",
+ "time",
  "tokio",
 ]
 

--- a/clis/tcli/Cargo.toml
+++ b/clis/tcli/Cargo.toml
@@ -31,6 +31,7 @@ serde_json.workspace = true
 serde_with.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
+time.workspace = true
 tokio = { workspace = true, features = ["full"] }
 
 telio = { path = "../.." }

--- a/clis/tcli/src/cli.rs
+++ b/clis/tcli/src/cli.rs
@@ -22,6 +22,7 @@ use tokio::{
 use crate::nord::{Error as NordError, Nord, OAuth};
 
 use std::str::FromStr;
+use std::time::SystemTime;
 use std::{
     fs,
     net::{IpAddr, Ipv4Addr, SocketAddr},
@@ -115,7 +116,10 @@ pub struct Cli {
 
 pub enum Resp {
     Info(String),
-    Event(Box<DevEvent>),
+    Event {
+        ts: SystemTime,
+        event: Box<DevEvent>,
+    },
     Error(Box<Error>),
     Quit,
 }
@@ -364,12 +368,16 @@ impl Cli {
                 let sender = sender.clone();
                 #[allow(unwrap_check)]
                 #[allow(clippy::unwrap_used)]
-                move |e: Box<DevEvent>| {
-                    if let DevEvent::Relay { body } = *e.clone() {
-                        *derp_server_lambda.lock() =
-                            body.filter(|s| s.conn_state != RelayState::Disconnected);
+                move |event: Box<DevEvent>| {
+                    let ts = SystemTime::now();
+
+                    if let DevEvent::Relay { body } = &*event {
+                        *derp_server_lambda.lock() = body
+                            .as_ref()
+                            .filter(|s| s.conn_state != RelayState::Disconnected)
+                            .cloned();
                     }
-                    sender.send(Resp::Event(e)).unwrap()
+                    sender.send(Resp::Event { ts, event }).unwrap()
                 }
             },
             None,


### PR DESCRIPTION
### Problem
It would be nice to have timestamps in the tcli events command output.

### Solution
The timestamps of events are recorded and displayed alongside events.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
