### PR TITLE
LLT-4598 LLT-4698 WG-STUN IPv6 -> IPv4 fallback, exp backoff fixes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,8 @@
 * LLT-4667: Fix libtelio panicking on linux + boringtun
 * LLT-4633: Bind to interfaces which has router property only on apple
 * LLT-4688: Add detailed logs on boringtun socket failures
+* LLT-4598: Introduce IPv6 -> IPv4 fallback in WG-STUN
+* LLT-4698: Fix exp. backoff in WG-STUN
 
 ### v4.2.1
 ----

--- a/crates/telio-traversal/src/endpoint_providers/local.rs
+++ b/crates/telio-traversal/src/endpoint_providers/local.rs
@@ -81,7 +81,7 @@ impl<T: WireGuard, G: GetIfAddrs> EndpointProvider for LocalInterfacesEndpointPr
         .unwrap_or_default();
     }
 
-    async fn trigger_endpoint_candidates_discovery(&self) -> Result<(), Error> {
+    async fn trigger_endpoint_candidates_discovery(&self, _force: bool) -> Result<(), Error> {
         task_exec!(&self.task, async move |s| {
             Ok(s.poll_local_endpoints().await)
         })
@@ -529,7 +529,7 @@ mod tests {
             );
 
             local_provider
-                .trigger_endpoint_candidates_discovery()
+                .trigger_endpoint_candidates_discovery(false)
                 .await
                 .unwrap();
         }

--- a/crates/telio-traversal/src/endpoint_providers/mod.rs
+++ b/crates/telio-traversal/src/endpoint_providers/mod.rs
@@ -116,7 +116,7 @@ pub trait EndpointProvider: Sync + Send + 'static {
         &self,
         tx: chan::Tx<EndpointCandidatesChangeEvent>,
     );
-    async fn trigger_endpoint_candidates_discovery(&self) -> Result<(), Error>;
+    async fn trigger_endpoint_candidates_discovery(&self, force: bool) -> Result<(), Error>;
     async fn handle_endpoint_gone_notification(&self);
 
     async fn send_ping(

--- a/crates/telio-traversal/src/endpoint_providers/upnp/mod.rs
+++ b/crates/telio-traversal/src/endpoint_providers/upnp/mod.rs
@@ -328,7 +328,7 @@ impl<Wg: WireGuard> EndpointProvider for UpnpEndpointProvider<Wg> {
         .unwrap_or_default()
     }
 
-    async fn trigger_endpoint_candidates_discovery(&self) -> Result<()> {
+    async fn trigger_endpoint_candidates_discovery(&self, _force: bool) -> Result<()> {
         let _ = task_exec!(&self.task, async move |s| {
             let _ = s.send_endpoint_candidate().await;
             Ok(())

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -1432,7 +1432,7 @@ impl Runtime {
         wg_controller::consolidate_wg_state(&self.requested_state, &self.entities, &self.features)
             .await?;
         for ep in self.entities.endpoint_providers().iter() {
-            if let Err(err) = ep.trigger_endpoint_candidates_discovery().await {
+            if let Err(err) = ep.trigger_endpoint_candidates_discovery(true).await {
                 // This can fail on first config, because it takes a bit of time to resolve
                 // stun endpoint for StunEndpointProvider for WgStunControll
                 telio_log_debug!("Failed to trigger: {}", err);

--- a/src/device/wg_controller.rs
+++ b/src/device/wg_controller.rs
@@ -164,7 +164,7 @@ async fn consolidate_wg_peers<
         if let Some(stun) = stun_ep_provider {
             if let Some(wg_stun_server) = requested_state.wg_stun_server.as_ref() {
                 if wg_stun_server.public_key == *key {
-                    stun.trigger_endpoint_candidates_discovery().await?;
+                    stun.trigger_endpoint_candidates_discovery(false).await?;
                 }
             }
         }


### PR DESCRIPTION
### Problems
- `WG-STUN` currently works with either `IPv6` or `IPv4`.
- Exp. back-off is being reset by `wg_controller` on every poll.

### Solutions
- Introduce IPv6 -> IPv4 fallback before rotating to next `WG-STUN` server.
- Do not reset exp. back-off on  `wg_controller` poll, when in `BackingOff` state.
- Increase exp. backoff only when server list is exhausted.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
