### PR TITLE
Remove xfail marks form stable tests

### DIFF
--- a/nat-lab/tests/test_dns.py
+++ b/nat-lab/tests/test_dns.py
@@ -634,7 +634,6 @@ async def test_dns_update(alpha_ip_stack: IPStack) -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.xfail(reason="Test is flaky - LLT-4563")
 async def test_dns_duplicate_requests_on_multiple_forward_servers() -> None:
     async with AsyncExitStack() as exit_stack:
         FIRST_DNS_SERVER = "8.8.8.8"

--- a/nat-lab/tests/test_events.py
+++ b/nat-lab/tests/test_events.py
@@ -521,10 +521,7 @@ async def test_event_content_exit_through_peer(
                 features=TelioFeatures(direct=Direct(providers=["stun"])),
             ),
             "10.0.254.7",
-            marks=[
-                pytest.mark.mac,
-                pytest.mark.xfail(reason="Test is flaky - JIRA issue LLT-4648"),
-            ],
+            marks=[pytest.mark.mac],
         ),
     ],
 )

--- a/nat-lab/tests/test_network_switch.py
+++ b/nat-lab/tests/test_network_switch.py
@@ -165,10 +165,7 @@ async def test_mesh_network_switch(
                 adapter_type=telio.AdapterType.WindowsNativeWg,
                 is_meshnet=False,
             ),
-            marks=[
-                pytest.mark.windows,
-                pytest.mark.xfail(reason="Test is flaky - LLT-4391"),
-            ],
+            marks=[pytest.mark.windows],
         ),
         pytest.param(
             SetupParameters(
@@ -176,10 +173,7 @@ async def test_mesh_network_switch(
                 adapter_type=telio.AdapterType.WireguardGo,
                 is_meshnet=False,
             ),
-            marks=[
-                pytest.mark.windows,
-                pytest.mark.xfail(reason="Test is flaky - LLT-4391"),
-            ],
+            marks=[pytest.mark.windows],
         ),
         pytest.param(
             SetupParameters(
@@ -189,6 +183,7 @@ async def test_mesh_network_switch(
             ),
             marks=[
                 pytest.mark.mac,
+                pytest.mark.xfail(reason="Test is flaky - LLT-4696"),
             ],
         ),
     ],


### PR DESCRIPTION
- Removed `xfail` mark from tests that didn't fail in last 7 days.
- `test_vpn_network_switch` (with a MAC_VM) marked as flaky since it recently failed

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
