### PR TITLE
Set RUST_BACKTRACE=full in environment when starting processes on docker

### DIFF
--- a/nat-lab/tests/utils/process/docker_process.py
+++ b/nat-lab/tests/utils/process/docker_process.py
@@ -36,7 +36,9 @@ class DockerProcess(Process):
         stdout_callback: Optional[StreamCallback] = None,
         stderr_callback: Optional[StreamCallback] = None,
     ) -> "DockerProcess":
-        self._execute = await self._container.exec(self._command, stdin=True)
+        self._execute = await self._container.exec(
+            self._command, stdin=True, environment={"RUST_BACKTRACE": "full"}
+        )
         if self._execute is None:
             return self
         async with self._execute.start() as exe_stream:


### PR DESCRIPTION
### Problem
When `panic!` happens we don't get a full backtrace on nat-lab.

### Solution
Enable backtrace printing via `RUST_BACKTRACE` environment variable. VMs are not supported since ssh process has no api to configure environment.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
