### PR TITLE
Fix fuzzing CI jobs

### DIFF
--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -9,7 +9,7 @@ jobs:
         - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         - uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.6
           with:
-            toolchain: nightly-2023-03-01
+            toolchain: nightly-2023-06-01
             override: true
         - run: cargo install cargo-fuzz --locked --version 0.11.2
         - name: fuzz telio proto
@@ -21,7 +21,7 @@ jobs:
         - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         - uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.6
           with:
-            toolchain: nightly-2023-03-01
+            toolchain: nightly-2023-06-01
             override: true
         - run: cargo install cargo-fuzz --locked --version 0.11.2
         - name: fuzz telio crypto decrypt_request
@@ -39,7 +39,7 @@ jobs:
         - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         - uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.6
           with:
-            toolchain: nightly-2023-03-01
+            toolchain: nightly-2023-06-01
             override: true
         - run: cargo install cargo-fuzz --locked --version 0.11.2
         - name: fuzz telio wg parse_get_packet


### PR DESCRIPTION
### Problem
The fuzzing CI jobs are failing on `cargo-fuzz` install stage or on the compilations stage, depending on the nightly version

### Solution
Update nightly rustc 2023-06-01 seems to be the working middle ground


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
