### PR TITLE
Dont notify socket waiter after cleanup

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -20,6 +20,7 @@
 * LLT-4661: Update wireguard-go and related Go dependencies
 * LLT-4528: Mute peers in proxy when upgrading to direct connection
 * LLT-4729: Fix maven upload
+* LLT-4562: Dont notify socket waiter in MacOS during cleanup
 
 <br>
 

--- a/crates/telio-sockets/src/protector/apple.rs
+++ b/crates/telio-sockets/src/protector/apple.rs
@@ -197,7 +197,6 @@ impl Protector for NativeProtector {
         if let Some(ref sw) = self.socket_watcher {
             let mut socks = sw.sockets.lock();
             socks.sockets.retain(|s| s != &socket);
-            socks.notify.notify_waiters();
         }
     }
 


### PR DESCRIPTION
### Problem
After turning off meshnet on macOs, there are a series of "Unable to bind" error messages.

### Solution
This happens because during cleanup sockets waiters are notified which tries to rebind to all the sockets again. As it is during cleanup, default interface sockets have already been closed and it is not able to bind hence the error message.

Removing the notify fixes the problem. 

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
