### PR TITLE
natlab: Fix macos network switch tests

### DIFF
--- a/nat-lab/tests/test_network_switch.py
+++ b/nat-lab/tests/test_network_switch.py
@@ -101,7 +101,6 @@ async def test_network_switcher(
             ),
             marks=[
                 pytest.mark.mac,
-                pytest.mark.xfail(reason="Flaky: LLT-1134"),
             ],
         ),
     ],
@@ -184,7 +183,6 @@ async def test_mesh_network_switch(
             ),
             marks=[
                 pytest.mark.mac,
-                pytest.mark.skip(reason="Flaky: LLT-1134"),
             ],
         ),
     ],

--- a/nat-lab/tests/utils/network_switcher/network_switcher_mac.py
+++ b/nat-lab/tests/utils/network_switcher/network_switcher_mac.py
@@ -14,6 +14,10 @@ class NetworkSwitcherMac(NetworkSwitcher):
             ["route", "add", "default", config.LINUX_VM_PRIMARY_GATEWAY]
         ).execute()
 
+        await self._connection.create_process(
+            ["route", "add", "-inet", config.VPN_SERVER_SUBNET, config.LINUX_VM_PRIMARY_GATEWAY]
+        ).execute()
+
     async def switch_to_secondary_network(self) -> None:
         await self._delete_existing_route()
 
@@ -21,5 +25,10 @@ class NetworkSwitcherMac(NetworkSwitcher):
             ["route", "add", "default", config.LINUX_VM_SECONDARY_GATEWAY]
         ).execute()
 
+        await self._connection.create_process(
+                ["route", "add", "-inet", config.VPN_SERVER_SUBNET, config.LINUX_VM_SECONDARY_GATEWAY]
+            ).execute()
+
     async def _delete_existing_route(self) -> None:
         await self._connection.create_process(["route", "delete", "default"]).execute()
+        await self._connection.create_process(["route", "delete", "-inet", config.VPN_SERVER_SUBNET]).execute()


### PR DESCRIPTION
### Problem
Both VPN and linux gateways were being added to the routing table as default destinations, so when switching to the secondary network, deleting the default route would also delete the VPN route. 

### Solution
Specify on the routing table the subnet destination of the packets that should be routed through the VPN interface. This way we can delete the default route while switching networks without touching the VPN route.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests