### PR TITLE
LLT-4874: Add FFI functions to create Features and Config objects from JSON strings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4885,8 +4885,8 @@ checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 
 [[package]]
 name = "uniffi"
-version = "0.25.0"
-source = "git+https://github.com/NordSecurity/uniffi-rs.git?tag=v0.25.0-1#de1e773204d0ddcda58faac0a77570f1f8056679"
+version = "0.3.1+v0.25.0"
+source = "git+https://github.com/NordSecurity/uniffi-rs.git?tag=v0.3.1+v0.25.0#1a5dc527165589456c3d7233107917e065192b03"
 dependencies = [
  "anyhow",
  "uniffi_build",
@@ -4896,8 +4896,8 @@ dependencies = [
 
 [[package]]
 name = "uniffi_bindgen"
-version = "0.25.0"
-source = "git+https://github.com/NordSecurity/uniffi-rs.git?tag=v0.25.0-1#de1e773204d0ddcda58faac0a77570f1f8056679"
+version = "0.3.1+v0.25.0"
+source = "git+https://github.com/NordSecurity/uniffi-rs.git?tag=v0.3.1+v0.25.0#1a5dc527165589456c3d7233107917e065192b03"
 dependencies = [
  "anyhow",
  "askama",
@@ -4919,8 +4919,8 @@ dependencies = [
 
 [[package]]
 name = "uniffi_build"
-version = "0.25.0"
-source = "git+https://github.com/NordSecurity/uniffi-rs.git?tag=v0.25.0-1#de1e773204d0ddcda58faac0a77570f1f8056679"
+version = "0.3.1+v0.25.0"
+source = "git+https://github.com/NordSecurity/uniffi-rs.git?tag=v0.3.1+v0.25.0#1a5dc527165589456c3d7233107917e065192b03"
 dependencies = [
  "anyhow",
  "camino",
@@ -4929,8 +4929,8 @@ dependencies = [
 
 [[package]]
 name = "uniffi_checksum_derive"
-version = "0.25.0"
-source = "git+https://github.com/NordSecurity/uniffi-rs.git?tag=v0.25.0-1#de1e773204d0ddcda58faac0a77570f1f8056679"
+version = "0.3.1+v0.25.0"
+source = "git+https://github.com/NordSecurity/uniffi-rs.git?tag=v0.3.1+v0.25.0#1a5dc527165589456c3d7233107917e065192b03"
 dependencies = [
  "quote 1.0.35",
  "syn 2.0.48",
@@ -4939,7 +4939,7 @@ dependencies = [
 [[package]]
 name = "uniffi_core"
 version = "0.25.0"
-source = "git+https://github.com/NordSecurity/uniffi-rs.git?tag=v0.25.0-1#de1e773204d0ddcda58faac0a77570f1f8056679"
+source = "git+https://github.com/NordSecurity/uniffi-rs.git?tag=v0.3.1+v0.25.0#1a5dc527165589456c3d7233107917e065192b03"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4953,8 +4953,8 @@ dependencies = [
 
 [[package]]
 name = "uniffi_macros"
-version = "0.25.0"
-source = "git+https://github.com/NordSecurity/uniffi-rs.git?tag=v0.25.0-1#de1e773204d0ddcda58faac0a77570f1f8056679"
+version = "0.3.1+v0.25.0"
+source = "git+https://github.com/NordSecurity/uniffi-rs.git?tag=v0.3.1+v0.25.0#1a5dc527165589456c3d7233107917e065192b03"
 dependencies = [
  "bincode",
  "camino",
@@ -4971,8 +4971,8 @@ dependencies = [
 
 [[package]]
 name = "uniffi_meta"
-version = "0.25.0"
-source = "git+https://github.com/NordSecurity/uniffi-rs.git?tag=v0.25.0-1#de1e773204d0ddcda58faac0a77570f1f8056679"
+version = "0.3.1+v0.25.0"
+source = "git+https://github.com/NordSecurity/uniffi-rs.git?tag=v0.3.1+v0.25.0#1a5dc527165589456c3d7233107917e065192b03"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4982,8 +4982,8 @@ dependencies = [
 
 [[package]]
 name = "uniffi_testing"
-version = "0.25.0"
-source = "git+https://github.com/NordSecurity/uniffi-rs.git?tag=v0.25.0-1#de1e773204d0ddcda58faac0a77570f1f8056679"
+version = "0.3.1+v0.25.0"
+source = "git+https://github.com/NordSecurity/uniffi-rs.git?tag=v0.3.1+v0.25.0#1a5dc527165589456c3d7233107917e065192b03"
 dependencies = [
  "anyhow",
  "camino",
@@ -4994,8 +4994,8 @@ dependencies = [
 
 [[package]]
 name = "uniffi_udl"
-version = "0.25.0"
-source = "git+https://github.com/NordSecurity/uniffi-rs.git?tag=v0.25.0-1#de1e773204d0ddcda58faac0a77570f1f8056679"
+version = "0.3.1+v0.25.0"
+source = "git+https://github.com/NordSecurity/uniffi-rs.git?tag=v0.3.1+v0.25.0#1a5dc527165589456c3d7233107917e065192b03"
 dependencies = [
  "anyhow",
  "uniffi_meta",
@@ -5201,7 +5201,7 @@ checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
 [[package]]
 name = "weedle2"
 version = "4.0.0"
-source = "git+https://github.com/NordSecurity/uniffi-rs.git?tag=v0.25.0-1#de1e773204d0ddcda58faac0a77570f1f8056679"
+source = "git+https://github.com/NordSecurity/uniffi-rs.git?tag=v0.3.1+v0.25.0#1a5dc527165589456c3d7233107917e065192b03"
 dependencies = [
  "nom",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,7 +153,7 @@ time = { version = "0.3.9", features = ["formatting"] }
 tokio = ">=1.22"
 tracing-subscriber = { version = "0.3.17", features = ["local-time"] }
 tracing-appender = "0.2.3"
-uniffi = { git = "https://github.com/NordSecurity/uniffi-rs.git", tag = "v0.25.0-1" }
+uniffi = { git = "https://github.com/NordSecurity/uniffi-rs.git", tag = "v0.3.1+v0.25.0" }
 url = "2.2.2"
 uuid = { version = "1.1.2", features = ["v4"] }
 winapi = { version = "0.3", features = ["netioapi", "ws2def"] }

--- a/src/libtelio.udl
+++ b/src/libtelio.udl
@@ -119,6 +119,15 @@ namespace libtelio {
 
     /// Get the public key that corresponds to a given private key.
     PublicKey generate_public_key(SecretKey secret_key);
+
+    /// Utility function to create a `Features` object from a json-string
+    /// Passing an empty string will return the default feature config
+    [Throws=TelioError]
+    Features string_to_features(string fstr);
+
+    /// Utility function to create a `Config` object from a json-string
+    [Throws=TelioError]
+    Config string_to_meshnet_config(string cfg_str);
 };
 
 interface telio {


### PR DESCRIPTION
### Problem
The FFI functions for Telio currently take strongly typed objects, but consumers might have a platform-specific representation of those types and would have an easier time passing json-encoded strings. 

### Solution
To make it easier for those consumers, this commit introduces functions to create objects from such strings. At this time we only see a need to do that for Features and Config, so the conversion functions have only been implemented for those types


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
