### PR TITLE
LLT-4616: Make QoS ping asynchronous

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,7 @@
 * LLT-4490: Ensure that meshnet entities are started only when meshnet is started
 * LLT-4335: Make blocking upnp gw search async
 * LLT-4620: Implement the post quantum key rotation mechanism
+* LLT-4616: Make nurse qos ping asynchronous
 
 <br>
 

--- a/crates/telio-utils/src/dual_target.rs
+++ b/crates/telio-utils/src/dual_target.rs
@@ -15,7 +15,7 @@ pub type Result<T> = std::result::Result<T, DualTargetError>;
 pub type Target = (Option<Ipv4Addr>, Option<Ipv6Addr>);
 
 /// DualTarget wrapper
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DualTarget {
     target: Target,
 }

--- a/crates/telio-wg/src/uapi.rs
+++ b/crates/telio-wg/src/uapi.rs
@@ -244,7 +244,7 @@ pub struct Event {
 }
 
 /// Analytics information to be conveyed
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct AnalyticsEvent {
     /// Public key of the Peer
     pub public_key: PublicKey,


### PR DESCRIPTION
### Problem
A few lana tests were failing as events were not being listed on the fetched database.

Initial investigation shown that if we have 2 nodes, where alpha supports only ipv6 and beta both ipv4 and ipv6, alpha's QoS fails to ping beta addresses (expectedly) as it doesn't support it. This way QoS will be busy pinging ([see](https://github.com/NordSecurity/libtelio/blob/b9fd30ad227195d46d8a0206d67857d09641220c/crates/telio-nurse/src/qos.rs#L186)), blocking the sending of the heartbeat event [here](https://github.com/NordSecurity/libtelio/blob/de92d11233a084645698ec0b04f5f183dd49c15d/crates/telio-nurse/src/nurse.rs#L228). 

### Solution
Make QoS ping asynchronous, launching non-blocking parallel pings.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
