### PR TITLE
[LLT-4855] Create connectivity events aggregation data model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4283,6 +4283,7 @@ dependencies = [
  "histogram",
  "md5",
  "nat-detect",
+ "parking_lot",
  "protobuf-codegen-pure",
  "rand",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4284,7 +4284,6 @@ dependencies = [
  "histogram",
  "md5",
  "nat-detect",
- "parking_lot",
  "protobuf-codegen-pure",
  "rand",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4279,6 +4279,7 @@ dependencies = [
  "async-trait",
  "bitflags 1.3.2",
  "crypto_box",
+ "csv",
  "futures",
  "histogram",
  "md5",

--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@
 * LLT-4916: Allow any case nicknames
 * LLT-4406: Implement error handling for proxy egress
 * LLT-4948: Change missed tick behavior from burst to delay
+* LLT-4855: Add Aggregator struct for connectivity events gathering
 
 <br>
 

--- a/crates/telio-model/src/api_config.rs
+++ b/crates/telio-model/src/api_config.rs
@@ -106,19 +106,19 @@ pub struct FeatureNurse {
     pub enable_nat_type_collection: Option<bool>,
     /// Enable/disable Relay connection data
     #[serde(default = "FeatureNurse::get_default_enable_relay_conn_data")]
-    pub enable_relay_conn_data: bool,
+    pub enable_relay_conn_data: Option<bool>,
     /// Enable/disable NAT-traversal connections data
     #[serde(default = "FeatureNurse::get_default_enable_nat_traversal_conn_data")]
-    pub enable_nat_traversal_conn_data: bool,
+    pub enable_nat_traversal_conn_data: Option<bool>,
 }
 
 impl FeatureNurse {
-    fn get_default_enable_relay_conn_data() -> bool {
-        true
+    fn get_default_enable_relay_conn_data() -> Option<bool> {
+        Some(true)
     }
 
-    fn get_default_enable_nat_traversal_conn_data() -> bool {
-        true
+    fn get_default_enable_nat_traversal_conn_data() -> Option<bool> {
+        Some(true)
     }
 }
 
@@ -555,8 +555,8 @@ mod tests {
             initial_heartbeat_interval: None,
             qos: None,
             enable_nat_type_collection: None,
-            enable_relay_conn_data: true,
-            enable_nat_traversal_conn_data: true,
+            enable_relay_conn_data: Some(true),
+            enable_nat_traversal_conn_data: Some(true),
         }),
         lana: Some(FeatureLana {
             event_path: "path/to/some/event/data".to_string(),
@@ -613,8 +613,8 @@ mod tests {
             initial_heartbeat_interval: None,
             qos: None,
             enable_nat_type_collection: None,
-            enable_relay_conn_data: true,
-            enable_nat_traversal_conn_data: true,
+            enable_relay_conn_data: Some(true),
+            enable_nat_traversal_conn_data: Some(true),
         }),
         lana: Some(FeatureLana {
             event_path: "path/to/some/event/data".to_string(),
@@ -809,8 +809,8 @@ mod tests {
                     buckets: Some(5),
                 }),
                 enable_nat_type_collection: None,
-                enable_relay_conn_data: true,
-                enable_nat_traversal_conn_data: true,
+                enable_relay_conn_data: Some(true),
+                enable_nat_traversal_conn_data: Some(true),
             }),
             lana: None,
             paths: None,
@@ -843,8 +843,8 @@ mod tests {
                     buckets: None,
                 }),
                 enable_nat_type_collection: None,
-                enable_relay_conn_data: true,
-                enable_nat_traversal_conn_data: true,
+                enable_relay_conn_data: Some(true),
+                enable_nat_traversal_conn_data: Some(true),
             }),
             lana: None,
             paths: None,
@@ -872,8 +872,8 @@ mod tests {
                 initial_heartbeat_interval: None,
                 qos: None,
                 enable_nat_type_collection: None,
-                enable_relay_conn_data: false,
-                enable_nat_traversal_conn_data: false,
+                enable_relay_conn_data: Some(false),
+                enable_nat_traversal_conn_data: Some(false),
             }),
             lana: None,
             paths: None,

--- a/crates/telio-model/src/api_config.rs
+++ b/crates/telio-model/src/api_config.rs
@@ -104,6 +104,22 @@ pub struct FeatureNurse {
     pub qos: Option<FeatureQoS>,
     /// Enable/disable collecting nat type
     pub enable_nat_type_collection: Option<bool>,
+    /// Enable/disable Relay connection data
+    #[serde(default = "FeatureNurse::get_default_enable_relay_conn_data")]
+    pub enable_relay_conn_data: bool,
+    /// Enable/disable NAT-traversal connections data
+    #[serde(default = "FeatureNurse::get_default_enable_nat_traversal_conn_data")]
+    pub enable_nat_traversal_conn_data: bool,
+}
+
+impl FeatureNurse {
+    fn get_default_enable_relay_conn_data() -> bool {
+        true
+    }
+
+    fn get_default_enable_nat_traversal_conn_data() -> bool {
+        true
+    }
 }
 
 /// Configurable features for Lana module
@@ -539,6 +555,8 @@ mod tests {
             initial_heartbeat_interval: None,
             qos: None,
             enable_nat_type_collection: None,
+            enable_relay_conn_data: true,
+            enable_nat_traversal_conn_data: true,
         }),
         lana: Some(FeatureLana {
             event_path: "path/to/some/event/data".to_string(),
@@ -595,6 +613,8 @@ mod tests {
             initial_heartbeat_interval: None,
             qos: None,
             enable_nat_type_collection: None,
+            enable_relay_conn_data: true,
+            enable_nat_traversal_conn_data: true,
         }),
         lana: Some(FeatureLana {
             event_path: "path/to/some/event/data".to_string(),
@@ -770,7 +790,9 @@ mod tests {
         let no_qos_json = r#"
         {
             "nurse": {
-                "fingerprint": "fingerprint_test"
+                "fingerprint": "fingerprint_test",
+                "enable_relay_conn_data": false,
+                "enable_nat_traversal_conn_data": false
             }
         }"#;
 
@@ -787,6 +809,8 @@ mod tests {
                     buckets: Some(5),
                 }),
                 enable_nat_type_collection: None,
+                enable_relay_conn_data: true,
+                enable_nat_traversal_conn_data: true,
             }),
             lana: None,
             paths: None,
@@ -819,6 +843,8 @@ mod tests {
                     buckets: None,
                 }),
                 enable_nat_type_collection: None,
+                enable_relay_conn_data: true,
+                enable_nat_traversal_conn_data: true,
             }),
             lana: None,
             paths: None,
@@ -846,6 +872,8 @@ mod tests {
                 initial_heartbeat_interval: None,
                 qos: None,
                 enable_nat_type_collection: None,
+                enable_relay_conn_data: false,
+                enable_nat_traversal_conn_data: false,
             }),
             lana: None,
             paths: None,

--- a/crates/telio-nurse/Cargo.toml
+++ b/crates/telio-nurse/Cargo.toml
@@ -16,6 +16,7 @@ crypto_box.workspace = true
 futures.workspace = true
 tracing.workspace = true
 nat-detect.workspace = true
+parking_lot.workspace = true
 rand.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/telio-nurse/Cargo.toml
+++ b/crates/telio-nurse/Cargo.toml
@@ -38,6 +38,8 @@ telio-utils.workspace = true
 telio-wg.workspace = true
 
 [dev-dependencies]
+csv = "1.1"
+
 telio-sockets.workspace = true
 telio-wg = { workspace = true, features = ["mockall"] }
 tokio = { workspace = true, features = ["net", "sync", "test-util"] }

--- a/crates/telio-nurse/Cargo.toml
+++ b/crates/telio-nurse/Cargo.toml
@@ -39,6 +39,8 @@ telio-wg.workspace = true
 
 [dev-dependencies]
 telio-sockets.workspace = true
+telio-wg = { workspace = true, features = ["mockall"] }
+tokio = { workspace = true, features = ["net", "sync", "test-util"] }
 
 [build-dependencies]
 protobuf-codegen-pure.workspace = true

--- a/crates/telio-nurse/Cargo.toml
+++ b/crates/telio-nurse/Cargo.toml
@@ -16,7 +16,6 @@ crypto_box.workspace = true
 futures.workspace = true
 tracing.workspace = true
 nat-detect.workspace = true
-parking_lot.workspace = true
 rand.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/telio-nurse/src/aggregator.rs
+++ b/crates/telio-nurse/src/aggregator.rs
@@ -1,0 +1,235 @@
+use std::{
+    collections::HashSet,
+    time::{Duration, Instant},
+};
+
+use parking_lot::RwLock;
+use serde::{ser::SerializeTuple, Serialize, Serializer};
+
+use telio_crypto::PublicKey;
+use telio_model::HashMap;
+use telio_utils::telio_log_warn;
+use telio_wg::{uapi::AnalyticsEvent, WireGuard};
+
+// Possible endpoint connection types
+// Their combinations give us strategies number to 15
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub enum EndpointType {
+    Relay = 0,
+    Local = 1,
+    Stun = 2,
+    UPnP = 3,
+}
+
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, Serialize)]
+pub enum RelayConnectionState {
+    Connecting = 16,
+    Connected = 17,
+}
+
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, Serialize)]
+pub struct RelayConnectionData {
+    state: RelayConnectionState,
+    reason: RelayConnectionChangeReason,
+}
+
+// Possible disconnection reasons
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, Serialize)]
+pub enum RelayConnectionChangeReason {
+    // 1XX reason numbers for configuration changes
+    DisabledByUser = 101,
+
+    // 2XX reason numbers for network problems
+    ConnectionTimeout = 201,
+    ConnectionTerminatedByServer = 202,
+    NetworkError = 203,
+}
+
+// Possible connectivity state changes
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub enum ConnectionState {
+    Relay(RelayConnectionState, RelayConnectionChangeReason),
+    Peer(EndpointType, EndpointType),
+}
+
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub struct PeerConnectionData {
+    initiator_ep_type: EndpointType,
+    reciever_ep_type: EndpointType,
+    rx_bytes: u64,
+    tx_bytes: u64,
+}
+
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub enum ConnectionData {
+    Relay(RelayConnectionData),
+    Peer(PeerConnectionData),
+}
+
+impl Serialize for ConnectionData {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            ConnectionData::Relay(conn_data) => {
+                let mut seq = serializer.serialize_tuple(2)?;
+                seq.serialize_element(&(conn_data.state as u64))?;
+                seq.serialize_element(&(conn_data.reason as u64))?;
+                seq.end()
+            }
+            ConnectionData::Peer(conn_data) => {
+                let strategy_id =
+                    (conn_data.initiator_ep_type as u64) * 4 + (conn_data.reciever_ep_type as u64);
+                let mut seq = serializer.serialize_tuple(3)?;
+                seq.serialize_element(&strategy_id)?;
+                seq.serialize_element(&(conn_data.rx_bytes as u64))?;
+                seq.serialize_element(&(conn_data.tx_bytes as u64))?;
+                seq.end()
+            }
+        }
+    }
+}
+
+// Event containing info about changed connection quality to a certain peer
+#[derive(Copy, Clone, Debug)]
+pub struct ExtAnalyticsEvent {
+    event: AnalyticsEvent,
+    state: ConnectionState,
+}
+
+// Ready to send data about some period of the
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub struct ConnectionSegmentData {
+    node: PublicKey,
+    start: Instant, // to ensure the segments are unique
+    length_in_ms: u128,
+    connection_data: ConnectionData,
+}
+
+// A container to store the connectivity data for our meshnet peers
+pub struct ConnectivityDataAggregator<W: WireGuard> {
+    current_peers_events: RwLock<HashMap<PublicKey, ExtAnalyticsEvent>>,
+    unacknowledged_segments: RwLock<HashSet<ConnectionSegmentData>>,
+
+    wg_interface: W,
+}
+
+impl<W: WireGuard> ConnectivityDataAggregator<W> {
+    // Create a new DataConnectivityAggregator instance
+    pub fn new(wg_interface: W) -> ConnectivityDataAggregator<W> {
+        ConnectivityDataAggregator {
+            current_peers_events: parking_lot::RwLock::new(HashMap::new()),
+            unacknowledged_segments: parking_lot::RwLock::new(HashSet::new()),
+            wg_interface,
+        }
+    }
+
+    pub fn add_state_change(&mut self, event: ExtAnalyticsEvent) {
+        let mut events_guard = self.current_peers_events.write();
+
+        match events_guard.entry(event.event.public_key) {
+            std::collections::hash_map::Entry::Occupied(mut entry) => {
+                let old_event = entry.get();
+
+                let connection_data = match old_event.state {
+                    ConnectionState::Relay(state, reason) => {
+                        ConnectionData::Relay(RelayConnectionData { state, reason })
+                    }
+                    ConnectionState::Peer(ep1, ep2) => ConnectionData::Peer(PeerConnectionData {
+                        initiator_ep_type: ep1,
+                        reciever_ep_type: ep2,
+                        rx_bytes: event.event.rx_bytes - old_event.event.rx_bytes,
+                        tx_bytes: event.event.tx_bytes - old_event.event.tx_bytes,
+                    }),
+                };
+
+                let length_in_ms = (event.event.timestamp - old_event.event.timestamp).as_millis();
+
+                // Just create a new segment here
+                self.unacknowledged_segments
+                    .write()
+                    .insert(ConnectionSegmentData {
+                        node: event.event.public_key,
+                        start: old_event.event.timestamp,
+                        length_in_ms,
+                        connection_data,
+                    });
+
+                entry.insert(event);
+            }
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                entry.insert(event);
+            }
+        };
+    }
+
+    pub fn collect_unacknowledged_segments(&self) -> Vec<ConnectionSegmentData> {
+        self.unacknowledged_segments
+            .read()
+            .clone()
+            .into_iter()
+            .collect()
+    }
+
+    async fn acknowledge_segments_transmission<T>(&mut self, info_key_set: T)
+    where
+        T: IntoIterator<Item = ConnectionSegmentData>,
+    {
+        if let Ok(wg_peers) = self.wg_interface.get_interface().await.map(|wgi| wgi.peers) {
+            let current_timestamp = Instant::now();
+
+            for peer_event in self.current_peers_events.write().values_mut() {
+                if current_timestamp - peer_event.event.timestamp
+                    > Duration::from_secs(60 * 60 * 24)
+                {
+                    match peer_event.state {
+                        ConnectionState::Relay(state, reason) => {
+                            Some(ConnectionData::Relay(RelayConnectionData { state, reason }))
+                        }
+                        ConnectionState::Peer(initiator_ep_type, reciever_ep_type) => wg_peers
+                            .get(&peer_event.event.public_key)
+                            .and_then(|wg_peer| wg_peer.rx_bytes.zip(wg_peer.tx_bytes))
+                            .map(|(rx_bytes, tx_bytes)| {
+                                peer_event.event.rx_bytes = rx_bytes;
+                                peer_event.event.tx_bytes = tx_bytes;
+                                ConnectionData::Peer(PeerConnectionData {
+                                    initiator_ep_type,
+                                    reciever_ep_type,
+                                    rx_bytes: rx_bytes - peer_event.event.rx_bytes,
+                                    tx_bytes: tx_bytes - peer_event.event.tx_bytes,
+                                })
+                            }),
+                    }
+                    .map_or_else(
+                        || {
+                            telio_log_warn!("Unable to get transfer data for peer");
+                        },
+                        |connection_data| {
+                            let length_in_ms =
+                                (current_timestamp - peer_event.event.timestamp).as_millis();
+                            self.unacknowledged_segments
+                                .write()
+                                .insert(ConnectionSegmentData {
+                                    node: peer_event.event.public_key,
+                                    start: peer_event.event.timestamp,
+                                    length_in_ms,
+                                    connection_data,
+                                });
+                            peer_event.event.timestamp = current_timestamp;
+                        },
+                    );
+                }
+            }
+        } else {
+            telio_log_warn!("Getting wireguard interfaces failed");
+        }
+
+        let mut storage_guard = self.unacknowledged_segments.write();
+        info_key_set.into_iter().for_each(|segment| {
+            if !storage_guard.remove(&segment) {
+                telio_log_warn!("Connectivity event for the given peer and timestamp not found");
+            }
+        })
+    }
+}

--- a/crates/telio-nurse/src/aggregator.rs
+++ b/crates/telio-nurse/src/aggregator.rs
@@ -1,30 +1,59 @@
-use std::{
-    collections::HashSet,
-    time::{Duration, Instant},
-};
+use std::{collections::HashSet, time::Duration};
+
+use tokio::time::Instant;
 
 use parking_lot::RwLock;
 use serde::{ser::SerializeTuple, Serialize, Serializer};
 
 use telio_crypto::PublicKey;
-use telio_model::{api_config::FeatureNurse, HashMap};
+use telio_model::{
+    api_config::{EndpointProvider, FeatureNurse},
+    HashMap,
+};
 use telio_utils::telio_log_warn;
-use telio_wg::{uapi::AnalyticsEvent, WireGuard};
+use telio_wg::{
+    uapi::{AnalyticsEvent, PeerState},
+    WireGuard,
+};
 
 // Possible endpoint connection types
 // Their combinations give us strategies number to 15
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
 pub enum EndpointType {
+    #[allow(dead_code)]
     Relay = 0,
     Local = 1,
     Stun = 2,
     UPnP = 3,
 }
 
+impl From<EndpointProvider> for EndpointType {
+    fn from(value: EndpointProvider) -> Self {
+        match value {
+            EndpointProvider::Local => EndpointType::Local,
+            EndpointProvider::Stun => EndpointType::Stun,
+            EndpointProvider::Upnp => EndpointType::UPnP,
+        }
+    }
+}
+
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, Serialize)]
 pub enum RelayConnectionState {
     Connecting = 16,
     Connected = 17,
+}
+
+impl From<PeerState> for RelayConnectionState {
+    fn from(value: PeerState) -> Self {
+        if let PeerState::Connected = value {
+            RelayConnectionState::Connected
+        } else {
+            if let PeerState::Disconnected = value {
+                telio_log_warn!("Got disconnected state for Relay server");
+            }
+            RelayConnectionState::Connecting
+        }
+    }
 }
 
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, Serialize)]
@@ -35,9 +64,11 @@ pub struct RelayConnectionData {
 
 // Possible disconnection reasons
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, Serialize)]
+#[allow(dead_code)]
 pub enum RelayConnectionChangeReason {
     // 1XX reason numbers for configuration changes
-    DisabledByUser = 101,
+    ConfigurationChange = 101,
+    DisabledByUser = 102,
 
     // 2XX reason numbers for network problems
     ConnectionTimeout = 201,
@@ -47,8 +78,9 @@ pub enum RelayConnectionChangeReason {
 
 // Possible connectivity state changes
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+#[allow(dead_code)]
 pub enum ConnectionState {
-    Relay(RelayConnectionState, RelayConnectionChangeReason),
+    Relay(RelayConnectionChangeReason),
     Peer(EndpointType, EndpointType),
 }
 
@@ -61,6 +93,7 @@ pub struct PeerConnectionData {
 }
 
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+#[allow(dead_code)]
 pub enum ConnectionData {
     Relay(RelayConnectionData),
     Peer(PeerConnectionData),
@@ -91,35 +124,19 @@ impl Serialize for ConnectionData {
     }
 }
 
-// Event containing info about changed connection quality to a certain peer
-#[derive(Copy, Clone, Debug)]
-pub struct ExtAnalyticsEvent {
-    event: AnalyticsEvent,
-    state: ConnectionState,
-}
-
-impl ExtAnalyticsEvent {
-    pub fn is_relay(&self) -> bool {
-        matches!(self.state, ConnectionState::Relay(..))
-    }
-
-    pub fn is_nat_traversal(&self) -> bool {
-        matches!(self.state, ConnectionState::Peer(..))
-    }
-}
-
 // Ready to send data about some period of the
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
 pub struct ConnectionSegmentData {
     node: PublicKey,
     start: Instant, // to ensure the segments are unique
-    length_in_ms: u128,
+    length: Duration,
     connection_data: ConnectionData,
 }
 
 // A container to store the connectivity data for our meshnet peers
+#[allow(dead_code)]
 pub struct ConnectivityDataAggregator<W: WireGuard> {
-    current_peers_events: RwLock<HashMap<PublicKey, ExtAnalyticsEvent>>,
+    current_events: RwLock<HashMap<PublicKey, (AnalyticsEvent, ConnectionState)>>,
     unacknowledged_segments: RwLock<HashSet<ConnectionSegmentData>>,
 
     aggregate_relay_events: bool,
@@ -130,9 +147,10 @@ pub struct ConnectivityDataAggregator<W: WireGuard> {
 
 impl<W: WireGuard> ConnectivityDataAggregator<W> {
     // Create a new DataConnectivityAggregator instance
+    #[allow(dead_code)]
     pub fn new(nurse_features: &FeatureNurse, wg_interface: W) -> ConnectivityDataAggregator<W> {
         ConnectivityDataAggregator {
-            current_peers_events: parking_lot::RwLock::new(HashMap::new()),
+            current_events: parking_lot::RwLock::new(HashMap::new()),
             unacknowledged_segments: parking_lot::RwLock::new(HashSet::new()),
             aggregate_relay_events: nurse_features.enable_relay_conn_data,
             aggregate_nat_traversal_events: nurse_features.enable_nat_traversal_conn_data,
@@ -140,85 +158,159 @@ impl<W: WireGuard> ConnectivityDataAggregator<W> {
         }
     }
 
-    pub fn add_state_change(&mut self, event: ExtAnalyticsEvent) {
-        if (event.is_relay() && !self.aggregate_relay_events)
-            || (event.is_nat_traversal() && !self.aggregate_nat_traversal_events)
-        {
+    #[allow(dead_code)]
+    pub fn change_peer_state_direct(
+        &mut self,
+        event: AnalyticsEvent,
+        initiator_ep: EndpointProvider,
+        responder_ep: EndpointProvider,
+    ) {
+        self.change_peer_state_common(event, initiator_ep.into(), responder_ep.into())
+    }
+
+    #[allow(dead_code)]
+    pub fn change_peer_state_relayed(&mut self, event: AnalyticsEvent) {
+        self.change_peer_state_common(event, EndpointType::Relay, EndpointType::Relay)
+    }
+
+    fn change_peer_state_common(
+        &mut self,
+        event: AnalyticsEvent,
+        initiator_ep: EndpointType,
+        responder_ep: EndpointType,
+    ) {
+        if !self.aggregate_nat_traversal_events {
             return;
         }
 
-        let mut events_guard = self.current_peers_events.write();
-
-        match events_guard.entry(event.event.public_key) {
+        match self.current_events.write().entry(event.public_key) {
             std::collections::hash_map::Entry::Occupied(mut entry) => {
-                let old_event = entry.get();
+                let (old_event, old_state) = entry.get();
 
-                let connection_data = match old_event.state {
-                    ConnectionState::Relay(state, reason) => {
-                        ConnectionData::Relay(RelayConnectionData { state, reason })
+                let connection_data = match old_state {
+                    ConnectionState::Relay(_) => {
+                        telio_log_warn!("Peer event for the relay server pubkey - discarding");
+                        return;
                     }
-                    ConnectionState::Peer(ep1, ep2) => ConnectionData::Peer(PeerConnectionData {
-                        initiator_ep_type: ep1,
-                        reciever_ep_type: ep2,
-                        rx_bytes: event.event.rx_bytes - old_event.event.rx_bytes,
-                        tx_bytes: event.event.tx_bytes - old_event.event.tx_bytes,
-                    }),
+                    ConnectionState::Peer(ep1, ep2) => {
+                        if old_event.peer_state == event.peer_state
+                            && *ep1 == initiator_ep
+                            && *ep2 == responder_ep
+                        {
+                            // Peers state remains unchanged - skipping the segment addition
+                            return;
+                        }
+                        ConnectionData::Peer(PeerConnectionData {
+                            initiator_ep_type: *ep1,
+                            reciever_ep_type: *ep2,
+                            rx_bytes: event.rx_bytes - old_event.rx_bytes,
+                            tx_bytes: event.tx_bytes - old_event.tx_bytes,
+                        })
+                    }
                 };
-
-                let length_in_ms = (event.event.timestamp - old_event.event.timestamp).as_millis();
 
                 // Just create a new segment here
                 self.unacknowledged_segments
                     .write()
                     .insert(ConnectionSegmentData {
-                        node: event.event.public_key,
-                        start: old_event.event.timestamp,
-                        length_in_ms,
+                        node: event.public_key,
+                        start: old_event.timestamp.into(),
+                        length: event.timestamp - old_event.timestamp,
                         connection_data,
                     });
 
-                entry.insert(event);
+                if event.peer_state == PeerState::Connected {
+                    entry.insert((event, ConnectionState::Peer(initiator_ep, responder_ep)));
+                } else {
+                    entry.remove();
+                }
             }
             std::collections::hash_map::Entry::Vacant(entry) => {
-                entry.insert(event);
+                if event.peer_state == PeerState::Connected {
+                    entry.insert((event, ConnectionState::Peer(initiator_ep, responder_ep)));
+                }
             }
         };
     }
 
-    pub fn collect_unacknowledged_segments(&self) -> Vec<ConnectionSegmentData> {
-        self.unacknowledged_segments
-            .read()
-            .clone()
-            .into_iter()
-            .collect()
+    #[allow(dead_code)]
+    pub fn change_relay_state(
+        &mut self,
+        event: AnalyticsEvent,
+        reason: RelayConnectionChangeReason,
+    ) {
+        if !self.aggregate_relay_events {
+            return;
+        }
+
+        match self.current_events.write().entry(event.public_key) {
+            std::collections::hash_map::Entry::Occupied(mut entry) => {
+                let (old_event, old_state) = entry.get();
+
+                let segment_connection_data = match old_state {
+                    ConnectionState::Relay(reason) => {
+                        if old_event.peer_state == event.peer_state {
+                            // The state remains unchanged
+                            return;
+                        }
+                        ConnectionData::Relay(RelayConnectionData {
+                            state: old_event.peer_state.into(),
+                            reason: *reason,
+                        })
+                    }
+                    ConnectionState::Peer(_, _) => {
+                        telio_log_warn!("Relay event for the meshnet node pubkey - discarding");
+                        return;
+                    }
+                };
+
+                // Just create a new segment here
+                self.unacknowledged_segments
+                    .write()
+                    .insert(ConnectionSegmentData {
+                        node: event.public_key,
+                        start: old_event.timestamp.into(),
+                        length: event.timestamp - old_event.timestamp,
+                        connection_data: segment_connection_data,
+                    });
+
+                entry.insert((event, ConnectionState::Relay(reason)));
+            }
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                entry.insert((event, ConnectionState::Relay(reason)));
+            }
+        };
     }
 
-    async fn acknowledge_segments_transmission<T>(&mut self, info_key_set: T)
-    where
-        T: IntoIterator<Item = ConnectionSegmentData>,
-    {
+    #[allow(dead_code)]
+    pub async fn collect_unacknowledged_segments(&self) -> Vec<ConnectionSegmentData> {
         if let Ok(wg_peers) = self.wg_interface.get_interface().await.map(|wgi| wgi.peers) {
             let current_timestamp = Instant::now();
 
-            for peer_event in self.current_peers_events.write().values_mut() {
-                if current_timestamp - peer_event.event.timestamp
+            for (peer_event, peer_state) in self.current_events.write().values_mut() {
+                if current_timestamp - Instant::from_std(peer_event.timestamp)
                     > Duration::from_secs(60 * 60 * 24)
                 {
-                    match peer_event.state {
-                        ConnectionState::Relay(state, reason) => {
-                            Some(ConnectionData::Relay(RelayConnectionData { state, reason }))
+                    match peer_state {
+                        ConnectionState::Relay(reason) => {
+                            Some(ConnectionData::Relay(RelayConnectionData {
+                                state: peer_event.peer_state.into(),
+                                reason: *reason,
+                            }))
                         }
                         ConnectionState::Peer(initiator_ep_type, reciever_ep_type) => wg_peers
-                            .get(&peer_event.event.public_key)
+                            .get(&peer_event.public_key)
                             .and_then(|wg_peer| wg_peer.rx_bytes.zip(wg_peer.tx_bytes))
                             .map(|(rx_bytes, tx_bytes)| {
-                                peer_event.event.rx_bytes = rx_bytes;
-                                peer_event.event.tx_bytes = tx_bytes;
+                                let d_rx_bytes = rx_bytes - peer_event.rx_bytes;
+                                let d_tx_bytes = tx_bytes - peer_event.tx_bytes;
+                                peer_event.rx_bytes = rx_bytes;
+                                peer_event.tx_bytes = tx_bytes;
                                 ConnectionData::Peer(PeerConnectionData {
-                                    initiator_ep_type,
-                                    reciever_ep_type,
-                                    rx_bytes: rx_bytes - peer_event.event.rx_bytes,
-                                    tx_bytes: tx_bytes - peer_event.event.tx_bytes,
+                                    initiator_ep_type: *initiator_ep_type,
+                                    reciever_ep_type: *reciever_ep_type,
+                                    rx_bytes: d_rx_bytes,
+                                    tx_bytes: d_tx_bytes,
                                 })
                             }),
                     }
@@ -227,17 +319,16 @@ impl<W: WireGuard> ConnectivityDataAggregator<W> {
                             telio_log_warn!("Unable to get transfer data for peer");
                         },
                         |connection_data| {
-                            let length_in_ms =
-                                (current_timestamp - peer_event.event.timestamp).as_millis();
                             self.unacknowledged_segments
                                 .write()
                                 .insert(ConnectionSegmentData {
-                                    node: peer_event.event.public_key,
-                                    start: peer_event.event.timestamp,
-                                    length_in_ms,
+                                    node: peer_event.public_key,
+                                    start: peer_event.timestamp.into(),
+                                    length: current_timestamp
+                                        - Instant::from_std(peer_event.timestamp),
                                     connection_data,
                                 });
-                            peer_event.event.timestamp = current_timestamp;
+                            peer_event.timestamp = current_timestamp.into();
                         },
                     );
                 }
@@ -246,11 +337,353 @@ impl<W: WireGuard> ConnectivityDataAggregator<W> {
             telio_log_warn!("Getting wireguard interfaces failed");
         }
 
+        self.unacknowledged_segments
+            .read()
+            .clone()
+            .into_iter()
+            .collect()
+    }
+
+    #[allow(dead_code)]
+    pub fn acknowledge_segments_transmission<T>(&mut self, segment_set: T)
+    where
+        T: IntoIterator<Item = ConnectionSegmentData>,
+    {
         let mut storage_guard = self.unacknowledged_segments.write();
-        info_key_set.into_iter().for_each(|segment| {
+        segment_set.into_iter().for_each(|segment| {
             if !storage_guard.remove(&segment) {
                 telio_log_warn!("Connectivity event for the given peer and timestamp not found");
             }
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::Ipv4Addr;
+
+    use telio_utils::DualTarget;
+    use telio_wg::{
+        uapi::{Interface, Peer, PeerState},
+        MockWireGuard,
+    };
+    use tokio::time;
+
+    use super::*;
+
+    async fn create_aggregator(
+        enable_relay_conn_data: bool,
+        enable_nat_traversal_conn_data: bool,
+        wg_interface: MockWireGuard,
+    ) -> ConnectivityDataAggregator<MockWireGuard> {
+        let nurse_features = FeatureNurse {
+            fingerprint: String::from("fingerprint_test"),
+            heartbeat_interval: None,
+            initial_heartbeat_interval: None,
+            qos: None,
+            enable_nat_type_collection: None,
+            enable_relay_conn_data,
+            enable_nat_traversal_conn_data,
+        };
+
+        ConnectivityDataAggregator::new(&nurse_features, wg_interface)
+    }
+
+    fn create_basic_event(n: u8) -> AnalyticsEvent {
+        AnalyticsEvent {
+            public_key: PublicKey(*b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+            endpoint: DualTarget::new((Some(Ipv4Addr::from([n, n, n, n])), None)).unwrap(), // Whatever
+            tx_bytes: 0, // We don't need them for Relay event
+            rx_bytes: 0,
+            peer_state: PeerState::Connected, // This should be the same as in the
+            timestamp: Instant::now().into(),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_aggregator_basic_scenario_relay() {
+        let mut wg_interface = MockWireGuard::new();
+        wg_interface
+            .expect_get_interface()
+            .returning(|| Ok(Default::default()));
+        let mut aggregator = create_aggregator(true, false, wg_interface).await;
+
+        // Initial event
+        let mut current_relay_event = create_basic_event(1);
+        let segment_start = current_relay_event.timestamp;
+        aggregator.change_relay_state(
+            current_relay_event,
+            RelayConnectionChangeReason::ConfigurationChange,
+        );
+
+        // And after 60 seconds some disconnect due to network error
+        current_relay_event.timestamp += Duration::from_secs(60);
+        current_relay_event.peer_state = PeerState::Connecting;
+        aggregator.change_relay_state(
+            current_relay_event,
+            RelayConnectionChangeReason::NetworkError,
+        );
+
+        let segments = aggregator.collect_unacknowledged_segments().await;
+        assert_eq!(segments.len(), 1);
+        assert_eq!(
+            segments[0],
+            ConnectionSegmentData {
+                node: current_relay_event.public_key,
+                start: segment_start.into(),
+                length: Duration::from_secs(60),
+                connection_data: ConnectionData::Relay(RelayConnectionData {
+                    state: RelayConnectionState::Connected,
+                    reason: RelayConnectionChangeReason::ConfigurationChange
+                })
+            }
+        );
+
+        aggregator.acknowledge_segments_transmission(segments);
+
+        let segments = aggregator.collect_unacknowledged_segments().await;
+        assert_eq!(segments.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_aggregator_basic_scenario_peer_relayed() {
+        let mut wg_interface = MockWireGuard::new();
+        wg_interface
+            .expect_get_interface()
+            .returning(|| Ok(Default::default()));
+        let mut aggregator = create_aggregator(false, true, wg_interface).await;
+
+        // Initial event
+        let mut current_peer_event = create_basic_event(1);
+        let segment_start = current_peer_event.timestamp;
+        aggregator.change_peer_state_relayed(current_peer_event);
+
+        // And after 60 seconds some disconnect due to network error
+        current_peer_event.timestamp += Duration::from_secs(60);
+        current_peer_event.peer_state = PeerState::Connecting;
+        current_peer_event.rx_bytes += 1000;
+        current_peer_event.tx_bytes += 2000;
+        aggregator.change_peer_state_relayed(current_peer_event);
+
+        let segments = aggregator.collect_unacknowledged_segments().await;
+        assert_eq!(segments.len(), 1);
+        assert_eq!(
+            segments[0],
+            ConnectionSegmentData {
+                node: current_peer_event.public_key,
+                start: segment_start.into(),
+                length: Duration::from_secs(60),
+                connection_data: ConnectionData::Peer(PeerConnectionData {
+                    initiator_ep_type: EndpointType::Relay,
+                    reciever_ep_type: EndpointType::Relay,
+                    rx_bytes: 1000,
+                    tx_bytes: 2000
+                })
+            }
+        );
+
+        aggregator.acknowledge_segments_transmission(segments);
+
+        let segments = aggregator.collect_unacknowledged_segments().await;
+        assert_eq!(segments.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_aggregator_basic_scenario_peer_direct() {
+        let mut wg_interface = MockWireGuard::new();
+        wg_interface
+            .expect_get_interface()
+            .returning(|| Ok(Default::default()));
+        let mut aggregator = create_aggregator(false, true, wg_interface).await;
+
+        // Initial event
+        let mut current_peer_event = create_basic_event(1);
+        let segment_start = current_peer_event.timestamp;
+        aggregator.change_peer_state_direct(
+            current_peer_event,
+            EndpointProvider::Upnp,
+            EndpointProvider::Local,
+        );
+
+        // And after 60 seconds some disconnect due to network error
+        current_peer_event.timestamp += Duration::from_secs(60);
+        current_peer_event.rx_bytes += 1000;
+        current_peer_event.tx_bytes += 2000;
+        aggregator.change_peer_state_relayed(current_peer_event);
+
+        let segments = aggregator.collect_unacknowledged_segments().await;
+        assert_eq!(segments.len(), 1);
+        assert_eq!(
+            segments[0],
+            ConnectionSegmentData {
+                node: current_peer_event.public_key,
+                start: segment_start.into(),
+                length: Duration::from_secs(60),
+                connection_data: ConnectionData::Peer(PeerConnectionData {
+                    initiator_ep_type: EndpointType::UPnP,
+                    reciever_ep_type: EndpointType::Local,
+                    rx_bytes: 1000,
+                    tx_bytes: 2000
+                })
+            }
+        );
+
+        aggregator.acknowledge_segments_transmission(segments);
+
+        let segments = aggregator.collect_unacknowledged_segments().await;
+        assert_eq!(segments.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_aggregator_disabled() {
+        let mut wg_interface = MockWireGuard::new();
+        wg_interface
+            .expect_get_interface()
+            .returning(|| Ok(Default::default()));
+        let mut aggregator = create_aggregator(false, false, wg_interface).await;
+
+        // Initial event
+        let mut current_peer_event = create_basic_event(1);
+        aggregator.change_peer_state_direct(
+            current_peer_event,
+            EndpointProvider::Upnp,
+            EndpointProvider::Local,
+        );
+
+        // And after 60 seconds some disconnect due to network error
+        current_peer_event.timestamp += Duration::from_secs(60);
+        current_peer_event.peer_state = PeerState::Connecting;
+        current_peer_event.rx_bytes += 1000;
+        current_peer_event.tx_bytes += 2000;
+        aggregator.change_peer_state_relayed(current_peer_event);
+
+        let segments = aggregator.collect_unacknowledged_segments().await;
+        assert_eq!(segments.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_aggregator_multiple_events_single_segment() {
+        let mut wg_interface = MockWireGuard::new();
+        wg_interface
+            .expect_get_interface()
+            .returning(|| Ok(Default::default()));
+        let mut aggregator = create_aggregator(false, true, wg_interface).await;
+
+        // Initial event
+        let mut current_peer_event = create_basic_event(1);
+        let segment_start = current_peer_event.timestamp;
+        aggregator.change_peer_state_direct(
+            current_peer_event,
+            EndpointProvider::Upnp,
+            EndpointProvider::Local,
+        );
+
+        // Send one more event with the same state
+        current_peer_event.timestamp += Duration::from_secs(60);
+        current_peer_event.rx_bytes += 1000;
+        current_peer_event.tx_bytes += 2000;
+        aggregator.change_peer_state_direct(
+            current_peer_event,
+            EndpointProvider::Upnp,
+            EndpointProvider::Local,
+        );
+
+        let segments = aggregator.collect_unacknowledged_segments().await;
+        assert_eq!(segments.len(), 0);
+
+        // And after 60 seconds some disconnect
+        current_peer_event.timestamp += Duration::from_secs(60);
+        current_peer_event.peer_state = PeerState::Connecting;
+        current_peer_event.rx_bytes += 1000;
+        current_peer_event.tx_bytes += 2000;
+        aggregator.change_peer_state_relayed(current_peer_event);
+
+        // And after 60 seconds connect again
+        current_peer_event.timestamp += Duration::from_secs(60);
+        current_peer_event.peer_state = PeerState::Connected;
+        current_peer_event.rx_bytes += 1000;
+        current_peer_event.tx_bytes += 2000;
+        aggregator.change_peer_state_relayed(current_peer_event);
+
+        // We don't gather periods of time when peer is disconnected, so we should have here only one segment
+        let segments = aggregator.collect_unacknowledged_segments().await;
+        assert_eq!(segments.len(), 1);
+        assert_eq!(
+            segments[0],
+            ConnectionSegmentData {
+                node: current_peer_event.public_key,
+                start: segment_start.into(),
+                length: Duration::from_secs(120),
+                connection_data: ConnectionData::Peer(PeerConnectionData {
+                    initiator_ep_type: EndpointType::UPnP,
+                    reciever_ep_type: EndpointType::Local,
+                    rx_bytes: 2000,
+                    tx_bytes: 4000
+                })
+            }
+        );
+
+        aggregator.acknowledge_segments_transmission(segments);
+
+        let segments = aggregator.collect_unacknowledged_segments().await;
+        assert_eq!(segments.len(), 0);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_aggregator_12h_segment() {
+        // Initial event
+        let current_peer_event = create_basic_event(1);
+        let segment_start = current_peer_event.timestamp;
+
+        let mut wg_interface = MockWireGuard::new();
+        let lambda_pk = current_peer_event.public_key;
+        wg_interface.expect_get_interface().returning(move || {
+            Ok(Interface {
+                peers: vec![(
+                    lambda_pk,
+                    Peer {
+                        public_key: lambda_pk,
+                        endpoint: None,
+                        rx_bytes: Some(3333),
+                        tx_bytes: Some(1111),
+                        ..Default::default()
+                    },
+                )]
+                .into_iter()
+                .collect(),
+                ..Default::default()
+            })
+        });
+        let mut aggregator = create_aggregator(false, true, wg_interface).await;
+
+        // Insert the first event
+        aggregator.change_peer_state_relayed(current_peer_event);
+
+        let segments = aggregator.collect_unacknowledged_segments().await;
+        assert_eq!(segments.len(), 0);
+
+        time::advance(Duration::from_secs(24 * 60 * 60 + 1)).await;
+
+        let segments = aggregator.collect_unacknowledged_segments().await;
+        assert_eq!(segments.len(), 1);
+        assert_eq!(
+            segments[0],
+            ConnectionSegmentData {
+                node: current_peer_event.public_key,
+                start: segment_start.into(),
+                length: Duration::from_secs(24 * 60 * 60 + 1),
+                connection_data: ConnectionData::Peer(PeerConnectionData {
+                    initiator_ep_type: EndpointType::Relay,
+                    reciever_ep_type: EndpointType::Relay,
+                    rx_bytes: 3333,
+                    tx_bytes: 1111
+                })
+            }
+        );
+
+        aggregator.acknowledge_segments_transmission(segments);
+
+        let segments = aggregator.collect_unacknowledged_segments().await;
+        assert_eq!(segments.len(), 0);
     }
 }

--- a/crates/telio-nurse/src/aggregator.rs
+++ b/crates/telio-nurse/src/aggregator.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, time::Duration};
+use std::{mem, thread::current, time::Duration};
 
 use tokio::time::Instant;
 
@@ -80,18 +80,15 @@ pub enum RelayConnectionChangeReason {
 // Possible connectivity state changes
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
 #[allow(dead_code)]
-pub enum ConnectionState {
-    Relay(RelayConnectionChangeReason),
-    Peer {
-        initiator_ep: EndpointType,
-        responder_ep: EndpointType,
-    },
+pub struct PeerConnectionState {
+    initiator_ep: EndpointType,
+    responder_ep: EndpointType,
 }
 
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
 pub struct PeerConnectionData {
-    initiator_ep_type: EndpointType,
-    reciever_ep_type: EndpointType,
+    initiator_ep: EndpointType,
+    responder_ep: EndpointType,
     rx_bytes: u64,
     tx_bytes: u64,
 }
@@ -108,13 +105,22 @@ pub enum ConnectionData {
 pub struct ConnectionSegmentData {
     node: PublicKey,
     start: Instant, // to ensure the segments are unique
-    length: Duration,
+    duration: Duration,
     connection_data: ConnectionData,
 }
 
+#[derive(Copy, Clone, Debug)]
+pub struct RelayEvent {
+    public_key: PublicKey,
+    peer_state: PeerState,
+    timestamp: Instant,
+    reason: RelayConnectionChangeReason,
+}
+
 struct AggregatorData {
-    current_events: HashMap<PublicKey, (AnalyticsEvent, ConnectionState)>,
-    unacknowledged_segments: HashSet<ConnectionSegmentData>,
+    current_relay_event: Option<RelayEvent>,
+    current_peer_events: HashMap<PublicKey, (AnalyticsEvent, PeerConnectionState)>,
+    unacknowledged_segments: Vec<ConnectionSegmentData>,
 }
 
 // A container to store the connectivity data for our meshnet peers
@@ -134,8 +140,9 @@ impl<W: WireGuard> ConnectivityDataAggregator<W> {
     pub fn new(nurse_features: &FeatureNurse, wg_interface: W) -> ConnectivityDataAggregator<W> {
         ConnectivityDataAggregator {
             data: parking_lot::RwLock::new(AggregatorData {
-                current_events: HashMap::new(),
-                unacknowledged_segments: HashSet::new(),
+                current_relay_event: None,
+                current_peer_events: HashMap::new(),
+                unacknowledged_segments: Vec::new(),
             }),
             aggregate_relay_events: nurse_features.enable_relay_conn_data,
             aggregate_nat_traversal_events: nurse_features.enable_nat_traversal_conn_data,
@@ -169,39 +176,29 @@ impl<W: WireGuard> ConnectivityDataAggregator<W> {
         }
 
         let mut data_guard = self.data.write();
-        let new_segment = match data_guard.current_events.entry(event.public_key) {
+        let new_segment = match data_guard.current_peer_events.entry(event.public_key) {
             std::collections::hash_map::Entry::Occupied(mut entry) => {
                 let (old_event, old_state) = entry.get().clone();
 
-                let connection_data = match old_state {
-                    ConnectionState::Relay(_) => {
-                        telio_log_warn!("Peer event for the relay server pubkey - discarding");
-                        return;
-                    }
-                    ConnectionState::Peer {
-                        initiator_ep: ep1,
-                        responder_ep: ep2,
-                    } => {
-                        if old_event.peer_state == event.peer_state
-                            && ep1 == initiator_ep
-                            && ep2 == responder_ep
-                        {
-                            // Peers state remains unchanged - skipping the segment addition
-                            return;
-                        }
-                        ConnectionData::Peer(PeerConnectionData {
-                            initiator_ep_type: ep1,
-                            reciever_ep_type: ep2,
-                            rx_bytes: event.rx_bytes - old_event.rx_bytes,
-                            tx_bytes: event.tx_bytes - old_event.tx_bytes,
-                        })
-                    }
+                let connection_data = if old_event.peer_state == event.peer_state
+                    && old_state.initiator_ep == initiator_ep
+                    && old_state.responder_ep == responder_ep
+                {
+                    // Peers state remains unchanged - skipping the segment addition
+                    return;
+                } else {
+                    ConnectionData::Peer(PeerConnectionData {
+                        initiator_ep: old_state.initiator_ep,
+                        responder_ep: old_state.responder_ep,
+                        rx_bytes: event.rx_bytes - old_event.rx_bytes,
+                        tx_bytes: event.tx_bytes - old_event.tx_bytes,
+                    })
                 };
 
                 if event.peer_state == PeerState::Connected {
                     entry.insert((
                         event,
-                        ConnectionState::Peer {
+                        PeerConnectionState {
                             initiator_ep,
                             responder_ep,
                         },
@@ -213,7 +210,7 @@ impl<W: WireGuard> ConnectivityDataAggregator<W> {
                 Some(ConnectionSegmentData {
                     node: event.public_key,
                     start: old_event.timestamp.into(),
-                    length: event.timestamp - old_event.timestamp,
+                    duration: event.timestamp - old_event.timestamp,
                     connection_data,
                 })
             }
@@ -221,7 +218,7 @@ impl<W: WireGuard> ConnectivityDataAggregator<W> {
                 if event.peer_state == PeerState::Connected {
                     entry.insert((
                         event,
-                        ConnectionState::Peer {
+                        PeerConnectionState {
                             initiator_ep,
                             responder_ep,
                         },
@@ -232,7 +229,7 @@ impl<W: WireGuard> ConnectivityDataAggregator<W> {
         };
 
         if let Some(segment) = new_segment {
-            data_guard.unacknowledged_segments.insert(segment);
+            data_guard.unacknowledged_segments.push(segment);
         }
     }
 
@@ -246,99 +243,113 @@ impl<W: WireGuard> ConnectivityDataAggregator<W> {
             return;
         }
 
+        let relay_event = RelayEvent {
+            public_key: event.public_key,
+            peer_state: event.peer_state,
+            timestamp: event.timestamp.into(),
+            reason,
+        };
+
         let mut data_guard = self.data.write();
-        let new_segment = match data_guard.current_events.entry(event.public_key) {
-            std::collections::hash_map::Entry::Occupied(mut entry) => {
-                let (old_event, old_state) = entry.get().clone();
 
-                let segment_connection_data = match old_state {
-                    ConnectionState::Relay(reason) => {
-                        if old_event.peer_state == event.peer_state {
-                            // The state remains unchanged
-                            return;
-                        }
-                        ConnectionData::Relay(RelayConnectionData {
-                            state: old_event.peer_state.into(),
-                            reason,
-                        })
-                    }
-                    ConnectionState::Peer { .. } => {
-                        telio_log_warn!("Relay event for the meshnet node pubkey - discarding");
-                        return;
-                    }
-                };
-
-                entry.insert((event, ConnectionState::Relay(reason)));
-
+        let new_segment = if let Some(old_relay_event) = data_guard.current_relay_event.as_ref() {
+            if old_relay_event.public_key != event.public_key
+                || old_relay_event.peer_state != event.peer_state
+            {
                 Some(ConnectionSegmentData {
-                    node: event.public_key,
-                    start: old_event.timestamp.into(),
-                    length: event.timestamp.duration_since(old_event.timestamp),
-                    connection_data: segment_connection_data,
+                    node: old_relay_event.public_key,
+                    start: old_relay_event.timestamp,
+                    duration: event
+                        .timestamp
+                        .duration_since(old_relay_event.timestamp.into()),
+                    connection_data: ConnectionData::Relay(RelayConnectionData {
+                        state: old_relay_event.peer_state.into(),
+                        reason: old_relay_event.reason,
+                    }),
                 })
-            }
-            std::collections::hash_map::Entry::Vacant(entry) => {
-                entry.insert((event, ConnectionState::Relay(reason)));
+            } else {
                 None
             }
+        } else {
+            data_guard.current_relay_event = Some(relay_event);
+            None
         };
 
         if let Some(segment) = new_segment {
-            data_guard.unacknowledged_segments.insert(segment);
+            data_guard.current_relay_event = Some(relay_event);
+            data_guard.unacknowledged_segments.push(segment);
         }
     }
 
     #[allow(dead_code)]
     pub async fn collect_unacknowledged_segments(&self) -> Vec<ConnectionSegmentData> {
         let mut data_guard = self.data.write();
-        if let Ok(wg_peers) = self.wg_interface.get_interface().await.map(|wgi| wgi.peers) {
-            let current_timestamp = Instant::now();
+        let current_timestamp = Instant::now();
 
+        println!("Current timestamp: {:?}", current_timestamp);
+        println!("Current realy event: {:?}", data_guard.current_relay_event);
+
+        // Handle long-lasting relay events
+        let new_relay_segment = data_guard
+            .current_relay_event
+            .as_mut()
+            .map(|e| (current_timestamp.duration_since(e.timestamp), e))
+            .filter(|(duration, _)| {
+                println!("Filtering");
+                *duration > DAY_DURATION
+            })
+            .map(|(duration, relay_event)| {
+                println!("Yeah, we are here!");
+                let segment = ConnectionSegmentData {
+                    node: relay_event.public_key,
+                    start: relay_event.timestamp,
+                    duration,
+                    connection_data: ConnectionData::Relay(RelayConnectionData {
+                        state: relay_event.peer_state.into(),
+                        reason: relay_event.reason,
+                    }),
+                };
+                relay_event.timestamp = current_timestamp;
+                segment
+            });
+        data_guard.unacknowledged_segments.extend(new_relay_segment);
+
+        // Handle long-lasting peer events
+        if let Ok(wg_peers) = self.wg_interface.get_interface().await.map(|wgi| wgi.peers) {
             let mut new_segments = Vec::new();
-            for (peer_event, peer_state) in data_guard.current_events.values_mut() {
+            for (peer_event, peer_state) in data_guard.current_peer_events.values_mut() {
                 let since_last_event =
                     current_timestamp.duration_since(Instant::from_std(peer_event.timestamp));
                 if since_last_event > DAY_DURATION {
-                    match peer_state {
-                        ConnectionState::Relay(reason) => {
-                            Some(ConnectionData::Relay(RelayConnectionData {
-                                state: peer_event.peer_state.into(),
-                                reason: *reason,
-                            }))
-                        }
-                        ConnectionState::Peer {
-                            initiator_ep,
-                            responder_ep,
-                        } => wg_peers
-                            .get(&peer_event.public_key)
-                            .and_then(|wg_peer| wg_peer.rx_bytes.zip(wg_peer.tx_bytes))
-                            .map(|(rx_bytes, tx_bytes)| {
-                                let d_rx_bytes = rx_bytes - peer_event.rx_bytes;
-                                let d_tx_bytes = tx_bytes - peer_event.tx_bytes;
-                                peer_event.rx_bytes = rx_bytes;
-                                peer_event.tx_bytes = tx_bytes;
-                                ConnectionData::Peer(PeerConnectionData {
-                                    initiator_ep_type: *initiator_ep,
-                                    reciever_ep_type: *responder_ep,
-                                    rx_bytes: d_rx_bytes,
-                                    tx_bytes: d_tx_bytes,
-                                })
-                            }),
-                    }
-                    .map_or_else(
-                        || {
-                            telio_log_warn!("Unable to get transfer data for peer");
-                        },
-                        |connection_data| {
-                            new_segments.push(ConnectionSegmentData {
-                                node: peer_event.public_key,
-                                start: peer_event.timestamp.into(),
-                                length: since_last_event,
-                                connection_data,
-                            });
-                            peer_event.timestamp = current_timestamp.into();
-                        },
-                    );
+                    wg_peers
+                        .get(&peer_event.public_key)
+                        .and_then(|wg_peer| wg_peer.rx_bytes.zip(wg_peer.tx_bytes))
+                        .map(|(rx_bytes, tx_bytes)| {
+                            let d_rx_bytes = rx_bytes - peer_event.rx_bytes;
+                            let d_tx_bytes = tx_bytes - peer_event.tx_bytes;
+                            peer_event.rx_bytes = rx_bytes;
+                            peer_event.tx_bytes = tx_bytes;
+                            ConnectionData::Peer(PeerConnectionData {
+                                initiator_ep: peer_state.initiator_ep,
+                                responder_ep: peer_state.responder_ep,
+                                rx_bytes: d_rx_bytes,
+                                tx_bytes: d_tx_bytes,
+                            })
+                        })
+                        .map_or_else(
+                            || {
+                                telio_log_warn!("Unable to get transfer data for peer");
+                            },
+                            |connection_data| {
+                                new_segments.push(ConnectionSegmentData {
+                                    node: peer_event.public_key,
+                                    start: peer_event.timestamp.into(),
+                                    duration: since_last_event,
+                                    connection_data,
+                                });
+                                peer_event.timestamp = current_timestamp.into();
+                            },
+                        );
                 }
             }
             data_guard
@@ -348,24 +359,7 @@ impl<W: WireGuard> ConnectivityDataAggregator<W> {
             telio_log_warn!("Getting wireguard interfaces failed");
         }
 
-        data_guard
-            .unacknowledged_segments
-            .clone()
-            .into_iter()
-            .collect()
-    }
-
-    #[allow(dead_code)]
-    pub fn acknowledge_segments_transmission<T>(&mut self, segment_set: T)
-    where
-        T: IntoIterator<Item = ConnectionSegmentData>,
-    {
-        let mut data_guard = self.data.write();
-        segment_set.into_iter().for_each(|segment| {
-            if !data_guard.unacknowledged_segments.remove(&segment) {
-                telio_log_warn!("Connectivity event for the given peer and timestamp not found");
-            }
-        })
+        mem::take(&mut data_guard.unacknowledged_segments)
     }
 }
 
@@ -412,7 +406,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_aggregator_basic_scenario_relay() {
+    async fn test_aggregator_relay_multiple_servers() {
         let mut wg_interface = MockWireGuard::new();
         wg_interface
             .expect_get_interface()
@@ -427,6 +421,23 @@ mod tests {
             RelayConnectionChangeReason::ConfigurationChange,
         );
 
+        // Repeated state after some time
+        current_relay_event.timestamp += Duration::from_secs(60);
+        aggregator.change_relay_state(
+            current_relay_event,
+            RelayConnectionChangeReason::ConfigurationChange,
+        );
+
+        // Change server event
+        let old_pubkey = current_relay_event.public_key;
+        current_relay_event.timestamp += Duration::from_secs(60);
+        let second_segment_start = current_relay_event.timestamp;
+        current_relay_event.public_key = PublicKey(*b"BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB");
+        aggregator.change_relay_state(
+            current_relay_event,
+            RelayConnectionChangeReason::ConfigurationChange,
+        );
+
         // And after 60 seconds some disconnect due to network error
         current_relay_event.timestamp += Duration::from_secs(60);
         current_relay_event.peer_state = PeerState::Connecting;
@@ -436,21 +447,34 @@ mod tests {
         );
 
         let segments = aggregator.collect_unacknowledged_segments().await;
-        assert_eq!(segments.len(), 1);
+        assert_eq!(segments.len(), 2);
+
+        println!("Our segments: {:?} {:?}", segments[0], segments[1]);
+
         assert_eq!(
             segments[0],
             ConnectionSegmentData {
-                node: current_relay_event.public_key,
+                node: old_pubkey,
                 start: segment_start.into(),
-                length: Duration::from_secs(60),
+                duration: Duration::from_secs(120),
                 connection_data: ConnectionData::Relay(RelayConnectionData {
                     state: RelayConnectionState::Connected,
                     reason: RelayConnectionChangeReason::ConfigurationChange
                 })
             }
         );
-
-        aggregator.acknowledge_segments_transmission(segments);
+        assert_eq!(
+            segments[1],
+            ConnectionSegmentData {
+                node: current_relay_event.public_key,
+                start: second_segment_start.into(),
+                duration: Duration::from_secs(60),
+                connection_data: ConnectionData::Relay(RelayConnectionData {
+                    state: RelayConnectionState::Connected,
+                    reason: RelayConnectionChangeReason::ConfigurationChange
+                })
+            }
+        );
 
         let segments = aggregator.collect_unacknowledged_segments().await;
         assert_eq!(segments.len(), 0);
@@ -483,17 +507,15 @@ mod tests {
             ConnectionSegmentData {
                 node: current_peer_event.public_key,
                 start: segment_start.into(),
-                length: Duration::from_secs(60),
+                duration: Duration::from_secs(60),
                 connection_data: ConnectionData::Peer(PeerConnectionData {
-                    initiator_ep_type: EndpointType::Relay,
-                    reciever_ep_type: EndpointType::Relay,
+                    initiator_ep: EndpointType::Relay,
+                    responder_ep: EndpointType::Relay,
                     rx_bytes: 1000,
                     tx_bytes: 2000
                 })
             }
         );
-
-        aggregator.acknowledge_segments_transmission(segments);
 
         let segments = aggregator.collect_unacknowledged_segments().await;
         assert_eq!(segments.len(), 0);
@@ -529,17 +551,15 @@ mod tests {
             ConnectionSegmentData {
                 node: current_peer_event.public_key,
                 start: segment_start.into(),
-                length: Duration::from_secs(60),
+                duration: Duration::from_secs(60),
                 connection_data: ConnectionData::Peer(PeerConnectionData {
-                    initiator_ep_type: EndpointType::UPnP,
-                    reciever_ep_type: EndpointType::Local,
+                    initiator_ep: EndpointType::UPnP,
+                    responder_ep: EndpointType::Local,
                     rx_bytes: 1000,
                     tx_bytes: 2000
                 })
             }
         );
-
-        aggregator.acknowledge_segments_transmission(segments);
 
         let segments = aggregator.collect_unacknowledged_segments().await;
         assert_eq!(segments.len(), 0);
@@ -624,24 +644,22 @@ mod tests {
             ConnectionSegmentData {
                 node: current_peer_event.public_key,
                 start: segment_start.into(),
-                length: Duration::from_secs(120),
+                duration: Duration::from_secs(120),
                 connection_data: ConnectionData::Peer(PeerConnectionData {
-                    initiator_ep_type: EndpointType::UPnP,
-                    reciever_ep_type: EndpointType::Local,
+                    initiator_ep: EndpointType::UPnP,
+                    responder_ep: EndpointType::Local,
                     rx_bytes: 2000,
                     tx_bytes: 4000
                 })
             }
         );
 
-        aggregator.acknowledge_segments_transmission(segments);
-
         let segments = aggregator.collect_unacknowledged_segments().await;
         assert_eq!(segments.len(), 0);
     }
 
     #[tokio::test(start_paused = true)]
-    async fn test_aggregator_24h_segment() {
+    async fn test_aggregator_24h_segment_peer() {
         // Initial event
         let current_peer_event = create_basic_event(1);
         let segment_start = current_peer_event.timestamp;
@@ -682,17 +700,55 @@ mod tests {
             ConnectionSegmentData {
                 node: current_peer_event.public_key,
                 start: segment_start.into(),
-                length: Duration::from_secs(24 * 60 * 60 + 1),
+                duration: Duration::from_secs(24 * 60 * 60 + 1),
                 connection_data: ConnectionData::Peer(PeerConnectionData {
-                    initiator_ep_type: EndpointType::Relay,
-                    reciever_ep_type: EndpointType::Relay,
+                    initiator_ep: EndpointType::Relay,
+                    responder_ep: EndpointType::Relay,
                     rx_bytes: 3333,
                     tx_bytes: 1111
                 })
             }
         );
 
-        aggregator.acknowledge_segments_transmission(segments);
+        let segments = aggregator.collect_unacknowledged_segments().await;
+        assert_eq!(segments.len(), 0);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_aggregator_24h_segment_relay() {
+        let current_relay_event = create_basic_event(1);
+        let segment_start = current_relay_event.timestamp;
+
+        let mut wg_interface = MockWireGuard::new();
+        wg_interface
+            .expect_get_interface()
+            .returning(move || Ok(Default::default()));
+        let mut aggregator = create_aggregator(true, false, wg_interface).await;
+
+        aggregator.change_relay_state(
+            current_relay_event,
+            RelayConnectionChangeReason::ConfigurationChange,
+        );
+
+        let segments = aggregator.collect_unacknowledged_segments().await;
+        assert_eq!(segments.len(), 0);
+
+        time::advance(Duration::from_secs(24 * 60 * 60 + 1)).await;
+
+        let segments = aggregator.collect_unacknowledged_segments().await;
+        assert_eq!(segments.len(), 1);
+        assert_eq!(
+            segments[0],
+            ConnectionSegmentData {
+                node: current_relay_event.public_key,
+                start: segment_start.into(),
+                duration: Duration::from_secs(24 * 60 * 60 + 1),
+                connection_data: ConnectionData::Relay(RelayConnectionData {
+                    state: RelayConnectionState::Connected,
+                    reason: RelayConnectionChangeReason::ConfigurationChange
+                })
+            }
+        );
 
         let segments = aggregator.collect_unacknowledged_segments().await;
         assert_eq!(segments.len(), 0);

--- a/crates/telio-nurse/src/lib.rs
+++ b/crates/telio-nurse/src/lib.rs
@@ -21,6 +21,9 @@ pub mod error;
 /// Main nurse module
 mod nurse;
 
+/// Connectivity data aggregator module
+mod aggregator;
+
 mod heartbeat;
 mod qos;
 mod rtt;

--- a/src/libtelio.udl
+++ b/src/libtelio.udl
@@ -409,9 +409,9 @@ dictionary FeatureNurse {
     /// Enable/disable collecting nat type
     boolean? enable_nat_type_collection;
     /// Enable/disable Relay connection data
-    boolean enable_relay_conn_data;
+    boolean? enable_relay_conn_data;
     /// Enable/disable NAT-traversal connections data
-    boolean enable_nat_traversal_conn_data;
+    boolean? enable_nat_traversal_conn_data;
 };
 
 /// QoS configuration options

--- a/src/libtelio.udl
+++ b/src/libtelio.udl
@@ -408,6 +408,10 @@ dictionary FeatureNurse {
     FeatureQoS? qos;
     /// Enable/disable collecting nat type
     boolean? enable_nat_type_collection;
+    /// Enable/disable Relay connection data
+    boolean enable_relay_conn_data;
+    /// Enable/disable NAT-traversal connections data
+    boolean enable_nat_traversal_conn_data;
 };
 
 /// QoS configuration options


### PR DESCRIPTION
### Problem
We need to prepare some API for NAT-traversal and Relay connections data gathering, which supports:
 - collecting events about:
   - changes in the connectivity to Relay servers
   - current state of the connections with the other Meshnet peers
 - processing the events of both types and represent the gathered information as ready-to-serialize format, as it was described in the corresponding RFC.

### Solution
In this PR I introduce an aggregator struct, which allows to store Relay (`change_relay_state` method) and NAT-traversal connection events (`change_peer_state_relayed` for relayed peers and `change_peer_state_direct` for the peers connected directly) and provides an API for `telio-nurse` module, so it can just download almost-serialized data and then effortlessly send it to the analytics server.

For the events collection we reuse the `AnalyticsEvents` struct to reduce the implementation overhead in the rest of the codebase.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
