### PR TITLE
LLT-4799: wg: Fix deadlock on interface callbacks when stopping

### DIFF
--- a/crates/telio-wg/src/windows/tunnel/interfacewatcher.rs
+++ b/crates/telio-wg/src/windows/tunnel/interfacewatcher.rs
@@ -340,13 +340,9 @@ impl InterfaceWatcher {
         );
 
         let self_ptr = CallerContext as *mut InterfaceWatcher;
-        if (*self_ptr).iface_cb_handle.clone().lock().is_ok() {
-            if NotificationType == MibAddInstance {
-                (*self_ptr).mib_add_instance(Row);
-            };
-        } else {
-            telio_log_error!("error obtaining lock");
-        }
+        if NotificationType == MibAddInstance {
+            (*self_ptr).mib_add_instance(Row);
+        };
 
         telio_log_trace!(
             "--- InterfaceWatcher::interface_change_callback: CallerContext {:p}, Row {:p}, NotificationType {}",

--- a/crates/telio-wg/src/windows/tunnel/mtumonitor.rs
+++ b/crates/telio-wg/src/windows/tunnel/mtumonitor.rs
@@ -135,18 +135,14 @@ impl MtuMonitor {
         );
 
         let self_ptr = CallerContext as *mut MtuMonitor;
-        if (*self_ptr).route_cb_handle.clone().lock().is_ok() {
-            if 0 == (*Row).DestinationPrefix.PrefixLength {
-                // Result can be ignored
-                match (*self_ptr).do_it() {
-                    Ok(_) => {}
-                    Err(err) => {
-                        telio_log_trace!("MtuMonitor::do_it returned error {}", err);
-                    }
+        if 0 == (*Row).DestinationPrefix.PrefixLength {
+            // Result can be ignored
+            match (*self_ptr).do_it() {
+                Ok(_) => {}
+                Err(err) => {
+                    telio_log_trace!("MtuMonitor::do_it returned error {}", err);
                 }
             }
-        } else {
-            telio_log_error!("error obtaining lock");
         }
 
         telio_log_trace!(
@@ -171,18 +167,14 @@ impl MtuMonitor {
         );
 
         let self_ptr = CallerContext as *mut MtuMonitor;
-        if (*self_ptr).iface_cb_handle.clone().lock().is_ok() {
-            if NotificationType == MibParameterNotification {
-                // Result can be ignored
-                match (*self_ptr).do_it() {
-                    Ok(_) => {}
-                    Err(err) => {
-                        telio_log_trace!("MtuMonitor::do_it returned error {}", err);
-                    }
+        if NotificationType == MibParameterNotification {
+            // Result can be ignored
+            match (*self_ptr).do_it() {
+                Ok(_) => {}
+                Err(err) => {
+                    telio_log_trace!("MtuMonitor::do_it returned error {}", err);
                 }
             }
-        } else {
-            telio_log_error!("error obtaining lock");
         }
 
         telio_log_trace!(


### PR DESCRIPTION
### Problem
There are a few places that can deadlock on `dev stop` due to incorrect use of [CancelMibChangeNotify2](https://learn.microsoft.com/en-us/windows/win32/api/netioapi/nf-netioapi-cancelmibchangenotify2#remarks).

Specifically:
-  https://github.com/NordSecurity/libtelio/blob/main/crates/telio-wg/src/windows/tunnel/interfacewatcher.rs#L108
- https://github.com/NordSecurity/libtelio/blob/main/crates/telio-wg/src/windows/tunnel/interfacewatcher.rs#

and

- https://github.com/NordSecurity/libtelio/blob/main/crates/telio-wg/src/windows/tunnel/mtumonitor.rs#L99
- https://github.com/NordSecurity/libtelio/blob/main/crates/telio-wg/src/windows/tunnel/mtumonitor.rs#L110
- https://github.com/NordSecurity/libtelio/blob/main/crates/telio-wg/src/windows/tunnel/mtumonitor.rs#L138
- https://github.com/NordSecurity/libtelio/blob/main/crates/telio-wg/src/windows/tunnel/mtumonitor.rs#L174

The deadlock can happen when the stop function lock’s callback’s handle, at the same time network change triggers the callback’s code on another thread, that tries to acquire the same lock to the callback’s handle. However, [CancelMibChangeNotify2](https://learn.microsoft.com/en-us/windows/win32/api/netioapi/nf-netioapi-cancelmibchangenotify2#remarks) will not be complete until that callback is done, both the stopping thread and callback thread are deadlocked.

### Solution
Add an atomic boolean to sinchronize between threads and sinalize that we're stopping telio and no more callbacks should be called.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
