### PR TITLE
[LLT-4420] Fix killing docker processes

### DIFF
--- a/nat-lab/bin/kill_process_by_natlab_id
+++ b/nat-lab/bin/kill_process_by_natlab_id
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+if [[ "$#" -ne 1 ]]; then
+    echo "Wrong number of parameters"
+    exit 1
+fi
+
+NATLAB_ID=$1
+
+for pid in $(ps -e -o pid=); do
+    if grep --null-data --text KILL_ID=${NATLAB_ID} /proc/${pid}/environ; then
+        echo "Killing ${pid}"
+        kill "${pid}"
+        exit 0
+    fi
+done
+
+echo "The process to kill not found"

--- a/nat-lab/tests/utils/process/docker_process.py
+++ b/nat-lab/tests/utils/process/docker_process.py
@@ -63,7 +63,14 @@ class DockerProcess(Process):
                         inspect = await self._execute.inspect()
                         await asyncio.sleep(0.01)
                     if inspect["ExitCode"] is None:
-                        os.system(f"sudo kill -9 {inspect['Pid']}")
+                        subprocess.run([
+                            "docker",
+                            "exec",
+                            "--privileged",
+                            self._container.id,
+                            "/opt/bin/kill_process_by_natlab_id",
+                            self._kill_id,
+                        ])
                 raise
             finally:
                 self._stream = None
@@ -100,16 +107,14 @@ class DockerProcess(Process):
                         inspect = await self._execute.inspect()
                         await asyncio.sleep(0.01)
                     if inspect["ExitCode"] is None:
-                        subprocess.run(
-                            [
-                                "docker",
-                                "exec",
-                                "--privileged",
-                                self._container.id,
-                                "/opt/bin/kill_process_by_natlab_id",
-                                self._kill_id,
-                            ]
-                        )
+                        subprocess.run([
+                            "docker",
+                            "exec",
+                            "--privileged",
+                            self._container.id,
+                            "/opt/bin/kill_process_by_natlab_id",
+                            self._kill_id,
+                        ])
 
     async def _read_loop(
         self,


### PR DESCRIPTION
It improves the experience of running the tests locally in two ways:
 - on some setups you can't just kill the docker process from host (even with sudo)
 - some tests won't need entering sudoer password anymore

### Problem
While running locally tests have sometimes problems with killing docker processes

### Solution
We can map the host PID to the PID inside the container and then kill it inside, which is done in this commit


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
