### PR TITLE
natlab police: Mark/unmark natlab tests

### DIFF
--- a/nat-lab/tests/test_client_basic_stun.py
+++ b/nat-lab/tests/test_client_basic_stun.py
@@ -12,10 +12,7 @@ from utils.connection_util import ConnectionTag, new_connection_by_tag
         pytest.param(
             ConnectionTag.WINDOWS_VM,
             "10.0.254.7",
-            marks=[
-                pytest.mark.windows,
-                pytest.mark.xfail(reason="test is flaky - LLT-4213"),
-            ],
+            marks=pytest.mark.windows,
         ),
         pytest.param(ConnectionTag.MAC_VM, "10.0.254.7", marks=pytest.mark.mac),
     ],

--- a/nat-lab/tests/test_connection_states.py
+++ b/nat-lab/tests/test_connection_states.py
@@ -53,10 +53,7 @@ from utils.ping import Ping
                     derp_1_limits=ConnectionLimits(1, 1),
                 ),
             ),
-            marks=[
-                pytest.mark.windows,
-                pytest.mark.xfail(reason="Flaky: LLT-4064"),
-            ],
+            marks=pytest.mark.windows,
         ),
         pytest.param(
             SetupParameters(

--- a/nat-lab/tests/test_dns.py
+++ b/nat-lab/tests/test_dns.py
@@ -186,6 +186,7 @@ async def test_dns(
         ),
     ],
 )
+@pytest.mark.xfail(reason="Test is flaky - LLT-4656")
 async def test_dns_port(alpha_ip_stack: IPStack) -> None:
     async with AsyncExitStack() as exit_stack:
         dns_server_address_alpha = get_dns_server_address(alpha_ip_stack)
@@ -712,6 +713,7 @@ async def test_dns_update(alpha_ip_stack: IPStack) -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.xfail(reason="Test is flaky - LLT-4563")
 async def test_dns_duplicate_requests_on_multiple_forward_servers() -> None:
     async with AsyncExitStack() as exit_stack:
         FIRST_DNS_SERVER = "8.8.8.8"

--- a/nat-lab/tests/test_events.py
+++ b/nat-lab/tests/test_events.py
@@ -348,10 +348,7 @@ async def test_event_content_vpn_connection(
                     derp_1_limits=ConnectionLimits(1, 1),
                 ),
             ),
-            marks=[
-                pytest.mark.windows,
-                pytest.mark.xfail(reason="Test is flaky - see JIRA issue LLT-4559"),
-            ],
+            marks=pytest.mark.windows,
         ),
         pytest.param(
             SetupParameters(
@@ -362,10 +359,7 @@ async def test_event_content_vpn_connection(
                     derp_1_limits=ConnectionLimits(1, 1),
                 ),
             ),
-            marks=[
-                pytest.mark.windows,
-                pytest.mark.xfail(reason="Test is flaky - see JIRA issue LLT-4559"),
-            ],
+            marks=pytest.mark.windows,
         ),
         pytest.param(
             SetupParameters(
@@ -476,7 +470,6 @@ async def test_event_content_exit_through_peer(
                 features=TelioFeatures(direct=Direct(providers=["stun"])),
             ),
             "10.0.254.1",
-            marks=pytest.mark.xfail(reason="Test is flaky - JIRA issue LLT-4558"),
         ),
         pytest.param(
             SetupParameters(
@@ -502,10 +495,7 @@ async def test_event_content_exit_through_peer(
                 features=TelioFeatures(direct=Direct(providers=["stun"])),
             ),
             "10.0.254.7",
-            marks=[
-                pytest.mark.windows,
-                pytest.mark.xfail(reason="Test is flaky - LLT-4357"),
-            ],
+            marks=pytest.mark.windows,
         ),
         pytest.param(
             SetupParameters(
@@ -518,10 +508,7 @@ async def test_event_content_exit_through_peer(
                 features=TelioFeatures(direct=Direct(providers=["stun"])),
             ),
             "10.0.254.7",
-            marks=[
-                pytest.mark.windows,
-                pytest.mark.xfail(reason="Test is flaky - LLT-4357"),
-            ],
+            marks=pytest.mark.windows,
         ),
         pytest.param(
             SetupParameters(

--- a/nat-lab/tests/test_lana.py
+++ b/nat-lab/tests/test_lana.py
@@ -1049,6 +1049,7 @@ async def test_lana_with_second_node_joining_later_meshnet_id_can_change(
 @pytest.mark.moose
 @pytest.mark.asyncio
 @pytest.mark.parametrize("alpha_ip_stack,beta_ip_stack", IP_STACK_TEST_CONFIGS)
+@pytest.mark.xfail(reason="test flaky - JIRA issue: LLT-4616")
 async def test_lana_same_meshnet_id_is_reported_after_a_restart(
     alpha_ip_stack: IPStack, beta_ip_stack: IPStack
 ):

--- a/nat-lab/tests/test_mesh_exit_through_peer.py
+++ b/nat-lab/tests/test_mesh_exit_through_peer.py
@@ -70,10 +70,7 @@ PHOTO_ALBUM_IPV6 = config.LIBTELIO_IPV6_WAN_SUBNET + "::adda:edde:5"
                     derp_1_limits=ConnectionLimits(1, 1),
                 ),
             ),
-            marks=[
-                pytest.mark.windows,
-                pytest.mark.xfail(reason="Test is flaky - LLT-4357"),
-            ],
+            marks=pytest.mark.windows,
         ),
         pytest.param(
             SetupParameters(

--- a/nat-lab/tests/test_mesh_plus_vpn.py
+++ b/nat-lab/tests/test_mesh_plus_vpn.py
@@ -424,7 +424,10 @@ async def test_vpn_plus_mesh(
                 ),
                 features=TelioFeatures(direct=Direct(providers=["local", "stun"])),
             ),
-            marks=pytest.mark.windows,
+            marks=[
+                pytest.mark.windows,
+                pytest.mark.xfail(reason="Test is flaky - LLT-4313"),
+            ],
         ),
         pytest.param(
             SetupParameters(

--- a/nat-lab/tests/test_mesh_plus_vpn.py
+++ b/nat-lab/tests/test_mesh_plus_vpn.py
@@ -55,10 +55,7 @@ from utils.ping import Ping
                     vpn_1_limits=ConnectionLimits(1, 1),
                 ),
             ),
-            marks=[
-                pytest.mark.windows,
-                pytest.mark.xfail(reason="Test is flaky - LLT-4357"),
-            ],
+            marks=pytest.mark.windows,
         ),
         pytest.param(
             SetupParameters(
@@ -175,10 +172,7 @@ async def test_mesh_plus_vpn_one_peer(
                     vpn_1_limits=ConnectionLimits(1, 1),
                 ),
             ),
-            marks=[
-                pytest.mark.windows,
-                pytest.mark.xfail(reason="Test is flaky - LLT-4357"),
-            ],
+            marks=pytest.mark.windows,
         ),
         pytest.param(
             SetupParameters(
@@ -294,19 +288,13 @@ async def test_mesh_plus_vpn_both_peers(
             ConnectionTag.WINDOWS_VM,
             AdapterType.WindowsNativeWg,
             "10.0.254.7",
-            marks=[
-                pytest.mark.windows,
-                pytest.mark.xfail(reason="Test is flaky - LLT-4357"),
-            ],
+            marks=pytest.mark.windows,
         ),
         pytest.param(
             ConnectionTag.WINDOWS_VM,
             AdapterType.WireguardGo,
             "10.0.254.7",
-            marks=[
-                pytest.mark.windows,
-                pytest.mark.xfail(reason="Test is flaky - LLT-4357"),
-            ],
+            marks=pytest.mark.windows,
         ),
         pytest.param(
             ConnectionTag.MAC_VM,

--- a/nat-lab/tests/test_mesh_remove_node.py
+++ b/nat-lab/tests/test_mesh_remove_node.py
@@ -44,10 +44,7 @@ from utils.ping import Ping
                     derp_1_limits=ConnectionLimits(1, 1),
                 ),
             ),
-            marks=[
-                pytest.mark.windows,
-                pytest.mark.xfail(reason="Test is flaky - LLT-4357"),
-            ],
+            marks=pytest.mark.windows,
         ),
         pytest.param(
             SetupParameters(

--- a/nat-lab/tests/test_network_switch.py
+++ b/nat-lab/tests/test_network_switch.py
@@ -92,7 +92,10 @@ async def test_network_switcher(
                 connection_tag=ConnectionTag.WINDOWS_VM,
                 adapter_type=telio.AdapterType.WireguardGo,
             ),
-            marks=pytest.mark.windows,
+            marks=[
+                pytest.mark.windows,
+                pytest.mark.xfail(reason="Test is flaky - LLT-4357"),
+            ],
         ),
         pytest.param(
             SetupParameters(

--- a/nat-lab/tests/test_vpn.py
+++ b/nat-lab/tests/test_vpn.py
@@ -190,10 +190,7 @@ async def test_vpn_connection(
                 is_meshnet=False,
             ),
             "10.0.254.7",
-            marks=[
-                pytest.mark.windows,
-                pytest.mark.xfail(reason="Test is flaky - JIRA issue: LLT-4554"),
-            ],
+            marks=pytest.mark.windows,
         ),
         pytest.param(
             SetupParameters(
@@ -210,7 +207,7 @@ async def test_vpn_connection(
             "10.0.254.7",
             marks=[
                 pytest.mark.windows,
-                pytest.mark.xfail(reason="Test is flaky - JIRA issue: LLT-4554"),
+                pytest.mark.xfail(reason="Test flaky: JIRA issue LLT-4554"),
             ],
         ),
         pytest.param(


### PR DESCRIPTION
### Problem
Some tests haven't failed for over a week, thus are considered no longer as flaky.
Some other tests failed during scheduled pipelines.

### Solution
Remove/add flaky marks.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
