### PR TITLE
Update wireguard-nt-rust to 1.0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5072,7 +5072,7 @@ dependencies = [
 [[package]]
 name = "wireguard-nt"
 version = "1.0.0"
-source = "git+https://github.com/NordSecurity/wireguard-nt-rust-wrapper?tag=v1.0.3#38b6a4223abe1117335efa440ca33361b8e74e8b"
+source = "git+https://github.com/NordSecurity/wireguard-nt-rust-wrapper?tag=v1.0.4#e2f2c1fe6ca27a4de6da7886be308fb2ffbb8c34"
 dependencies = [
  "bitflags 1.3.2",
  "ipnet",

--- a/crates/telio-wg/Cargo.toml
+++ b/crates/telio-wg/Cargo.toml
@@ -53,6 +53,6 @@ ipnet.workspace = true
 sha2.workspace = true
 winapi = { workspace = true, features = ["nldef"] }
 
-wireguard-nt = { git = "https://github.com/NordSecurity/wireguard-nt-rust-wrapper", tag = "v1.0.3" }
+wireguard-nt = { git = "https://github.com/NordSecurity/wireguard-nt-rust-wrapper", tag = "v1.0.4" }
 
 wg-go-rust-wrapper = { path = "../../wireguard-go-rust-wrapper" }


### PR DESCRIPTION
### Problem
The wireguard-nt `get_config_uapi` call returns a garbage preshared key, even when not used for the peer.

### Solution
Update `wireguard-nt-rust-wrapper` to 1.0.4 so that to include changes from https://github.com/NordSecurity/wireguard-nt-rust-wrapper/pull/4


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
