### PR TITLE
Fix telio-pq fuzing action after x25519-dalek update

### DIFF
--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -44,7 +44,7 @@ jobs:
         - run: cargo install cargo-fuzz --locked --version 0.11.2
         - name: fuzz telio pq parse_get_packet
           working-directory: crates/telio-pq
-          run: cargo fuzz run parse_get_packet -- -max_total_time=180
+          run: CARGO_CFG_CURVE25519_DALEK_BACKEND="serial" cargo fuzz run parse_get_packet -- -max_total_time=180
         - name: fuzz telio pq parse_rekey_packet
           working-directory: crates/telio-pq
-          run: cargo fuzz run parse_rekey_packet -- -max_total_time=180
+          run: CARGO_CFG_CURVE25519_DALEK_BACKEND="serial" cargo fuzz run parse_rekey_packet -- -max_total_time=180


### PR DESCRIPTION
Fuzzing uses a nightly compiler, which stopped compiling the library some time ago. This commit fixes the problem

### Problem
telio-pq-fuzz action not passing

### Solution
Disable stdsimd backend for x25519-dalek


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
