### PR TITLE
natlab: Specify destination on macos VPN routing rule

### DIFF
--- a/nat-lab/tests/test_network_switch.py
+++ b/nat-lab/tests/test_network_switch.py
@@ -101,7 +101,6 @@ async def test_network_switcher(
             ),
             marks=[
                 pytest.mark.mac,
-                pytest.mark.xfail(reason="Flaky: LLT-1134"),
             ],
         ),
     ],
@@ -187,7 +186,6 @@ async def test_mesh_network_switch(
             ),
             marks=[
                 pytest.mark.mac,
-                pytest.mark.skip(reason="Flaky: LLT-1134"),
             ],
         ),
     ],
@@ -203,7 +201,6 @@ async def test_vpn_network_switch(alpha_setup_params: SetupParameters) -> None:
         network_switcher = alpha_conn_mngr.network_switcher
 
         wg_server = config.WG_SERVER
-
         await client_alpha.connect_to_vpn(
             str(wg_server["ipv4"]), int(wg_server["port"]), str(wg_server["public_key"])
         )
@@ -213,11 +210,9 @@ async def test_vpn_network_switch(alpha_setup_params: SetupParameters) -> None:
 
         ip = await testing.wait_long(stun.get(alpha_connection, config.STUN_SERVER))
         assert ip == wg_server["ipv4"], f"wrong public IP when connected to VPN {ip}"
-
         assert network_switcher
         await network_switcher.switch_to_secondary_network()
         await client_alpha.notify_network_change()
-
         # This is really silly.. For some reason, adding a short sleep here allows the VPN
         # connection to be restored faster. The difference is almost 5 seconds. Without
         # the sleep, the test fails often due to timeouts. Its as if feeding data into

--- a/nat-lab/tests/utils/router/mac_router.py
+++ b/nat-lab/tests/utils/router/mac_router.py
@@ -1,10 +1,5 @@
 from .router import Router, IPStack, IPProto
-from config import (
-    LIBTELIO_IPV6_WG_SUBNET,
-    LINUX_VM_PRIMARY_GATEWAY,
-    DERP_SERVERS,
-    VPN_SERVER_SUBNET,
-)
+from config import LIBTELIO_IPV6_WG_SUBNET
 from contextlib import asynccontextmanager
 from typing import AsyncIterator, List
 from utils.connection import Connection
@@ -64,16 +59,6 @@ class MacRouter(Router):
                 ],
             ).execute()
 
-            for derp in DERP_SERVERS:
-                await self._connection.create_process(
-                    [
-                        "route",
-                        "add",
-                        str(derp.get("ipv4")) + "/32",
-                        LINUX_VM_PRIMARY_GATEWAY,
-                    ],
-                ).execute()
-
         if self.ip_stack in [IPStack.IPv6, IPStack.IPv4v6]:
             await self._connection.create_process(
                 [
@@ -89,15 +74,24 @@ class MacRouter(Router):
     async def create_vpn_route(self) -> None:
         if self.ip_stack in [IPStack.IPv4, IPStack.IPv4v6]:
             await self._connection.create_process(
-                ["route", "delete", "-inet", "default"]
+                [
+                    "route",
+                    "add",
+                    "-inet",
+                    "0/1",
+                    "-interface",
+                    self._interface_name,
+                ]
             ).execute()
-
             await self._connection.create_process(
-                ["route", "add", "-inet", "default", "-interface", self._interface_name]
-            ).execute()
-
-            await self._connection.create_process(
-                ["route", "add", "-inet", VPN_SERVER_SUBNET, LINUX_VM_PRIMARY_GATEWAY]
+                [
+                    "route",
+                    "add",
+                    "-inet",
+                    "128/1",
+                    "-interface",
+                    self._interface_name,
+                ]
             ).execute()
 
         if self.ip_stack in [IPStack.IPv6, IPStack.IPv4v6]:
@@ -118,11 +112,11 @@ class MacRouter(Router):
     async def delete_vpn_route(self) -> None:
         if self.ip_stack in [IPStack.IPv4, IPStack.IPv4v6]:
             await self._connection.create_process(
-                ["route", "delete", "-inet", "default"]
+                ["route", "delete", "-inet", "0/1"]
             ).execute()
 
             await self._connection.create_process(
-                ["route", "add", "-inet", "default", LINUX_VM_PRIMARY_GATEWAY]
+                ["route", "delete", "-inet", "128/1"]
             ).execute()
 
         if self.ip_stack in [IPStack.IPv6, IPStack.IPv4v6]:


### PR DESCRIPTION
### Problem

Both VPN and linux gateways were being added to the routing table as default destinations, so when switching to the secondary network, deleting the default route would also delete the VPN route.

### Solution

Specify on the routing table the subnet destination of the packets that should be routed through the VPN interface. This way we can delete the default route while switching networks without touching the VPN route.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests