### PR TITLE
Flush libmoose changes upon sending heartbeat event

### DIFF
--- a/crates/telio-lana/src/event_log_file.rs
+++ b/crates/telio-lana/src/event_log_file.rs
@@ -461,6 +461,11 @@ pub mod moose {
         }
     }
 
+    /// Mocked moose function
+    pub fn flush_changes() -> std::result::Result<Result, Error> {
+        Ok(Result::Success)
+    }
+
     /// Mocked moose function.
     pub fn fetch_specific_context(name: &str) -> std::result::Result<String, Error> {
         match super::event_log("fetch_specific_context", Some(vec![name])) {

--- a/crates/telio-nurse/src/nurse.rs
+++ b/crates/telio-nurse/src/nurse.rs
@@ -251,6 +251,8 @@ impl State {
             qos_data.rtt_loss,
             qos_data.tx
         );
+
+        let _ = lana!(flush_changes);
     }
 
     fn meshnet_id() -> Uuid {


### PR DESCRIPTION
libtelio heartbeat event is generally a once an hour occurance, therefore it is expected that event throughput is so low, that the moose queue will never contain more than one element. What is more, in tests there is an expectation that after triggering the analytics, database will contain events relatively soon. For some reason this does not happen in about 10% of the cases. This change is an attempt to verify whether flushing has impact on the event queueing.
