### PR TITLE
Add 'ar' wrapper script for the 'aarch64-linux-gnu' architecture

### DIFF
--- a/linkers/d-aarch64-linux-gnu-ar
+++ b/linkers/d-aarch64-linux-gnu-ar
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+AR=$(basename $0)
+AR=${AR#"d-"}
+ARGS=$@
+
+exec $AR $ARGS


### PR DESCRIPTION
### Problem
After https://github.com/NordSecurity/libtelio/commit/93dd02ae7381d9f6668ef719ead502d34b7db4d8 building for nat-lab failed on macos host - `d-aarch64-linux-gnu-gcc` was trying to invoke `/libtelio-build/libtelio/linkers/d-aarch64-linux-gnu-ar`.

### Solution
Create a wrapper called `d-aarch64-linux-gnu-ar` that calls `aarch64-linux-gnu-gcc`.
