### PR TITLE
[LLT-4543] log ffi calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3686,6 +3686,7 @@ dependencies = [
  "num_cpus",
  "parking_lot",
  "pretty_assertions",
+ "rand",
  "rstest",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ parking_lot.workspace = true
 serde.workspace = true
 serde_with.workspace = true
 serde_json.workspace = true
+rand.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["full"] }
 tracing.workspace = true

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 * LLT-4662: Update rustix dependency
 * LLT-4667: Fix panic in boringtun
 * LLT-4663: Update zerocopy dependency
+* LLT-4543: Log ffi calls
 
 ### v4.2.1
 ----

--- a/crates/telio-model/src/config.rs
+++ b/crates/telio-model/src/config.rs
@@ -3,6 +3,7 @@
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use serde_json::{from_value, Error, Value};
+use telio_utils::Hidden;
 
 use std::{
     net::{IpAddr, Ipv4Addr},
@@ -19,7 +20,7 @@ pub struct PeerBase {
     /// Public key of the peer
     pub public_key: PublicKey,
     /// Hostname of the peer
-    pub hostname: String,
+    pub hostname: Hidden<String>,
     /// Ip address of peer
     pub ip_addresses: Option<Vec<IpAddr>>,
     /// Nickname for the peer
@@ -177,7 +178,6 @@ impl PartialConfig {
 
 /// Rust representation of [meshnet map]
 /// A network map of all the Peers and the servers
-/// [meshnet map]: https://docs.nordvpn.com/client-api/#get-map
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct Config {
     #[serde(flatten)]
@@ -332,7 +332,7 @@ mod tests {
                 public_key: "qj1pru+cP0mU9K0FrU8e0JYtTaPo0YiQG8O2NbFHeH4="
                     .parse()
                     .unwrap(),
-                hostname: "everest-alice.nord".to_owned(),
+                hostname: telio_utils::Hidden("everest-alice.nord".to_owned()),
                 ip_addresses: Some(vec!["198.51.100.42".parse().unwrap()]),
                 nickname: Some("bunnyg".to_owned()),
             },
@@ -343,7 +343,7 @@ mod tests {
                         public_key: "LRrbraNJXOrVdnpXy6gA/XcpmxymE0oMZlzP5Pqi20I="
                             .parse()
                             .unwrap(),
-                        hostname: "everest-bob.nord".to_owned(),
+                        hostname: telio_utils::Hidden("everest-bob.nord".to_owned()),
                         ip_addresses: Some(vec!["198.51.100.43".parse().unwrap()]),
                         nickname: Some("".to_owned()),
                     },
@@ -357,7 +357,7 @@ mod tests {
                         public_key: "LRrbraNJXOrVdnpXy6gA/XcpmxymE0oMZlzP5Pqi20I="
                             .parse()
                             .unwrap(),
-                        hostname: "everest-alice.nord".to_owned(),
+                        hostname: telio_utils::Hidden("everest-alice.nord".to_owned()),
                         ip_addresses: Some(vec!["198.51.100.43".parse().unwrap()]),
                         nickname: None,
                     },

--- a/crates/telio-model/src/mesh.rs
+++ b/crates/telio-model/src/mesh.rs
@@ -111,7 +111,7 @@ impl From<&PeerBase> for Node {
                 .as_ref()
                 .map(|ips| ips.iter().map(|a| (*a).into()).collect())
                 .unwrap_or_default(),
-            hostname: Some(peer.hostname.to_owned()),
+            hostname: Some(peer.hostname.0.to_owned().to_string()),
             ..Default::default()
         }
     }
@@ -126,7 +126,7 @@ impl From<&Peer> for Node {
                 .as_ref()
                 .map(|ips| ips.iter().map(|a| (*a).into()).collect())
                 .unwrap_or_default(),
-            hostname: Some(peer.hostname.to_owned()),
+            hostname: Some(peer.hostname.0.to_owned().to_string()),
             allow_incoming_connections: peer.allow_incoming_connections,
             allow_peer_send_files: peer.allow_peer_send_files,
             ..Default::default()

--- a/crates/telio-utils/src/hidden.rs
+++ b/crates/telio-utils/src/hidden.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// When printed in release mode it will not reveal inner data instead
 /// replacing it with `****`.
-#[derive(Deserialize, Serialize, Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Default, Deserialize, Serialize, Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[serde(transparent)]
 pub struct Hidden<T>(pub T);
 

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -704,7 +704,7 @@ impl RequestedState {
             .filter_map(|v| {
                 v.ip_addresses
                     .as_ref()
-                    .map(|ips| (v.hostname.to_owned(), ips.clone()))
+                    .map(|ips| (v.hostname.0.to_owned().to_string(), ips.clone()))
             })
             .collect()
     }
@@ -1629,7 +1629,7 @@ impl Runtime {
                     ip_addresses: meshnet_peer.base.ip_addresses.clone().unwrap_or_default(),
                     allowed_ips: peer.allowed_ips.clone(),
                     endpoint,
-                    hostname: Some(meshnet_peer.base.hostname.clone()),
+                    hostname: Some(meshnet_peer.base.hostname.0.clone().to_string()),
                     allow_incoming_connections: meshnet_peer.allow_incoming_connections,
                     allow_peer_send_files: meshnet_peer.allow_peer_send_files,
                     path: path_type,
@@ -1861,7 +1861,7 @@ mod tests {
         nickname: Option<String>,
     ) -> PeerBase {
         PeerBase {
-            hostname,
+            hostname: telio_utils::Hidden(hostname),
             ip_addresses,
             nickname,
             ..Default::default()
@@ -2171,7 +2171,7 @@ mod tests {
         let peer_base = PeerBase {
             identifier: "identifier".to_owned(),
             public_key: pubkey,
-            hostname: "hostname".to_owned(),
+            hostname: telio_utils::Hidden("hostname".to_owned()),
             ip_addresses: Some(vec![IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))]),
             nickname: Some("nickname".to_owned()),
         };
@@ -2247,7 +2247,7 @@ mod tests {
             this: PeerBase {
                 identifier: "identifier".to_owned(),
                 public_key: private_key.public(),
-                hostname: "hostname".to_owned(),
+                hostname: telio_utils::Hidden("hostname".to_owned()),
                 ip_addresses: Some(vec![IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))]),
                 nickname: Some("nickname".to_owned()),
             },
@@ -2336,7 +2336,7 @@ mod tests {
         let peer_base = PeerBase {
             identifier: "identifier".to_owned(),
             public_key: pubkey,
-            hostname: "hostname".to_owned(),
+            hostname: telio_utils::Hidden("hostname".to_owned()),
             ip_addresses: Some(vec![IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))]),
             nickname: Some("nickname".to_owned()),
         };
@@ -2529,7 +2529,7 @@ mod tests {
             let peer_base = PeerBase {
                 identifier: "identifier".to_owned(),
                 public_key,
-                hostname: "hostname".to_owned(),
+                hostname: telio_utils::Hidden("hostname".to_owned()),
                 ip_addresses: Some(vec![IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))]),
                 nickname: Some("nickname".to_owned()),
             };
@@ -2593,7 +2593,7 @@ mod tests {
         let peer_base = PeerBase {
             identifier: "identifier".to_owned(),
             public_key: new_private_key.public(),
-            hostname: "hostname".to_owned(),
+            hostname: telio_utils::Hidden("hostname".to_owned()),
             ip_addresses: Some(vec![IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))]),
             nickname: Some("nickname".to_owned()),
         };
@@ -2703,7 +2703,7 @@ mod tests {
         let peer_base = PeerBase {
             identifier: "identifier".to_owned(),
             public_key: private_key.public(),
-            hostname: "hostname".to_owned(),
+            hostname: telio_utils::Hidden("hostname".to_owned()),
             ip_addresses: Some(vec![
                 IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
                 IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0xc00a, 0x2ff)),

--- a/src/ffi/types.rs
+++ b/src/ffi/types.rs
@@ -31,7 +31,15 @@ pub enum telio_result {
 impl std::error::Error for telio_result {}
 impl std::fmt::Display for telio_result {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        match self {
+            TELIO_RES_ALREADY_STARTED => write!(f, "Device is already started"),
+            TELIO_RES_INVALID_KEY => write!(f, "Cannot parse key as base64 string"),
+            TELIO_RES_BAD_CONFIG => write!(f, "Cannot Parse Configuration "),
+            TELIO_RES_LOCK_ERROR => write!(f, "Cannot lock a mutex"),
+            TELIO_RES_INVALID_STRING => write!(f, "Cannot parse a string"),
+            TELIO_RES_ERROR => write!(f, "Unknown error"),
+            TELIO_RES_OK => write!(f, "Operation was successful"),
+        }
     }
 }
 pub use telio_result::*;
@@ -72,7 +80,7 @@ pub type telio_event_fn = unsafe extern "C" fn(*mut c_void, *const c_char);
 
 #[allow(non_camel_case_types)]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 /// Event callback
 pub struct telio_event_cb {
     /// Context to pass to callback.
@@ -87,7 +95,7 @@ pub type telio_logger_fn = unsafe extern "C" fn(*mut c_void, telio_log_level, *c
 
 #[allow(non_camel_case_types)]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 /// Logging callback
 pub struct telio_logger_cb {
     /// Context to pass to callback.


### PR DESCRIPTION
### Problem
To have a better idea on during debugging, it is better if we have an idea of the ffi calls.
#instrument from tracing crate is not used as there is a separate task to add span ids which isn't implemented yet.

### Solution
Log most of ffi calls and their parameters.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
