### PR TITLE
Release-candidate v4.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3658,7 +3658,7 @@ dependencies = [
 
 [[package]]
 name = "telio"
-version = "4.0.5"
+version = "4.2.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "telio"
-version = "4.0.5"
+version = "4.2.0"
 authors = ["info@nordvpn.com"]
 edition = "2018"
 license = "GPL-3.0-only"

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,5 @@
-### UNRELEASED
+### v4.2.0
+### **Space-cakes**
 ---
 * LLT-3777: Apply rebinding logic to all Apple platforms
 * LLT-4002: Review log-levels of spammy log messages


### PR DESCRIPTION
Branching off release v4.2 line, but would be nice to merge `Cargo.toml` version changes and `Cargo.lock` back into `main`

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
