### PR TITLE
Resolve LLT-4617: fix pytest collection error on python3.11

### DIFF
--- a/nat-lab/tests/helpers.py
+++ b/nat-lab/tests/helpers.py
@@ -26,7 +26,9 @@ class SetupParameters:
         default=None
     )
     adapter_type: AdapterType = field(default=AdapterType.Default)
-    features: TelioFeatures = field(default=TelioFeatures())
+    features: TelioFeatures = field(
+        default_factory=lambda: TelioFeatures(is_test_env=True)
+    )
     is_meshnet: bool = field(default=True)
     derp_servers: Optional[List[Dict[str, Any]]] = field(default=None)
 

--- a/nat-lab/tests/telio_features.py
+++ b/nat-lab/tests/telio_features.py
@@ -20,8 +20,8 @@ class SkipUnresponsivePeers(DataClassJsonMixin):
 class Direct(DataClassJsonMixin):
     providers: Optional[List[str]] = None
     endpoint_interval_secs: Optional[int] = 5
-    skip_unresponsive_peers: Optional[SkipUnresponsivePeers] = SkipUnresponsivePeers(
-        no_handshake_threshold_secs=180
+    skip_unresponsive_peers: Optional[SkipUnresponsivePeers] = field(
+        default_factory=lambda: SkipUnresponsivePeers(no_handshake_threshold_secs=180)
     )
 
 


### PR DESCRIPTION
### Problem
 Python3.11 doesn't allow mutable default values that contains `default_factory`.
[reference](https://docs.python.org/3/library/dataclasses.html#:~:text=default_factory%3A%20If%20provided%2C%20it%20must%20be%20a%20zero%2Dargument%20callable%20that%20will%20be%20called%20when%20a%20default%20value%20is%20needed%20for%20this%20field.%20Among%20other%20purposes%2C%20this%20can%20be%20used%20to%20specify%20fields%20with%20mutable%20default%20values%2C%20as%20discussed%20below.%20It%20is%20an%20error%20to%20specify%20both%20default%20and%20default_factory.)


### Solution
Therefore `default_factory` has to be used.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
