### PR TITLE
natlab: Remove alpha asserts after network switch

### DIFF
--- a/nat-lab/tests/test_network_switch.py
+++ b/nat-lab/tests/test_network_switch.py
@@ -234,7 +234,6 @@ async def test_vpn_network_switch(alpha_setup_params: SetupParameters) -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.xfail(reason="Flaky: LLT-4605")
 @pytest.mark.timeout(90)
 @pytest.mark.parametrize(
     "alpha_setup_params",
@@ -315,18 +314,15 @@ async def test_mesh_network_switch_direct(
         derp_connected_future = alpha_client.wait_for_event_on_any_derp(
             [State.Connected]
         )
+
+        # Beta doesn't change its endpoint, so WG roaming may be used by alpha node to restore
+        # the connection, so no node event is logged in that case
         peers_connected_relay_future = asyncio.gather(
-            alpha_client.wait_for_event_peer(
-                beta.public_key, [State.Connected], [PathType.Relay]
-            ),
             beta_client.wait_for_event_peer(
                 alpha.public_key, [State.Connected], [PathType.Relay]
             ),
         )
         peers_connected_direct_future = asyncio.gather(
-            alpha_client.wait_for_event_peer(
-                beta.public_key, [State.Connected], [PathType.Direct]
-            ),
             beta_client.wait_for_event_peer(
                 alpha.public_key, [State.Connected], [PathType.Direct]
             ),


### PR DESCRIPTION
### Problem
`test_mesh_network_switch_direct` triggers network switch on node alpha and then strictly requires node events transitioning direct->relay and later vice-versa relay->direct, but due to the fact that beta node has not changed its endpoint, alpha node may trigger roaming in beta (by sending any packet to beta) restoring direct connection without the need for direct->relay and relay->direct cycle. The presence of this cycle is inherently racy.

### Solution
Remove alpha's assertions after network switch, as beta's are enough.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
