### PR TITLE
Mark some windows tests as flaky

### DIFF
--- a/nat-lab/tests/test_events.py
+++ b/nat-lab/tests/test_events.py
@@ -502,7 +502,10 @@ async def test_event_content_exit_through_peer(
                 features=TelioFeatures(direct=Direct(providers=["stun"])),
             ),
             "10.0.254.7",
-            marks=pytest.mark.windows,
+            marks=[
+                pytest.mark.windows,
+                pytest.mark.xfail(reason="Test is flaky - LLT-4357"),
+            ],
         ),
         pytest.param(
             SetupParameters(
@@ -515,7 +518,10 @@ async def test_event_content_exit_through_peer(
                 features=TelioFeatures(direct=Direct(providers=["stun"])),
             ),
             "10.0.254.7",
-            marks=pytest.mark.windows,
+            marks=[
+                pytest.mark.windows,
+                pytest.mark.xfail(reason="Test is flaky - LLT-4357"),
+            ],
         ),
         pytest.param(
             SetupParameters(

--- a/nat-lab/tests/test_mesh_exit_through_peer.py
+++ b/nat-lab/tests/test_mesh_exit_through_peer.py
@@ -222,12 +222,18 @@ async def test_mesh_exit_through_peer(
         pytest.param(
             ConnectionTag.WINDOWS_VM,
             telio.AdapterType.WindowsNativeWg,
-            marks=pytest.mark.windows,
+            marks=[
+                pytest.mark.windows,
+                pytest.mark.xfail(reason="Test is flaky - LLT-4357"),
+            ],
         ),
         pytest.param(
             ConnectionTag.WINDOWS_VM,
             telio.AdapterType.WireguardGo,
-            marks=pytest.mark.windows,
+            marks=[
+                pytest.mark.windows,
+                pytest.mark.xfail(reason="Test is flaky - LLT-4357"),
+            ],
         ),
         pytest.param(
             ConnectionTag.MAC_VM, telio.AdapterType.Default, marks=pytest.mark.mac

--- a/nat-lab/tests/test_mesh_plus_vpn.py
+++ b/nat-lab/tests/test_mesh_plus_vpn.py
@@ -175,7 +175,10 @@ async def test_mesh_plus_vpn_one_peer(
                     vpn_1_limits=ConnectionLimits(1, 1),
                 ),
             ),
-            marks=pytest.mark.windows,
+            marks=[
+                pytest.mark.windows,
+                pytest.mark.xfail(reason="Test is flaky - LLT-4357"),
+            ],
         ),
         pytest.param(
             SetupParameters(
@@ -291,13 +294,19 @@ async def test_mesh_plus_vpn_both_peers(
             ConnectionTag.WINDOWS_VM,
             AdapterType.WindowsNativeWg,
             "10.0.254.7",
-            marks=pytest.mark.windows,
+            marks=[
+                pytest.mark.windows,
+                pytest.mark.xfail(reason="Test is flaky - LLT-4357"),
+            ],
         ),
         pytest.param(
             ConnectionTag.WINDOWS_VM,
             AdapterType.WireguardGo,
             "10.0.254.7",
-            marks=pytest.mark.windows,
+            marks=[
+                pytest.mark.windows,
+                pytest.mark.xfail(reason="Test is flaky - LLT-4357"),
+            ],
         ),
         pytest.param(
             ConnectionTag.MAC_VM,

--- a/nat-lab/tests/test_network_switch.py
+++ b/nat-lab/tests/test_network_switch.py
@@ -174,7 +174,10 @@ async def test_mesh_network_switch(
                 adapter_type=telio.AdapterType.WireguardGo,
                 is_meshnet=False,
             ),
-            marks=pytest.mark.windows,
+            marks=[
+                pytest.mark.windows,
+                pytest.mark.xfail(reason="Test is flaky - LLT-4391"),
+            ],
         ),
         pytest.param(
             SetupParameters(

--- a/nat-lab/tests/test_vpn.py
+++ b/nat-lab/tests/test_vpn.py
@@ -208,7 +208,10 @@ async def test_vpn_connection(
                 is_meshnet=False,
             ),
             "10.0.254.7",
-            marks=pytest.mark.windows,
+            marks=[
+                pytest.mark.windows,
+                pytest.mark.xfail(reason="Test is flaky - JIRA issue: LLT-4554"),
+            ],
         ),
         pytest.param(
             SetupParameters(


### PR DESCRIPTION
### Problem
In the last week we have seen some failurs in windows tests. Some of the tests already have been marked as flaky for Wireguard-NT adapter type, but not for WireGuard-go. Weekly report shows, that flakyness is not dependant on the WG implementation, therefore marking WG-GO tests flaky as well.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
