### PR TITLE
LLT-4799 Disable management interface during tests

### DIFF
--- a/nat-lab/tests/utils/connection/docker_connection.py
+++ b/nat-lab/tests/utils/connection/docker_connection.py
@@ -2,14 +2,17 @@ from .connection import Connection, TargetOS
 from aiodocker.containers import DockerContainer
 from typing import List
 from utils.process import Process, DockerProcess
+from datetime import datetime
 
 
 class DockerConnection(Connection):
     _container: DockerContainer
 
-    def __init__(self, container: DockerContainer):
+    def __init__(self, container: DockerContainer, container_name: str):
         super().__init__(TargetOS.Linux)
+        self._name = container_name
         self._container = container
 
     def create_process(self, command: List[str]) -> "Process":
+        print(datetime.now(), "Executing", command, "on", self._name)
         return DockerProcess(self._container, command)

--- a/nat-lab/tests/utils/connection/docker_connection.py
+++ b/nat-lab/tests/utils/connection/docker_connection.py
@@ -1,8 +1,8 @@
 from .connection import Connection, TargetOS
 from aiodocker.containers import DockerContainer
+from datetime import datetime
 from typing import List
 from utils.process import Process, DockerProcess
-from datetime import datetime
 
 
 class DockerConnection(Connection):

--- a/nat-lab/tests/utils/connection/ssh_connection.py
+++ b/nat-lab/tests/utils/connection/ssh_connection.py
@@ -4,6 +4,7 @@ from .connection import Connection, TargetOS
 from typing import List
 from utils import cmd_exe_escape
 from utils.process import Process, SshProcess
+from datetime import datetime
 
 
 class SshConnection(Connection):
@@ -14,6 +15,7 @@ class SshConnection(Connection):
         self._connection = connection
 
     def create_process(self, command: List[str]) -> "Process":
+        print(datetime.now(), "Executing", command, "on", self.target_os)
         if self._target_os == TargetOS.Windows:
             escape_argument = cmd_exe_escape.escape_argument
         elif self._target_os in [TargetOS.Linux, TargetOS.Mac]:

--- a/nat-lab/tests/utils/connection/ssh_connection.py
+++ b/nat-lab/tests/utils/connection/ssh_connection.py
@@ -1,10 +1,10 @@
 import asyncssh
 import shlex
 from .connection import Connection, TargetOS
+from datetime import datetime
 from typing import List
 from utils import cmd_exe_escape
 from utils.process import Process, SshProcess
-from datetime import datetime
 
 
 class SshConnection(Connection):

--- a/nat-lab/tests/utils/vm/container_util.py
+++ b/nat-lab/tests/utils/vm/container_util.py
@@ -26,7 +26,9 @@ async def _reset(connection: Connection) -> None:
 
 @asynccontextmanager
 async def get(docker: Docker, container_name: str) -> AsyncIterator[DockerConnection]:
-    connection = DockerConnection(await docker.containers.get(container_name))
+    connection = DockerConnection(
+        await docker.containers.get(container_name), container_name
+    )
     try:
         await _prepare(connection)
         yield connection


### PR DESCRIPTION
### Describtion
libvirt uses management interface to configure and/or provision the virtual machines, unfortunately this interface is completely controlled by libvirt and can issue/renew DHCP leases any time, especially if default route to it has been deleted (we used to do that in tests). This introduces competition against primary/secondary interfaces default routes which is used for testing. During tests - management interface should never be used, therefore this PR ensures, that this interface is disabled during tests.
    
Note that this will cause `vagrant ssh` to not work during tests, but one can always use `ssh vagrant@10.55.0.11` to connect to windows machines.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
