### PR TITLE
Sometimes trust-dns sends 2 requests to the same server for the same hostname - align tests

### DIFF
--- a/nat-lab/tests/test_dns.py
+++ b/nat-lab/tests/test_dns.py
@@ -760,12 +760,12 @@ async def test_dns_duplicate_requests_on_multiple_forward_servers() -> None:
         await asyncio.sleep(1)
 
         tcpdump_stdout = process.get_stdout()
-        results = re.findall(
+        results = set(re.findall(
             r".* IP .* > (?P<dest_ip>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\.\d{1,5}: .* A\?.*",
             tcpdump_stdout,
-        )  # fmt: skip
+        ))  # fmt: skip
 
-        assert results in ([FIRST_DNS_SERVER], [SECOND_DNS_SERVER]), tcpdump_stdout
+        assert results in ({FIRST_DNS_SERVER}, {SECOND_DNS_SERVER}), tcpdump_stdout
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Problem

The failing tcpdump as logged in gitlab:
```
[2023-12-07 14:05:33] FAILED tests/test_dns.py::test_dns_duplicate_requests_on_multiple_forward_servers - AssertionError: 13:45:54.047097 IP 192.168.101.104.55778 > 1.1.1.1.53: 40350+ A? google.com. (28)
[2023-12-07 14:05:33]   13:45:54.047795 IP 192.168.101.104.58864 > 1.1.1.1.53: 2779+ A? google.com. (28)13:45:54.053094 IP 1.1.1.1.53 > 192.168.101.104.55778: 40350 1/0/0 A 142.250.184.206 (44)13:45:54.053593 IP 1.1.1.1.53 > 192.168.101.104.58864: 2779 1/0/0 A 142.250.185.110 (44)13:45:54.053713 IP 192.168.101.104.53814 > 8.8.8.8.53: 56612+ AAAA? google.com. (28)13:45:54.054460 IP 192.168.101.104.52010 > 8.8.8.8.53: 8245+ AAAA? google.com. (28)13:45:54.067647 IP 8.8.8.8.53 > 192.168.101.104.53814: 56612 1/0/0 AAAA 2a00:1450:4001:810::200e (56)13:45:54.068588 IP 8.8.8.8.53 > 192.168.101.104.52010: 8245 1/0/0 AAAA 2a00:1450:4001:810::200e (56)
```
Notice 2 separate lines. First with one query, second (very long) with all the others. Cleaning this gives us:

```
13:45:54.047097 IP 192.168.101.104.55778 > 1.1.1.1.53: 40350+ A? google.com. (28)
13:45:54.047795 IP 192.168.101.104.58864 > 1.1.1.1.53: 2779+ A? google.com. (28)
13:45:54.053094 IP 1.1.1.1.53 > 192.168.101.104.55778: 40350 1/0/0 A 142.250.184.206 (44)
13:45:54.053593 IP 1.1.1.1.53 > 192.168.101.104.58864: 2779 1/0/0 A 142.250.185.110 (44)
13:45:54.053713 IP 192.168.101.104.53814 > 8.8.8.8.53: 56612+ AAAA? google.com. (28)
13:45:54.054460 IP 192.168.101.104.52010 > 8.8.8.8.53: 8245+ AAAA? google.com. (28)
13:45:54.067647 IP 8.8.8.8.53 > 192.168.101.104.53814: 56612 1/0/0 AAAA 2a00:1450:4001:810::200e (56)
13:45:54.068588 IP 8.8.8.8.53 > 192.168.101.104.52010: 8245 1/0/0 AAAA 2a00:1450:4001:810::200e (56)
```

We can see that for the `A` record we have only one dns server queried, but due to the line split it resulted in a **list** of two equal entries.

### Solution

Since we care if the 2 different dns server had been asked, convert list to set to remove duplicates.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
