### PR TITLE
Mark test_mesh_reconnect and test_lana_with_same_meshnet as flaky

### DIFF
--- a/nat-lab/tests/test_lana.py
+++ b/nat-lab/tests/test_lana.py
@@ -365,6 +365,7 @@ async def run_default_scenario(
 
 @pytest.mark.moose
 @pytest.mark.asyncio
+@pytest.mark.xfail(reason="test flaky - JIRA issue: LLT-4591")
 @pytest.mark.parametrize("alpha_ip_stack,beta_ip_stack", IP_STACK_TEST_CONFIGS)
 async def test_lana_with_same_meshnet(
     alpha_ip_stack: IPStack, beta_ip_stack: IPStack

--- a/nat-lab/tests/test_reconnections.py
+++ b/nat-lab/tests/test_reconnections.py
@@ -10,6 +10,7 @@ from utils.ping import Ping
 
 
 @pytest.mark.asyncio
+@pytest.mark.xfail(reason="test flaky - JIRA issue: LLT-4593")
 @pytest.mark.parametrize(
     "alpha_setup_params",
     [


### PR DESCRIPTION
Marked tests as flaky
 - LLT-4591: test_lana_with_same_meshnet
 - LLT-4593: test_mesh_reconnect


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
