### PR TITLE
Llt 4827 wireguard go version check

### DIFF
--- a/.github/workflows/wg_go_version_check.yml
+++ b/.github/workflows/wg_go_version_check.yml
@@ -1,0 +1,23 @@
+name: Wireguard-go version update check
+on: [pull_request]
+permissions: {}
+
+jobs:
+  wireguard-go-version-update-check:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        with:
+          fetch-depth: 0
+      - run: |
+          WG_GO_CHANGED=$(git diff --name-only ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} | grep wireguard-go-rust-wrapper/wireguard-go/ | wc -l)
+          if [ $WG_GO_CHANGED -gt 0 ]
+          then
+            echo Wireguard-go source code updated
+            WG_GO_VERSION_UPDATED=$(git diff ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} -- wireguard-go-rust-wrapper/wireguard-go/main.go | grep "+func wg_go_version_" | wc -l)
+            if [ $WG_GO_VERSION_UPDATED -eq 0 ]
+            then
+              echo Wireguard-go source has changed but wg_go_version_x_y_z seems to be not updated
+              exit 1
+            fi
+          fi

--- a/crates/telio-wg/src/adapter/wireguard_go.rs
+++ b/crates/telio-wg/src/adapter/wireguard_go.rs
@@ -1,7 +1,7 @@
 #[cfg(windows)]
 use wg_go_rust_wrapper::{
     wg_go_free_cmd_res, wg_go_get_adapter_luid, wg_go_get_wg_socket, wg_go_log_cb, wg_go_logger_fn,
-    wg_go_send_uapi_cmd, wg_go_start_named, wg_go_start_with_tun, wg_go_stop,
+    wg_go_send_uapi_cmd, wg_go_start_named, wg_go_start_with_tun, wg_go_stop, wg_go_version_4_2_2,
     CallWindowsStaticGoRuntimeInit,
 };
 
@@ -61,6 +61,10 @@ impl WireguardGo {
             // Workaround for hanging wireguard-go due to missing Go runtime init when building with MSVC toolchain.
             #[cfg(windows)]
             CallWindowsStaticGoRuntimeInit();
+
+            // This call to wg_go_version_x_y_z does not do anything, but this function needs to be called somewhere
+            // where it's not optimized away by linker.
+            wg_go_version_4_2_2();
         }
 
         let handle = unsafe {

--- a/wireguard-go-rust-wrapper/src/lib.rs
+++ b/wireguard-go-rust-wrapper/src/lib.rs
@@ -1,5 +1,6 @@
-use libc::{c_char, c_int};
+use libc::{c_char, c_int, int32_t};
 use std::ffi::c_void;
+use std::sync::Once;
 
 #[link(name = "wireguard-go", kind = "static")]
 extern "C" {
@@ -10,6 +11,7 @@ extern "C" {
     pub fn wg_go_free_cmd_res(resp: *const c_char);
     pub fn wg_go_stop(handle: i32);
     pub fn wg_go_get_adapter_luid(handle: i32) -> u64;
+    pub fn wg_go_version_4_2_2();
 }
 
 #[allow(non_camel_case_types)]

--- a/wireguard-go-rust-wrapper/wireguard-go/main.go
+++ b/wireguard-go-rust-wrapper/wireguard-go/main.go
@@ -25,6 +25,7 @@ import (
 	"math"
 	"math/rand"
 	"runtime"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"time"
@@ -132,8 +133,16 @@ func get_tunnel_entry(handle int32) (*TunnelEntry, error) {
 	return nil, InvalidHandle
 }
 
+func logStackTraceOnPanic() {
+	if r := recover(); r != nil {
+		criticalf("wireguard-go panicked:\n" + string(debug.Stack()))
+	}
+}
+
 //export wg_go_start_named
 func wg_go_start_named(name *C.char, log C.wg_go_log_cb) C.int32_t {
+	defer logStackTraceOnPanic()
+
 	var watcher *interfaceWatcher
 	var err error
 	if loggerFunc == 0 {
@@ -142,7 +151,6 @@ func wg_go_start_named(name *C.char, log C.wg_go_log_cb) C.int32_t {
 	}
 
 	ifname := C.GoString(name)
-
 	if runtime.GOOS == "windows" {
 		watcher, err = watchInterface()
 		if err != nil {
@@ -227,6 +235,8 @@ func get_errno_from_error(err error) int64 {
 
 //export wg_go_send_uapi_cmd
 func wg_go_send_uapi_cmd(handle C.int32_t, cmd *C.char) *C.char {
+	defer logStackTraceOnPanic()
+
 	entry, err := get_tunnel_entry(int32(handle))
 	if err != nil || entry == nil {
 		errorf("entry is nil or error: %v", err)
@@ -256,16 +266,19 @@ func wg_go_send_uapi_cmd(handle C.int32_t, cmd *C.char) *C.char {
 
 //export wg_go_start_with_tun
 func wg_go_start_with_tun(fd C.int32_t, log C.wg_go_log_cb) C.int32_t {
+	defer logStackTraceOnPanic()
 	return PlatformSpecific_StartWithTun(fd, log)
 }
 
 //export wg_go_get_wg_socket
 func wg_go_get_wg_socket(handle C.int32_t, ipv6 bool, cmd *C.char) *C.char {
+	defer logStackTraceOnPanic()
 	return PlatformSpecific_GetWgSocket(handle, ipv6)
 }
 
 //export wg_go_free_cmd_res
 func wg_go_free_cmd_res(resp *C.char) {
+	defer logStackTraceOnPanic()
 	if resp != nil {
 		C.free(unsafe.Pointer(resp))
 	}
@@ -273,6 +286,8 @@ func wg_go_free_cmd_res(resp *C.char) {
 
 //export wg_go_stop
 func wg_go_stop(handle C.int32_t) {
+	defer logStackTraceOnPanic()
+
 	entry, err := get_tunnel_entry(int32(handle))
 	if err != nil || entry == nil {
 		errorf("entry is nil or error: %v", err)
@@ -290,6 +305,8 @@ func wg_go_stop(handle C.int32_t) {
 
 //export wg_go_get_adapter_luid
 func wg_go_get_adapter_luid(handle C.int32_t) C.uint64_t {
+	defer logStackTraceOnPanic()
+
 	entry, err := get_tunnel_entry(int32(handle))
 	if err != nil || entry == nil {
 		errorf("entry is nil or error: %v", err)

--- a/wireguard-go-rust-wrapper/wireguard-go/main.go
+++ b/wireguard-go-rust-wrapper/wireguard-go/main.go
@@ -300,4 +300,15 @@ func wg_go_get_adapter_luid(handle C.int32_t) C.uint64_t {
 	return C.uint64_t(luid)
 }
 
+// This function is added in order to have a way of validating during link time
+// that the proper version of wireguard-go library is linked.
+// In the past we had an accident where some old version of wireguard-go was linked
+// into libtelio in the release build. The root-cause is not found yet.
+// When changes to the wireguard-go are done the version number should be updated.
+// There is wireguard-go-version-update-check job in GitHub Actions validating
+// that this version was updated when there was a change in the wireguard-go code.
+//
+//export wg_go_version_4_2_2
+func wg_go_version_4_2_2() {}
+
 func main() {}


### PR DESCRIPTION
### Problem
1. There is a bug somewhere in our build system. Because of that it might happen that the old version of wireguard-go is linked into the release package. The bug is not found yet but this should protect us from releasing incorrect package.
2. Wireguard-go logs from panic are lost when telio.dll is run inside a windows service.
### Solution
1. Temporary solution is to add an export with a version string in it to the wireguard-go library. Because it requires manual effort to update it a github actions job is added to monitor that the version is updated every time there are changes done to the wireguard-go lib itself. 
2. Print stacktrace to our logger in case of a panic



### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
