### PR TITLE
LLT-4797: Remove xfail from all tests

### DIFF
--- a/nat-lab/tests/test_direct_connection.py
+++ b/nat-lab/tests/test_direct_connection.py
@@ -287,7 +287,6 @@ async def test_direct_failing_paths(setup_params: List[SetupParameters]) -> None
 
 
 @pytest.mark.asyncio
-@pytest.mark.xfail(reason="test flaky - JIRA issue: LLT-4132")
 @pytest.mark.parametrize("setup_params, _reflexive_ip", UHP_WORKING_PATHS)
 async def test_direct_working_paths(
     setup_params: List[SetupParameters],
@@ -349,7 +348,6 @@ async def test_direct_working_paths_stun_ipv6() -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.xfail(reason="test flaky - JIRA issue: LLT-4132")
 @pytest.mark.parametrize("setup_params, reflexive_ip", UHP_WORKING_PATHS)
 async def test_direct_short_connection_loss(
     setup_params: List[SetupParameters], reflexive_ip: str
@@ -437,7 +435,6 @@ async def test_direct_connection_loss_for_infinity(
 
 
 @pytest.mark.asyncio
-@pytest.mark.xfail(reason="test is flaky - LLT-4441")
 @pytest.mark.parametrize("setup_params, _reflexive_ip", UHP_WORKING_PATHS)
 async def test_direct_working_paths_with_skip_unresponsive_peers(
     setup_params: List[SetupParameters], _reflexive_ip: str
@@ -493,7 +490,6 @@ async def test_direct_working_paths_with_skip_unresponsive_peers(
 
 @pytest.mark.timeout(90)
 @pytest.mark.asyncio
-@pytest.mark.xfail(reason="test is flaky - LLT-4115")
 @pytest.mark.parametrize(
     "setup_params",
     [
@@ -615,7 +611,6 @@ async def test_direct_connection_endpoint_gone(
 
 @pytest.mark.asyncio
 # Regression test for LLT-4306
-@pytest.mark.xfail(reason="Test is flaky - JIRA issue LLT-4555")
 @pytest.mark.parametrize(
     "setup_params",
     [

--- a/nat-lab/tests/test_dns.py
+++ b/nat-lab/tests/test_dns.py
@@ -161,7 +161,6 @@ async def test_dns(
         ),
     ],
 )
-@pytest.mark.xfail(reason="Test is flaky - LLT-4656")
 async def test_dns_port(alpha_ip_stack: IPStack) -> None:
     async with AsyncExitStack() as exit_stack:
         dns_server_address_alpha = get_dns_server_address(alpha_ip_stack)

--- a/nat-lab/tests/test_events.py
+++ b/nat-lab/tests/test_events.py
@@ -211,7 +211,6 @@ async def test_event_content_meshnet(
             "10.0.254.7",
             marks=[
                 pytest.mark.windows,
-                pytest.mark.xfail(reason="Test is flaky - LLT-4522"),
             ],
         ),
         pytest.param(
@@ -228,7 +227,6 @@ async def test_event_content_meshnet(
             "10.0.254.7",
             marks=[
                 pytest.mark.windows,
-                pytest.mark.xfail(reason="Test is flaky - LLT-4522"),
             ],
         ),
         pytest.param(
@@ -474,7 +472,6 @@ async def test_event_content_exit_through_peer(
                 features=TelioFeatures(direct=Direct(providers=["stun"])),
             ),
             "10.0.254.1",
-            marks=pytest.mark.xfail(reason="Test is flaky - JIRA issue LLT-4686"),
         ),
         pytest.param(
             SetupParameters(

--- a/nat-lab/tests/test_mesh_exit_through_peer.py
+++ b/nat-lab/tests/test_mesh_exit_through_peer.py
@@ -221,7 +221,6 @@ async def test_mesh_exit_through_peer(
             telio.AdapterType.WindowsNativeWg,
             marks=[
                 pytest.mark.windows,
-                pytest.mark.xfail(reason="Test is flaky - LLT-4357"),
             ],
         ),
         pytest.param(
@@ -229,7 +228,6 @@ async def test_mesh_exit_through_peer(
             telio.AdapterType.WireguardGo,
             marks=[
                 pytest.mark.windows,
-                pytest.mark.xfail(reason="Test is flaky - LLT-4357"),
             ],
         ),
         pytest.param(

--- a/nat-lab/tests/test_mesh_plus_vpn.py
+++ b/nat-lab/tests/test_mesh_plus_vpn.py
@@ -69,7 +69,6 @@ from utils.ping import Ping
             ),
             marks=[
                 pytest.mark.windows,
-                pytest.mark.xfail(reason="Test is flaky - LLT-4357"),
             ],
         ),
         pytest.param(
@@ -186,7 +185,6 @@ async def test_mesh_plus_vpn_one_peer(
             ),
             marks=[
                 pytest.mark.windows,
-                pytest.mark.xfail(reason="Test is flaky - LLT-4357"),
             ],
         ),
         pytest.param(
@@ -399,7 +397,6 @@ async def test_vpn_plus_mesh(
                 ),
                 features=TelioFeatures(direct=Direct(providers=["local", "stun"])),
             ),
-            marks=pytest.mark.xfail(reason="Test is flaky - LLT-4665"),
         ),
         pytest.param(
             SetupParameters(
@@ -414,7 +411,6 @@ async def test_vpn_plus_mesh(
             ),
             marks=[
                 pytest.mark.linux_native,
-                pytest.mark.xfail(reason="Test is flaky - LLT-4665"),
             ],
         ),
         pytest.param(
@@ -430,7 +426,6 @@ async def test_vpn_plus_mesh(
             ),
             marks=[
                 pytest.mark.windows,
-                pytest.mark.xfail(reason="Test is flaky - LLT-4313"),
             ],
         ),
         pytest.param(
@@ -446,7 +441,6 @@ async def test_vpn_plus_mesh(
             ),
             marks=[
                 pytest.mark.windows,
-                pytest.mark.xfail(reason="Test is flaky - LLT-4313"),
             ],
         ),
         pytest.param(
@@ -462,7 +456,6 @@ async def test_vpn_plus_mesh(
             ),
             marks=[
                 pytest.mark.mac,
-                pytest.mark.xfail(reason="Test is flaky - LLT-4684"),
             ],
         ),
     ],
@@ -540,7 +533,6 @@ async def test_vpn_plus_mesh_over_direct(
 
 @pytest.mark.asyncio
 @pytest.mark.timeout(150)
-@pytest.mark.xfail(reason="Test is flaky - JIRA issue LLT-4560")
 @pytest.mark.parametrize(
     "alpha_setup_params",
     [
@@ -595,7 +587,6 @@ async def test_vpn_plus_mesh_over_direct(
             ),
             marks=[
                 pytest.mark.windows,
-                pytest.mark.xfail(reason="test is flaky - LLT-4314"),
             ],
         ),
         pytest.param(
@@ -611,7 +602,6 @@ async def test_vpn_plus_mesh_over_direct(
             ),
             marks=[
                 pytest.mark.mac,
-                pytest.mark.xfail(reason="test is flaky - LLT-4116"),
             ],
         ),
     ],

--- a/nat-lab/tests/test_mesh_remove_node.py
+++ b/nat-lab/tests/test_mesh_remove_node.py
@@ -46,7 +46,6 @@ from utils.ping import Ping
             ),
             marks=[
                 pytest.mark.windows,
-                pytest.mark.xfail(reason="Test is flaky - LLT-4683"),
             ],
         ),
         pytest.param(
@@ -71,7 +70,6 @@ from utils.ping import Ping
             ),
             marks=[
                 pytest.mark.mac,
-                pytest.mark.xfail(reason="Test is flaky - LLT-4683"),
             ],
         ),
     ],

--- a/nat-lab/tests/test_network_switch.py
+++ b/nat-lab/tests/test_network_switch.py
@@ -91,7 +91,6 @@ async def test_network_switcher(
             ),
             marks=[
                 pytest.mark.windows,
-                pytest.mark.xfail(reason="Test is flaky - LLT-4357"),
             ],
         ),
         pytest.param(
@@ -180,7 +179,6 @@ async def test_mesh_network_switch(
             ),
             marks=[
                 pytest.mark.mac,
-                pytest.mark.xfail(reason="Test is flaky - LLT-4696"),
             ],
         ),
     ],
@@ -234,9 +232,7 @@ async def test_vpn_network_switch(alpha_setup_params: SetupParameters) -> None:
                 adapter_type=telio.AdapterType.BoringTun,
                 features=TelioFeatures(direct=Direct(providers=["stun"])),
             ),
-            marks=[
-                pytest.mark.xfail(reason="Flaky: LLT-4677"),
-            ],
+            marks=[],
         ),
         pytest.param(
             SetupParameters(
@@ -254,7 +250,6 @@ async def test_vpn_network_switch(alpha_setup_params: SetupParameters) -> None:
             ),
             marks=[
                 pytest.mark.windows,
-                pytest.mark.xfail(reason="Flaky: LLT-4673"),
             ],
         ),
         pytest.param(
@@ -273,7 +268,6 @@ async def test_vpn_network_switch(alpha_setup_params: SetupParameters) -> None:
             ),
             marks=[
                 pytest.mark.mac,
-                pytest.mark.xfail(reason="Flaky: LLT-4600"),
             ],
         ),
     ],

--- a/nat-lab/tests/test_reconnections.py
+++ b/nat-lab/tests/test_reconnections.py
@@ -45,7 +45,6 @@ from utils.ping import Ping
             ),
             marks=[
                 pytest.mark.windows,
-                pytest.mark.xfail(reason="test flaky - JIRA issue: LLT-4593"),
             ],
         ),
         pytest.param(
@@ -59,7 +58,6 @@ from utils.ping import Ping
             ),
             marks=[
                 pytest.mark.windows,
-                pytest.mark.xfail(reason="test flaky - JIRA issue: LLT-4593"),
             ],
         ),
         pytest.param(

--- a/nat-lab/tests/test_vpn.py
+++ b/nat-lab/tests/test_vpn.py
@@ -80,7 +80,6 @@ async def _connect_vpn(
             "10.0.254.7",
             marks=[
                 pytest.mark.windows,
-                pytest.mark.xfail(reason="Test flaky: JIRA issue LLT-4554"),
             ],
         ),
         pytest.param(
@@ -97,7 +96,6 @@ async def _connect_vpn(
             "10.0.254.7",
             marks=[
                 pytest.mark.windows,
-                pytest.mark.xfail(reason="Test flaky: JIRA issue LLT-4554"),
             ],
         ),
         pytest.param(
@@ -114,7 +112,6 @@ async def _connect_vpn(
             "10.0.254.7",
             marks=[
                 pytest.mark.mac,
-                pytest.mark.xfail(reason="Test flaky: JIRA issue LLT-4682"),
             ],
         ),
     ],
@@ -195,7 +192,6 @@ async def test_vpn_connection(
             "10.0.254.7",
             marks=[
                 pytest.mark.windows,
-                pytest.mark.xfail(reason="Flaky: LLT-4674"),
             ],
         ),
         pytest.param(
@@ -213,7 +209,6 @@ async def test_vpn_connection(
             "10.0.254.7",
             marks=[
                 pytest.mark.windows,
-                pytest.mark.xfail(reason="Test flaky: JIRA issue LLT-4554"),
             ],
         ),
         pytest.param(


### PR DESCRIPTION
### Problem
Xfail has given us more problems than benefits, by allowing us to let our natlab test suite deteriorate and by hiding test failures during development. We are now removing it, and disallowing it moving forward, to foster test quality and increase confidence in our tests.

### Solution
Remove the remaining xfail marks.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
