### PR TITLE
Use newer version of boringtun

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,7 +390,7 @@ dependencies = [
 [[package]]
 name = "boringtun"
 version = "0.5.2"
-source = "git+https://github.com/NordSecurity/boringtun.git?tag=v1.1.5#a881e19390166b89e8df7ce78cca3b1811a837a7"
+source = "git+https://github.com/NordSecurity/boringtun.git?tag=v1.1.6#8a2356b3bd84e1355150dc77fbad9201dabbc5c4"
 dependencies = [
  "aead",
  "base64 0.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,7 +146,7 @@ url = "2.2.2"
 uuid = { version = "1.1.2", features = ["v4"] }
 winapi = { version = "0.3", features = ["netioapi", "ws2def"] }
 
-boringtun = { git = "https://github.com/NordSecurity/boringtun.git", tag = "v1.1.5" }
+boringtun = { git = "https://github.com/NordSecurity/boringtun.git", tag = "v1.1.6" }
 x25519-dalek = { version = "2.0.0-pre.1", features = ["reusable_secrets", "static_secrets"] }
 
 telio-crypto = { version = "0.1.0", path = "./crates/telio-crypto" }

--- a/changelog.md
+++ b/changelog.md
@@ -51,6 +51,7 @@
 * LLT-4552: Add way to flush events when stopping
 * LLT-4225: Migrate Telio to use the tracing crate instead of log crate
 * LLT-4583: Don't add IPv6 addresses to wireguard when IPv6 feature is disabled
+* LLT-4613: Fix boringtun performs spurious rekeying
 
 <br>
 


### PR DESCRIPTION
### Problem
Boringtun performs spurious rekeying

### Solution
Use fixed boringtun (https://github.com/NordSecurity/boringtun/pull/8) 


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
