### PR TITLE
[LLT-4729] Fix upload-maven ci/cd job

### DIFF
--- a/android/templates/init.gradle
+++ b/android/templates/init.gradle
@@ -1,5 +1,40 @@
+
 ext.findRustlsPlatformVerifierProject = {
-    def cmdProcessBuilder = new ProcessBuilder(new String[] { "/root/.cargo/bin/cargo", "metadata", "--format-version", "1", "--manifest-path", "$PATH_TO_DEPENDENT_CRATE" })
+    // This template is run by libetlio-build's package-aar and upload-maven
+    // jobs.
+    // In these jobs, gradle project is located in diffent places:
+    // - package-aar - in libtelio project
+    // - upload-maven - in libetlio-build project
+    // 
+    // [file(..)](https://docs.gradle.org/current/javadoc/org/gradle/api/Project.html#file-java.lang.Object-)
+    // will get path relative to android_aar/ or android_aar/main dir. So we can check if any of them have manifest we need
+    //
+    def findManifest = {
+        println("root: " + file(".").absolutePath)
+        def files = [
+            file("../Cargo.toml"), 
+            file("../../Cargo.toml"), 
+            file("../libtelio/Cargo.toml"), 
+            file("../../libtelio/Cargo.toml"),
+        ]
+        println("looking in:")
+        println(files)
+        
+        def path = files.find { it.exists() }?.absolutePath
+
+        println("found path: " + path)
+        if (path == null) {
+            println("failed to find Cargo.toml")
+            throw new RuntimeException("could not find Cargo.toml")
+        }
+        path
+    }
+
+    def cmdProcessBuilder = new ProcessBuilder(new String[] { 
+        "/root/.cargo/bin/cargo", "metadata", 
+        "--format-version", "1", 
+        "--manifest-path", findManifest()
+    })
     def dependencyInfoText = new StringBuffer()
 
     def cmdProcess = cmdProcessBuilder.start()

--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,7 @@
 * LLT-4557: Document functions from helpers.py
 * LLT-4661: Update wireguard-go and related Go dependencies
 * LLT-4528: Mute peers in proxy when upgrading to direct connection
+* LLT-4729: Fix maven upload
 
 <br>
 


### PR DESCRIPTION
### Problem
Gradle invokes project in to ci/cd jobs
package-aar and upload-maven and in both of them
gradle project is in different dirs.

Using absolute path from build_libetlio script
causes an error as both of them ar run in
different jobs and as such path also changes.

### Solution
This implementation switches to using file(..)
function that get paths relative to project dir.
They can be either android_aar or android_aar/main
due to gradle weirdness :/.
findManifest checks 4 possible locations.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests

