### PR TITLE
natlab: Add dig timeout to allow process failure

### DIFF
--- a/nat-lab/tests/utils/dns.py
+++ b/nat-lab/tests/utils/dns.py
@@ -26,3 +26,30 @@ async def query_dns(
     if expected_output:
         for expected_str in expected_output:
             assert re.search(expected_str, dns_output, re.DOTALL) is not None
+
+
+async def query_dns_port(
+    connection: Connection,
+    port: str,
+    host_name: str,
+    dns_server: str,
+    expected_output: Optional[List[str]] = None,
+    options: Optional[str] = None,
+    extra_host_options: Optional[List[str]] = None,
+) -> None:
+    cmd = [
+        "dig",
+        options if options else "+timeout=1",
+        "@" + dns_server,
+        "-p",
+        port,
+        host_name,
+    ]
+    if extra_host_options:
+        cmd += list(extra_opt for extra_opt in extra_host_options)
+
+    response = await testing.wait_long(connection.create_process(cmd).execute())
+    dns_output = response.get_stdout()
+    if expected_output:
+        for expected_str in expected_output:
+            assert re.search(expected_str, dns_output, re.DOTALL) is not None


### PR DESCRIPTION
### Problem
On `test_dns_port`, `dig` command is used which has by default 5 seconds timeout for each retry (3 tries by default). 
Enabling magic_dns can take sometimes more than we expect and the 1s timeout from `wait_normal` might not be enough.

### Solution
Increase command timeout from `wait_normal`->`wait_long` and assert we get process error when the 3 tries are finished.

There might be still an issue with libtelio, however as I could not reproduce the issue locally and the logs are no longer available these changes should place us in a better position to debug it if the test fails again in the future.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
