### PR TITLE
LLT-4913: Decrease ping failure logs level

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 * LLT-4154: Optimize Upnp/Stun providers
 * LLT-4908: Lowered DNS TTL time for nicknames and NXDomain responses
 * LLT-4915: Update the moose tracker to v1.0.0-libtelioApp
+* LLT-4913: Skip qos analytics ping for unconnected peers
 
 <br>
 

--- a/crates/telio-firewall/src/firewall.rs
+++ b/crates/telio-firewall/src/firewall.rs
@@ -1263,8 +1263,6 @@ impl Firewall for StatefullFirewall {
     }
 
     fn process_outbound_packet(&self, public_key: &[u8; 32], buffer: &[u8]) -> bool {
-        telio_log_debug!("Outbound packet");
-
         match unwrap_option_or_return!(buffer.first(), false) >> 4 {
             4 => self.process_outbound_ip_packet::<Ipv4Packet>(public_key, buffer),
             6 if self.allow_ipv6 => {

--- a/crates/telio-nurse/src/qos.rs
+++ b/crates/telio-nurse/src/qos.rs
@@ -12,7 +12,7 @@ use telio_crypto::PublicKey;
 use telio_task::{io::mc_chan, Runtime, RuntimeExt, WaitResponse};
 use telio_wg::uapi::{AnalyticsEvent, PeerState};
 
-use telio_utils::{telio_log_debug, DualTarget};
+use telio_utils::{telio_log_debug, telio_log_trace, DualTarget};
 
 use crate::config::QoSConfig;
 
@@ -369,7 +369,7 @@ impl Analytics {
     ///
     /// * `event` - Received WG event.
     async fn handle_wg_event(&mut self, event: AnalyticsEvent) {
-        telio_log_debug!("WG event: {:?}", event);
+        telio_log_trace!("WG event: {:?}", event);
         self.nodes
             .entry(event.public_key)
             .and_modify(|n| {

--- a/crates/telio-nurse/src/qos.rs
+++ b/crates/telio-nurse/src/qos.rs
@@ -395,6 +395,15 @@ impl Analytics {
             self.ping_channel_tx = ping_channel_tx.downgrade();
 
             for (_, node) in self.nodes.iter() {
+                if node.peer_state != PeerState::Connected {
+                    telio_log_debug!(
+                        "{:?} is in {:?} state, skipping analytics ping.",
+                        node.public_key,
+                        node.peer_state
+                    );
+                    continue;
+                }
+
                 let (pk, endpoint) = (node.public_key, node.endpoint);
                 let pinger = Arc::clone(&self.ping_backend);
                 let ping_channel_tx = ping_channel_tx.clone();

--- a/crates/telio-nurse/src/rtt/ping.rs
+++ b/crates/telio-nurse/src/rtt/ping.rs
@@ -147,7 +147,7 @@ impl Ping {
                 }
                 Err(e) => {
                     results.unsuccessful_pings += 1;
-                    telio_log_error!("Ping error: {}", e.to_string());
+                    telio_log_debug!("Ping {} error: {}", host, e.to_string());
                 }
             }
         }

--- a/crates/telio-wg/src/wg.rs
+++ b/crates/telio-wg/src/wg.rs
@@ -471,7 +471,7 @@ impl State {
 
     async fn uapi_request(&mut self, cmd: &Cmd) -> Result<Response, Error> {
         let ret = self.adapter.send_uapi_cmd(cmd).await?;
-        telio_log_debug!("UAPI request: {}, response: {}", &cmd.to_string(), &ret);
+        telio_log_debug!("UAPI request: {}, response: {:?}", &cmd.to_string(), &ret);
 
         // Count continuous adapter failures.
         // As observed on Windows, a vNIC driver might fail a call right after wake-up,


### PR DESCRIPTION
### Problem
Ping timeout errors were being spammed into the logs of release versions of libtelio.

### Solution
Besides changing the log level of this [specific log](https://github.com/NordSecurity/libtelio/pull/352/files#diff-5f3177de9978ef3efc6f9a22d22bba482cd008c98e79b921c2b7188268973fd3L150) to `DEBUG` the following changes were made:
- Clean or decrease the level of some logs.
- Skip analytics ping for unconnected peers and don't touch any data as analytics can still compute if the node is connected or not by analysing the connection time and the heartbeat interval.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
