### PR TITLE
Update boringtun to 1.1.7 which uses saturating_sub to avoid duration overflow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,7 +390,7 @@ dependencies = [
 [[package]]
 name = "boringtun"
 version = "0.5.2"
-source = "git+https://github.com/NordSecurity/boringtun.git?tag=v1.1.6#8a2356b3bd84e1355150dc77fbad9201dabbc5c4"
+source = "git+https://github.com/NordSecurity/boringtun.git?tag=v1.1.7#05b398cea32e20eb2d59b29aea742f6bb3cbb7bf"
 dependencies = [
  "aead",
  "base64 0.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,7 +146,7 @@ url = "2.2.2"
 uuid = { version = "1.1.2", features = ["v4"] }
 winapi = { version = "0.3", features = ["netioapi", "ws2def"] }
 
-boringtun = { git = "https://github.com/NordSecurity/boringtun.git", tag = "v1.1.6" }
+boringtun = { git = "https://github.com/NordSecurity/boringtun.git", tag = "v1.1.7" }
 x25519-dalek = { version = "2.0.0-pre.1", features = ["reusable_secrets", "static_secrets"] }
 
 telio-crypto = { version = "0.1.0", path = "./crates/telio-crypto" }

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 ### UNRELEASED
 ----
 * LLT-4662: Update rustix dependency
+* LLT-4667: Fix panic in boringtun
 
 ### v4.2.1
 ----


### PR DESCRIPTION
### Problem
Some tests panic in boringtun due to duration overflow when subtracting.

### Solution
Update to boringtun 1.1.7 which likely fixes panic in duration overflow wen subtracting.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
