### PR TITLE
Resolve LLT-4812: Reenable windows management interface on natlab.

### DIFF
--- a/nat-lab/tests/test_network_switch.py
+++ b/nat-lab/tests/test_network_switch.py
@@ -52,12 +52,13 @@ async def test_network_switcher(
         )
 
         assert conn_mngr.network_switcher
-        await conn_mngr.network_switcher.switch_to_secondary_network()
-
-        assert (
-            await testing.wait_long(stun.get(conn_mngr.connection, config.STUN_SERVER))
-            == secondary_ip
-        )
+        async with conn_mngr.network_switcher.switch_to_secondary_network():
+            assert (
+                await testing.wait_long(
+                    stun.get(conn_mngr.connection, config.STUN_SERVER)
+                )
+                == secondary_ip
+            )
 
 
 @pytest.mark.asyncio
@@ -129,11 +130,13 @@ async def test_mesh_network_switch(
             await testing.wait_long(ping.wait_for_next_ping())
 
         assert alpha_conn_mngr.network_switcher
-        await alpha_conn_mngr.network_switcher.switch_to_secondary_network()
-        await client_alpha.notify_network_change()
+        async with alpha_conn_mngr.network_switcher.switch_to_secondary_network():
+            await client_alpha.notify_network_change()
 
-        async with Ping(alpha_conn_mngr.connection, beta.ip_addresses[0]).run() as ping:
-            await testing.wait_long(ping.wait_for_next_ping())
+            async with Ping(
+                alpha_conn_mngr.connection, beta.ip_addresses[0]
+            ).run() as ping:
+                await testing.wait_long(ping.wait_for_next_ping())
 
 
 @pytest.mark.asyncio
@@ -204,21 +207,23 @@ async def test_vpn_network_switch(alpha_setup_params: SetupParameters) -> None:
         ip = await testing.wait_long(stun.get(alpha_connection, config.STUN_SERVER))
         assert ip == wg_server["ipv4"], f"wrong public IP when connected to VPN {ip}"
         assert network_switcher
-        await network_switcher.switch_to_secondary_network()
-        await client_alpha.notify_network_change()
-        # This is really silly.. For some reason, adding a short sleep here allows the VPN
-        # connection to be restored faster. The difference is almost 5 seconds. Without
-        # the sleep, the test fails often due to timeouts. Its as if feeding data into
-        # a connection, which is being restored, bogs down the connection and it takes
-        # more time for the connection to be restored.
-        if alpha_connection.target_os == TargetOS.Windows:
-            await asyncio.sleep(1.0)
+        async with network_switcher.switch_to_secondary_network():
+            await client_alpha.notify_network_change()
+            # This is really silly.. For some reason, adding a short sleep here allows the VPN
+            # connection to be restored faster. The difference is almost 5 seconds. Without
+            # the sleep, the test fails often due to timeouts. Its as if feeding data into
+            # a connection, which is being restored, bogs down the connection and it takes
+            # more time for the connection to be restored.
+            if alpha_connection.target_os == TargetOS.Windows:
+                await asyncio.sleep(1.0)
 
-        async with Ping(alpha_connection, config.PHOTO_ALBUM_IP).run() as ping:
-            await testing.wait_long(ping.wait_for_next_ping())
+            async with Ping(alpha_connection, config.PHOTO_ALBUM_IP).run() as ping:
+                await testing.wait_long(ping.wait_for_next_ping())
 
-        ip = await testing.wait_long(stun.get(alpha_connection, config.STUN_SERVER))
-        assert ip == wg_server["ipv4"], f"wrong public IP when connected to VPN {ip}"
+            ip = await testing.wait_long(stun.get(alpha_connection, config.STUN_SERVER))
+            assert (
+                ip == wg_server["ipv4"]
+            ), f"wrong public IP when connected to VPN {ip}"
 
 
 @pytest.mark.asyncio
@@ -324,7 +329,9 @@ async def test_mesh_network_switch_direct(
                 peers_connected_direct_future,
             ]
         ) as (derp, relay, direct):
-            await network_switcher.switch_to_secondary_network()
+            await exit_stack.enter_async_context(
+                network_switcher.switch_to_secondary_network()
+            )
             await alpha_client.notify_network_change()
             await derp
             await relay

--- a/nat-lab/tests/utils/connection_util.py
+++ b/nat-lab/tests/utils/connection_util.py
@@ -163,7 +163,7 @@ LAN_ADDR_MAP_V6: Dict[ConnectionTag, str] = {
 class ConnectionManager:
     connection: Connection
     gw_connection: Optional[Connection]
-    network_switcher: Optional[NetworkSwitcher]
+    network_switcher: NetworkSwitcher
     tracker: ConnectionTracker
 
 
@@ -202,7 +202,7 @@ async def new_connection_raw(tag: ConnectionTag) -> AsyncIterator[Connection]:
 
 async def create_network_switcher(
     tag: ConnectionTag, connection: Connection
-) -> Optional[NetworkSwitcher]:
+) -> NetworkSwitcher:
     if tag in DOCKER_SERVICE_IDS:
         return NetworkSwitcherDocker(connection)
 
@@ -212,7 +212,7 @@ async def create_network_switcher(
     if tag == ConnectionTag.MAC_VM:
         return NetworkSwitcherMac(connection)
 
-    return None
+    assert False, f"tag {tag} not supported"
 
 
 @asynccontextmanager
@@ -222,29 +222,31 @@ async def new_connection_manager_by_tag(
 ) -> AsyncIterator[ConnectionManager]:
     async with new_connection_raw(tag) as connection:
         network_switcher = await create_network_switcher(tag, connection)
-        if network_switcher:
-            await network_switcher.switch_to_primary_network()
-        if tag in DOCKER_GW_MAP:
-            async with new_connection_raw(DOCKER_GW_MAP[tag]) as gw_connection:
+        async with network_switcher.switch_to_primary_network():
+            if tag in DOCKER_GW_MAP:
+                async with new_connection_raw(DOCKER_GW_MAP[tag]) as gw_connection:
+                    async with ConnectionTracker(
+                        gw_connection, conn_tracker_config
+                    ).run() as conn_tracker:
+                        yield ConnectionManager(
+                            connection,
+                            gw_connection,
+                            network_switcher,
+                            conn_tracker,
+                        )
+            else:
                 async with ConnectionTracker(
-                    gw_connection, conn_tracker_config
+                    connection, conn_tracker_config
                 ).run() as conn_tracker:
                     yield ConnectionManager(
-                        connection, gw_connection, network_switcher, conn_tracker
+                        connection, None, network_switcher, conn_tracker
                     )
-        else:
-            async with ConnectionTracker(
-                connection, conn_tracker_config
-            ).run() as conn_tracker:
-                yield ConnectionManager(
-                    connection, None, network_switcher, conn_tracker
-                )
 
 
 @asynccontextmanager
 async def new_connection_with_network_switcher(
     tag: ConnectionTag,
-) -> AsyncIterator[Tuple[Connection, Optional[NetworkSwitcher]]]:
+) -> AsyncIterator[Tuple[Connection, NetworkSwitcher]]:
     async with new_connection_manager_by_tag(tag) as conn_manager:
         yield (conn_manager.connection, conn_manager.network_switcher)
 

--- a/nat-lab/tests/utils/network_switcher/network_switcher.py
+++ b/nat-lab/tests/utils/network_switcher/network_switcher.py
@@ -1,4 +1,6 @@
 from abc import ABC, abstractmethod
+from contextlib import asynccontextmanager
+from typing import AsyncIterator
 
 
 class NetworkSwitcher(ABC):
@@ -6,9 +8,11 @@ class NetworkSwitcher(ABC):
         pass
 
     @abstractmethod
-    async def switch_to_primary_network(self) -> None:
-        pass
+    @asynccontextmanager
+    async def switch_to_primary_network(self) -> AsyncIterator:
+        yield
 
     @abstractmethod
-    async def switch_to_secondary_network(self) -> None:
-        pass
+    @asynccontextmanager
+    async def switch_to_secondary_network(self) -> AsyncIterator:
+        yield

--- a/nat-lab/tests/utils/network_switcher/network_switcher_docker.py
+++ b/nat-lab/tests/utils/network_switcher/network_switcher_docker.py
@@ -1,4 +1,6 @@
 from .network_switcher import NetworkSwitcher
+from contextlib import asynccontextmanager
+from typing import AsyncIterator
 from utils.connection import Connection
 
 
@@ -6,12 +8,16 @@ class NetworkSwitcherDocker(NetworkSwitcher):
     def __init__(self, connection: Connection) -> None:
         self._connection = connection
 
-    async def switch_to_primary_network(self) -> None:
+    @asynccontextmanager
+    async def switch_to_primary_network(self) -> AsyncIterator:
         await self._connection.create_process(
             ["/libtelio/nat-lab/bin/configure_route.sh", "primary"]
         ).execute()
+        yield
 
-    async def switch_to_secondary_network(self) -> None:
+    @asynccontextmanager
+    async def switch_to_secondary_network(self) -> AsyncIterator:
         await self._connection.create_process(
             ["/libtelio/nat-lab/bin/configure_route.sh", "secondary"]
         ).execute()
+        yield

--- a/nat-lab/tests/utils/network_switcher/network_switcher_mac.py
+++ b/nat-lab/tests/utils/network_switcher/network_switcher_mac.py
@@ -6,6 +6,8 @@ from config import (
     LINUX_VM_SECONDARY_GATEWAY,
     VPN_SERVER_SUBNET,
 )
+from contextlib import asynccontextmanager
+from typing import AsyncIterator
 from utils.connection import Connection
 
 
@@ -13,7 +15,8 @@ class NetworkSwitcherMac(NetworkSwitcher):
     def __init__(self, connection: Connection) -> None:
         self._connection = connection
 
-    async def switch_to_primary_network(self) -> None:
+    @asynccontextmanager
+    async def switch_to_primary_network(self) -> AsyncIterator:
         await self._delete_existing_route()
 
         await self._connection.create_process(
@@ -33,8 +36,10 @@ class NetworkSwitcherMac(NetworkSwitcher):
                     LINUX_VM_PRIMARY_GATEWAY,
                 ],
             ).execute()
+        yield
 
-    async def switch_to_secondary_network(self) -> None:
+    @asynccontextmanager
+    async def switch_to_secondary_network(self) -> AsyncIterator:
         await self._delete_existing_route()
 
         await self._connection.create_process(
@@ -54,6 +59,7 @@ class NetworkSwitcherMac(NetworkSwitcher):
                     LINUX_VM_SECONDARY_GATEWAY,
                 ],
             ).execute()
+        yield
 
     async def _delete_existing_route(self) -> None:
         await self._connection.create_process(["route", "delete", "default"]).execute()

--- a/nat-lab/tests/utils/network_switcher/network_switcher_windows.py
+++ b/nat-lab/tests/utils/network_switcher/network_switcher_windows.py
@@ -1,8 +1,9 @@
 import config
 import re
 from .network_switcher import NetworkSwitcher
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import AsyncIterator, List, Optional
 from utils.connection import Connection
 from utils.process import ProcessExecError
 
@@ -70,9 +71,9 @@ class NetworkSwitcherWindows(NetworkSwitcher):
             connection, await ConfiguredInterfaces.create(connection)
         )
 
-    async def switch_to_primary_network(self) -> None:
+    @asynccontextmanager
+    async def switch_to_primary_network(self) -> AsyncIterator:
         await self._delete_existing_route()
-
         await self._connection.create_process(
             [
                 "netsh",
@@ -85,10 +86,14 @@ class NetworkSwitcherWindows(NetworkSwitcher):
                 f"nexthop={config.LINUX_VM_PRIMARY_GATEWAY}",
             ]
         ).execute()
+        try:
+            yield
+        finally:
+            await self._enable_management_interface()
 
-    async def switch_to_secondary_network(self) -> None:
+    @asynccontextmanager
+    async def switch_to_secondary_network(self) -> AsyncIterator:
         await self._delete_existing_route()
-
         await self._connection.create_process(
             [
                 "netsh",
@@ -101,6 +106,10 @@ class NetworkSwitcherWindows(NetworkSwitcher):
                 f"nexthop={config.LINUX_VM_SECONDARY_GATEWAY}",
             ]
         ).execute()
+        try:
+            yield
+        finally:
+            await self._enable_management_interface()
 
     async def _delete_existing_route(self) -> None:
         # Deleting routes by interface name instead of network destination (0.0.0.0/0) makes
@@ -145,5 +154,18 @@ class NetworkSwitcherWindows(NetworkSwitcher):
                     "interface",
                     self._interfaces.default,
                     "disable",
+                ]
+            ).execute()
+
+    async def _enable_management_interface(self) -> None:
+        if self._interfaces.default is not None:
+            await self._connection.create_process(
+                [
+                    "netsh",
+                    "interface",
+                    "set",
+                    "interface",
+                    self._interfaces.default,
+                    "enable",
                 ]
             ).execute()


### PR DESCRIPTION
### Problem
Windows management interface is beind disabled during tests, but never reenabled, causing `vagrant ssh windows` to not work. 

### Solution
Reenable windows management interface once test is done.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
