### PR TITLE
Update boringtun to v1.1.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,7 +390,7 @@ dependencies = [
 [[package]]
 name = "boringtun"
 version = "0.5.2"
-source = "git+https://github.com/NordSecurity/boringtun.git?tag=v1.1.8#85bee7ba92938c303745c262c6f0ca71f39c4af0"
+source = "git+https://github.com/NordSecurity/boringtun.git?tag=v1.1.9#f84f63c12bc7b0eb6f17f33978da57e33b0db007"
 dependencies = [
  "aead",
  "base64 0.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,7 +153,7 @@ url = "2.2.2"
 uuid = { version = "1.1.2", features = ["v4"] }
 winapi = { version = "0.3", features = ["netioapi", "ws2def"] }
 
-boringtun = { git = "https://github.com/NordSecurity/boringtun.git", tag = "v1.1.8" }
+boringtun = { git = "https://github.com/NordSecurity/boringtun.git", tag = "v1.1.9" }
 x25519-dalek = { version = "2.0.0-pre.1", features = ["reusable_secrets", "static_secrets"] }
 
 telio-crypto = { version = "0.1.0", path = "./crates/telio-crypto" }

--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@
 * LLT-4381: Use OS certificates instead of hardcoded mozilla list
 * LLT-4667: Fix libtelio panicking on linux + boringtun
 * LLT-4633: Bind to interfaces which has router property only on apple
+* LLT-4688: Add detailed logs on boringtun socket failures
 
 ### v4.2.1
 ----


### PR DESCRIPTION
The changes include more logging and better error handling on socket methods failure.

### Problem
Boringtun is silently ignoring `sendto()/recvfrom()` errors

### Solution
Log errors in boringtun crate


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
