### PR TITLE
LLT-4614: implement wg post quantum handshake in libtelio codebase

### DIFF
--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -33,3 +33,15 @@ jobs:
         - name: fuzz telio crypto decrypt_response
           working-directory: crates/telio-crypto
           run: cargo fuzz run decrypt_response -- -max_total_time=180
+  telio-wg-fuzzing:
+      runs-on: ubuntu-22.04
+      steps:
+        - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        - uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.6
+          with:
+            toolchain: nightly-2023-03-01
+            override: true
+        - run: cargo install cargo-fuzz --locked --version 0.11.2
+        - name: fuzz telio wg parse_get_packet
+          working-directory: crates/telio-wg
+          run: cargo fuzz run parse_get_packet -- -max_total_time=180

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,6 +474,7 @@ version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
 dependencies = [
+ "jobserver",
  "libc",
 ]
 
@@ -1090,6 +1091,12 @@ name = "downcast"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
+name = "dunce"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
 
 [[package]]
 name = "either"
@@ -1886,6 +1893,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
+name = "jobserver"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c37f63953c4c63420ed5fd3d6d398c719489b9f872b9fa683262f8edd363c7d"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2571,6 +2587,37 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "pqcrypto-internals"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9d34bec6abe2283e6de7748b68b292d1ffa2203397e3e71380ff8418a49fb46"
+dependencies = [
+ "cc",
+ "dunce",
+ "getrandom",
+ "libc",
+]
+
+[[package]]
+name = "pqcrypto-kyber"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe9d9695c19e525d5366c913562a331fbeef9a2ad801d9a9ded61a0e4c2fe0fb"
+dependencies = [
+ "cc",
+ "glob",
+ "libc",
+ "pqcrypto-internals",
+ "pqcrypto-traits",
+]
+
+[[package]]
+name = "pqcrypto-traits"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e851c7654eed9e68d7d27164c454961a616cf8c203d500607ef22c737b51bb"
 
 [[package]]
 name = "predicates"
@@ -4042,6 +4089,7 @@ name = "telio-wg"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "base64 0.13.1",
  "boringtun",
  "cc",
  "futures",
@@ -4052,7 +4100,11 @@ dependencies = [
  "libc",
  "mockall",
  "ntest",
+ "pnet_packet 0.28.0",
+ "pqcrypto-kyber",
+ "pqcrypto-traits",
  "pretty_assertions",
+ "rand",
  "serde",
  "serde_json",
  "sha2",

--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@
 * LLT-4225: Migrate Telio to use the tracing crate instead of log crate
 * LLT-4594: Fix session keeper's bug, to enable ICMP6 packets
 * LLT-4597: Fix QoS' IPv6 pinging
+* LLT-4614: Implement the post quantum VPN handshake
 
 <br>
 

--- a/clis/tcli/src/main.rs
+++ b/clis/tcli/src/main.rs
@@ -93,7 +93,7 @@ fn main() -> Result<()> {
                     _ => (),
                 },
                 Error(e) => {
-                    println!("error: {}", e)
+                    println!("error: {e:#?}")
                 }
                 Quit => {
                     if let Some(idx) = message_idx {

--- a/crates/telio-crypto/src/lib.rs
+++ b/crates/telio-crypto/src/lib.rs
@@ -81,7 +81,8 @@ impl SecretKey {
         Self::gen_with(&mut rand::rngs::StdRng::from_entropy())
     }
 
-    pub(crate) fn gen_with(rng: &mut (impl RngCore + CryptoRng)) -> Self {
+    /// Generates a new random SecretKey with provided RNG
+    pub fn gen_with(rng: &mut (impl RngCore + CryptoRng)) -> Self {
         let mut key = SecretKey([0u8; KEY_SIZE]);
         rng.fill_bytes(&mut key.0);
         // Key clamping

--- a/crates/telio-crypto/src/lib.rs
+++ b/crates/telio-crypto/src/lib.rs
@@ -27,7 +27,7 @@ use std::{convert::TryInto, fmt};
 use rand::prelude::*;
 use serde_with::{DeserializeFromStr, SerializeDisplay};
 
-/// Secret/Public key size in bytes
+/// Secret, Public and Wireguard Preshared key size in bytes
 pub const KEY_SIZE: usize = 32;
 
 /// Secret key type
@@ -41,6 +41,12 @@ pub struct SecretKey([u8; KEY_SIZE]);
     Default, PartialOrd, Ord, PartialEq, Eq, Hash, Copy, Clone, DeserializeFromStr, SerializeDisplay,
 )]
 pub struct PublicKey(pub [u8; KEY_SIZE]);
+
+/// Preshared key type
+#[derive(
+    Default, PartialOrd, Ord, PartialEq, Eq, Hash, Copy, Clone, DeserializeFromStr, SerializeDisplay,
+)]
+pub struct PresharedKey(pub [u8; KEY_SIZE]);
 
 /// Error returned when parsing fails for SecretKey or PublicKey.
 #[derive(Debug, thiserror::Error)]
@@ -123,6 +129,13 @@ impl SecretKey {
 }
 
 impl PublicKey {
+    /// Create new key from bytes
+    pub const fn new(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+}
+
+impl PresharedKey {
     /// Create new key from bytes
     pub const fn new(bytes: [u8; 32]) -> Self {
         Self(bytes)
@@ -282,7 +295,7 @@ macro_rules! gen_common {
         gen_common!($($tt),+);
     };
 }
-gen_common!(SecretKey, PublicKey);
+gen_common!(SecretKey, PublicKey, PresharedKey);
 
 #[cfg(test)]
 mod tests {

--- a/crates/telio-dns/src/dns.rs
+++ b/crates/telio-dns/src/dns.rs
@@ -149,11 +149,8 @@ impl DnsResolver for LocalDnsResolver {
         Peer {
             public_key: self.public_key(),
             endpoint: Some(([127, 0, 0, 1], self.socket_port).into()),
-            persistent_keepalive_interval: None,
             allowed_ips,
-            rx_bytes: None,
-            tx_bytes: None,
-            time_since_last_handshake: None,
+            ..Default::default()
         }
     }
 

--- a/crates/telio-model/src/api_config.rs
+++ b/crates/telio-model/src/api_config.rs
@@ -245,6 +245,20 @@ impl Default for FeatureValidateKeys {
 #[serde(transparent)]
 pub struct FeatureBoringtunResetConns(pub bool);
 
+/// Turns on post quantum VPN tunnel
+#[derive(Default, Clone, Copy, Debug, PartialEq, Eq, Deserialize)]
+pub struct FeaturePostQuantumVPN {
+    /// Initial handshake timeout in seconds
+    #[serde(default = "FeaturePostQuantumVPN::default_handshake_timeout_s")]
+    pub handshake_timeout_s: u32,
+}
+
+impl FeaturePostQuantumVPN {
+    const fn default_handshake_timeout_s() -> u32 {
+        8
+    }
+}
+
 fn deserialize_providers<'de, D>(de: D) -> Result<Option<HashSet<EndpointProvider>>, D::Error>
 where
     D: Deserializer<'de>,
@@ -304,6 +318,9 @@ pub struct Features {
     pub boringtun_reset_connections: FeatureBoringtunResetConns,
     /// If and for how long to flush events when stopping telio. Setting to Some(0) means waiting until all events have been flushed, regardless of how long it takes
     pub flush_events_on_stop_timeout_seconds: Option<u64>,
+    /// Flag to turn on post quantum VPN tunnel
+    #[serde(default)]
+    pub post_quantum_vpn: Option<FeaturePostQuantumVPN>,
 }
 
 impl FeaturePaths {
@@ -407,7 +424,11 @@ mod tests {
             "validate_keys": false,
             "ipv6": true,
             "nicknames": true,
-            "boringtun_reset_connections": true
+            "boringtun_reset_connections": true,
+            "post_quantum_vpn":
+            {
+                "handshake_timeout_s": 16
+            }
         }"#;
 
     static EXPECTED_FEATURES: Lazy<Features> = Lazy::new(|| Features {
@@ -456,6 +477,9 @@ mod tests {
         nicknames: true,
         boringtun_reset_connections: FeatureBoringtunResetConns(true),
         flush_events_on_stop_timeout_seconds: None,
+        post_quantum_vpn: Some(FeaturePostQuantumVPN {
+            handshake_timeout_s: 16,
+        }),
     });
 
     static EXPECTED_FEATURES_WITHOUT_TEST_ENV: Lazy<Features> = Lazy::new(|| Features {
@@ -498,6 +522,7 @@ mod tests {
         nicknames: false,
         boringtun_reset_connections: FeatureBoringtunResetConns(false),
         flush_events_on_stop_timeout_seconds: None,
+        post_quantum_vpn: None,
     });
 
     #[test]
@@ -669,6 +694,7 @@ mod tests {
             nicknames: false,
             boringtun_reset_connections: Default::default(),
             flush_events_on_stop_timeout_seconds: None,
+            post_quantum_vpn: Default::default(),
         };
 
         let empty_qos_features = Features {
@@ -695,6 +721,7 @@ mod tests {
             nicknames: false,
             boringtun_reset_connections: Default::default(),
             flush_events_on_stop_timeout_seconds: None,
+            post_quantum_vpn: Default::default(),
         };
 
         let no_qos_features = Features {
@@ -716,6 +743,7 @@ mod tests {
             nicknames: false,
             boringtun_reset_connections: Default::default(),
             flush_events_on_stop_timeout_seconds: None,
+            post_quantum_vpn: Default::default(),
         };
 
         assert_eq!(from_str::<Features>(full_json).unwrap(), full_features);
@@ -756,6 +784,7 @@ mod tests {
             nicknames: false,
             boringtun_reset_connections: Default::default(),
             flush_events_on_stop_timeout_seconds: None,
+            post_quantum_vpn: Default::default(),
         };
 
         let empty_features = Features {
@@ -773,6 +802,7 @@ mod tests {
             nicknames: false,
             boringtun_reset_connections: Default::default(),
             flush_events_on_stop_timeout_seconds: None,
+            post_quantum_vpn: Default::default(),
         };
 
         assert_eq!(from_str::<Features>(full_json).unwrap(), full_features);
@@ -814,6 +844,7 @@ mod tests {
             nicknames: false,
             boringtun_reset_connections: Default::default(),
             flush_events_on_stop_timeout_seconds: None,
+            post_quantum_vpn: Default::default(),
         };
 
         assert_eq!(Features::default(), expected_defaults);

--- a/crates/telio-wg/Cargo.toml
+++ b/crates/telio-wg/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 
 [features]
 test-adapter = []
+fuzzing = []
 
 [dependencies]
 # pqcrypto version is fixed, because the newer version implements incompatible kyber kem according to draft specs

--- a/crates/telio-wg/Cargo.toml
+++ b/crates/telio-wg/Cargo.toml
@@ -10,6 +10,9 @@ publish = false
 test-adapter = []
 
 [dependencies]
+# pqcrypto version is fixed, because the newer version implements incompatible kyber kem according to draft specs
+pqcrypto-kyber = { version = "=0.7.6", default-features = false, features = ["std"] }
+pqcrypto-traits = "0.3.5"
 slog-stdlog = "4.1.0"
 wireguard-uapi = { version = "2.0.4", features = ["xplatform"]}
 
@@ -22,9 +25,11 @@ lazy_static.workspace = true
 libc.workspace = true
 tracing.workspace = true
 mockall = { workspace = true, optional = true }
+pnet_packet.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 slog.workspace = true
+rand.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["full"] }
 
@@ -35,6 +40,7 @@ telio-task.workspace = true
 telio-utils.workspace = true
 
 [dev-dependencies]
+base64.workspace = true
 mockall.workspace = true
 ntest.workspace = true
 pretty_assertions.workspace = true

--- a/crates/telio-wg/fuzz/Cargo.toml
+++ b/crates/telio-wg/fuzz/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "telio-wg-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+license = "GPL-3.0-only"
+repository = "https://github.com/NordSecurity/libtelio"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[dependencies.telio-wg]
+path = ".."
+features = ["fuzzing"]
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[profile.release]
+debug = 1
+
+[[bin]]
+name = "parse_get_packet"
+path = "fuzz_targets/parse_get_packet.rs"
+test = false
+doc = false

--- a/crates/telio-wg/fuzz/fuzz_targets/parse_get_packet.rs
+++ b/crates/telio-wg/fuzz/fuzz_targets/parse_get_packet.rs
@@ -1,0 +1,7 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let _result = telio_wg::pq::parse_get_response_fuzz(data);
+});

--- a/crates/telio-wg/src/lib.rs
+++ b/crates/telio-wg/src/lib.rs
@@ -8,6 +8,8 @@ pub(crate) mod adapter;
 pub(crate) mod wg;
 pub(crate) mod windows;
 
+/// Post quantum primitives
+pub mod pq;
 pub mod uapi;
 
 pub use crate::{

--- a/crates/telio-wg/src/pq.rs
+++ b/crates/telio-wg/src/pq.rs
@@ -190,6 +190,12 @@ async fn handshake(
     Ok(TunnelSock { tunn, sock })
 }
 
+/// Public function exposed for fuzzing framework
+#[cfg(feature = "fuzzing")]
+pub fn parse_get_response_fuzz(pkgbuf: &[u8]) -> Result<kyber768::Ciphertext, Error> {
+    parse_get_response(pkgbuf)
+}
+
 fn parse_get_response(pkgbuf: &[u8]) -> Result<kyber768::Ciphertext, Error> {
     let mut cipherbuf = [0; CIPHERTEXT_LEN as usize];
 

--- a/crates/telio-wg/src/pq.rs
+++ b/crates/telio-wg/src/pq.rs
@@ -1,0 +1,354 @@
+use std::{
+    collections::btree_map::Range,
+    convert::TryInto,
+    io::{self, Read, Write},
+    net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4},
+    ops::RangeInclusive,
+    time::Duration,
+};
+
+use boringtun::noise;
+use pnet_packet::{
+    ip::{self, IpNextHeaderProtocols},
+    ipv4::{self, Ipv4Flags, Ipv4Packet, MutableIpv4Packet},
+    udp::{self, MutableUdpPacket, UdpPacket},
+    Packet,
+};
+use pqcrypto_kyber::kyber768;
+use pqcrypto_traits::kem::{Ciphertext, PublicKey, SharedSecret};
+use rand::{prelude::Distribution, SeedableRng};
+use tokio::net::{ToSocketAddrs, UdpSocket};
+
+const SERVICE_PORT: u16 = 6480;
+const LOCAL_PORT_RANGE: RangeInclusive<u16> = 49152..=u16::MAX; // dynamic port range
+const LOCAL_IP: Ipv4Addr = Ipv4Addr::new(10, 5, 0, 2);
+const REMOTE_IP: Ipv4Addr = Ipv4Addr::new(10, 5, 0, 1);
+const HANDSHAKE_VERSION: u32 = 1;
+const CIPHERTEXT_LEN: u32 = kyber768::ciphertext_bytes() as _;
+
+const IPV4_HEADER_LEN: usize = 20;
+const UDP_HEADER_LEN: usize = 8;
+
+/// The PQ module error type
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// IO error
+    #[error("IO: {0:?}")]
+    Io(#[from] io::Error),
+    /// Generic unrecoverable error
+    #[error("Generic: {0}")]
+    Generic(String),
+}
+
+impl From<String> for Error {
+    fn from(value: String) -> Self {
+        Self::Generic(value)
+    }
+}
+
+impl From<&str> for Error {
+    fn from(value: &str) -> Self {
+        Self::Generic(value.to_string())
+    }
+}
+
+impl From<tokio::time::error::Elapsed> for Error {
+    fn from(value: tokio::time::error::Elapsed) -> Self {
+        Self::Io(io::Error::new(io::ErrorKind::TimedOut, value))
+    }
+}
+
+/// Post quantum keys retrived from hanshake
+#[derive(Clone, Copy)]
+pub struct PqKeys {
+    /// Kyber shared secret
+    pub pq_shared: telio_crypto::PresharedKey,
+    /// X25519 secret key
+    pub wg_secret: telio_crypto::SecretKey,
+}
+
+struct TunnelSock {
+    tunn: Box<noise::Tunn>,
+    sock: telio_sockets::External<UdpSocket>,
+}
+
+/// Get PQ keys from the VPN server
+/// The packet sequence is as follows
+///
+/// 1) C -> S             : Client sends WG hansake packet                           
+/// 2) S -> C             : Server responds to handsake                              
+/// 3) C -> S (in tunnel) : Client sends a UDP PQ GET packet with keys               
+/// 4) S -> C (in tunnel) : Server responds with UDP packet containing the ciphertext
+///
+/// The shared key is established which should be used as,
+/// a WG preshared key for subsequent connection
+pub async fn fetch_keys(
+    sock_pool: &telio_sockets::SocketPool,
+    endpoint: impl ToSocketAddrs,
+    secret: &telio_crypto::SecretKey,
+    peers_pubkey: &telio_crypto::PublicKey,
+) -> Result<PqKeys, Error> {
+    let TunnelSock { tunn, sock } = handshake(sock_pool, endpoint, secret, peers_pubkey).await?;
+
+    let mut rng = rand::rngs::StdRng::from_entropy();
+
+    // Generate keys
+    let wg_secret = telio_crypto::SecretKey::gen_with(&mut rng);
+    let (pq_public, pq_secret) = kyber768::keypair();
+    let wg_public = telio_crypto::PublicKey::from(&wg_secret);
+
+    // Send GET packet
+    let pkgbuf = create_get_packet(&wg_public, &pq_public, &mut rng); // 4 KiB
+
+    let mut recvbuf = [0u8; 2048]; // 2 KiB buffer should suffice
+    match tunn.encapsulate(&pkgbuf, &mut recvbuf) {
+        noise::TunnResult::Err(err) => {
+            return Err(format!("Failed to encapsulate PQ keys message: {err:?}").into())
+        }
+        noise::TunnResult::WriteToNetwork(buf) => {
+            sock.send(buf).await?;
+        }
+        _ => return Err("Unexpected WG tunnel output".into()),
+    }
+
+    // Receive response
+    let read = sock.recv(&mut recvbuf).await?;
+
+    let mut msgbuf = [0u8; 2048]; // 2 KiB buffer should shuffice
+
+    #[allow(index_access_check)]
+    let ciphertext = match tunn.decapsulate(None, &recvbuf[..read], &mut msgbuf) {
+        noise::TunnResult::Err(err) => {
+            return Err(format!("Failed to decapsulate PQ keys message: {err:?}").into())
+        }
+        noise::TunnResult::WriteToTunnelV4(buf, _) => parse_get_response(buf)?,
+        _ => return Err("Unexpected WG tunnel output".into()),
+    };
+
+    // Extract the shared secret
+    let pq_shared = kyber768::decapsulate(&ciphertext, &pq_secret);
+    let pq_shared = telio_crypto::PresharedKey::new(
+        pq_shared
+            .as_bytes()
+            .try_into()
+            .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?,
+    );
+
+    Ok(PqKeys {
+        pq_shared,
+        wg_secret,
+    })
+}
+
+async fn handshake(
+    sock_pool: &telio_sockets::SocketPool,
+    endpoint: impl ToSocketAddrs,
+    secret: &telio_crypto::SecretKey,
+    peers_pubkey: &telio_crypto::PublicKey,
+) -> Result<TunnelSock, Error> {
+    let sock = sock_pool
+        .new_external_udp((Ipv4Addr::UNSPECIFIED, 0), None)
+        .await?;
+    sock.connect(endpoint).await?;
+
+    let tunn = noise::Tunn::new(
+        secret.into_bytes().into(),
+        peers_pubkey.0.into(),
+        None,
+        None,
+        0,
+        None,
+    )?;
+
+    let mut pkgbuf = [0u8; 2048];
+    match tunn.encapsulate(&[], &mut pkgbuf) {
+        noise::TunnResult::Err(err) => {
+            return Err(format!("Failed to encapsulate handshake message: {err:?}").into())
+        }
+        noise::TunnResult::WriteToNetwork(buf) => {
+            sock.send(buf).await?;
+        }
+        _ => return Err("Unexpected WG tunnel output".into()),
+    }
+
+    // The response should be 92, so the buffer is sufficient
+    let read = sock.recv(&mut pkgbuf).await?;
+
+    let mut msgbuf = [0u8; 2048];
+
+    #[allow(index_access_check)]
+    match tunn.decapsulate(None, &pkgbuf[..read], &mut msgbuf) {
+        noise::TunnResult::Err(err) => {
+            return Err(format!("Failed to decapsulate handshake message: {err:?}").into())
+        }
+        noise::TunnResult::WriteToNetwork(_) => {
+            // This is a outgoing keep alive message, we can skip sending it for the hanshake
+        }
+        _ => return Err("Unexpected WG tunnel output".into()),
+    }
+
+    Ok(TunnelSock { tunn, sock })
+}
+
+fn parse_get_response(pkgbuf: &[u8]) -> Result<kyber768::Ciphertext, Error> {
+    let mut cipherbuf = [0; CIPHERTEXT_LEN as usize];
+
+    let ip = Ipv4Packet::new(pkgbuf).ok_or(io::Error::new(
+        io::ErrorKind::InvalidData,
+        "Invalid PQ keys IP packet received",
+    ))?;
+
+    let udp = UdpPacket::new(ip.payload()).ok_or(io::Error::new(
+        io::ErrorKind::InvalidData,
+        "Invalid PQ keys UDP packet received",
+    ))?;
+
+    let mut data = io::Cursor::new(udp.payload());
+
+    let mut version = [0u8; 4];
+    data.read_exact(&mut version)?;
+    let version = u32::from_le_bytes(version);
+    if version != HANDSHAKE_VERSION {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "Server responded with invalid PQ handshake version",
+        )
+        .into());
+    }
+
+    let mut ciphertext_len = [0u8; 4];
+    data.read_exact(&mut ciphertext_len)?;
+    let ciphertext_len = u32::from_le_bytes(ciphertext_len);
+
+    if ciphertext_len != CIPHERTEXT_LEN {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "Server responded with invalid PQ handshake ciphertext lenght",
+        )
+        .into());
+    }
+
+    data.read_exact(&mut cipherbuf)?;
+
+    let ct = kyber768::Ciphertext::from_bytes(&cipherbuf)
+        .map_err(|err| format!("Invalid PQ ciphertext received: {err:?}"))?;
+
+    Ok(ct)
+}
+
+fn create_get_packet(
+    wg_public: &telio_crypto::PublicKey,
+    pq_public: &kyber768::PublicKey,
+    rng: &mut impl rand::Rng,
+) -> Vec<u8> {
+    let mut pkgbuf = Vec::with_capacity(1024 * 4); // 4 KiB
+    pkgbuf.resize(IPV4_HEADER_LEN + UDP_HEADER_LEN, 0);
+
+    push_get_method_udp_payload(&mut pkgbuf, wg_public, pq_public);
+    fill_get_packet_headers(pkgbuf.as_mut_slice(), rng);
+
+    pkgbuf
+}
+
+/// The payload looks as follows:
+///
+/// ---------------------------------
+///  version           , u32le , = 1
+/// ---------------------------------
+///  method            , u32le , = 0
+/// ---------------------------------
+///  WG pubkey len     , u32le , = 32
+/// ---------------------------------
+///  WG pubkey bytes   , [u8]
+/// ---------------------------------
+///  Kyber pubkey len  , u32le, = 1184
+/// ---------------------------------
+///  Kyber pubkey bytes, [u8]
+/// ---------------------------------
+fn push_get_method_udp_payload(
+    pkgbuf: &mut Vec<u8>,
+    wg_public: &telio_crypto::PublicKey,
+    pq_public: &kyber768::PublicKey,
+) {
+    let method = 0u32; // get
+
+    // UDP packet payload
+    pkgbuf.extend_from_slice(&HANDSHAKE_VERSION.to_le_bytes());
+    pkgbuf.extend_from_slice(&method.to_le_bytes());
+    pkgbuf.extend_from_slice(&(wg_public.len() as u32).to_le_bytes());
+    pkgbuf.extend_from_slice(wg_public);
+    pkgbuf.extend_from_slice(&(pq_public.as_bytes().len() as u32).to_le_bytes());
+    pkgbuf.extend_from_slice(pq_public.as_bytes());
+}
+
+/// Sets up UDP and IP headers in the provided buffer
+///
+/// # Panics
+///
+/// Panics if the buffer size is less than IP + UDP headers bytes.
+fn fill_get_packet_headers(pkgbuf: &mut [u8], rng: &mut impl rand::Rng) {
+    let pkg_len = pkgbuf.len();
+
+    #[allow(clippy::expect_used)]
+    #[allow(index_access_check)]
+    let mut udppkg = MutableUdpPacket::new(&mut pkgbuf[IPV4_HEADER_LEN..])
+        .expect("UDP buffer should not be too small");
+    udppkg.set_source(random_port(rng));
+    udppkg.set_destination(SERVICE_PORT);
+    udppkg.set_length((pkg_len - IPV4_HEADER_LEN) as _);
+    udppkg.set_checksum(udp::ipv4_checksum(
+        &udppkg.to_immutable(),
+        &LOCAL_IP,
+        &REMOTE_IP,
+    ));
+    drop(udppkg);
+
+    #[allow(clippy::expect_used)]
+    #[allow(index_access_check)]
+    let mut ippkg = MutableIpv4Packet::new(&mut pkgbuf[..IPV4_HEADER_LEN])
+        .expect("IPv4 buffer should not be too small");
+    ippkg.set_version(4);
+    ippkg.set_header_length(5);
+    ippkg.set_total_length(pkg_len as _);
+    ippkg.set_flags(Ipv4Flags::DontFragment);
+    ippkg.set_ttl(0xFF);
+    ippkg.set_next_level_protocol(IpNextHeaderProtocols::Udp);
+    ippkg.set_source(LOCAL_IP);
+    ippkg.set_destination(REMOTE_IP);
+    ippkg.set_checksum(ipv4::checksum(&ippkg.to_immutable()));
+}
+
+fn random_port(rng: &mut impl rand::Rng) -> u16 {
+    rand::distributions::Uniform::new_inclusive(LOCAL_PORT_RANGE.start(), LOCAL_PORT_RANGE.end())
+        .sample(rng)
+}
+
+#[cfg(test)]
+mod tests {
+    use pqcrypto_kyber::kyber768;
+    use pqcrypto_traits::kem::{Ciphertext, SecretKey, SharedSecret};
+
+    #[test]
+    // The Kyber KEM has two competing algorithms and the library we're using changed the algorithm in their new version.
+    // The test here is for capturing the eventual regression when the library is updated for example.
+    fn decapsulate_kyber_ciphertext() {
+        let secret_key = "e4GyMtQVorJvBtpRTeJAazMEnXg5dqwBexBXDTSwBbwuMUJLPDVktyWFzFhBa9NOr1ISwSGuHhmx1bQPWqhGv6ds4xZu9OtZLlsoRCJI/cKRmJBb1HNcyWUYFMV33BGcofxjggml00zISWux8ntAYWQkQ4GL8GaN1xxTjJdnZ4qyMPFQpTCvFMo0Gwu8uoxWmQQAiffEaiZfetNWwkYJ+YFW4Hm82ZYsXmgAb1IQ3RYQRTW7DGor8CKy8rkYTwVgT6GptArKClM+AWiRCQDL5PIGtyoyUUJVmSpyRNZFEPwY1nJOIVBqSeA/ZNMI8vCfhoAKFhfEhKMem3KpKvJYlJOC+0JMHAQQOntilDyY9Cc1sJxdbcNWIlo5IVhLW3FxD7dJ0HPDg9dhYXxyqjMAvHhCF2kUcSgdrFViV0LEe1rOweKFdJkyRKGo2va57ltz0IB00hIEFiRmavCkCXeWtEmIa/YrH7EBjOhNNWZ9GoOtuclWIoZeh0XNNZA0eySiCTWXL1QPTyhF9oeDV1dzNOKm7UCiPpNku7CVGMOF1FM1olBqG4soDKfN/RIsc/oV96S4GlK5IIgF/kDO4ryNOVFX0pl/Kls6koq5P9sVnzsGR4cGAuWU3RZdaKMu6BtEFXZh6VEqb/tAOtE3Mad2byYNOpOsIlhDX0awLhcbQRVVokQEyCKIx5OBqefJ1iNMEuiOj6ZT+FZPyRyyXXwM/FtugXQAX1ow+ge/PpWwAZvFkoFPh4OLyIpJT3U2GpKp5dKd/fZEiKdLX0SM7xoD1HcKXAqud1p0UmyfqLFZgCkVM/tDTthbz7Wk6ilGo9eyMNeAcKOWRwR71WDNzPUgqYzB+Ox600miwtYzHlillIZMelO/zBdypzZFrZhGynMAmxxMtKiXTbtkELxFMzpQTHhvuxSFfbFRJnoHYDYlprYP8xul8SCQDEQLwZdkVfwzE5qzGZw/YvogPUkSEbBSoEAqonYDg9WnYdaNKkeK83yGkLV5vOcUVKc4utstr6vJbGA1Bype34DFZeouqBEgWHMywXkPZ2dSXgVP/vl9gwRNErxpvDVfQIFZ3cFPdIQgt4bJx1sRYUvKKsOeNJtjk/KFzfDMkje2ogKPz8iTYnBRzWfOnPUIhDI/QZhSoAEYxwTNJvunyKlPYjCuG7U1z0M5UNVw7QuyiaumxOy0dGFNKraN8JTDqbgoC6xaWfCZR0qybkE0tceOhaa+8ZsigaxnqGh4gjErkpnMvUGKXAAVsLbHlygOEgd1u8tl46ERZzxdr1t0JTrJnxayCnwiW1ywqfk1gPd0hcg2k7goZJDNW4Aet3OsboRtLGUNE5xChMzBsnVVCxBH4aV/HHgmFbds4xeVLXC/sUlpMFgeahPMQvFeMSUgPWYmhAbPvMUTrCZPuwcGzQKZMdN7P3YJ4Is7KHOs1ddc3PxM6zC7/AOjBEkecIWp9GlDRUhVQHIqV1R1OiczeLky5YA5VqlgOEhY9qIzI+lrGVMGfRiu/PHBcxiq/lhItIRNupgRBzKOyKooKVJxS5hBJVyTNZiOICNswiKRhaEmfrGkBEE4XLE3uLlvwxUyo4C5kIFPq3xw0uRbK8U6CANRaTskM6swRCV3MMupGwcHI7dY7eUfJoGFaFyOQFqCqKWsjGC7qxqJbVYRWyFLLAin3SKiKwpgGwyKxGdt1hSH32R86DI04TR7SRwqMLqIbNVKX8qRIKd0KmdTHLp39XGm2iAHWSo2FgI8WoC0lLdIv3OcQYZMILJjAQJPaiR62MfOJpkf6uYpRlHBbIQnEjbGRUikmzYlsCxHu/wT0llZBjaL7rrBxQux71eCu6cqKvi7xkMH0gu5QAdOcmUbCswBQOJYwDqBSxMlJmyM7pM7aJhF62xQ1UMf8iexWhokltnMAXN0wqG0V8pI1DKLyncymyYYUjS6jxC9lQuD+3zEAPy2ZHOXbpe4DBMGzdBsGnzPUVJOlFcXPMYbjoVNEbhqhhCydnVhafidbPe4tFDFJdtDhQhNtjCK/VS0vDrKmSErWaKBhYSgKxYDtCDB/0CdKnC6EJwmoJUSLMtw/eFNCll3KFOE51EKkXg6KuYQiOzCIoE5P8w3LyZotUm9gohhXvsl8pZD9oFsl0YQUEd6Qqkbrqa8gSdL7ABWwpI+b1IdTYYB68QgU6OkpnMt7wXEGaxsnYY1aYWJARk+vkdmaLNFsCoxcOnFv6Z24cmfGBEe0LB/HsV2DREmzbUSIcVwjZsGOLMqcsCq+bCD8eWEeIu8wamiwUGmGVMTwFOxMjMPEBKhvLa2UthpEeEuPLwNjbg0AtyCL4p0/5Qo2tS0YphM+5GlrCJkjVwbfHmAnHivXlzCK9hNchqo5URXlHJOjehD2WSvBIvPQCi9IYAgSMAd/BNrq1eDCCzAOoali5QswxPD22AbHfrBkBWXy9JTyZJCExwRP5ZVTjIPSGKC++uVBce8aDZ+kVKPP1GOsXqxVikC0xVOfyMTCDN2/qSUMAcBMCaiEgSTFZdyyvgrHsVntJOHw9h1HaupMxuXuSNo5ms2zOCaTOiKR4tZYSMCxTaRLNRlLnPEHvsRxyFE1DpmIIPKn3KUt9kaUWM+ovwJy4tHu4nMUPJfsGem+ccsQdDE80uwJtLFeUC845FQC+HLoLecoNzOfhghxVcGhsyEUUIbRKmlOgEtI7OpmuSWB9xqocirBTx05ZI/f5lzqtgUXRiRx9wxCgoFZlY/33o2qieSLxlV5afEYCuKqIxE93aQmvcNkDwZbyNOD/IJV2g+3Ks4JEqlR0YLqPNyj4qomzp+IOY/hDgeftoJUKcxTUWDZXYmuIAjH1CSBgm4l+o9hHWGl1pl3LIGn1KNMhK5A1yNX3AqCHl6J8gjAcw3XKSmMMRZPEdMlFgVTLcicWSd6iZ1NyvO+fM8bkOKR7Gn6ekPzspztVtwl1ayzYXLMWRUdOhqtWtukCarIEXFyFG8ByKlsVQCRvKMSUCjp0eRHoIP/SnMGUufs1ZCM5ejwXZR/EK6XoNmyNQUrrVNGuB/2sm9Z/FLEEwShFiVlYMXvGFcZubPr03TqybQWtkXQ0KQxvxhLgLsk495B3i13F342yT5m1OX3Wor1JNyV6nAolgf/IDQGyXh9fBzETTooRcbl8jLfllhVDimPrZMw7488eXXw9qet8DIjUCP4UQ3B4R/jsSx";
+        let ciphertext = "1PXYvRAU31rbjedEJLRVRiNVShRNt9RrBar0hzN4iqBQuSBYyVwZy4FwMHRQz5cnljn5gsQlUP3+jhkYL5YQqNy//oJtBwCz2NWzjXu2BzphKJaGE9FbBmvpwhTa70BdYbCri11GOK+bO6dpTTFaF0NqMhdDlMuvD9yv93RzTNfoZtVuqjTGvitx2bY+aCshir8mZ9iox3kyxcf8OIR7mFjUNQgRPgmvdmYSHqFuvaOSWQjxlzdkG0V3zlUr7IUusGLYFDSMqHPqMbm2HTWcaF7UsF/NwrUcUsm2mxev7QBu7nIBWQzMmnWacH6/0cxj/AOfv8TsdK6QUYrSYUFTHVWkbXwodpG4/5kzt6z4BhqS7d3Z30Pg4K+PA/5yQseGpgADOZlHfoqEysdDZ7Y+dypaXVX2Z6kUokwIcxKglJQYUTezGwUztukiTSVoTJ2osTJ5LnU3quuP/NZmdKdsuUs0fBaPTQ7gl2gaxc3LhXjmOPvU8VNZf0hJNlA91h6RCgCbn0z634I8LmCr94TZa1GJcIy7JvKZC2g9XhoIdjSuDuzjH0T7qixqZwib+wGzUJ5Mcz+SIMCwpSIALxsyOfuB5/E2eLnbtt1TWwMCq1O6HSgjDD2dT0qV3AQ9ZKkbggfjG53npNfK82zufBPhWphTly6Fv9yCWguXH/9pK46MnBUVWeiB1RQFl9/R/oflkg5Mlqe07lmBNWotYlg14IVG+ZF69jKtp6dIBe2bWzvH4SYn/2bhpwGGWZUQ1ZkoZvY6dUqglhnTzmBgXdXLSVDueVklXg1saHIFWYug/Friy+U5mU6AxYs1uEqfdf7x1GWbHjyHsaDG1WSGx2xHQ+5nvGsM7a9LR83BMtiFgJe9cWxPvYdD16FZEbax9uu1kgY+3ESgjJXY5uTD7igx0SuR+Q6DBc+7GwFY7Ox9U1FHUg2+mAV4QTh/gsA1d2FXkORbs/1GUMP8cjkmOyIVaNegPYPgsF22UyNbE3h25biTY+XbP3x9E2fCDGGB4XTG8muwBljndoiBuyp0xyCZ1IGl3siS13RXCJbkY7hFLVyOWExHZB2hQ6TX6a7wLP88YtbKcJK9viyixWz+Uky4CypYh7W55+RUabuIWybrPti3JJAazesHJXhefdnRTmd3nUWzpAI81pg5mEMGS42FyelfBOiXhTxaAJrsYH8ujmJc4rG88AK0jFdAP7J1HfJKC+fPvT44zyPnxrUuQ/f7rkPMOmX1uEliKzSnecHs0102Gmj0RFxkqjCZNgvAL/XX4Uy7+nbjCeQfKAG4AX7xIYm6gzcFb11CEeGPDFqEMHta+ocGmH8HYJ43K07fh0JaSfcqLrHeH/vZCib5cc8kddVqMVobOh9uFgpV8VUStozBPJL7z3nMiegI/P/QHzwEnKk5IHamyWJcMWRIodz6Fzh7ZC+JRsXITtKvvrxJ+tA=";
+
+        let expected_shared = "T4KKTwQOEQ43G1UzPbBVzi219KXJ54qh6w24IMPEc0A=";
+
+        let shared = {
+            let sk_bytes = base64::decode(secret_key).unwrap();
+            let secret_key = kyber768::SecretKey::from_bytes(&sk_bytes).unwrap();
+
+            let ct_bytes = base64::decode(ciphertext).unwrap();
+            let ciphertext = kyber768::Ciphertext::from_bytes(&ct_bytes).unwrap();
+
+            let shared = kyber768::decapsulate(&ciphertext, &secret_key);
+
+            base64::encode(shared.as_bytes())
+        };
+
+        assert_eq!(shared, expected_shared);
+    }
+}

--- a/src/device/wg_controller.rs
+++ b/src/device/wg_controller.rs
@@ -769,6 +769,7 @@ fn compare_peers(a: &telio_wg::uapi::Peer, b: &telio_wg::uapi::Peer) -> bool {
         && a.endpoint == b.endpoint
         && a.persistent_keepalive_interval == b.persistent_keepalive_interval
         && a.allowed_ips == b.allowed_ips
+        && a.preshared_key == b.preshared_key
 }
 
 fn is_peer_proxying(
@@ -1384,6 +1385,7 @@ mod tests {
                         rx_bytes: None,
                         tx_bytes: None,
                         time_since_last_handshake: None,
+                        preshared_key: None,
                     }))
                     .return_once(|_| Ok(()));
             }


### PR DESCRIPTION
### Problem
We want to make the VPN tunnel post-quantum safe.

### Solution
The solution performs an initial wireguard connection during which a preshared key is established as the shared secret of the kyber768 key exchange mechanism.
The preshared key is used for the subsequent wireguard tunnel being created just after the  initial handshake

There isn't any unit or integration test because that's a separate task and @LukasPukenis is responsible for this one.
The PR doesn't contain the rekey mechanism for similar reasons, it's going to be implemented in subsequent PRs.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
