### PR TITLE
LLT-4674: Stabilize DNS queries in natlab tests

### DIFF
--- a/nat-lab/tests/utils/dns.py
+++ b/nat-lab/tests/utils/dns.py
@@ -1,0 +1,28 @@
+import re
+from config import LIBTELIO_DNS_IPV4
+from typing import List, Optional
+from utils import testing
+from utils.connection import Connection
+
+
+async def query_dns(
+    connection: Connection,
+    host_name: str,
+    expected_output: Optional[List[str]] = None,
+    dns_server: Optional[str] = None,
+    options: Optional[str] = None,
+) -> None:
+    response = await testing.wait_long(
+        connection.create_process(
+            [
+                "nslookup",
+                options if options else "-timeout=1",
+                host_name,
+                dns_server if dns_server else LIBTELIO_DNS_IPV4,
+            ]
+        ).execute()
+    )
+    dns_output = response.get_stdout()
+    if expected_output:
+        for expected_str in expected_output:
+            assert re.search(expected_str, dns_output, re.DOTALL) is not None


### PR DESCRIPTION
### Problem
`test_dns_through_exit` would sometimes fail. Local testing showed that `nslookup` was sometimes not returning any results. 

### Solution
`test_dns.py` had abstracted calls to `nslookup` to a dedicated function but that function was not used in `test_dns_through_exit.py`. That function is now moved to a dedicated utils file to make it easier to share. Additionally, the function was made more stable by slightly increasing how long the test waits for a DNS response, removing the retry option passed to `nslookup` to allow it to retry infinitely, and lastly by setting the internal timeout for `nslookup` to only a second, which means it will retry over and over instead of just waiting.

Before the fix I could reliably reproduce the flakiness of `test_dns_through_exit`, with one of the variants failing on average every 5th time or so. After the fix, I ran every variant for 50 times without a single failure.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
