### PR TITLE
Add wildcarded subdomains to peers dns records

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 ----
 * LLT-4006: Restrict nat-lab containers capabilities
 * LLT-4586: Fix wireguard-go initialization crash
+* LLT-4634: Add wildcarded domains to DNS records
 
 <br>
 


### PR DESCRIPTION
### Problem
Currently it is not possible to use <something>.<nickname/hostname>.nord as a domain name. It is quite useful when single server in meshnet hosts multiple services.

### Solution
Add wildcarded entries to the dns records list.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
