### PR TITLE
Add network info to Mac VM logs

### DIFF
--- a/nat-lab/tests/telio.py
+++ b/nat-lab/tests/telio.py
@@ -1,24 +1,25 @@
 import asyncio
+import datetime
 import json
 import os
 import re
 import shlex
-import datetime
 from collections import Counter
-from config import DERP_PRIMARY, DERP_SERVERS
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
-from dataclasses_json import dataclass_json, DataClassJsonMixin
 from enum import Enum
-from mesh_api import Node, Meshmap
+from typing import AsyncIterator, List, Optional, Set
+
+from config import DERP_PRIMARY, DERP_SERVERS
+from dataclasses_json import DataClassJsonMixin, dataclass_json
+from mesh_api import Meshmap, Node
 from telio_features import TelioFeatures
-from typing import List, Set, Optional, AsyncIterator
 from utils import asyncio_util
 from utils.connection import Connection, TargetOS
 from utils.connection_util import get_libtelio_binary_path
 from utils.output_notifier import OutputNotifier
 from utils.process import Process
-from utils.router import Router, new_router, IPStack
+from utils.router import IPStack, Router, new_router
 
 
 # Equivalent of `libtelio/telio-wg/src/uapi.rs`

--- a/nat-lab/tests/telio.py
+++ b/nat-lab/tests/telio.py
@@ -885,7 +885,7 @@ class Client:
         os.makedirs(log_dir, exist_ok=True)
 
         log_content = await self.get_log()
-        network_info_info = await self.get_network_info()
+
         if self._connection.target_os == TargetOS.Linux:
             process = self._connection.create_process(["cat", "/etc/hostname"])
             await process.execute()
@@ -917,6 +917,7 @@ class Client:
                 filename = f"{filename[:249]}_{i}.log"
                 i += 1
 
+        network_info_info = await self.get_network_info()
         with open(
             os.path.join(log_dir, filename),
             "w",

--- a/nat-lab/tests/telio.py
+++ b/nat-lab/tests/telio.py
@@ -5,15 +5,14 @@ import os
 import re
 import shlex
 from collections import Counter
+from config import DERP_PRIMARY, DERP_SERVERS
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
-from enum import Enum
-from typing import AsyncIterator, List, Optional, Set
-
-from config import DERP_PRIMARY, DERP_SERVERS
 from dataclasses_json import DataClassJsonMixin, dataclass_json
+from enum import Enum
 from mesh_api import Meshmap, Node
 from telio_features import TelioFeatures
+from typing import AsyncIterator, List, Optional, Set
 from utils import asyncio_util
 from utils.connection import Connection, TargetOS
 from utils.connection_util import get_libtelio_binary_path

--- a/nat-lab/tests/telio.py
+++ b/nat-lab/tests/telio.py
@@ -870,9 +870,12 @@ class Client:
             await routing_table_info.execute()
             syslog_info = self._connection.create_process(["syslog"])
             await syslog_info.execute()
-            return routing_table_info.get_stdout() + interface_info.get_stdout() + '\n'.join(syslog_info.get_stdout().splitlines()[-20:])
-        else:
-            return ""
+            return (
+                routing_table_info.get_stdout()
+                + interface_info.get_stdout()
+                + "\n".join(syslog_info.get_stdout().splitlines()[-20:])
+            )
+        return ""
 
     async def save_logs(self) -> None:
         if os.environ.get("NATLAB_SAVE_LOGS") is None:

--- a/nat-lab/tests/telio.py
+++ b/nat-lab/tests/telio.py
@@ -873,7 +873,9 @@ class Client:
             syslog_info = self._connection.create_process(["syslog"])
             await syslog_info.execute()
             start_time_str = self._start_time.strftime("%Y-%m-%d %H:%M:%S")
-            log_info = self._connection.create_process(["log", "show", "--start", start_time_str])
+            log_info = self._connection.create_process(
+                ["log", "show", "--start", start_time_str]
+            )
             await log_info.execute()
             return (
                 start_time_str


### PR DESCRIPTION
### Problem
It is currently difficult to reproduce LLT-4600 and a couple of more Mac VM related flaky NAT-Lab tests.

### Solution
Added network interface name and IP, routing table and the last 20 lines of syslog to a separate log file for MAC VM.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
