### PR TITLE
LLT-4899: Improve printing in test_dns_duplicate_requests_on_multiple_forward_servers

### DIFF
--- a/nat-lab/tests/test_dns.py
+++ b/nat-lab/tests/test_dns.py
@@ -651,12 +651,16 @@ async def test_dns_duplicate_requests_on_multiple_forward_servers() -> None:
         await asyncio.sleep(1)
 
         tcpdump_stdout = process.get_stdout()
+        tcpdump_stderr = process.get_stderr()
         results = set(re.findall(
             r".* IP .* > (?P<dest_ip>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\.\d{1,5}: .* A\?.*",
             tcpdump_stdout,
         ))  # fmt: skip
 
-        assert results in ({FIRST_DNS_SERVER}, {SECOND_DNS_SERVER}), tcpdump_stdout
+        assert results in (
+            {FIRST_DNS_SERVER},
+            {SECOND_DNS_SERVER},
+        ), f"tcpdump stdout:\n{tcpdump_stdout}\ntcpdump stderr:\n{tcpdump_stderr}"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Problem
test_dns_duplicate_requests_on_multiple_forward_servers has been flaky and we don't have proper output in the logs because tcpdump has empty stdout.

### Solution
Improves the printing by labeling the stdout print to make it easier to identify when stdout was empty, and starts printing stderr as well in case something just went wrong


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
