### PR TITLE
Backport to main: LLT-4633 bind to interfaces which has router property only

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@
 * LLT-4310: Change stun client/server to the one, which supports IPv6
 * LLT-4381: Use OS certificates instead of hardcoded mozilla list
 * LLT-4667: Fix libtelio panicking on linux + boringtun
+* LLT-4633: Bind to interfaces which has router property only on apple
 
 ### v4.2.1
 ----


### PR DESCRIPTION
When libtelio is selecting interfaces candidates to bind to for underlying VPN configuration, multiple candidates may be available, in certain circumstances libtelio would select interface without access to the internet meaning, that VPN connection fails to be established. This Pull requests adds additional requirement for interface to have "Router" property when building candidate list.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
