### PR TITLE
Unmark boringtun TCP closing test as not-flaky anymore

### DIFF
--- a/nat-lab/tests/test_mesh_firewall.py
+++ b/nat-lab/tests/test_mesh_firewall.py
@@ -522,7 +522,6 @@ async def test_mesh_firewall_file_share_port(
 
 
 @pytest.mark.asyncio
-@pytest.mark.xfail(reason="test flaky - JIRA issue: LLT-4553")
 @pytest.mark.parametrize(
     "alpha_ip_stack,beta_ip_stack",
     [
@@ -558,7 +557,6 @@ async def test_mesh_firewall_file_share_port(
     [
         (telio.AdapterType.BoringTun, telio.AdapterType.BoringTun),
         (telio.AdapterType.BoringTun, telio.AdapterType.LinuxNativeWg),
-        (telio.AdapterType.LinuxNativeWg, telio.AdapterType.LinuxNativeWg),
         (telio.AdapterType.LinuxNativeWg, telio.AdapterType.BoringTun),
     ],
 )
@@ -668,7 +666,6 @@ async def test_mesh_firewall_tcp_stuck_in_last_ack_state_conn_kill_from_server_s
 
 
 @pytest.mark.asyncio
-@pytest.mark.xfail(reason="test flaky - JIRA issue: LLT-4553")
 @pytest.mark.parametrize(
     "alpha_ip_stack,beta_ip_stack",
     [
@@ -704,7 +701,6 @@ async def test_mesh_firewall_tcp_stuck_in_last_ack_state_conn_kill_from_server_s
     [
         (telio.AdapterType.BoringTun, telio.AdapterType.BoringTun),
         (telio.AdapterType.BoringTun, telio.AdapterType.LinuxNativeWg),
-        (telio.AdapterType.LinuxNativeWg, telio.AdapterType.LinuxNativeWg),
         (telio.AdapterType.LinuxNativeWg, telio.AdapterType.BoringTun),
     ],
 )


### PR DESCRIPTION
Any of the test cases (parameterized) for the TCP closing sequence has not failed even once in the last week. What is more, the test is testing changes fixing telio-firewall TCP closing sequence. Due to telio-firewall being used only for boringtun - LinuxNativeWG<->LinuxNativeWG test case has been removed as it is not testing anything of importance.
