### PR TITLE
Allow null values for telio_connect_to_exit_node() call

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3819,7 +3819,7 @@ dependencies = [
 
 [[package]]
 name = "telio"
-version = "4.2.3"
+version = "4.2.4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "telio"
-version = "4.2.3"
+version = "4.2.4"
 authors = ["info@nordvpn.com"]
 edition = "2018"
 license = "GPL-3.0-only"

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+### v4.2.4
+---
+* LLT-4878: Fix FFI layer which forbids NULL for `telio_connect_to_exit_node()` calls
+
+<br>
+
 ### v4.2.3
 ---
 * LLT-4869: Fix maven upload

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -569,7 +569,7 @@ pub extern "C" fn telio_connect_to_exit_node(
 ) -> telio_result {
     telio_log_info!(
         "telio_connect_to_exit_node entry with instance id :{}. Public Key: {:?}. Allowed IP: {:?}. Endpoint: {:?}",
-        dev.id, ffi_try!(char_ptr_to_type::<PublicKey>(public_key)), ffi_try!(char_ptr_to_type::<String>(allowed_ips)), ffi_try!(char_ptr_to_type::<SocketAddr>(endpoint))
+        dev.id, char_ptr_to_type::<PublicKey>(public_key), char_ptr_to_type::<String>(allowed_ips), char_ptr_to_type::<SocketAddr>(endpoint)
     );
     telio_connect_to_exit_node_with_id(dev, null(), public_key, allowed_ips, endpoint)
 }


### PR DESCRIPTION
### Problem

With the argument logging PR, we have accidentally introduced a check, which forbids NULL values in telio_connect_to_exit_node() arguments. Which is expected when client application attempts to route traffic.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
