### PR TITLE
Revert "Merge pull request #327 from NordSecurity/LLT-4870_revert-pos…

### DIFF
--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -33,4 +33,18 @@ jobs:
         - name: fuzz telio crypto decrypt_response
           working-directory: crates/telio-crypto
           run: cargo fuzz run decrypt_response -- -max_total_time=180
-
+  telio-pq-fuzzing:
+      runs-on: ubuntu-22.04
+      steps:
+        - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        - uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.6
+          with:
+            toolchain: nightly-2023-06-01
+            override: true
+        - run: cargo install cargo-fuzz --locked --version 0.11.2
+        - name: fuzz telio pq parse_get_packet
+          working-directory: crates/telio-pq
+          run: cargo fuzz run parse_get_packet -- -max_total_time=180
+        - name: fuzz telio pq parse_rekey_packet
+          working-directory: crates/telio-pq
+          run: cargo fuzz run parse_rekey_packet -- -max_total_time=180

--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -31,4 +31,4 @@ jobs:
           project-id: ${{ secrets.PROJECT_ID }}
           schedule: ${{ github.event_name == 'schedule' }}
           cancel-outdated-pipelines: ${{ github.ref_name != 'main' }}
-          triggered-ref: v0.4.15
+          triggered-ref: v0.4.16

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,5 +15,4 @@ libtelio-build-pipeline:
 
   trigger:
     project: $LIBTELIO_BUILD_PROJECT_PATH
-    branch: v0.4.15
-    strategy: depend
+    branch: v0.4.16

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -565,6 +565,7 @@ version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
 dependencies = [
+ "jobserver",
  "libc",
 ]
 
@@ -1197,6 +1198,12 @@ name = "downcast"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
+name = "dunce"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
 
 [[package]]
 name = "either"
@@ -2051,6 +2058,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
+name = "jobserver"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c37f63953c4c63420ed5fd3d6d398c719489b9f872b9fa683262f8edd363c7d"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2832,6 +2848,37 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "pqcrypto-internals"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9d34bec6abe2283e6de7748b68b292d1ffa2203397e3e71380ff8418a49fb46"
+dependencies = [
+ "cc",
+ "dunce",
+ "getrandom",
+ "libc",
+]
+
+[[package]]
+name = "pqcrypto-kyber"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe9d9695c19e525d5366c913562a331fbeef9a2ad801d9a9ded61a0e4c2fe0fb"
+dependencies = [
+ "cc",
+ "glob",
+ "libc",
+ "pqcrypto-internals",
+ "pqcrypto-traits",
+]
+
+[[package]]
+name = "pqcrypto-traits"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e851c7654eed9e68d7d27164c454961a616cf8c203d500607ef22c737b51bb"
 
 [[package]]
 name = "predicates"
@@ -4101,6 +4148,7 @@ dependencies = [
  "telio-model",
  "telio-nat-detect",
  "telio-nurse",
+ "telio-pq",
  "telio-proto",
  "telio-proxy",
  "telio-relay",
@@ -4256,6 +4304,26 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "telio-pq"
+version = "0.1.0"
+dependencies = [
+ "base64 0.13.1",
+ "boringtun",
+ "pnet_packet 0.28.0",
+ "pqcrypto-kyber",
+ "pqcrypto-traits",
+ "rand",
+ "telio-crypto",
+ "telio-model",
+ "telio-sockets",
+ "telio-task",
+ "telio-utils",
+ "thiserror",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -4458,6 +4526,7 @@ dependencies = [
  "mockall",
  "ntest",
  "pretty_assertions",
+ "rand",
  "serde",
  "serde_json",
  "sha2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ telio-nat-detect.workspace = true
 telio-nurse.workspace = true
 telio-proto.workspace = true
 telio-proxy.workspace = true
+telio-pq.workspace = true
 telio-relay.workspace = true
 telio-sockets.workspace = true
 telio-task.workspace = true
@@ -177,3 +178,4 @@ telio-test = { version = "1.0.0", path = "./crates/telio-test" }
 telio-traversal = { version = "0.1.0",  path = "./crates/telio-traversal" }
 telio-utils = { version = "0.1.0", path = "./crates/telio-utils" }
 telio-wg = { version = "0.1.0", path = "./crates/telio-wg" }
+telio-pq = { version = "0.1.0", path = "./crates/telio-pq" }

--- a/changelog.md
+++ b/changelog.md
@@ -33,6 +33,7 @@
 * LLT-4698: Fix exp. backoff in WG-STUN
 * LLT-4490: Ensure that meshnet entities are started only when meshnet is started
 * LLT-4335: Make blocking upnp gw search async
+* LLT-4620: Implement the post quantum key rotation mechanism
 * LLT-4616: Make nurse qos ping asynchronous
 * LLT-4652: Bump boringtun version to v1.1.10
 * LLT-4557: Document functions from helpers.py
@@ -51,6 +52,7 @@
 * LLT-4225: Migrate Telio to use the tracing crate instead of log crate
 * LLT-4594: Fix session keeper's bug, to enable ICMP6 packets
 * LLT-4597: Fix QoS' IPv6 pinging
+* LLT-4614: Implement the post quantum VPN handshake
 
 <br>
 

--- a/clis/tcli/src/main.rs
+++ b/clis/tcli/src/main.rs
@@ -93,7 +93,7 @@ fn main() -> Result<()> {
                     _ => (),
                 },
                 Error(e) => {
-                    println!("error: {}", e)
+                    println!("error: {e:#?}")
                 }
                 Quit => {
                     if let Some(idx) = message_idx {

--- a/crates/telio-crypto/src/lib.rs
+++ b/crates/telio-crypto/src/lib.rs
@@ -27,7 +27,7 @@ use std::{convert::TryInto, fmt};
 use rand::prelude::*;
 use serde_with::{DeserializeFromStr, SerializeDisplay};
 
-/// Secret/Public key size in bytes
+/// Secret, Public and Wireguard Preshared key size in bytes
 pub const KEY_SIZE: usize = 32;
 
 /// Secret key type
@@ -41,6 +41,12 @@ pub struct SecretKey([u8; KEY_SIZE]);
     Default, PartialOrd, Ord, PartialEq, Eq, Hash, Copy, Clone, DeserializeFromStr, SerializeDisplay,
 )]
 pub struct PublicKey(pub [u8; KEY_SIZE]);
+
+/// Preshared key type
+#[derive(
+    Default, PartialOrd, Ord, PartialEq, Eq, Hash, Copy, Clone, DeserializeFromStr, SerializeDisplay,
+)]
+pub struct PresharedKey(pub [u8; KEY_SIZE]);
 
 /// Error returned when parsing fails for SecretKey or PublicKey.
 #[derive(Debug, thiserror::Error)]
@@ -81,7 +87,8 @@ impl SecretKey {
         Self::gen_with(&mut rand::rngs::StdRng::from_entropy())
     }
 
-    pub(crate) fn gen_with(rng: &mut (impl RngCore + CryptoRng)) -> Self {
+    /// Generates a new random SecretKey with provided RNG
+    pub fn gen_with(rng: &mut (impl RngCore + CryptoRng)) -> Self {
         let mut key = SecretKey([0u8; KEY_SIZE]);
         rng.fill_bytes(&mut key.0);
         // Key clamping
@@ -122,6 +129,13 @@ impl SecretKey {
 }
 
 impl PublicKey {
+    /// Create new key from bytes
+    pub const fn new(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+}
+
+impl PresharedKey {
     /// Create new key from bytes
     pub const fn new(bytes: [u8; 32]) -> Self {
         Self(bytes)
@@ -281,7 +295,7 @@ macro_rules! gen_common {
         gen_common!($($tt),+);
     };
 }
-gen_common!(SecretKey, PublicKey);
+gen_common!(SecretKey, PublicKey, PresharedKey);
 
 #[cfg(test)]
 mod tests {

--- a/crates/telio-dns/src/dns.rs
+++ b/crates/telio-dns/src/dns.rs
@@ -149,11 +149,8 @@ impl DnsResolver for LocalDnsResolver {
         Peer {
             public_key: self.public_key(),
             endpoint: Some(([127, 0, 0, 1], self.socket_port).into()),
-            persistent_keepalive_interval: None,
             allowed_ips,
-            rx_bytes: None,
-            tx_bytes: None,
-            time_since_last_handshake: None,
+            ..Default::default()
         }
     }
 

--- a/crates/telio-model/src/api_config.rs
+++ b/crates/telio-model/src/api_config.rs
@@ -284,6 +284,28 @@ impl FeatureEndpointProvidersOptimization {
 #[serde(transparent)]
 pub struct FeatureBoringtunResetConns(pub bool);
 
+/// Turns on post quantum VPN tunnel
+#[derive(Default, Clone, Copy, Debug, PartialEq, Eq, Deserialize)]
+pub struct FeaturePostQuantumVPN {
+    /// Initial handshake retry interval in seconds
+    #[serde(default = "FeaturePostQuantumVPN::default_handshake_retry_interval_s")]
+    pub handshake_retry_interval_s: u32,
+
+    /// Rekey interval in seconds
+    #[serde(default = "FeaturePostQuantumVPN::default_rekey_interval_s")]
+    pub rekey_interval_s: u32,
+}
+
+impl FeaturePostQuantumVPN {
+    const fn default_handshake_retry_interval_s() -> u32 {
+        8
+    }
+
+    const fn default_rekey_interval_s() -> u32 {
+        90
+    }
+}
+
 fn deserialize_providers<'de, D>(de: D) -> Result<Option<EndpointProviders>, D::Error>
 where
     D: Deserializer<'de>,
@@ -356,6 +378,9 @@ pub struct Features {
     pub boringtun_reset_connections: FeatureBoringtunResetConns,
     /// If and for how long to flush events when stopping telio. Setting to Some(0) means waiting until all events have been flushed, regardless of how long it takes
     pub flush_events_on_stop_timeout_seconds: Option<u64>,
+    /// Post quantum VPN tunnel configuration
+    #[serde(default)]
+    pub post_quantum_vpn: Option<FeaturePostQuantumVPN>,
     /// No link detection mechanism
     #[serde(default)]
     pub link_detection: Option<FeatureLinkDetection>,
@@ -462,7 +487,12 @@ mod tests {
             "validate_keys": false,
             "ipv6": true,
             "nicknames": true,
-            "boringtun_reset_connections": true
+            "boringtun_reset_connections": true,
+            "post_quantum_vpn":
+            {
+                "handshake_retry_interval_s": 16,
+                "rekey_interval_s": 120
+            }
         }"#;
 
     static EXPECTED_FEATURES_WITH_IS_TEST_ENV: Lazy<Features> = Lazy::new(|| Features {
@@ -512,6 +542,10 @@ mod tests {
         nicknames: true,
         boringtun_reset_connections: FeatureBoringtunResetConns(true),
         flush_events_on_stop_timeout_seconds: None,
+        post_quantum_vpn: Some(FeaturePostQuantumVPN {
+            handshake_retry_interval_s: 16,
+            rekey_interval_s: 120,
+        }),
         link_detection: None,
     });
     static EXPECTED_FEATURES_WITHOUT_IS_TEST_ENV: Lazy<Features> = Lazy::new(|| Features {
@@ -554,6 +588,7 @@ mod tests {
         nicknames: false,
         boringtun_reset_connections: FeatureBoringtunResetConns(false),
         flush_events_on_stop_timeout_seconds: None,
+        post_quantum_vpn: None,
         link_detection: None,
     });
 
@@ -729,6 +764,7 @@ mod tests {
             nicknames: false,
             boringtun_reset_connections: Default::default(),
             flush_events_on_stop_timeout_seconds: None,
+            post_quantum_vpn: Default::default(),
             link_detection: None,
         };
 
@@ -757,6 +793,7 @@ mod tests {
             nicknames: false,
             boringtun_reset_connections: Default::default(),
             flush_events_on_stop_timeout_seconds: None,
+            post_quantum_vpn: Default::default(),
             link_detection: None,
         };
 
@@ -780,6 +817,7 @@ mod tests {
             nicknames: false,
             boringtun_reset_connections: Default::default(),
             flush_events_on_stop_timeout_seconds: None,
+            post_quantum_vpn: Default::default(),
             link_detection: None,
         };
 
@@ -822,6 +860,7 @@ mod tests {
             nicknames: false,
             boringtun_reset_connections: Default::default(),
             flush_events_on_stop_timeout_seconds: None,
+            post_quantum_vpn: Default::default(),
             link_detection: None,
         };
 
@@ -841,6 +880,7 @@ mod tests {
             nicknames: false,
             boringtun_reset_connections: Default::default(),
             flush_events_on_stop_timeout_seconds: None,
+            post_quantum_vpn: Default::default(),
             link_detection: None,
         };
 
@@ -869,6 +909,7 @@ mod tests {
             nicknames: false,
             boringtun_reset_connections: Default::default(),
             flush_events_on_stop_timeout_seconds: None,
+            post_quantum_vpn: Default::default(),
             link_detection: Default::default(),
         };
 
@@ -923,6 +964,7 @@ mod tests {
             nicknames: false,
             boringtun_reset_connections: Default::default(),
             flush_events_on_stop_timeout_seconds: None,
+            post_quantum_vpn: Default::default(),
             link_detection: None,
         };
 

--- a/crates/telio-pq/Cargo.toml
+++ b/crates/telio-pq/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "telio-pq"
+version = "0.1.0"
+edition = "2021"
+license = "GPL-3.0-only"
+repository = "https://github.com/NordSecurity/libtelio"
+publish = false
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[features]
+fuzzing = []
+
+[dependencies]
+# pqcrypto version is fixed, because the newer version implements incompatible kyber kem according to draft specs
+pqcrypto-kyber = { version = "=0.7.6", default-features = false, features = ["std"] }
+pqcrypto-traits = "0.3.5"
+
+telio-crypto.workspace = true
+telio-model.workspace = true
+telio-sockets.workspace = true
+telio-task.workspace = true
+telio-utils.workspace = true
+
+boringtun.workspace = true
+pnet_packet.workspace = true
+rand.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+
+[dev-dependencies]
+base64.workspace = true

--- a/crates/telio-pq/fuzz/Cargo.toml
+++ b/crates/telio-pq/fuzz/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "telio-pq-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+license = "GPL-3.0-only"
+repository = "https://github.com/NordSecurity/libtelio"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[dependencies.telio-pq]
+path = ".."
+features = ["fuzzing"]
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[profile.release]
+debug = 1
+
+[[bin]]
+name = "parse_get_packet"
+path = "fuzz_targets/parse_get_packet.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "parse_rekey_packet"
+path = "fuzz_targets/parse_rekey_packet.rs"
+test = false
+doc = false

--- a/crates/telio-pq/fuzz/fuzz_targets/parse_get_packet.rs
+++ b/crates/telio-pq/fuzz/fuzz_targets/parse_get_packet.rs
@@ -1,0 +1,7 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let _result = telio_pq::fuzz::parse_get_response(data);
+});

--- a/crates/telio-pq/fuzz/fuzz_targets/parse_rekey_packet.rs
+++ b/crates/telio-pq/fuzz/fuzz_targets/parse_rekey_packet.rs
@@ -1,0 +1,7 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let _result = telio_pq::fuzz::parse_rekey_response(data);
+});

--- a/crates/telio-pq/src/conn.rs
+++ b/crates/telio-pq/src/conn.rs
@@ -1,0 +1,88 @@
+use std::{net::SocketAddr, sync::Arc, time::Duration};
+
+use tokio::task::JoinHandle;
+
+use telio_model::api_config::FeaturePostQuantumVPN;
+use telio_task::io::chan;
+use telio_utils::{telio_log_debug, telio_log_warn};
+
+pub struct ConnKeyRotation {
+    task: JoinHandle<()>,
+}
+
+impl ConnKeyRotation {
+    pub fn run(
+        chan: chan::Tx<super::Event>,
+        socket_pool: Arc<telio_sockets::SocketPool>,
+        addr: SocketAddr,
+        wg_secret: telio_crypto::SecretKey,
+        peer: telio_crypto::PublicKey,
+        features: &FeaturePostQuantumVPN,
+    ) -> Self {
+        telio_log_debug!("Starting PQ task");
+
+        let rekey_interval = Duration::from_secs(features.rekey_interval_s as _);
+        let request_retry = Duration::from_secs(features.handshake_retry_interval_s as _);
+
+        let task = async move {
+            let mut interval = tokio::time::interval(request_retry);
+            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+            let mut keys = loop {
+                interval.tick().await;
+
+                // Dylint is unhappy about the `fetch_keys` future size
+                // and asks for using `Box::pin` to move it on the heap
+                match Box::pin(super::proto::fetch_keys(
+                    &socket_pool,
+                    addr,
+                    &wg_secret,
+                    &peer,
+                ))
+                .await
+                {
+                    Ok(keys) => break keys,
+                    Err(err) => telio_log_warn!("Failed to fetch PQ keys: {err}"),
+                }
+            };
+
+            // The channel is allways open during the library operation.
+            // It can only be closed on library shutdown, in that case we
+            // may not care since the task itself will be killed soon
+            #[allow(mpsc_blocking_send)]
+            let _ = chan.send(super::Event::Handshake(addr, keys)).await;
+
+            let mut interval = tokio::time::interval(rekey_interval);
+            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+            interval.tick().await; // This call returns immedietly
+            loop {
+                interval.tick().await;
+
+                match super::proto::rekey(&socket_pool).await {
+                    Ok(key) => {
+                        keys.pq_shared = key;
+
+                        // The channel is allways open during the library operation.
+                        // It can only be closed on library shutdown, in that case we
+                        // may not care since the task itself will be killed soon
+                        #[allow(mpsc_blocking_send)]
+                        let _ = chan.send(super::Event::Rekey(keys)).await;
+                    }
+                    Err(err) => telio_log_warn!("Failed to perform PQ rekey: {err}"),
+                }
+            }
+        };
+
+        let task = tokio::spawn(task);
+
+        Self { task }
+    }
+}
+
+impl Drop for ConnKeyRotation {
+    fn drop(&mut self) {
+        self.task.abort();
+        telio_log_debug!("PQ rekey task aborted");
+    }
+}

--- a/crates/telio-pq/src/entity.rs
+++ b/crates/telio-pq/src/entity.rs
@@ -1,0 +1,89 @@
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use telio_model::api_config::FeaturePostQuantumVPN;
+use telio_task::io::chan;
+use telio_utils::telio_log_debug;
+
+struct Peer {
+    addr: SocketAddr,
+    /// This is a key rotation task guard, its `Drop` implementation aborts the task
+    _rotation_task: super::conn::ConnKeyRotation,
+    keys: Option<super::Keys>,
+}
+
+pub struct Entity {
+    features: FeaturePostQuantumVPN,
+    sockets: Arc<telio_sockets::SocketPool>,
+    peer: Option<Peer>,
+}
+
+impl Entity {
+    pub fn new(features: FeaturePostQuantumVPN, sockets: Arc<telio_sockets::SocketPool>) -> Self {
+        Self {
+            features,
+            sockets,
+            peer: None,
+        }
+    }
+
+    pub fn keys(&self) -> Option<&super::Keys> {
+        self.peer.as_ref().and_then(|p| p.keys.as_ref())
+    }
+
+    pub fn on_event(&mut self, event: super::Event) {
+        let Some(peer) = &mut self.peer else {
+            return;
+        };
+
+        match event {
+            super::Event::Handshake(addr, keys) => {
+                if peer.addr == addr {
+                    peer.keys = Some(keys);
+                }
+            }
+            super::Event::Rekey(super::Keys {
+                wg_secret,
+                pq_shared,
+            }) => {
+                if let Some(keys) = &mut peer.keys {
+                    // Check if we are still talking to the same exit node
+                    if keys.wg_secret == wg_secret {
+                        // and only then update the preshared key,
+                        // otherwise we're connecting to different node already
+                        keys.pq_shared = pq_shared;
+                    } else {
+                        telio_log_debug!(
+                            "PQ secret key does not match, ignoring shared secret rotation"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn stop(&mut self) {
+        self.peer = None;
+    }
+
+    pub fn start(
+        &mut self,
+        chan: chan::Tx<super::Event>,
+        addr: SocketAddr,
+        wg_secret: telio_crypto::SecretKey,
+        peer: telio_crypto::PublicKey,
+    ) {
+        self.peer = Some(Peer {
+            addr,
+            _rotation_task: super::conn::ConnKeyRotation::run(
+                chan,
+                self.sockets.clone(),
+                addr,
+                wg_secret,
+                peer,
+                &self.features,
+            ),
+            keys: None,
+        });
+    }
+}

--- a/crates/telio-pq/src/lib.rs
+++ b/crates/telio-pq/src/lib.rs
@@ -1,0 +1,60 @@
+mod conn;
+mod entity;
+mod proto;
+
+use std::io;
+use std::net::SocketAddr;
+
+pub use entity::Entity;
+
+/// Post quantum keys retrived from hanshake
+#[derive(Clone, Copy)]
+pub struct Keys {
+    /// Kyber shared secret
+    pub pq_shared: telio_crypto::PresharedKey,
+    /// X25519 secret key
+    pub wg_secret: telio_crypto::SecretKey,
+}
+
+#[derive(Copy, Clone)]
+pub enum Event {
+    Handshake(SocketAddr, Keys),
+    Rekey(Keys),
+}
+
+/// The PQ module error type
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// IO error
+    #[error("IO: {0:?}")]
+    Io(#[from] io::Error),
+    /// Generic unrecoverable error
+    #[error("Generic: {0}")]
+    Generic(String),
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+impl From<String> for Error {
+    fn from(value: String) -> Self {
+        Self::Generic(value)
+    }
+}
+
+impl From<&str> for Error {
+    fn from(value: &str) -> Self {
+        Self::Generic(value.to_string())
+    }
+}
+
+impl From<tokio::time::error::Elapsed> for Error {
+    fn from(value: tokio::time::error::Elapsed) -> Self {
+        Self::Io(io::Error::new(io::ErrorKind::TimedOut, value))
+    }
+}
+
+/// Public functions exposed for fuzzing framework
+#[cfg(feature = "fuzzing")]
+pub mod fuzz {
+    pub use super::proto::{parse_get_response, parse_rekey_response};
+}

--- a/crates/telio-pq/src/proto.rs
+++ b/crates/telio-pq/src/proto.rs
@@ -1,0 +1,414 @@
+use std::{
+    convert::TryInto,
+    io::{self, Read},
+    net::Ipv4Addr,
+    ops::RangeInclusive,
+};
+
+use boringtun::noise;
+use pnet_packet::{
+    ip::IpNextHeaderProtocols,
+    ipv4::{self, Ipv4Flags, Ipv4Packet, MutableIpv4Packet},
+    udp::{self, MutableUdpPacket, UdpPacket},
+    Packet,
+};
+use pqcrypto_kyber::kyber768;
+use pqcrypto_traits::kem::{Ciphertext, PublicKey, SharedSecret};
+use rand::{prelude::Distribution, RngCore, SeedableRng};
+use tokio::net::{ToSocketAddrs, UdpSocket};
+
+const SERVICE_PORT: u16 = 6480;
+const LOCAL_PORT_RANGE: RangeInclusive<u16> = 49152..=u16::MAX; // dynamic port range
+const LOCAL_IP: Ipv4Addr = Ipv4Addr::new(10, 5, 0, 2);
+const REMOTE_IP: Ipv4Addr = Ipv4Addr::new(10, 5, 0, 1);
+const PQ_PROTO_VERSION: u32 = 1;
+const CIPHERTEXT_LEN: u32 = kyber768::ciphertext_bytes() as _;
+
+const IPV4_HEADER_LEN: usize = 20;
+const UDP_HEADER_LEN: usize = 8;
+
+type RekeyStatus = u8;
+
+struct TunnelSock {
+    tunn: Box<noise::Tunn>,
+    sock: telio_sockets::External<UdpSocket>,
+}
+
+/// Get PQ keys from the VPN server
+/// The packet sequence is as follows
+///
+/// 1) C -> S             : Client sends WG hansake packet                           
+/// 2) S -> C             : Server responds to handsake                              
+/// 3) C -> S (in tunnel) : Client sends a UDP PQ GET packet with keys               
+/// 4) S -> C (in tunnel) : Server responds with UDP packet containing the ciphertext
+///
+/// The shared key is established which should be used as,
+/// a WG preshared key for subsequent connection
+pub async fn fetch_keys(
+    sock_pool: &telio_sockets::SocketPool,
+    endpoint: impl ToSocketAddrs,
+    secret: &telio_crypto::SecretKey,
+    peers_pubkey: &telio_crypto::PublicKey,
+) -> super::Result<super::Keys> {
+    let TunnelSock { tunn, sock } = handshake(sock_pool, endpoint, secret, peers_pubkey).await?;
+
+    let mut rng = rand::rngs::StdRng::from_entropy();
+
+    // Generate keys
+    let wg_secret = telio_crypto::SecretKey::gen_with(&mut rng);
+    let (pq_public, pq_secret) = kyber768::keypair();
+    let wg_public = telio_crypto::PublicKey::from(&wg_secret);
+
+    // Send GET packet
+    let pkgbuf = create_get_packet(&wg_public, &pq_public, &mut rng); // 4 KiB
+
+    let mut recvbuf = [0u8; 2048]; // 2 KiB buffer should suffice
+    match tunn.encapsulate(&pkgbuf, &mut recvbuf) {
+        noise::TunnResult::Err(err) => {
+            return Err(format!("Failed to encapsulate PQ keys message: {err:?}").into())
+        }
+        noise::TunnResult::WriteToNetwork(buf) => {
+            sock.send(buf).await?;
+        }
+        _ => return Err("Unexpected WG tunnel output".into()),
+    }
+
+    // Receive response
+    let read = sock.recv(&mut recvbuf).await?;
+
+    let mut msgbuf = [0u8; 2048]; // 2 KiB buffer should shuffice
+
+    #[allow(index_access_check)]
+    let ciphertext = match tunn.decapsulate(None, &recvbuf[..read], &mut msgbuf) {
+        noise::TunnResult::Err(err) => {
+            return Err(format!("Failed to decapsulate PQ keys message: {err:?}").into())
+        }
+        noise::TunnResult::WriteToTunnelV4(buf, _) => parse_get_response(buf)?,
+        _ => return Err("Unexpected WG tunnel output".into()),
+    };
+
+    // Extract the shared secret
+    let pq_shared = kyber768::decapsulate(&ciphertext, &pq_secret);
+    let pq_shared = telio_crypto::PresharedKey::new(
+        pq_shared
+            .as_bytes()
+            .try_into()
+            .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?,
+    );
+
+    Ok(super::Keys {
+        pq_shared,
+        wg_secret,
+    })
+}
+
+/// Establsh new PQ preshared key with the VPN server
+pub async fn rekey(
+    sock_pool: &telio_sockets::SocketPool,
+) -> super::Result<telio_crypto::PresharedKey> {
+    let mut preshared = [0u8; telio_crypto::KEY_SIZE];
+
+    let mut rng = rand::rngs::StdRng::from_entropy();
+    rng.fill_bytes(&mut preshared);
+    let preshared = telio_crypto::PresharedKey::new(preshared);
+
+    let mut pkgbuf = Vec::with_capacity(1024 * 4); // 4 KiB
+    push_rekey_method_udp_payload(&mut pkgbuf, &preshared);
+
+    let sock = sock_pool
+        .new_internal_udp((Ipv4Addr::UNSPECIFIED, 0), None)
+        .await?;
+    sock.connect((REMOTE_IP, SERVICE_PORT)).await?;
+
+    sock.send(&pkgbuf).await?;
+
+    let mut recvbuf = [0u8; 1024];
+    let read = sock.recv(&mut recvbuf).await?;
+
+    #[allow(index_access_check)]
+    let status = parse_rekey_response(&recvbuf[..read])?;
+
+    const SUCCESS_CODE: RekeyStatus = 0;
+    if status != SUCCESS_CODE {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("VPN server returned status code: {status}"),
+        )
+        .into());
+    }
+
+    Ok(preshared)
+}
+
+async fn handshake(
+    sock_pool: &telio_sockets::SocketPool,
+    endpoint: impl ToSocketAddrs,
+    secret: &telio_crypto::SecretKey,
+    peers_pubkey: &telio_crypto::PublicKey,
+) -> super::Result<TunnelSock> {
+    let sock = sock_pool
+        .new_external_udp((Ipv4Addr::UNSPECIFIED, 0), None)
+        .await?;
+    sock.connect(endpoint).await?;
+
+    let tunn = noise::Tunn::new(
+        secret.into_bytes().into(),
+        peers_pubkey.0.into(),
+        None,
+        None,
+        0,
+        None,
+    )?;
+
+    let mut pkgbuf = [0u8; 2048];
+    match tunn.encapsulate(&[], &mut pkgbuf) {
+        noise::TunnResult::Err(err) => {
+            return Err(format!("Failed to encapsulate handshake message: {err:?}").into())
+        }
+        noise::TunnResult::WriteToNetwork(buf) => {
+            sock.send(buf).await?;
+        }
+        _ => return Err("Unexpected WG tunnel output".into()),
+    }
+
+    // The response should be 92, so the buffer is sufficient
+    let read = sock.recv(&mut pkgbuf).await?;
+
+    let mut msgbuf = [0u8; 2048];
+
+    #[allow(index_access_check)]
+    match tunn.decapsulate(None, &pkgbuf[..read], &mut msgbuf) {
+        noise::TunnResult::Err(err) => {
+            return Err(format!("Failed to decapsulate handshake message: {err:?}").into())
+        }
+        noise::TunnResult::WriteToNetwork(_) => {
+            // This is a outgoing keep alive message, we can skip sending it for the hanshake
+        }
+        _ => return Err("Unexpected WG tunnel output".into()),
+    }
+
+    Ok(TunnelSock { tunn, sock })
+}
+
+pub fn parse_rekey_response(pkgbuf: &[u8]) -> super::Result<RekeyStatus> {
+    let mut data = io::Cursor::new(pkgbuf);
+
+    let mut version = [0u8; 4];
+    data.read_exact(&mut version)?;
+    let version = u32::from_le_bytes(version);
+    if version != PQ_PROTO_VERSION {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "Server responded with invalid PQ rekey version",
+        )
+        .into());
+    }
+
+    let mut code = [0u8; 1];
+    data.read_exact(&mut code)?;
+
+    #[allow(index_access_check)]
+    Ok(code[0])
+}
+
+pub fn parse_get_response(pkgbuf: &[u8]) -> super::Result<kyber768::Ciphertext> {
+    let mut cipherbuf = [0; CIPHERTEXT_LEN as usize];
+
+    let ip = Ipv4Packet::new(pkgbuf).ok_or(io::Error::new(
+        io::ErrorKind::InvalidData,
+        "Invalid PQ keys IP packet received",
+    ))?;
+
+    let udp = UdpPacket::new(ip.payload()).ok_or(io::Error::new(
+        io::ErrorKind::InvalidData,
+        "Invalid PQ keys UDP packet received",
+    ))?;
+
+    let mut data = io::Cursor::new(udp.payload());
+
+    let mut version = [0u8; 4];
+    data.read_exact(&mut version)?;
+    let version = u32::from_le_bytes(version);
+    if version != PQ_PROTO_VERSION {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "Server responded with invalid PQ handshake version",
+        )
+        .into());
+    }
+
+    let mut ciphertext_len = [0u8; 4];
+    data.read_exact(&mut ciphertext_len)?;
+    let ciphertext_len = u32::from_le_bytes(ciphertext_len);
+
+    if ciphertext_len != CIPHERTEXT_LEN {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "Server responded with invalid PQ handshake ciphertext lenght",
+        )
+        .into());
+    }
+
+    data.read_exact(&mut cipherbuf)?;
+
+    let ct = kyber768::Ciphertext::from_bytes(&cipherbuf)
+        .map_err(|err| format!("Invalid PQ ciphertext received: {err:?}"))?;
+
+    Ok(ct)
+}
+
+fn create_get_packet(
+    wg_public: &telio_crypto::PublicKey,
+    pq_public: &kyber768::PublicKey,
+    rng: &mut impl rand::Rng,
+) -> Vec<u8> {
+    let mut pkgbuf = Vec::with_capacity(1024 * 4); // 4 KiB
+    pkgbuf.resize(IPV4_HEADER_LEN + UDP_HEADER_LEN, 0);
+
+    push_get_method_udp_payload(&mut pkgbuf, wg_public, pq_public);
+    fill_get_packet_headers(pkgbuf.as_mut_slice(), rng);
+
+    pkgbuf
+}
+
+/// The GET payload looks as follows:
+///
+/// ---------------------------------
+///  version           , u32le, = 1
+/// ---------------------------------
+///  method            , u32le, = 0
+/// ---------------------------------
+///  WG pubkey len     , u32le, = 32
+/// ---------------------------------
+///  WG pubkey bytes   , [u8]
+/// ---------------------------------
+///  Kyber pubkey len  , u32le, = 1184
+/// ---------------------------------
+///  Kyber pubkey bytes, [u8]
+/// ---------------------------------
+fn push_get_method_udp_payload(
+    pkgbuf: &mut Vec<u8>,
+    wg_public: &telio_crypto::PublicKey,
+    pq_public: &kyber768::PublicKey,
+) {
+    let method = 0u32; // get
+
+    // UDP packet payload
+    pkgbuf.extend_from_slice(&PQ_PROTO_VERSION.to_le_bytes());
+    pkgbuf.extend_from_slice(&method.to_le_bytes());
+    pkgbuf.extend_from_slice(&(wg_public.len() as u32).to_le_bytes());
+    pkgbuf.extend_from_slice(wg_public);
+    pkgbuf.extend_from_slice(&(pq_public.as_bytes().len() as u32).to_le_bytes());
+    pkgbuf.extend_from_slice(pq_public.as_bytes());
+}
+
+/// The REKEY payload looks as follows:
+///
+/// --------------------------------
+///  version           , u32le, = 1
+/// --------------------------------
+///  method            , u32le, = 1
+/// --------------------------------
+///  WG preshared len  , u32le, = 32
+/// --------------------------------
+///  WG preshared bytes, [u8]
+/// --------------------------------
+fn push_rekey_method_udp_payload(pkgbuf: &mut Vec<u8>, preshared: &telio_crypto::PresharedKey) {
+    let method = 1u32; // rekey
+
+    // UDP packet payload
+    pkgbuf.extend_from_slice(&PQ_PROTO_VERSION.to_le_bytes());
+    pkgbuf.extend_from_slice(&method.to_le_bytes());
+    pkgbuf.extend_from_slice(&(preshared.len() as u32).to_le_bytes());
+    pkgbuf.extend_from_slice(preshared);
+}
+
+/// Sets up UDP and IP headers in the provided buffer
+///
+/// # Panics
+///
+/// Panics if the buffer size is less than IP + UDP headers bytes.
+fn fill_get_packet_headers(pkgbuf: &mut [u8], rng: &mut impl rand::Rng) {
+    let pkg_len = pkgbuf.len();
+
+    #[allow(clippy::expect_used)]
+    #[allow(index_access_check)]
+    let mut udppkg = MutableUdpPacket::new(&mut pkgbuf[IPV4_HEADER_LEN..])
+        .expect("UDP buffer should not be too small");
+    udppkg.set_source(random_port(rng));
+    udppkg.set_destination(SERVICE_PORT);
+    udppkg.set_length((pkg_len - IPV4_HEADER_LEN) as _);
+    udppkg.set_checksum(udp::ipv4_checksum(
+        &udppkg.to_immutable(),
+        &LOCAL_IP,
+        &REMOTE_IP,
+    ));
+    drop(udppkg);
+
+    #[allow(clippy::expect_used)]
+    #[allow(index_access_check)]
+    let mut ippkg = MutableIpv4Packet::new(&mut pkgbuf[..IPV4_HEADER_LEN])
+        .expect("IPv4 buffer should not be too small");
+    ippkg.set_version(4);
+    ippkg.set_header_length(5);
+    ippkg.set_total_length(pkg_len as _);
+    ippkg.set_flags(Ipv4Flags::DontFragment);
+    ippkg.set_ttl(0xFF);
+    ippkg.set_next_level_protocol(IpNextHeaderProtocols::Udp);
+    ippkg.set_source(LOCAL_IP);
+    ippkg.set_destination(REMOTE_IP);
+    ippkg.set_checksum(ipv4::checksum(&ippkg.to_immutable()));
+}
+
+fn random_port(rng: &mut impl rand::Rng) -> u16 {
+    rand::distributions::Uniform::new_inclusive(LOCAL_PORT_RANGE.start(), LOCAL_PORT_RANGE.end())
+        .sample(rng)
+}
+
+#[cfg(test)]
+mod tests {
+    use pqcrypto_kyber::kyber768;
+    use pqcrypto_traits::kem::{Ciphertext, SecretKey, SharedSecret};
+
+    #[test]
+    // The Kyber KEM has two competing algorithms and the library we're using changed the algorithm in their new version.
+    // The test here is for capturing the eventual regression when the library is updated for example.
+    fn decapsulate_kyber_ciphertext() {
+        let secret_key = "e4GyMtQVorJvBtpRTeJAazMEnXg5dqwBexBXDTSwBbwuMUJLPDVktyWFzFhBa9NOr1ISwSGuHhmx1bQPWqhGv6ds4xZu9OtZLlsoRCJI/cKRmJBb1HNcyWUYFMV33BGcofxjggml00zISWux8ntAYWQkQ4GL8GaN1xxTjJdnZ4qyMPFQpTCvFMo0Gwu8uoxWmQQAiffEaiZfetNWwkYJ+YFW4Hm82ZYsXmgAb1IQ3RYQRTW7DGor8CKy8rkYTwVgT6GptArKClM+AWiRCQDL5PIGtyoyUUJVmSpyRNZFEPwY1nJOIVBqSeA/ZNMI8vCfhoAKFhfEhKMem3KpKvJYlJOC+0JMHAQQOntilDyY9Cc1sJxdbcNWIlo5IVhLW3FxD7dJ0HPDg9dhYXxyqjMAvHhCF2kUcSgdrFViV0LEe1rOweKFdJkyRKGo2va57ltz0IB00hIEFiRmavCkCXeWtEmIa/YrH7EBjOhNNWZ9GoOtuclWIoZeh0XNNZA0eySiCTWXL1QPTyhF9oeDV1dzNOKm7UCiPpNku7CVGMOF1FM1olBqG4soDKfN/RIsc/oV96S4GlK5IIgF/kDO4ryNOVFX0pl/Kls6koq5P9sVnzsGR4cGAuWU3RZdaKMu6BtEFXZh6VEqb/tAOtE3Mad2byYNOpOsIlhDX0awLhcbQRVVokQEyCKIx5OBqefJ1iNMEuiOj6ZT+FZPyRyyXXwM/FtugXQAX1ow+ge/PpWwAZvFkoFPh4OLyIpJT3U2GpKp5dKd/fZEiKdLX0SM7xoD1HcKXAqud1p0UmyfqLFZgCkVM/tDTthbz7Wk6ilGo9eyMNeAcKOWRwR71WDNzPUgqYzB+Ox600miwtYzHlillIZMelO/zBdypzZFrZhGynMAmxxMtKiXTbtkELxFMzpQTHhvuxSFfbFRJnoHYDYlprYP8xul8SCQDEQLwZdkVfwzE5qzGZw/YvogPUkSEbBSoEAqonYDg9WnYdaNKkeK83yGkLV5vOcUVKc4utstr6vJbGA1Bype34DFZeouqBEgWHMywXkPZ2dSXgVP/vl9gwRNErxpvDVfQIFZ3cFPdIQgt4bJx1sRYUvKKsOeNJtjk/KFzfDMkje2ogKPz8iTYnBRzWfOnPUIhDI/QZhSoAEYxwTNJvunyKlPYjCuG7U1z0M5UNVw7QuyiaumxOy0dGFNKraN8JTDqbgoC6xaWfCZR0qybkE0tceOhaa+8ZsigaxnqGh4gjErkpnMvUGKXAAVsLbHlygOEgd1u8tl46ERZzxdr1t0JTrJnxayCnwiW1ywqfk1gPd0hcg2k7goZJDNW4Aet3OsboRtLGUNE5xChMzBsnVVCxBH4aV/HHgmFbds4xeVLXC/sUlpMFgeahPMQvFeMSUgPWYmhAbPvMUTrCZPuwcGzQKZMdN7P3YJ4Is7KHOs1ddc3PxM6zC7/AOjBEkecIWp9GlDRUhVQHIqV1R1OiczeLky5YA5VqlgOEhY9qIzI+lrGVMGfRiu/PHBcxiq/lhItIRNupgRBzKOyKooKVJxS5hBJVyTNZiOICNswiKRhaEmfrGkBEE4XLE3uLlvwxUyo4C5kIFPq3xw0uRbK8U6CANRaTskM6swRCV3MMupGwcHI7dY7eUfJoGFaFyOQFqCqKWsjGC7qxqJbVYRWyFLLAin3SKiKwpgGwyKxGdt1hSH32R86DI04TR7SRwqMLqIbNVKX8qRIKd0KmdTHLp39XGm2iAHWSo2FgI8WoC0lLdIv3OcQYZMILJjAQJPaiR62MfOJpkf6uYpRlHBbIQnEjbGRUikmzYlsCxHu/wT0llZBjaL7rrBxQux71eCu6cqKvi7xkMH0gu5QAdOcmUbCswBQOJYwDqBSxMlJmyM7pM7aJhF62xQ1UMf8iexWhokltnMAXN0wqG0V8pI1DKLyncymyYYUjS6jxC9lQuD+3zEAPy2ZHOXbpe4DBMGzdBsGnzPUVJOlFcXPMYbjoVNEbhqhhCydnVhafidbPe4tFDFJdtDhQhNtjCK/VS0vDrKmSErWaKBhYSgKxYDtCDB/0CdKnC6EJwmoJUSLMtw/eFNCll3KFOE51EKkXg6KuYQiOzCIoE5P8w3LyZotUm9gohhXvsl8pZD9oFsl0YQUEd6Qqkbrqa8gSdL7ABWwpI+b1IdTYYB68QgU6OkpnMt7wXEGaxsnYY1aYWJARk+vkdmaLNFsCoxcOnFv6Z24cmfGBEe0LB/HsV2DREmzbUSIcVwjZsGOLMqcsCq+bCD8eWEeIu8wamiwUGmGVMTwFOxMjMPEBKhvLa2UthpEeEuPLwNjbg0AtyCL4p0/5Qo2tS0YphM+5GlrCJkjVwbfHmAnHivXlzCK9hNchqo5URXlHJOjehD2WSvBIvPQCi9IYAgSMAd/BNrq1eDCCzAOoali5QswxPD22AbHfrBkBWXy9JTyZJCExwRP5ZVTjIPSGKC++uVBce8aDZ+kVKPP1GOsXqxVikC0xVOfyMTCDN2/qSUMAcBMCaiEgSTFZdyyvgrHsVntJOHw9h1HaupMxuXuSNo5ms2zOCaTOiKR4tZYSMCxTaRLNRlLnPEHvsRxyFE1DpmIIPKn3KUt9kaUWM+ovwJy4tHu4nMUPJfsGem+ccsQdDE80uwJtLFeUC845FQC+HLoLecoNzOfhghxVcGhsyEUUIbRKmlOgEtI7OpmuSWB9xqocirBTx05ZI/f5lzqtgUXRiRx9wxCgoFZlY/33o2qieSLxlV5afEYCuKqIxE93aQmvcNkDwZbyNOD/IJV2g+3Ks4JEqlR0YLqPNyj4qomzp+IOY/hDgeftoJUKcxTUWDZXYmuIAjH1CSBgm4l+o9hHWGl1pl3LIGn1KNMhK5A1yNX3AqCHl6J8gjAcw3XKSmMMRZPEdMlFgVTLcicWSd6iZ1NyvO+fM8bkOKR7Gn6ekPzspztVtwl1ayzYXLMWRUdOhqtWtukCarIEXFyFG8ByKlsVQCRvKMSUCjp0eRHoIP/SnMGUufs1ZCM5ejwXZR/EK6XoNmyNQUrrVNGuB/2sm9Z/FLEEwShFiVlYMXvGFcZubPr03TqybQWtkXQ0KQxvxhLgLsk495B3i13F342yT5m1OX3Wor1JNyV6nAolgf/IDQGyXh9fBzETTooRcbl8jLfllhVDimPrZMw7488eXXw9qet8DIjUCP4UQ3B4R/jsSx";
+        let ciphertext = "1PXYvRAU31rbjedEJLRVRiNVShRNt9RrBar0hzN4iqBQuSBYyVwZy4FwMHRQz5cnljn5gsQlUP3+jhkYL5YQqNy//oJtBwCz2NWzjXu2BzphKJaGE9FbBmvpwhTa70BdYbCri11GOK+bO6dpTTFaF0NqMhdDlMuvD9yv93RzTNfoZtVuqjTGvitx2bY+aCshir8mZ9iox3kyxcf8OIR7mFjUNQgRPgmvdmYSHqFuvaOSWQjxlzdkG0V3zlUr7IUusGLYFDSMqHPqMbm2HTWcaF7UsF/NwrUcUsm2mxev7QBu7nIBWQzMmnWacH6/0cxj/AOfv8TsdK6QUYrSYUFTHVWkbXwodpG4/5kzt6z4BhqS7d3Z30Pg4K+PA/5yQseGpgADOZlHfoqEysdDZ7Y+dypaXVX2Z6kUokwIcxKglJQYUTezGwUztukiTSVoTJ2osTJ5LnU3quuP/NZmdKdsuUs0fBaPTQ7gl2gaxc3LhXjmOPvU8VNZf0hJNlA91h6RCgCbn0z634I8LmCr94TZa1GJcIy7JvKZC2g9XhoIdjSuDuzjH0T7qixqZwib+wGzUJ5Mcz+SIMCwpSIALxsyOfuB5/E2eLnbtt1TWwMCq1O6HSgjDD2dT0qV3AQ9ZKkbggfjG53npNfK82zufBPhWphTly6Fv9yCWguXH/9pK46MnBUVWeiB1RQFl9/R/oflkg5Mlqe07lmBNWotYlg14IVG+ZF69jKtp6dIBe2bWzvH4SYn/2bhpwGGWZUQ1ZkoZvY6dUqglhnTzmBgXdXLSVDueVklXg1saHIFWYug/Friy+U5mU6AxYs1uEqfdf7x1GWbHjyHsaDG1WSGx2xHQ+5nvGsM7a9LR83BMtiFgJe9cWxPvYdD16FZEbax9uu1kgY+3ESgjJXY5uTD7igx0SuR+Q6DBc+7GwFY7Ox9U1FHUg2+mAV4QTh/gsA1d2FXkORbs/1GUMP8cjkmOyIVaNegPYPgsF22UyNbE3h25biTY+XbP3x9E2fCDGGB4XTG8muwBljndoiBuyp0xyCZ1IGl3siS13RXCJbkY7hFLVyOWExHZB2hQ6TX6a7wLP88YtbKcJK9viyixWz+Uky4CypYh7W55+RUabuIWybrPti3JJAazesHJXhefdnRTmd3nUWzpAI81pg5mEMGS42FyelfBOiXhTxaAJrsYH8ujmJc4rG88AK0jFdAP7J1HfJKC+fPvT44zyPnxrUuQ/f7rkPMOmX1uEliKzSnecHs0102Gmj0RFxkqjCZNgvAL/XX4Uy7+nbjCeQfKAG4AX7xIYm6gzcFb11CEeGPDFqEMHta+ocGmH8HYJ43K07fh0JaSfcqLrHeH/vZCib5cc8kddVqMVobOh9uFgpV8VUStozBPJL7z3nMiegI/P/QHzwEnKk5IHamyWJcMWRIodz6Fzh7ZC+JRsXITtKvvrxJ+tA=";
+
+        let expected_shared = "T4KKTwQOEQ43G1UzPbBVzi219KXJ54qh6w24IMPEc0A=";
+
+        let shared = {
+            let sk_bytes = base64::decode(secret_key).unwrap();
+            let secret_key = kyber768::SecretKey::from_bytes(&sk_bytes).unwrap();
+
+            let ct_bytes = base64::decode(ciphertext).unwrap();
+            let ciphertext = kyber768::Ciphertext::from_bytes(&ct_bytes).unwrap();
+
+            let shared = kyber768::decapsulate(&ciphertext, &secret_key);
+
+            base64::encode(shared.as_bytes())
+        };
+
+        assert_eq!(shared, expected_shared);
+    }
+
+    #[test]
+    fn parse_get_response() {
+        let testpkg = b"\x45\x00\x04\x64\x1E\x6E\x40\x00\x40\x11\x04\x0F\x0A\x05\x00\x01\x0A\x05\x00\x02\x19\x50\xF4\x47\x04\x50\xE0\x10\x01\x00\x00\x00\x40\x04\x00\x00\x67\xA6\x9C\x16\x98\xFF\x14\x9E\xEF\xBA\xDE\x97\x4F\x08\x42\x23\xCD\x4B\xD3\x35\xBE\x77\x80\x65\x31\x57\x4F\x28\x8E\x44\x8E\x8D\xB8\xA5\xB5\xDF\x02\x53\x33\x53\x2A\xDC\x84\x83\x01\x67\x6B\x66\xAD\x44\xAE\x77\x33\xA1\x0A\x92\x8A\xDA\xF1\xAD\x1B\xFF\x39\xB0\xCA\x28\x0C\xA7\x05\xD7\xCF\x8A\x57\xD2\x08\x2F\x4C\xA7\xB7\xF3\x9B\xEE\x0D\xA5\x09\x5B\xF9\xB3\x35\x95\x35\x07\x9D\x83\xE5\xE0\x3C\x9D\x77\xB9\xF7\x96\xF3\x76\x93\x43\x61\x67\xD3\xED\x61\x39\xB8\x71\xEA\x54\xD2\xFD\xCE\xDE\x98\xFF\x7A\x05\x01\x57\x35\xB0\x47\x3A\xC9\x67\x52\x51\xAD\xE2\x6A\x2A\x2E\x80\xD6\xBB\x25\x5E\x69\xAC\x34\x65\xFF\xC4\xD4\x09\x35\x0B\x09\xD3\x4B\xCE\xC2\x40\xAD\xD8\xDF\x9F\x34\x20\x9A\xA6\xEC\xCF\x81\x52\xBD\xE6\x5C\xBD\xE9\x8C\xD6\xD4\xAD\x5D\x5A\x57\xB4\x64\x61\x9E\x51\xC7\x6D\xE7\x4D\x6A\xBF\x23\x71\x9D\xEB\x42\x4E\xF7\x8D\xD6\x84\x31\xED\x3F\x15\x70\xAB\xA5\xA9\x0D\x80\x80\xAA\xA3\xA8\x7E\x17\x4B\x99\x8B\xA9\x39\xB5\x2E\x61\x67\xE1\xCD\x59\xD8\x0D\x21\xA5\xFA\x5E\xF1\x9C\x34\x67\x44\xB8\x2B\xDB\xD8\x19\x8B\xE2\x15\xA2\x30\x5E\x0D\x6A\xD4\x45\x5A\xF4\x0C\x91\x55\x4D\xFA\xB6\xDB\xDD\x69\xE2\x96\x75\xEE\xA0\x32\x4E\x5D\x39\xA9\x27\xF6\x64\xF1\x98\x05\x39\x71\x0F\x3E\x3B\x4E\x19\x0C\x21\x4B\x39\xC5\xAC\x8C\xC1\xF6\xE3\x6D\x13\x66\xDF\x35\xD9\x0E\xB0\x8D\x81\x94\xD6\x0B\xCA\x3C\x3A\xF2\x66\xF4\xF7\x40\xFE\x59\x39\x26\x44\x75\x7D\x4A\xAD\xEE\x4E\x8C\xD8\xB4\xCB\xFE\xEA\xE9\xA4\x5A\x9C\x6C\x3F\x0E\xE1\xCD\x64\x7E\xDA\x47\x4E\x07\xCC\x78\x2F\x50\x6F\x5B\x52\x22\x29\x23\x5A\xEA\x2D\xEB\x3F\x9E\xEC\x15\xDE\x1F\x44\x5C\x16\x95\xC0\x1F\xA2\x90\x5F\xA3\x31\x8F\xFE\x4A\x31\xA8\x34\xBC\x3A\xF9\x1D\x7F\x34\x02\xDF\xD7\xD3\x4F\x96\x73\x73\x18\x16\x9C\x87\x97\xD4\xCE\x63\xC2\x83\x90\x2D\xC8\xDF\x6A\xAB\xFD\x81\x74\x8F\xDF\x09\x6D\xA3\xCD\xB7\x50\xE1\x88\xA6\x75\xCD\x8B\x55\x75\xD2\x26\x49\xC4\x6E\x9A\x2B\xA5\x13\xDB\x8F\xC7\x9E\xE9\x6E\xE2\xEE\x9F\x1E\xAF\x77\xF8\x89\x17\xF2\xD5\xF7\x89\x3F\xC3\x18\x16\x86\x57\x1F\x9F\xD0\xF1\xC3\xCC\x45\x67\xA2\x45\x6A\x16\x6B\x2B\xF5\xAA\x56\x6E\x80\xC0\x91\x1D\x2B\x0A\xCB\xCF\x1F\x80\x20\x18\x71\x6B\x6E\x46\x5C\x05\xE4\x73\x7E\xB4\x2B\x98\x40\x23\xC8\x6C\xA4\xCB\xD6\x12\xF6\xF4\xCB\x06\x75\xBC\x6B\xDC\x44\x71\xBB\x11\x69\x97\x8B\xD2\x15\xAD\x98\xBB\xCD\xA2\x5A\x77\x3D\xFC\xC3\x43\x79\xC8\xF9\x33\x87\x22\x9E\x20\x02\x63\x23\x48\xDD\xC7\x45\x44\x06\x10\x16\x4C\x35\x26\xB0\xAC\x5C\x98\x24\x9D\xC2\x1A\x48\x48\x49\x0F\x93\xE8\x6E\xE7\xB3\x77\xD2\xE5\x64\xDD\x49\x1C\x87\x77\x98\x11\xF6\xD0\x0C\xEB\x95\x73\x46\x51\x9F\xFC\x10\x23\x19\xD3\x73\x08\xFA\xFF\xCF\x70\x5C\x03\x34\x53\xC9\x65\x76\x00\xB9\x7C\x1C\x30\x1A\x9E\x0E\xD6\x2B\x8F\xB5\xC9\x50\xDA\x4B\x37\xF2\xC2\x86\x07\xB4\xE1\x70\x42\x1A\xAB\x70\x9F\x06\x72\xED\xBF\x45\x1D\xEA\x3E\x6C\xCF\xC6\x74\x0C\xA8\x9B\xAB\xCF\xEC\x62\xA9\xAB\x70\xF9\x1C\xA0\xBF\x99\x86\x3D\x1F\xE0\xA9\xCC\x9A\x6E\xD2\x8B\xB4\xBB\x29\xFA\xC3\x7D\xAC\xF9\x3C\x44\x06\xC8\xB2\x49\x3F\x26\x86\xA7\x8B\x13\x8E\x3A\xDF\x73\xEC\x94\xAE\xA2\x0C\x4C\x19\x13\x85\xED\x50\xF3\xCA\x53\xA5\x8E\x9F\xC6\x00\x44\xD8\x73\x08\x2C\xA0\x4D\x7A\xB0\xF7\xE5\x25\xD0\x22\x78\x47\x08\xB1\x55\x01\x98\x5A\xCE\xB8\x6B\x4B\x2F\x0B\x83\x54\x83\x70\xC8\xEB\xCE\x41\xA7\xBF\x33\x9A\x58\xDA\x36\x79\x56\xFD\x88\x30\x94\x31\x48\xF5\x9E\xA6\x2D\xEA\x05\x03\x27\x9E\x76\x72\xA6\xC8\x45\xFD\xEF\xB4\xCB\xBF\xC5\xC3\x02\x13\x33\x37\x02\xD8\x8A\x3C\x8A\x46\xC3\x3C\xBA\x0A\xEB\x9D\x46\x81\xF2\x97\xD5\x38\xFD\xC8\xF4\x6A\x7B\x56\x23\xED\x70\xA6\x58\x40\x61\x0A\x3C\x48\xE3\x01\xE4\x32\xFA\xC5\xE9\x80\xAB\x1B\x37\x04\x45\x0D\x10\x6E\x54\x18\xDE\xAA\x4E\xF0\x0A\x56\x45\xA4\x27\xE2\xC2\xA3\x0D\xB4\x57\xDE\xD0\x08\xE5\xE0\xBE\xF8\xC9\x8F\x1D\x09\x2D\x18\x83\xB4\xBD\x64\xD2\x52\x6C\x16\x81\x7C\x6F\x0F\x04\x62\x6D\x38\xFF\x11\xA1\xED\x86\xF2\xB0\xE1\x72\x33\xF0\x99\xBD\xC5\xA6\x00\xF5\x2C\x3D\x73\xFE\xE8\xBB\x75\xF5\xF5\x5C\x8D\x71\xE8\x90\xF7\x5D\xFE\x3B\x6D\xD3\xCE\x02\x6E\x4F\x07\x6E\x89\xBD\x62\x15\xCB\xB5\xFE\x8E\xCE\x28\x34\xFC\xA0\xC5\xFE\x4A\x8C\x6E\xFE\x8C\xE0\x5B\x3B\x72\x9F\x26\x46\xA3\x62\x36\x4B\xDA\x1F\xB1\xC6\xC2\x31\x4B\xB6\x5A\x95\xF9\x5F\x74\x38\x65\x42\xF5\x6D\xB8\x9B\xFB\x95\xDA\xCE\xEB\x47\xC8\x00\xFC\x15\x29\x23\x1A\xD0\xD7\x84\x4F\xBA\x0F\x03\xBE\x78\x51\x03\x8E\x89\xA5\xBF\xD0\x26\x75\xA5\x27\x2F\x97\x98\x01\x68\x33\x88\x4A\x62\x8B\x49\x8E\x18\x33\xA9\x0C\x5C\x07\x0D\x9C\xAC\x11\xD9\x39\x60\xAA\xD8\x28\x64\x19\xE6\xDE\x61\xEC\xC4\x0B\x72\x21\xED\xAA\x54\xDD\xC8\xE6\x0F\x0C\x51\x8D\xF7";
+
+        let cipher = super::parse_get_response(testpkg).unwrap();
+
+        let expected = b"\x67\xA6\x9C\x16\x98\xFF\x14\x9E\xEF\xBA\xDE\x97\x4F\x08\x42\x23\xCD\x4B\xD3\x35\xBE\x77\x80\x65\x31\x57\x4F\x28\x8E\x44\x8E\x8D\xB8\xA5\xB5\xDF\x02\x53\x33\x53\x2A\xDC\x84\x83\x01\x67\x6B\x66\xAD\x44\xAE\x77\x33\xA1\x0A\x92\x8A\xDA\xF1\xAD\x1B\xFF\x39\xB0\xCA\x28\x0C\xA7\x05\xD7\xCF\x8A\x57\xD2\x08\x2F\x4C\xA7\xB7\xF3\x9B\xEE\x0D\xA5\x09\x5B\xF9\xB3\x35\x95\x35\x07\x9D\x83\xE5\xE0\x3C\x9D\x77\xB9\xF7\x96\xF3\x76\x93\x43\x61\x67\xD3\xED\x61\x39\xB8\x71\xEA\x54\xD2\xFD\xCE\xDE\x98\xFF\x7A\x05\x01\x57\x35\xB0\x47\x3A\xC9\x67\x52\x51\xAD\xE2\x6A\x2A\x2E\x80\xD6\xBB\x25\x5E\x69\xAC\x34\x65\xFF\xC4\xD4\x09\x35\x0B\x09\xD3\x4B\xCE\xC2\x40\xAD\xD8\xDF\x9F\x34\x20\x9A\xA6\xEC\xCF\x81\x52\xBD\xE6\x5C\xBD\xE9\x8C\xD6\xD4\xAD\x5D\x5A\x57\xB4\x64\x61\x9E\x51\xC7\x6D\xE7\x4D\x6A\xBF\x23\x71\x9D\xEB\x42\x4E\xF7\x8D\xD6\x84\x31\xED\x3F\x15\x70\xAB\xA5\xA9\x0D\x80\x80\xAA\xA3\xA8\x7E\x17\x4B\x99\x8B\xA9\x39\xB5\x2E\x61\x67\xE1\xCD\x59\xD8\x0D\x21\xA5\xFA\x5E\xF1\x9C\x34\x67\x44\xB8\x2B\xDB\xD8\x19\x8B\xE2\x15\xA2\x30\x5E\x0D\x6A\xD4\x45\x5A\xF4\x0C\x91\x55\x4D\xFA\xB6\xDB\xDD\x69\xE2\x96\x75\xEE\xA0\x32\x4E\x5D\x39\xA9\x27\xF6\x64\xF1\x98\x05\x39\x71\x0F\x3E\x3B\x4E\x19\x0C\x21\x4B\x39\xC5\xAC\x8C\xC1\xF6\xE3\x6D\x13\x66\xDF\x35\xD9\x0E\xB0\x8D\x81\x94\xD6\x0B\xCA\x3C\x3A\xF2\x66\xF4\xF7\x40\xFE\x59\x39\x26\x44\x75\x7D\x4A\xAD\xEE\x4E\x8C\xD8\xB4\xCB\xFE\xEA\xE9\xA4\x5A\x9C\x6C\x3F\x0E\xE1\xCD\x64\x7E\xDA\x47\x4E\x07\xCC\x78\x2F\x50\x6F\x5B\x52\x22\x29\x23\x5A\xEA\x2D\xEB\x3F\x9E\xEC\x15\xDE\x1F\x44\x5C\x16\x95\xC0\x1F\xA2\x90\x5F\xA3\x31\x8F\xFE\x4A\x31\xA8\x34\xBC\x3A\xF9\x1D\x7F\x34\x02\xDF\xD7\xD3\x4F\x96\x73\x73\x18\x16\x9C\x87\x97\xD4\xCE\x63\xC2\x83\x90\x2D\xC8\xDF\x6A\xAB\xFD\x81\x74\x8F\xDF\x09\x6D\xA3\xCD\xB7\x50\xE1\x88\xA6\x75\xCD\x8B\x55\x75\xD2\x26\x49\xC4\x6E\x9A\x2B\xA5\x13\xDB\x8F\xC7\x9E\xE9\x6E\xE2\xEE\x9F\x1E\xAF\x77\xF8\x89\x17\xF2\xD5\xF7\x89\x3F\xC3\x18\x16\x86\x57\x1F\x9F\xD0\xF1\xC3\xCC\x45\x67\xA2\x45\x6A\x16\x6B\x2B\xF5\xAA\x56\x6E\x80\xC0\x91\x1D\x2B\x0A\xCB\xCF\x1F\x80\x20\x18\x71\x6B\x6E\x46\x5C\x05\xE4\x73\x7E\xB4\x2B\x98\x40\x23\xC8\x6C\xA4\xCB\xD6\x12\xF6\xF4\xCB\x06\x75\xBC\x6B\xDC\x44\x71\xBB\x11\x69\x97\x8B\xD2\x15\xAD\x98\xBB\xCD\xA2\x5A\x77\x3D\xFC\xC3\x43\x79\xC8\xF9\x33\x87\x22\x9E\x20\x02\x63\x23\x48\xDD\xC7\x45\x44\x06\x10\x16\x4C\x35\x26\xB0\xAC\x5C\x98\x24\x9D\xC2\x1A\x48\x48\x49\x0F\x93\xE8\x6E\xE7\xB3\x77\xD2\xE5\x64\xDD\x49\x1C\x87\x77\x98\x11\xF6\xD0\x0C\xEB\x95\x73\x46\x51\x9F\xFC\x10\x23\x19\xD3\x73\x08\xFA\xFF\xCF\x70\x5C\x03\x34\x53\xC9\x65\x76\x00\xB9\x7C\x1C\x30\x1A\x9E\x0E\xD6\x2B\x8F\xB5\xC9\x50\xDA\x4B\x37\xF2\xC2\x86\x07\xB4\xE1\x70\x42\x1A\xAB\x70\x9F\x06\x72\xED\xBF\x45\x1D\xEA\x3E\x6C\xCF\xC6\x74\x0C\xA8\x9B\xAB\xCF\xEC\x62\xA9\xAB\x70\xF9\x1C\xA0\xBF\x99\x86\x3D\x1F\xE0\xA9\xCC\x9A\x6E\xD2\x8B\xB4\xBB\x29\xFA\xC3\x7D\xAC\xF9\x3C\x44\x06\xC8\xB2\x49\x3F\x26\x86\xA7\x8B\x13\x8E\x3A\xDF\x73\xEC\x94\xAE\xA2\x0C\x4C\x19\x13\x85\xED\x50\xF3\xCA\x53\xA5\x8E\x9F\xC6\x00\x44\xD8\x73\x08\x2C\xA0\x4D\x7A\xB0\xF7\xE5\x25\xD0\x22\x78\x47\x08\xB1\x55\x01\x98\x5A\xCE\xB8\x6B\x4B\x2F\x0B\x83\x54\x83\x70\xC8\xEB\xCE\x41\xA7\xBF\x33\x9A\x58\xDA\x36\x79\x56\xFD\x88\x30\x94\x31\x48\xF5\x9E\xA6\x2D\xEA\x05\x03\x27\x9E\x76\x72\xA6\xC8\x45\xFD\xEF\xB4\xCB\xBF\xC5\xC3\x02\x13\x33\x37\x02\xD8\x8A\x3C\x8A\x46\xC3\x3C\xBA\x0A\xEB\x9D\x46\x81\xF2\x97\xD5\x38\xFD\xC8\xF4\x6A\x7B\x56\x23\xED\x70\xA6\x58\x40\x61\x0A\x3C\x48\xE3\x01\xE4\x32\xFA\xC5\xE9\x80\xAB\x1B\x37\x04\x45\x0D\x10\x6E\x54\x18\xDE\xAA\x4E\xF0\x0A\x56\x45\xA4\x27\xE2\xC2\xA3\x0D\xB4\x57\xDE\xD0\x08\xE5\xE0\xBE\xF8\xC9\x8F\x1D\x09\x2D\x18\x83\xB4\xBD\x64\xD2\x52\x6C\x16\x81\x7C\x6F\x0F\x04\x62\x6D\x38\xFF\x11\xA1\xED\x86\xF2\xB0\xE1\x72\x33\xF0\x99\xBD\xC5\xA6\x00\xF5\x2C\x3D\x73\xFE\xE8\xBB\x75\xF5\xF5\x5C\x8D\x71\xE8\x90\xF7\x5D\xFE\x3B\x6D\xD3\xCE\x02\x6E\x4F\x07\x6E\x89\xBD\x62\x15\xCB\xB5\xFE\x8E\xCE\x28\x34\xFC\xA0\xC5\xFE\x4A\x8C\x6E\xFE\x8C\xE0\x5B\x3B\x72\x9F\x26\x46\xA3\x62\x36\x4B\xDA\x1F\xB1\xC6\xC2\x31\x4B\xB6\x5A\x95\xF9\x5F\x74\x38\x65\x42\xF5\x6D\xB8\x9B\xFB\x95\xDA\xCE\xEB\x47\xC8\x00\xFC\x15\x29\x23\x1A\xD0\xD7\x84\x4F\xBA\x0F\x03\xBE\x78\x51\x03\x8E\x89\xA5\xBF\xD0\x26\x75\xA5\x27\x2F\x97\x98\x01\x68\x33\x88\x4A\x62\x8B\x49\x8E\x18\x33\xA9\x0C\x5C\x07\x0D\x9C\xAC\x11\xD9\x39\x60\xAA\xD8\x28\x64\x19\xE6\xDE\x61\xEC\xC4\x0B\x72\x21\xED\xAA\x54\xDD\xC8\xE6\x0F\x0C\x51\x8D\xF7";
+        assert_eq!(cipher.as_bytes(), expected);
+    }
+
+    #[test]
+    fn parse_rekey_response() {
+        let testpkg = b"\x01\x00\x00\x00\x00";
+
+        let status = super::parse_rekey_response(testpkg).unwrap();
+        assert_eq!(status, 0);
+    }
+}

--- a/crates/telio-wg/Cargo.toml
+++ b/crates/telio-wg/Cargo.toml
@@ -22,6 +22,7 @@ lazy_static.workspace = true
 libc.workspace = true
 tracing.workspace = true
 mockall = { workspace = true, optional = true }
+rand.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 slog.workspace = true

--- a/crates/telio-wg/src/uapi.rs
+++ b/crates/telio-wg/src/uapi.rs
@@ -2,7 +2,7 @@
 
 use ipnetwork::{IpNetwork, IpNetworkError};
 use serde::{Deserialize, Serialize};
-use telio_crypto::{KeyDecodeError, PublicKey, SecretKey};
+use telio_crypto::{KeyDecodeError, PresharedKey, PublicKey, SecretKey};
 use telio_model::mesh::{LinkState, Node, NodeState};
 use telio_utils::{telio_log_warn, DualTarget};
 use wireguard_uapi::{get, xplatform::set};
@@ -44,6 +44,8 @@ pub struct Peer {
     pub tx_bytes: Option<u64>,
     /// Time since last handshakeor `None`, differs from WireGuard field meaning
     pub time_since_last_handshake: Option<Duration>,
+    /// The peer's preshared key
+    pub preshared_key: Option<PresharedKey>,
 }
 
 impl From<get::Peer> for Peer {
@@ -64,6 +66,11 @@ impl From<get::Peer> for Peer {
             time_since_last_handshake: Peer::calculate_time_since_last_handshake(Some(
                 item.last_handshake_time,
             )),
+            preshared_key: if item.preshared_key == [0; 32] {
+                None
+            } else {
+                Some(PresharedKey(item.preshared_key))
+            },
         }
     }
 }
@@ -81,6 +88,7 @@ impl From<set::Peer> for Peer {
                 .map(|ip| IpNetwork::new(ip.ipaddr, ip.cidr_mask))
                 .collect::<Result<Vec<IpNetwork>, _>>()
                 .unwrap_or_default(),
+            preshared_key: item.preshared_key.map(PresharedKey),
             ..Default::default()
         }
     }
@@ -136,6 +144,7 @@ impl From<&Peer> for set::Peer {
                     cidr_mask: ip.prefix(),
                 })
                 .collect(),
+            preshared_key: item.preshared_key.map(|psk| psk.0),
             ..Default::default()
         }
     }
@@ -547,6 +556,11 @@ fn parse_peer<R: Read>(
                     } else {
                         last_handshake_time = Some(sec);
                     }
+                }
+                "preshared_key" => {
+                    peer.preshared_key = Some(val.parse().map_err(|e: KeyDecodeError| {
+                        Error::ParsingError("preshared_key", e.to_string())
+                    })?);
                 }
                 "public_key" => {
                     break (

--- a/crates/telio-wg/src/wg.rs
+++ b/crates/telio-wg/src/wg.rs
@@ -799,6 +799,8 @@ pub mod tests {
 
     use lazy_static::lazy_static;
     use mockall::predicate;
+    use rand::{RngCore, SeedableRng};
+    use telio_crypto::PresharedKey;
     use telio_sockets::NativeProtector;
     use tokio::{runtime::Handle, sync::Mutex, task, time::sleep};
 
@@ -1253,10 +1255,24 @@ pub mod tests {
         } = setup().await;
         let mut iface = Interface::default();
         let pubkey = SecretKey::gen().public();
+
+        let mut rng = rand::rngs::StdRng::from_seed(Default::default());
+        let preshared1 = PresharedKey::new({
+            let mut bytes = [0u8; 32];
+            rng.fill_bytes(&mut bytes);
+            bytes
+        });
+        let preshared2 = PresharedKey::new({
+            let mut bytes = [0u8; 32];
+            rng.fill_bytes(&mut bytes);
+            bytes
+        });
+
         let mut peer = Peer {
             public_key: pubkey,
             endpoint: Some(([1, 1, 1, 1], 123).into()),
             persistent_keepalive_interval: Some(25),
+            preshared_key: Some(preshared1),
             ..Default::default()
         };
 
@@ -1282,6 +1298,7 @@ pub mod tests {
         assert_eq!(iface.clone(), wg.get_interface().await.unwrap());
 
         peer.endpoint = Some(([1, 1, 1, 1], 124).into());
+        peer.preshared_key = Some(preshared2);
 
         iface.peers.insert(pubkey, peer.clone());
 

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -147,6 +147,10 @@ pub enum Error {
     #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
     #[error("Socket pool error")]
     SocketPoolError(#[from] telio_sockets::protector::platform::Error),
+    #[error(transparent)]
+    PostQuantum(#[from] telio_pq::Error),
+    #[error("Cannot setup meshnet when the post quantum VPN is set up")]
+    MeshnetUnavailableWithPQ,
 }
 
 pub type Result<T = ()> = std::result::Result<T, Error>;
@@ -235,6 +239,8 @@ pub struct Entities {
 
     // Nurse
     nurse: Option<Arc<Nurse>>,
+
+    postquantum_wg: Option<telio_pq::Entity>,
 }
 
 impl Entities {
@@ -293,6 +299,7 @@ pub struct EventListeners {
     derp_event_subscriber: mc_chan::Rx<Box<DerpServer>>,
     endpoint_upgrade_event_subscriber: chan::Rx<UpgradeRequestChangeEvent>,
     stun_server_subscriber: chan::Rx<Option<StunServer>>,
+    post_quantum_subscriber: chan::Rx<telio_pq::Event>,
 }
 
 pub struct EventPublishers {
@@ -309,6 +316,9 @@ pub struct EventPublishers {
     endpoint_upgrade_event_subscriber: chan::Tx<UpgradeRequestChangeEvent>,
     stun_server_publisher: chan::Tx<Option<StunServer>>,
     derp_events_publisher: mc_chan::Tx<Box<DerpServer>>,
+
+    /// Passed down the PQ key rotation task
+    post_quantum_publisher: chan::Tx<telio_pq::Event>,
 }
 
 // All of the instances and state required to run local DNS resolver for NordNames
@@ -599,8 +609,7 @@ impl Device {
                 rt.connect_exit_node(&node).boxed().await?;
                 Ok(rt.entities.wireguard_interface.clone())
             })
-            .await
-            .map_err(Error::from)?;
+            .await?;
 
             // TODO: delete this as sockets are protected from within boringtun itself
             #[cfg(not(windows))]
@@ -987,6 +996,12 @@ impl Runtime {
         let wg_upgrade_sync = Chan::default();
         let stun_server_events = Chan::default();
 
+        let post_quantum = Chan::default();
+
+        let postquantum_wg = features
+            .post_quantum_vpn
+            .map(|pq_features| telio_pq::Entity::new(pq_features, socket_pool.clone()));
+
         Ok(Runtime {
             features,
             requested_state,
@@ -997,6 +1012,7 @@ impl Runtime {
                 meshnet: None,
                 socket_pool,
                 nurse,
+                postquantum_wg,
             },
             event_listeners: EventListeners {
                 wg_endpoint_publish_event_subscriber: wg_endpoint_publish_events.rx,
@@ -1004,6 +1020,7 @@ impl Runtime {
                 derp_event_subscriber: derp_events.rx,
                 endpoint_upgrade_event_subscriber: wg_upgrade_sync.rx,
                 stun_server_subscriber: stun_server_events.rx,
+                post_quantum_subscriber: post_quantum.rx,
             },
             event_publishers: EventPublishers {
                 libtelio_event_publisher: libtelio_wide_event_publisher,
@@ -1013,6 +1030,7 @@ impl Runtime {
                 endpoint_upgrade_event_subscriber: wg_upgrade_sync.tx,
                 stun_server_publisher: stun_server_events.tx,
                 derp_events_publisher: derp_events.tx,
+                post_quantum_publisher: post_quantum.tx,
             },
             polling_interval: interval_at(tokio::time::Instant::now(), Duration::from_secs(5)),
             #[cfg(test)]
@@ -1412,6 +1430,11 @@ impl Runtime {
     }
 
     async fn set_config(&mut self, config: &Option<Config>) -> Result {
+        if self.features.post_quantum_vpn.is_some() && config.is_some() {
+            // Post quantum VPN is enabled and we're trying to set up the meshnet
+            return Err(Error::MeshnetUnavailableWithPQ);
+        }
+
         if let Some(cfg) = config {
             let should_validate_keys = self.features.validate_keys.0;
             let keys_match =
@@ -1607,7 +1630,16 @@ impl Runtime {
                 self.reconfigure_dns_peer(dns, &dns.get_default_dns_servers())
                     .await?;
             }
-        } else if exit_node.endpoint.is_none() {
+        } else if let Some(addr) = exit_node.endpoint {
+            if let Some(pq_entt) = &mut self.entities.postquantum_wg {
+                pq_entt.start(
+                    self.event_publishers.post_quantum_publisher.clone(),
+                    addr,
+                    self.requested_state.device_config.private_key,
+                    exit_node.public_key,
+                );
+            }
+        } else {
             return Err(Error::EndpointNotProvided);
         }
 
@@ -1688,6 +1720,10 @@ impl Runtime {
                 &self.features,
             )
             .await?;
+        }
+
+        if let Some(pq_entt) = &mut self.entities.postquantum_wg {
+            pq_entt.stop();
         }
 
         Ok(())
@@ -1880,6 +1916,22 @@ impl TaskRuntime for Runtime {
                         |e| {
                             telio_log_warn!("WireGuard controller failure: {:?}. Ignoring", e);
                         });
+                Ok(())
+            },
+
+            Some(pq_event) = self.event_listeners.post_quantum_subscriber.recv() => {
+                telio_log_debug!("WG consolidation triggered by PQ event");
+
+                if let Some(pq_entt) = &mut self.entities.postquantum_wg {
+                    pq_entt.on_event(pq_event);
+                }
+
+                if let Err(err) = wg_controller::consolidate_wg_state(&self.requested_state, &self.entities, &self.features)
+                    .await
+                {
+                    telio_log_warn!("WireGuard controller failure: {err:?}. Ignoring");
+                }
+
                 Ok(())
             },
 

--- a/src/libtelio.udl
+++ b/src/libtelio.udl
@@ -371,6 +371,8 @@ dictionary Features {
     u64? flush_events_on_stop_timeout_seconds;
     /// No-link detection mechanism
     FeatureLinkDetection? link_detection;
+    /// Post quantum VPN tunnel configuration
+    FeaturePostQuantumVPN? post_quantum_vpn;
 };
 
 /// Configurable features for Wireguard peers
@@ -484,6 +486,15 @@ dictionary FeatureLinkDetection {
     /// Configurable rtt in seconds
     u64 rtt_seconds;
 };
+
+/// Turns on post quantum VPN tunnel
+dictionary FeaturePostQuantumVPN {
+    /// Initial handshake retry interval in seconds
+    u32 handshake_retry_interval_s;
+    /// Rekey interval in seconds
+    u32 rekey_interval_s;
+};
+
 
 /// Rust representation of [meshnet map]
 /// A network map of all the Peers and the servers


### PR DESCRIPTION
It turned out that the problem was not with the PQ implementation but with the usage of sccahce in CI/CD which breaks `libtelio.a` in case it's built with a native C static library.

### Problem
The `libteliio.a` static lib failed to link with with executable on Mac and Linux. The problem is solved by now in the build repo.

### Solution
Revert the revert


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
