### PR TITLE
Fix CPC unresponsive time threshold

### DIFF
--- a/nat-lab/tests/test_direct_connection.py
+++ b/nat-lab/tests/test_direct_connection.py
@@ -37,7 +37,7 @@ def _generate_setup_parameter_pair(
                 direct=Direct(
                     providers=endpoint_providers,
                     skip_unresponsive_peers=SkipUnresponsivePeers(
-                        no_handshake_threshold_secs=10
+                        no_handshake_threshold_secs=180
                     ),
                 ),
             ),


### PR DESCRIPTION
CPC implemented an optimization to avoid sending CMMs and pings to nodes which are offline. The "offline" in the context of this optimization is determined by the time since last handshake. Wireguard attempts new handshake every 120-180s, but somehow the value in the tests for CPC "offline" threshold has been set to 10s (single tests are rarely allowed to run for longer, than single wireguard sessions). This means, that every time, when direct connection is not formed in the first 10s - it will not be attempted anymore. And this introduces non-deterministic failures in the tests.



### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
