### PR TITLE
Moved MacVM network info gathering earlier before telio is closed.

### DIFF
--- a/nat-lab/tests/telio.py
+++ b/nat-lab/tests/telio.py
@@ -933,7 +933,6 @@ class Client:
         ) as f:
             f.write(log_content)
 
-
     async def save_mac_network_info(self) -> None:
         if os.environ.get("NATLAB_SAVE_LOGS") is None:
             return


### PR DESCRIPTION
### Problem
Moved MacVM network info gathering earlier before telio is closed and cleaned up, because previously a lot of useful information had been missing due to the cleanup

### Solution
Network gathering is now done before Telio is closed.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
