### PR TITLE
Use boringtun with saturating duration it timers.rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,7 +390,7 @@ dependencies = [
 [[package]]
 name = "boringtun"
 version = "0.5.2"
-source = "git+https://github.com/NordSecurity/boringtun.git?tag=v1.1.7#05b398cea32e20eb2d59b29aea742f6bb3cbb7bf"
+source = "git+https://github.com/NordSecurity/boringtun.git?tag=v1.1.8#85bee7ba92938c303745c262c6f0ca71f39c4af0"
 dependencies = [
  "aead",
  "base64 0.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,7 +153,7 @@ url = "2.2.2"
 uuid = { version = "1.1.2", features = ["v4"] }
 winapi = { version = "0.3", features = ["netioapi", "ws2def"] }
 
-boringtun = { git = "https://github.com/NordSecurity/boringtun.git", tag = "v1.1.7" }
+boringtun = { git = "https://github.com/NordSecurity/boringtun.git", tag = "v1.1.8" }
 x25519-dalek = { version = "2.0.0-pre.1", features = ["reusable_secrets", "static_secrets"] }
 
 telio-crypto = { version = "0.1.0", path = "./crates/telio-crypto" }

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 * LLT-4543: Log ffi calls
 * LLT-4310: Change stun client/server to the one, which supports IPv6
 * LLT-4381: Use OS certificates instead of hardcoded mozilla list
+* LLT-4667: Fix libtelio panicking on linux + boringtun
 
 ### v4.2.1
 ----


### PR DESCRIPTION
This should fix rare crash during startup caused by negative duration.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
