### PR TITLE
Use rustls-platform-verifier without a dependency on custom rust-security-framework

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3186,7 +3186,7 @@ dependencies = [
 [[package]]
 name = "rustls-platform-verifier"
 version = "0.1.0"
-source = "git+https://github.com/tomaszklak/rustls-platform-verifier.git?rev=1eeed2dc3a4a7f437220875feb31e50cdec0bf07#1eeed2dc3a4a7f437220875feb31e50cdec0bf07"
+source = "git+https://github.com/tomaszklak/rustls-platform-verifier.git?rev=2db68dd17d76eadb062176b913040341b99ef4f3#2db68dd17d76eadb062176b913040341b99ef4f3"
 dependencies = [
  "core-foundation",
  "core-foundation-sys",
@@ -3196,8 +3196,8 @@ dependencies = [
  "rustls",
  "rustls-native-certs",
  "rustls-webpki",
- "security-framework 2.9.2 (git+https://github.com/tomaszklak/rust-security-framework.git?rev=8ad72839ab82c5dcdbadece710f3f813df76b5ce)",
- "security-framework-sys 2.9.1 (git+https://github.com/tomaszklak/rust-security-framework.git?rev=8ad72839ab82c5dcdbadece710f3f813df76b5ce)",
+ "security-framework 2.9.2 (git+https://github.com/kornelski/rust-security-framework.git?rev=67a610ec215d207cd158664ab5cf6eca9552ff9f)",
+ "security-framework-sys 2.9.1 (git+https://github.com/kornelski/rust-security-framework.git?rev=67a610ec215d207cd158664ab5cf6eca9552ff9f)",
  "webpki-roots",
  "winapi",
 ]
@@ -3318,14 +3318,14 @@ dependencies = [
 [[package]]
 name = "security-framework"
 version = "2.9.2"
-source = "git+https://github.com/tomaszklak/rust-security-framework.git?rev=8ad72839ab82c5dcdbadece710f3f813df76b5ce#8ad72839ab82c5dcdbadece710f3f813df76b5ce"
+source = "git+https://github.com/kornelski/rust-security-framework.git?rev=67a610ec215d207cd158664ab5cf6eca9552ff9f#67a610ec215d207cd158664ab5cf6eca9552ff9f"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
  "core-foundation-sys",
  "libc",
  "num-bigint",
- "security-framework-sys 2.9.1 (git+https://github.com/tomaszklak/rust-security-framework.git?rev=8ad72839ab82c5dcdbadece710f3f813df76b5ce)",
+ "security-framework-sys 2.9.1 (git+https://github.com/kornelski/rust-security-framework.git?rev=67a610ec215d207cd158664ab5cf6eca9552ff9f)",
 ]
 
 [[package]]
@@ -3341,7 +3341,7 @@ dependencies = [
 [[package]]
 name = "security-framework-sys"
 version = "2.9.1"
-source = "git+https://github.com/tomaszklak/rust-security-framework.git?rev=8ad72839ab82c5dcdbadece710f3f813df76b5ce#8ad72839ab82c5dcdbadece710f3f813df76b5ce"
+source = "git+https://github.com/kornelski/rust-security-framework.git?rev=67a610ec215d207cd158664ab5cf6eca9552ff9f#67a610ec215d207cd158664ab5cf6eca9552ff9f"
 dependencies = [
  "core-foundation-sys",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ once_cell.workspace = true
 
 [target.'cfg(target_os = "android")'.dependencies]
 jni = "0.19"
-rustls-platform-verifier = { git = "https://github.com/tomaszklak/rustls-platform-verifier.git", rev = "1eeed2dc3a4a7f437220875feb31e50cdec0bf07" }
+rustls-platform-verifier = { git = "https://github.com/tomaszklak/rustls-platform-verifier.git", rev = "2db68dd17d76eadb062176b913040341b99ef4f3" }
 
 [dev-dependencies]
 slog-async = "2.7"

--- a/crates/telio-relay/Cargo.toml
+++ b/crates/telio-relay/Cargo.toml
@@ -13,7 +13,7 @@ rustls-pemfile = "1.0.0"
 tokio-rustls = { version = "0.24.1", features = ["dangerous_configuration"] }
 tokio-util = "0.7.3"
 tokio-stream = "0.1.9"
-rustls-platform-verifier = { git = "https://github.com/tomaszklak/rustls-platform-verifier.git", rev = "1eeed2dc3a4a7f437220875feb31e50cdec0bf07" }
+rustls-platform-verifier = { git = "https://github.com/tomaszklak/rustls-platform-verifier.git", rev = "2db68dd17d76eadb062176b913040341b99ef4f3" }
 
 async-trait.workspace = true
 bytes.workspace = true

--- a/deny.toml
+++ b/deny.toml
@@ -56,7 +56,7 @@ skip-tree = []
 unknown-registry = "warn"
 unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-allow-git = ["https://github.com/tomaszklak/rustls-platform-verifier.git", "https://github.com/tomaszklak/rust-security-framework.git"]
+allow-git = ["https://github.com/tomaszklak/rustls-platform-verifier.git","https://github.com/kornelski/rust-security-framework"]
 
 [sources.allow-org]
 github = ["NordSecurity"]


### PR DESCRIPTION
Recently `rust-security-framework` got a PR that includes all the changes we needed for tvOS. There's no release yet, but latest main branch contains all that we need so let's use an updated for of `rustls-platform-verifier` that uses official `rust-security-framework` repository. 


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
