### PR TITLE
traversal: Fix libtelio block on upnp gateway search

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1756,8 +1756,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "556b5a75cd4adb7c4ea21c64af1c48cefb2ce7d43dc4352c720a1fe47c21f355"
 dependencies = [
  "attohttpc",
+ "bytes",
+ "futures",
+ "http",
+ "hyper",
  "log",
  "rand",
+ "tokio",
  "url",
  "xmltree",
 ]

--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,9 @@
 * LLT-4598: Introduce IPv6 -> IPv4 fallback in WG-STUN
 * LLT-4698: Fix exp. backoff in WG-STUN
 * LLT-4490: Ensure that meshnet entities are started only when meshnet is started
+* LLT-4335: Make blocking upnp gw search async
+
+<br>
 
 ### v4.2.1
 ----

--- a/crates/telio-traversal/Cargo.toml
+++ b/crates/telio-traversal/Cargo.toml
@@ -11,7 +11,7 @@ bytecodec = "0.4.15"
 enum-map = "2.5.0"
 http = "0.2.8"
 if-addrs = "0.7.0"
-igd = "0.12.1"
+igd = { version = "0.12.1", features = ["aio"] }
 sm = "0.9.0"
 stun_codec = "0.1.13"
 

--- a/nat-lab/tests/test_upnp_connection.py
+++ b/nat-lab/tests/test_upnp_connection.py
@@ -93,12 +93,14 @@ async def test_upnp_route_removed(
             SetupParameters(
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
                 adapter_type=AdapterType.BoringTun,
+                features=TelioFeatures(direct=Direct(providers=["upnp"])),
             ),
         ),
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
                 adapter_type=AdapterType.LinuxNativeWg,
+                features=TelioFeatures(direct=Direct(providers=["upnp"])),
             ),
             marks=pytest.mark.linux_native,
         ),
@@ -106,6 +108,7 @@ async def test_upnp_route_removed(
             SetupParameters(
                 connection_tag=ConnectionTag.WINDOWS_VM,
                 adapter_type=AdapterType.WindowsNativeWg,
+                features=TelioFeatures(direct=Direct(providers=["upnp"])),
             ),
             marks=pytest.mark.windows,
         ),
@@ -113,6 +116,7 @@ async def test_upnp_route_removed(
             SetupParameters(
                 connection_tag=ConnectionTag.WINDOWS_VM,
                 adapter_type=AdapterType.WireguardGo,
+                features=TelioFeatures(direct=Direct(providers=["upnp"])),
             ),
             marks=pytest.mark.windows,
         ),
@@ -120,6 +124,7 @@ async def test_upnp_route_removed(
             SetupParameters(
                 connection_tag=ConnectionTag.MAC_VM,
                 adapter_type=AdapterType.BoringTun,
+                features=TelioFeatures(direct=Direct(providers=["upnp"])),
             ),
             marks=pytest.mark.mac,
         ),


### PR DESCRIPTION
### Problem
UPnP started blocking whole libtelio due to blocking sockets used in igd crate. In this case, a call to search_gateway() in third party igd crate blocks processing loop for UPnP endpoint provider, blocking all task_exec!()'s as well, including cross_ping_check pinging and its processing loop, then all CPC's functions using task_exec!() are blocked too and eventually blocks the device processing loop that uses CPC for endpoint validation. From there the whole libtelio is blocked.

### Solution
Spawn a thread to run `search_gateway()` call on a dedicated pool for blocking tasks, using `tokio::task::spawn_blocking()`.

Also, during implementation it was found that the backing off was not working as expected, after the first iteration when the `PinnedSleep` completed a new instance was never being reassigned. This PR also tackles it.

EDIT: It was decided to enable async feature for the igd crate (feature = ["aio"]), avoiding calling sync on async code.

EDIT2: Removed most of the search task logic and added the igd `search_gateway()` call directly on the `tokio::select!` from the main loop

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
