### PR TITLE
[LLT-4366] Make tests passing under tarpaulin

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,4 +14,4 @@ jobs:
       - name: Verify download
         run: echo '564ea439a14eced45cdb3e50b55a463502d9fbfb7722535c5d0390b6577ce343  cargo-tarpaulin' | sha256sum --check --status
       - name: Run cargo-tarpaulin
-        run: ./cargo-tarpaulin -v --all --out Xml --offline --exclude-files '../3rd-party/*,clis/*'
+        run: sudo -E env "PATH=$PATH:/home/runner/.cargo" ./cargo-tarpaulin -v --all --out Xml --offline --exclude-files '../3rd-party/*,clis/*'

--- a/crates/telio-sockets/src/protector/linux.rs
+++ b/crates/telio-sockets/src/protector/linux.rs
@@ -66,7 +66,6 @@ mod tests {
 
     use super::*;
 
-    #[cfg(not(tarpaulin))]
     #[rstest]
     #[case(IpAddr::V4(Ipv4Addr::LOCALHOST))]
     #[case(IpAddr::V4(Ipv4Addr::UNSPECIFIED))]
@@ -85,6 +84,7 @@ mod tests {
             }
             Err(e) => panic!("Unexpected error: {:?}", e),
         };
+
         assert!(protector.make_external(socket.as_native_socket()).is_ok());
 
         let socket = match TcpListener::bind(addr) {

--- a/crates/telio-sockets/src/socket_pool.rs
+++ b/crates/telio-sockets/src/socket_pool.rs
@@ -326,11 +326,10 @@ mod tests {
     }
 
     #[rstest]
-    #[case(IpAddr::V4(Ipv4Addr::LOCALHOST))]
     #[cfg(not(windows))]
+    #[case(IpAddr::V4(Ipv4Addr::LOCALHOST))]
     #[case(IpAddr::V4(Ipv4Addr::UNSPECIFIED))]
     #[case(IpAddr::V6(Ipv6Addr::LOCALHOST))]
-    #[cfg(not(any(windows, tarpaulin)))]
     #[case(IpAddr::V6(Ipv6Addr::UNSPECIFIED))]
     #[tokio::test]
     async fn internal_udp_socket_can_transfer_data(#[case] ip_addr: IpAddr) {
@@ -359,11 +358,10 @@ mod tests {
     }
 
     #[rstest]
-    #[case(IpAddr::V4(Ipv4Addr::LOCALHOST))]
     #[cfg(not(windows))]
+    #[case(IpAddr::V4(Ipv4Addr::LOCALHOST))]
     #[case(IpAddr::V4(Ipv4Addr::UNSPECIFIED))]
     #[case(IpAddr::V6(Ipv6Addr::LOCALHOST))]
-    #[cfg(not(any(windows, tarpaulin)))]
     #[case(IpAddr::V6(Ipv6Addr::UNSPECIFIED))]
     #[tokio::test]
     async fn external_udp_socket_can_transfer_data(#[case] ip_addr: IpAddr) {


### PR DESCRIPTION
Add privilege to make all tests passing under tarpaulin

### Problem
Some tests lacked privileges to pass when run under tarpaulin

### Solution
Run the tarpaulin with `sudo`

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
