### PR TITLE
LLT-4850: Add missing VPN peer meshnet address to analytics

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@
 * LLT-2515: Implement PMTU discovery for VPN connection paths on Linux/Android
 * LLT-4978: Bump moose tracker to v2.0.0-libtelioApp
 * LLT-4968: Make the default nurse initial_heartbeat_interval to be 5 minutes
+* LLT-4850: Add missing VPN meshnet address to analytics
 
 <br>
 

--- a/crates/telio-model/src/constants.rs
+++ b/crates/telio-model/src/constants.rs
@@ -1,0 +1,8 @@
+//! Telio constants definition
+
+/// VPN IPv4 Meshnet Address
+pub const VPN_INTERNAL_IPV4: [u8; 4] = [100, 64, 0, 1];
+/// VPN IPv6 Meshnet Address
+pub const VPN_INTERNAL_IPV6: [u16; 8] = [64884, 64884, 26991, 0, 0, 0, 0, 1];
+/// VPN IPv4 Non-Meshnet Address
+pub const VPN_EXTERNAL_IPV4: [u8; 4] = [10, 5, 0, 1];

--- a/crates/telio-model/src/lib.rs
+++ b/crates/telio-model/src/lib.rs
@@ -2,6 +2,7 @@
 //! Crate containing models of various components
 pub mod api_config;
 pub mod config;
+pub mod constants;
 pub mod event;
 pub mod mesh;
 pub mod validation;

--- a/crates/telio-nurse/src/qos.rs
+++ b/crates/telio-nurse/src/qos.rs
@@ -37,7 +37,7 @@ pub struct NodeInfo {
     pub connected_time: Duration,
 
     // RTT
-    pub endpoint: DualTarget,
+    pub ip_addresses: Vec<DualTarget>,
     pub rtt_histogram: Histogram,
     pub rtt_loss_histogram: Histogram,
     pub rtt6_histogram: Histogram,
@@ -95,7 +95,7 @@ impl From<AnalyticsEvent> for NodeInfo {
             last_event: event.timestamp,
             last_wg_event: event.timestamp,
             connected_time: Duration::default(),
-            endpoint: event.endpoint,
+            ip_addresses: event.dual_ip_addresses,
             rtt_histogram: Histogram::new(),
             rtt_loss_histogram: Histogram::new(),
             rtt6_histogram: Histogram::new(),
@@ -194,7 +194,7 @@ impl Runtime for Analytics {
             // Wireguard event
             Ok(wg_event) = self.io.wg_channel.recv() => {
                 Self::guard(async move {
-                    self.handle_wg_event(*wg_event).await;
+                    self.handle_wg_event(&wg_event).await;
                     Ok(())
                 })
             },
@@ -370,7 +370,7 @@ impl Analytics {
     /// # Arguments
     ///
     /// * `event` - Received WG event.
-    async fn handle_wg_event(&mut self, event: AnalyticsEvent) {
+    async fn handle_wg_event(&mut self, event: &AnalyticsEvent) {
         telio_log_trace!("WG event: {:?}", event);
         self.nodes
             .entry(event.public_key)
@@ -378,15 +378,15 @@ impl Analytics {
                 // Check if peer was not paused
                 let pause: bool = (event.timestamp - n.last_event).as_secs() > 10;
                 // Update current state
-                n.update_connection_duration(&event, pause);
-                // Update rtt info
-                n.endpoint = event.endpoint;
+                n.update_connection_duration(event, pause);
+                // Update rtt info (mesh address)
+                n.ip_addresses = event.dual_ip_addresses.clone();
                 // Update throughput info
-                n.update_throughput_info(&event);
+                n.update_throughput_info(event);
                 // Update last event timestamp
                 n.last_event = event.timestamp;
             })
-            .or_insert_with(|| NodeInfo::from(event));
+            .or_insert_with(|| NodeInfo::from(event.clone()));
     }
 
     /// Launch ping task for every node.
@@ -406,13 +406,40 @@ impl Analytics {
                     continue;
                 }
 
-                let (pk, endpoint) = (node.public_key, node.endpoint);
+                let (pk, ip_addresses) = (node.public_key, node.ip_addresses.clone());
                 let pinger = Arc::clone(&self.ping_backend);
                 let ping_channel_tx = ping_channel_tx.clone();
 
                 tokio::spawn(async move {
                     if let Some(pinger) = &*pinger {
-                        Box::pin(pinger.perform((pk, endpoint), ping_channel_tx)).await;
+                        let mut dpr = DualPingResults::default();
+                        let mut ip_addresses = ip_addresses.iter().peekable();
+
+                        while let Some(ip_address) = ip_addresses.next() {
+                            dpr = Box::pin(pinger.perform((pk, *ip_address))).await;
+
+                            if let Some(results_v4) = &dpr.v4 {
+                                if results_v4.successful_pings != 0 {
+                                    break;
+                                }
+                            }
+                            if let Some(results_v6) = &dpr.v6 {
+                                if results_v6.successful_pings != 0 {
+                                    break;
+                                }
+                            }
+
+                            if let Some(next_ip) = ip_addresses.peek() {
+                                let _ = ping_channel_tx.send((pk, dpr.clone())).await;
+                                telio_log_debug!(
+                                    "Node was not reachable through {:?}, trying {:?}.",
+                                    ip_address,
+                                    next_ip
+                                );
+                            }
+                        }
+
+                        let _ = ping_channel_tx.send((pk, dpr)).await;
                     }
                 });
             }
@@ -423,17 +450,18 @@ impl Analytics {
         if let Some(pinger) = &*self.ping_backend {
             self.nodes.entry(dpr.0).and_modify(|node| {
                 if let Some(results_v4) = dpr.1.v4 {
-                    let u64_avg = std::convert::TryInto::try_into(
+                    let rtt_avg = std::convert::TryInto::try_into(
                         results_v4
                             .avg_rtt
                             .map_or(Duration::from_millis(0), |a| a)
                             .as_millis(),
                     )
                     .unwrap_or(0u64);
-                    let _ = node.rtt_histogram.increment(u64_avg);
-                    let _ = node.rtt_loss_histogram.increment(
-                        (100 * results_v4.unsuccessful_pings / pinger.no_of_tries) as u64,
-                    );
+                    let rtt_loss =
+                        (100 * results_v4.unsuccessful_pings / pinger.no_of_tries) as u64;
+
+                    let _ = node.rtt_histogram.increment(rtt_avg);
+                    let _ = node.rtt_loss_histogram.increment(rtt_loss);
                 }
 
                 if let Some(results_v6) = dpr.1.v6 {
@@ -561,7 +589,7 @@ mod tests {
         let mut event = generate_event();
 
         // assert that node is inserted successfully
-        analytics.handle_wg_event(event).await;
+        analytics.handle_wg_event(&event).await;
         let node = analytics.nodes.get(&event.public_key).unwrap();
 
         assert_eq!(analytics.nodes.len(), 1);
@@ -569,7 +597,7 @@ mod tests {
         assert_eq!(node.peer_state, PeerState::Connected);
         assert_eq!(node.last_event, event.timestamp);
         assert_eq!(node.last_wg_event, event.timestamp);
-        assert_eq!(node.endpoint, event.endpoint);
+        assert_eq!(node.ip_addresses, event.dual_ip_addresses);
 
         // histograms should be empty
         let mut expected_output = OutputData::new(analytics.buckets);
@@ -579,16 +607,16 @@ mod tests {
 
         // update node with different data
         event.timestamp += Duration::from_secs(2);
-        event.endpoint = DualTarget::new((
+        event.dual_ip_addresses = vec![DualTarget::new((
             Some(Ipv4Addr::new(192, 168, 1, 1)),
             Some(Ipv6Addr::new(0xfc02, 0, 0, 0, 0, 0, 0, 0x01)),
         ))
-        .unwrap();
+        .unwrap()];
         event.peer_state = PeerState::Disconnected;
         event.tx_bytes = 10;
         event.rx_bytes = 20;
 
-        analytics.handle_wg_event(event).await;
+        analytics.handle_wg_event(&event).await;
         let node = analytics.nodes.get(&event.public_key).unwrap();
 
         assert_eq!(analytics.nodes.len(), 1);
@@ -596,7 +624,7 @@ mod tests {
         assert_eq!(node.peer_state, PeerState::Disconnected);
         assert_eq!(node.last_event, event.timestamp);
         assert_eq!(node.last_wg_event, event.timestamp);
-        assert_eq!(node.endpoint, event.endpoint);
+        assert_eq!(node.ip_addresses, event.dual_ip_addresses);
         assert_eq!(node.connected_time, Duration::from_secs(2));
 
         // throughput in B/sec, so it's split by half as connected time is 2s
@@ -621,7 +649,7 @@ mod tests {
         let mut event = generate_event();
 
         // insert node through first event
-        analytics.handle_wg_event(event).await;
+        analytics.handle_wg_event(&event).await;
 
         // perform a couple of pings to fill up histograms
         for _ in 0..4 {
@@ -636,20 +664,20 @@ mod tests {
         assert_eq!(output, OutputData::new(analytics.buckets));
 
         // Add invalid ipv6 address and some dummy data
-        event.endpoint = DualTarget::new((
+        event.dual_ip_addresses = vec![DualTarget::new((
             Some(Ipv4Addr::new(127, 0, 0, 1)),
             Some(Ipv6Addr::new(0xfc02, 0, 0, 0, 0, 0, 0, 0x01)),
         ))
-        .unwrap();
+        .unwrap()];
         event.timestamp += Duration::from_secs(2);
         event.tx_bytes = 10;
         event.rx_bytes = 20;
-        analytics.handle_wg_event(event).await;
+        analytics.handle_wg_event(&event).await;
 
         event.timestamp += Duration::from_secs(5);
         event.tx_bytes = 50;
         event.rx_bytes = 80;
-        analytics.handle_wg_event(event).await;
+        analytics.handle_wg_event(&event).await;
 
         // perform ping with new data
         analytics.perform_ping();
@@ -662,7 +690,7 @@ mod tests {
         assert_eq!(node.last_event, event.timestamp);
         assert_eq!(node.last_wg_event, event.timestamp);
         assert_eq!(node.connected_time, Duration::from_secs(7));
-        assert_eq!(node.endpoint, event.endpoint);
+        assert_eq!(node.ip_addresses, event.dual_ip_addresses);
         assert_eq!(node.last_tx_bytes, 50);
         assert_eq!(node.last_rx_bytes, 80);
 
@@ -699,14 +727,14 @@ mod tests {
         let sk = SecretKey::gen();
         let pk = sk.public();
         let timestamp = Instant::now();
-        let endpoint = DualTarget::new((
+        let dual_ip_addresses = vec![DualTarget::new((
             Some(Ipv4Addr::new(127, 0, 0, 1)),
             Some(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)),
         ))
-        .unwrap();
+        .unwrap()];
         AnalyticsEvent {
             public_key: pk,
-            endpoint,
+            dual_ip_addresses,
             peer_state: PeerState::Connected,
             timestamp,
             tx_bytes: Default::default(),
@@ -733,7 +761,7 @@ mod tests {
             last_event: Instant::now(),
             last_wg_event: Instant::now(),
             connected_time,
-            endpoint: DualTarget::new((Some(Ipv4Addr::new(127, 0, 0, 1)), None)).unwrap(),
+            ip_addresses: vec![DualTarget::new((Some(Ipv4Addr::new(127, 0, 0, 1)), None)).unwrap()],
             rtt_histogram: histogram.clone(),
             rtt_loss_histogram: histogram.clone(),
             rtt6_histogram: histogram.clone(),

--- a/crates/telio-nurse/src/rtt/ping.rs
+++ b/crates/telio-nurse/src/rtt/ping.rs
@@ -6,7 +6,6 @@ use std::{convert::TryInto, net::IpAddr};
 use surge_ping::{
     Client, Config as PingerConfig, ConfigBuilder, PingIdentifier, PingSequence, ICMP,
 };
-use tokio::sync::mpsc;
 
 use telio_crypto::PublicKey;
 use telio_utils::{telio_log_debug, telio_log_error, DualTarget};
@@ -55,16 +54,11 @@ impl Ping {
     /// # Arguments
     ///
     /// * `node` - `NodeInfo` instance to get endpoint to ping and to store RTT information.
-    pub async fn perform(
-        &self,
-        target: (PublicKey, DualTarget),
-        results_tx: mpsc::Sender<(PublicKey, DualPingResults)>,
-    ) {
+    pub async fn perform(&self, target: (PublicKey, DualTarget)) -> DualPingResults {
         let dpr = self.perform_average_rtt(&target.1).await;
-
         telio_log_debug!("{:?}, no_of_tries: {}", dpr, self.no_of_tries);
 
-        let _ = results_tx.send((target.0, dpr)).await;
+        dpr
     }
 
     async fn perform_average_rtt(&self, target: &DualTarget) -> DualPingResults {

--- a/crates/telio-utils/src/dual_target.rs
+++ b/crates/telio-utils/src/dual_target.rs
@@ -15,9 +15,10 @@ pub type Result<T> = std::result::Result<T, DualTargetError>;
 pub type Target = (Option<Ipv4Addr>, Option<Ipv6Addr>);
 
 /// DualTarget wrapper
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct DualTarget {
-    target: Target,
+    /// Ipv4/Ipv6 tuple
+    pub target: Target,
 }
 
 impl DualTarget {

--- a/crates/telio-wg/src/uapi.rs
+++ b/crates/telio-wg/src/uapi.rs
@@ -11,7 +11,7 @@ use std::{
     collections::BTreeMap,
     fmt::{self, Display, Formatter},
     io::{BufRead, BufReader, Read},
-    net::{AddrParseError, SocketAddr},
+    net::{AddrParseError, IpAddr, SocketAddr},
     num::ParseIntError,
     panic,
     str::FromStr,
@@ -34,6 +34,8 @@ pub struct Peer {
     pub public_key: PublicKey,
     /// Peer's endpoint with `IP address` and `UDP port` number
     pub endpoint: Option<SocketAddr>,
+    /// Mesh's IP addresses of peer
+    pub ip_addresses: Vec<IpAddr>,
     /// Keep alive interval, `seconds` or `None`
     pub persistent_keepalive_interval: Option<u32>,
     /// Vector of allowed IPs
@@ -54,6 +56,7 @@ impl From<get::Peer> for Peer {
         Self {
             public_key: PublicKey(item.public_key),
             endpoint: item.endpoint,
+            ip_addresses: Default::default(),
             persistent_keepalive_interval: Some(item.persistent_keepalive_interval.into()),
             allowed_ips: item
                 .allowed_ips
@@ -244,12 +247,12 @@ pub struct Event {
 }
 
 /// Analytics information to be conveyed
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 pub struct AnalyticsEvent {
     /// Public key of the Peer
     pub public_key: PublicKey,
     /// Mesh's IP target of peer
-    pub endpoint: DualTarget,
+    pub dual_ip_addresses: Vec<DualTarget>,
     /// Number of transmitted bytes
     pub tx_bytes: u64,
     /// Number of recieved bytes

--- a/nat-lab/tests/test_lana_validator.py
+++ b/nat-lab/tests/test_lana_validator.py
@@ -272,7 +272,7 @@ def test_mem_nat_type_validator() -> None:
 
 def test_lana_event_validator() -> None:
     test_validator = (
-        Validator.basic_validator(meshnet_id="86bee206-9082")
+        Validator.basic_validator("beta", meshnet_id="86bee206-9082")
         .add_connectivity_matrix_validator(
             exists=True,
             no_of_connections=3,
@@ -291,10 +291,12 @@ def test_lana_event_validator() -> None:
         .add_external_links_validator(
             exists=True,
             contains=["delta", "charlie"],
-            does_not_contain=["alpha"],
+            does_not_contain=["alpha", "beta", "gamma"],
             all_connections_up=True,
             no_of_connections=2,
         )
     )
-
-    check_validator(test_validator, TEST_EVENT, DUMMY_EVENT)
+    res = test_validator.validate(TEST_EVENT)
+    assert res[0], res[1]
+    res = test_validator.validate(DUMMY_EVENT)
+    assert not res[0], res[1]

--- a/nat-lab/tests/utils/analytics/event_validator.py
+++ b/nat-lab/tests/utils/analytics/event_validator.py
@@ -7,6 +7,24 @@ IPV4_BIT = 0b00000100
 IPV6_BIT = 0b00001000
 
 
+# Add external peers to peers list
+#
+# External links can have two forms:
+#     - "vpn":md5(server_ip):<state>
+#     - <meshnet_id>:<node_fingerprint>:<state>
+# For convenience, vpn node is always identified by "vpn" string, other nodes by their fingerprint
+def process_external_peers(event, peers):
+    if event.external_links != "":
+        external_links = event.external_links.split(",")
+        for link in external_links:
+            external_peer_fp = (
+                link.split(":")[0]
+                if link.split(":")[0] == "vpn"
+                else link.split(":")[1]
+            )
+            peers.append(external_peer_fp)
+
+
 class ExistanceValidator:
     def validate(self, value):
         return (value is not None) and (value != "")
@@ -267,52 +285,238 @@ class HeartbeatIntervalValidator:
         return self._validator.validate(event.heartbeat_interval)
 
 
-class ReceivedDataValidator:
-    def __init__(self, exists=True):
-        self._validator = StringValidator(exists=exists)
-
-    def validate(self, event):
-        return self._validator.validate(event.received_data)
-
-
 class RttValidator:
-    def __init__(self, exists=True):
-        self._validator = StringValidator(exists=exists)
+    def __init__(
+        self,
+        exists=True,
+        members: Optional[List[str]] = None,
+        equals="",
+        contains: Optional[List[str]] = None,
+        does_not_contain: Optional[List[str]] = None,
+    ):
+        self._members = members
+        if not members:
+            self._validator = StringValidator(exists=exists)
+        else:
+            self._validator = StringValidator(
+                exists=exists,
+                equals=equals,
+                contains=contains,
+                does_not_contain=does_not_contain,
+            )
 
     def validate(self, event):
-        return self._validator.validate(event.rtt)
+        if not self._members:
+            return self._validator.validate(event.rtt)
+
+        rtt_list = event.rtt.split(",")
+        peers = event.members.split(",")
+        process_external_peers(event, peers)
+
+        peers_rtt = dict(zip(peers, rtt_list))
+
+        for member in self._members:
+            rtt = peers_rtt.get(member)
+            if rtt:
+                assert self._validator.validate(rtt), member
+            else:
+                assert False, member
+        return True
 
 
 class RttLossValidator:
-    def __init__(self, exists=True):
-        self._validator = StringValidator(exists=exists)
+    def __init__(
+        self,
+        exists=True,
+        members: Optional[List[str]] = None,
+        equals="",
+        contains: Optional[List[str]] = None,
+        does_not_contain: Optional[List[str]] = None,
+    ):
+        self._members = members
+        if not members:
+            self._validator = StringValidator(exists=exists)
+        else:
+            self._validator = StringValidator(
+                exists=exists,
+                equals=equals,
+                contains=contains,
+                does_not_contain=does_not_contain,
+            )
 
     def validate(self, event):
-        return self._validator.validate(event.rtt_loss)
+        if not self._members:
+            return self._validator.validate(event.rtt_loss)
+
+        rtt_loss_list = event.rtt_loss.split(",")
+        peers = event.members.split(",")
+        process_external_peers(event, peers)
+
+        peers_rtt_loss = dict(zip(peers, rtt_loss_list))
+
+        for member in self._members:
+            rtt_loss = peers_rtt_loss.get(member)
+            if rtt_loss:
+                assert self._validator.validate(rtt_loss), member
+            else:
+                assert False, member
+        return True
 
 
 class Rtt6Validator:
-    def __init__(self, exists=True):
-        self._validator = StringValidator(exists=exists)
+    def __init__(
+        self,
+        exists=True,
+        members: Optional[List[str]] = None,
+        equals="",
+        contains: Optional[List[str]] = None,
+        does_not_contain: Optional[List[str]] = None,
+    ):
+        self._members = members
+        if not members:
+            self._validator = StringValidator(exists=exists)
+        else:
+            self._validator = StringValidator(
+                exists=exists,
+                equals=equals,
+                contains=contains,
+                does_not_contain=does_not_contain,
+            )
 
     def validate(self, event):
-        return self._validator.validate(event.rtt6)
+        if not self._members:
+            return self._validator.validate(event.rtt6)
+
+        rtt6_list = event.rtt6.split(",")
+        peers = event.members.split(",")
+        process_external_peers(event, peers)
+
+        peers_rtt6 = dict(zip(peers, rtt6_list))
+
+        for member in self._members:
+            rtt6 = peers_rtt6.get(member)
+            if rtt6:
+                assert self._validator.validate(rtt6), member
+            else:
+                assert False, member
+        return True
 
 
 class Rtt6LossValidator:
-    def __init__(self, exists=True):
-        self._validator = StringValidator(exists=exists)
+    def __init__(
+        self,
+        exists=True,
+        members: Optional[List[str]] = None,
+        equals="",
+        contains: Optional[List[str]] = None,
+        does_not_contain: Optional[List[str]] = None,
+    ):
+        self._members = members
+        if not members:
+            self._validator = StringValidator(exists=exists)
+        else:
+            self._validator = StringValidator(
+                exists=exists,
+                equals=equals,
+                contains=contains,
+                does_not_contain=does_not_contain,
+            )
 
     def validate(self, event):
-        return self._validator.validate(event.rtt6_loss)
+        if not self._members:
+            return self._validator.validate(event.rtt6_loss)
+
+        rtt6_loss_list = event.rtt6_loss.split(",")
+        peers = event.members.split(",")
+        process_external_peers(event, peers)
+
+        peers_rtt6_loss = dict(zip(peers, rtt6_loss_list))
+
+        for member in self._members:
+            rtt6_loss = peers_rtt6_loss.get(member)
+            if rtt6_loss:
+                assert self._validator.validate(rtt6_loss), member
+            else:
+                assert False, member
+        return True
 
 
 class SentDataValidator:
-    def __init__(self, exists=True):
-        self._validator = StringValidator(exists=exists)
+    def __init__(
+        self,
+        exists=True,
+        members: Optional[List[str]] = None,
+        equals="",
+        contains: Optional[List[str]] = None,
+        does_not_contain: Optional[List[str]] = None,
+    ):
+        self._members = members
+        if not members:
+            self._validator = StringValidator(exists=exists)
+        else:
+            self._validator = StringValidator(
+                exists=exists,
+                equals=equals,
+                contains=contains,
+                does_not_contain=does_not_contain,
+            )
 
     def validate(self, event):
-        return self._validator.validate(event.sent_data)
+        if not self._members:
+            return self._validator.validate(event.sent_data)
+
+        sent_data_list = event.sent_data.split(",")
+        peers = event.members.split(",")
+        process_external_peers(event, peers)
+
+        peers_sent_data = dict(zip(peers, sent_data_list))
+
+        for member in self._members:
+            sent_data = peers_sent_data.get(member)
+            if sent_data:
+                assert self._validator.validate(sent_data), member
+            else:
+                assert False, member
+        return True
+
+
+class ReceivedDataValidator:
+    def __init__(
+        self,
+        exists=True,
+        members: Optional[List[str]] = None,
+        equals="",
+        contains: Optional[List[str]] = None,
+        does_not_contain: Optional[List[str]] = None,
+    ):
+        self._members = members
+        if not members:
+            self._validator = StringValidator(exists=exists)
+        else:
+            self._validator = StringValidator(
+                exists=exists,
+                equals=equals,
+                contains=contains,
+                does_not_contain=does_not_contain,
+            )
+
+    def validate(self, event):
+        if not self._members:
+            return self._validator.validate(event.received_data)
+
+        received_data_list = event.received_data.split(",")
+        peers = event.members.split(",")
+        process_external_peers(event, peers)
+
+        peers_received_data = dict(zip(peers, received_data_list))
+
+        for member in self._members:
+            received_data = peers_received_data.get(member)
+            if received_data:
+                assert self._validator.validate(received_data), member
+            else:
+                assert False, member
+        return True
 
 
 class NatTypeValidator:
@@ -337,8 +541,9 @@ class MemNatTypeValidator:
 
 
 class EventValidator:
-    def __init__(self):
+    def __init__(self, node_fingerprint):
         self._validators = []
+        self.node_fingerprint = node_fingerprint
 
     def add_name_validator(self, name=""):
         self._validators.append(NameValidator(name=name))
@@ -419,28 +624,118 @@ class EventValidator:
         self._validators.append(HeartbeatIntervalValidator(value=value, equals=equals))
         return self
 
-    def add_received_data_validator(self, exists=True):
-        self._validators.append(ReceivedDataValidator(exists=exists))
+    def add_rtt_validator(
+        self,
+        exists=True,
+        members: Optional[List[str]] = None,
+        equals="",
+        contains: Optional[List[str]] = None,
+        does_not_contain: Optional[List[str]] = None,
+    ):
+        self._validators.append(
+            RttValidator(
+                exists,
+                members,
+                equals,
+                contains,
+                does_not_contain,
+            )
+        )
         return self
 
-    def add_rtt_validator(self, exists=True):
-        self._validators.append(RttValidator(exists=exists))
+    def add_rtt_loss_validator(
+        self,
+        exists=True,
+        members: Optional[List[str]] = None,
+        equals="",
+        contains: Optional[List[str]] = None,
+        does_not_contain: Optional[List[str]] = None,
+    ):
+        self._validators.append(
+            RttLossValidator(
+                exists,
+                members,
+                equals,
+                contains,
+                does_not_contain,
+            )
+        )
         return self
 
-    def add_rtt_loss_validator(self, exists=True):
-        self._validators.append(RttLossValidator(exists=exists))
+    def add_rtt6_validator(
+        self,
+        exists=True,
+        members: Optional[List[str]] = None,
+        equals="",
+        contains: Optional[List[str]] = None,
+        does_not_contain: Optional[List[str]] = None,
+    ):
+        self._validators.append(
+            Rtt6Validator(
+                exists,
+                members,
+                equals,
+                contains,
+                does_not_contain,
+            )
+        )
         return self
 
-    def add_rtt6_validator(self, exists=True):
-        self._validators.append(Rtt6Validator(exists=exists))
+    def add_rtt6_loss_validator(
+        self,
+        exists=True,
+        members: Optional[List[str]] = None,
+        equals="",
+        contains: Optional[List[str]] = None,
+        does_not_contain: Optional[List[str]] = None,
+    ):
+        self._validators.append(
+            Rtt6LossValidator(
+                exists,
+                members,
+                equals,
+                contains,
+                does_not_contain,
+            )
+        )
         return self
 
-    def add_rtt6_loss_validator(self, exists=True):
-        self._validators.append(Rtt6LossValidator(exists=exists))
+    def add_sent_data_validator(
+        self,
+        exists=True,
+        members: Optional[List[str]] = None,
+        equals="",
+        contains: Optional[List[str]] = None,
+        does_not_contain: Optional[List[str]] = None,
+    ):
+        self._validators.append(
+            SentDataValidator(
+                exists,
+                members,
+                equals,
+                contains,
+                does_not_contain,
+            )
+        )
         return self
 
-    def add_sent_data_validator(self, exists=True):
-        self._validators.append(SentDataValidator(exists=exists))
+    def add_received_data_validator(
+        self,
+        exists=True,
+        members: Optional[List[str]] = None,
+        equals="",
+        contains: Optional[List[str]] = None,
+        does_not_contain: Optional[List[str]] = None,
+    ):
+        self._validators.append(
+            ReceivedDataValidator(
+                exists,
+                members,
+                equals,
+                contains,
+                does_not_contain,
+            )
+        )
         return self
 
     def add_nat_type_validators(
@@ -459,29 +754,23 @@ class EventValidator:
         self._validators.append(MemNatTypeValidator(value))
         return self
 
-    def validate(self, event) -> bool:
+    def validate(self, event) -> tuple[bool, str]:
         for validator in self._validators:
             if not validator.validate(event):
-                return False
-        return True
+                return False, type(validator).__name__
+        return True, ""
 
 
 def basic_validator(
-    node_fingerprint: str = "", heartbeat_interval: int = 3600, meshnet_id: str = ""
+    node_fingerprint: str, heartbeat_interval: int = 3600, meshnet_id: str = ""
 ) -> EventValidator:
     event_validator = (
-        EventValidator()
+        EventValidator(node_fingerprint)
         .add_name_validator("heartbeat")
         .add_category_validator("service_quality")
         .add_fingerprint_validator(exists=True, equals=meshnet_id)
         .add_heartbeat_interval_validator(value=heartbeat_interval, equals=True)
         .add_connection_duration_validator(exists=True)
-        .add_received_data_validator(exists=True)
-        .add_rtt_validator(exists=True)
-        .add_rtt_loss_validator(exists=True)
-        .add_rtt6_validator(exists=True)
-        .add_rtt6_loss_validator(exists=True)
-        .add_sent_data_validator(exists=True)
     )
     if node_fingerprint != "":
         # Current node should always be in the members list

--- a/src/device/wg_controller.rs
+++ b/src/device/wg_controller.rs
@@ -3,13 +3,14 @@ use ipnetwork::IpNetwork;
 use std::collections::HashMap;
 use std::collections::{BTreeMap, HashSet};
 use std::iter::FromIterator;
-use std::net::IpAddr;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::sync::Arc;
 use std::time::Duration;
 use telio_crypto::PublicKey;
 use telio_dns::DnsResolver;
 use telio_firewall::firewall::{Firewall, FILE_SEND_PORT};
 use telio_model::api_config::Features;
+use telio_model::constants::{VPN_EXTERNAL_IPV4, VPN_INTERNAL_IPV4, VPN_INTERNAL_IPV6};
 use telio_model::mesh::NodeState::Connected;
 use telio_model::EndpointMap;
 use telio_model::SocketAddr;
@@ -472,9 +473,15 @@ async fn build_requested_peers_list<
             // Exit node is a fresh node, therefore - insert create new peer
             let public_key = exit_node.public_key;
             let endpoint = exit_node.endpoint;
-            let persistent_keepalive_interval = requested_state.keepalive_periods.vpn;
-            // If the PQ VPN is set up we need to configure the preshared key
 
+            let mut ip_addresses = vec![IpAddr::V4(Ipv4Addr::from(VPN_INTERNAL_IPV4))];
+            if features.ipv6 {
+                ip_addresses.push(IpAddr::V6(Ipv6Addr::from(VPN_INTERNAL_IPV6)));
+            }
+            ip_addresses.push(IpAddr::V4(Ipv4Addr::from(VPN_EXTERNAL_IPV4)));
+            let persistent_keepalive_interval = requested_state.keepalive_periods.vpn;
+
+            // If the PQ VPN is set up we need to configure the preshared key
             match post_quantum_vpn.map(telio_pq::Entity::keys) {
                 Some(None) => {
                     // The post quantum state is not ready, we don't want to set up quantum
@@ -489,6 +496,7 @@ async fn build_requested_peers_list<
                             peer: telio_wg::uapi::Peer {
                                 public_key,
                                 endpoint,
+                                ip_addresses,
                                 persistent_keepalive_interval,
                                 allowed_ips,
                                 preshared_key,
@@ -532,12 +540,15 @@ async fn build_requested_peers_list<
         } else {
             vec![IpNetwork::V4("100.64.0.4/32".parse()?)]
         };
+        let ip_addresses = allowed_ips.iter().copied().map(|ip| ip.ip()).collect();
+
         requested_peers.insert(
             public_key,
             RequestedPeer {
                 peer: telio_wg::uapi::Peer {
                     public_key,
                     endpoint: Some(endpoint),
+                    ip_addresses,
                     persistent_keepalive_interval,
                     allowed_ips,
                     ..Default::default()
@@ -590,6 +601,12 @@ async fn build_requested_meshnet_peers_list<
             let persistent_keepalive_interval = requested_state.keepalive_periods.proxying;
             let endpoint = proxy_endpoints.get(&public_key).cloned();
 
+            // Keep track of meshnet IP needed for instance for QoS analytics
+            let ip_addresses = match deduplicated_peer_ips.get(&public_key) {
+                Some(ips) => ips.clone(),
+                None => vec![],
+            };
+
             // Retrieve node's meshnet IP from config, and convert it into `/32` network type for v4, and `/128` for v6
             let allowed_ips = deduplicated_peer_ips
                 .remove(&public_key)
@@ -615,6 +632,7 @@ async fn build_requested_meshnet_peers_list<
                     peer: telio_wg::uapi::Peer {
                         public_key,
                         endpoint,
+                        ip_addresses,
                         persistent_keepalive_interval,
                         allowed_ips,
                         ..Default::default()
@@ -1488,14 +1506,18 @@ mod tests {
                 .returning(move || Ok(map.clone()));
         }
 
-        fn then_add_peer(&mut self, input: Vec<(PublicKey, SocketAddr, u32, Vec<IpNetwork>)>) {
+        fn then_add_peer(
+            &mut self,
+            input: Vec<(PublicKey, SocketAddr, u32, Vec<IpNetwork>, Vec<IpAddr>)>,
+        ) {
             for i in input {
                 self.wireguard_interface
                     .expect_add_peer()
                     .once()
                     .with(eq(Peer {
                         public_key: i.0,
-                        endpoint: Some(i.1.into()),
+                        endpoint: Some(i.1),
+                        ip_addresses: i.4,
                         persistent_keepalive_interval: Some(i.2),
                         allowed_ips: i.3,
                         rx_bytes: None,
@@ -1640,7 +1662,8 @@ mod tests {
             pub_key,
             proxy_endpoint,
             proxying_keepalive_time,
-            allowed_ips.into_iter().map(|ip| ip.into()).collect(),
+            allowed_ips.iter().copied().map(|ip| ip.into()).collect(),
+            allowed_ips,
         )]);
 
         f.consolidate_peers().await;
@@ -1685,7 +1708,8 @@ mod tests {
             pub_key,
             remote_wg_endpoint,
             direct_keepalive_period,
-            allowed_ips.into_iter().map(|ip| ip.into()).collect(),
+            allowed_ips.iter().copied().map(|ip| ip.into()).collect(),
+            allowed_ips,
         )]);
         f.then_proxy_mute(vec![(
             pub_key,
@@ -1740,7 +1764,8 @@ mod tests {
             pub_key,
             remote_wg_endpoint,
             direct_keepalive_period,
-            allowed_ips.into_iter().map(|ip| ip.into()).collect(),
+            allowed_ips.iter().copied().map(|ip| ip.into()).collect(),
+            allowed_ips,
         )]);
         f.then_request_upgrade(vec![(pub_key, remote_wg_endpoint, local_wg_endpoint)]);
         f.then_keeper_add_node(vec![(pub_key, ip1, Some(ip1v6), direct_keepalive_period)]);
@@ -1786,7 +1811,8 @@ mod tests {
             pub_key,
             proxy_endpoint,
             proxying_keepalive_period,
-            allowed_ips.into_iter().map(|ip| ip.into()).collect(),
+            allowed_ips.iter().copied().map(|ip| ip.into()).collect(),
+            allowed_ips,
         )]);
 
         f.consolidate_peers().await;
@@ -1885,7 +1911,8 @@ mod tests {
             pub_key,
             proxy_endpoint,
             proxying_keepalive_period,
-            allowed_ips.into_iter().map(|ip| ip.into()).collect(),
+            allowed_ips.iter().copied().map(|ip| ip.into()).collect(),
+            allowed_ips,
         )]);
         f.then_notify_failed_wg_connection(vec![pub_key]);
         f.then_keeper_remove_node(vec![pub_key]);
@@ -1935,6 +1962,11 @@ mod tests {
             )
             .unwrap(),
         ];
+        let ip_addresses = vec![
+            IpAddr::V4(Ipv4Addr::from(VPN_INTERNAL_IPV4)),
+            IpAddr::V6(Ipv6Addr::from(VPN_INTERNAL_IPV6)),
+            IpAddr::V4(Ipv4Addr::from(VPN_EXTERNAL_IPV4)),
+        ];
 
         let endpoint_raw = SocketAddr::from(([192, 168, 0, 1], 13));
         let endpoint = Some(endpoint_raw);
@@ -1962,6 +1994,7 @@ mod tests {
             endpoint_raw,
             vpn_persistent_keepalive,
             allowed_ips,
+            ip_addresses,
         )]);
 
         f.consolidate_peers().await;
@@ -1981,6 +2014,7 @@ mod tests {
             )
             .unwrap(),
         ];
+        let ip_addresses = allowed_ips.iter().copied().map(|ip| ip.network()).collect();
 
         let stun_port = 1234;
         let endpoint_ip = Ipv4Addr::from([100, 10, 0, 17]);
@@ -2008,6 +2042,7 @@ mod tests {
             endpoint_raw,
             stun_persistent_keepalive,
             allowed_ips,
+            ip_addresses,
         )]);
 
         f.consolidate_peers().await;
@@ -2054,7 +2089,8 @@ mod tests {
             pub_key,
             remote_wg_endpoint,
             DEFAULT_DIRECT_PERSISTENT_KEEPALIVE_PERIOD,
-            allowed_ips.into_iter().map(|ip| ip.into()).collect(),
+            allowed_ips.iter().copied().map(|ip| ip.into()).collect(),
+            allowed_ips,
         )]);
         f.then_proxy_mute(vec![(
             pub_key,


### PR DESCRIPTION
### Problem
QoS ping was being done over ip addresses retrieved from the subnets on `allowed_ips` field. This led to issues on missing data for exit node peers that have `0.0.0.0/0` subnet.

### Solution
This PR adds an additional field to `Peer` structs so that we can track which meshnet address a specific peer was given.
VPN peers have `[100.64.0.1, 10.5.0.1]` ip addresses assigned, however when meshnet is enabled `100.64.0.1` is reachable otherwise it isn't. Therefore`100.64.0.1` is treated as the default address to ping and `10.5.0.1` as alternative when the other is not reachable. Both should be reachable at normal circumstances.

Eg.:
```
{
    ...
    "context": {
        "application": {
            "arch": "x86_64",
            "libtelioapp": {
                "config": {
                    "external_links": "vpn:6c980a87b6607f5b60d0bd57470f66fe:6",
                    "internal_meshnet": {
                        "connectivity_matrix": "0:1:3",
                        "fp": "de919f74-168f-4236-b17b-1825985fb051",
                        "fp_nat": "Unknown",
                        "members": "c8571935cc534a3a7f3002d9142f9044df4d90f90f1f220aa3afe7f5234a83ba,vpn_miss_tst",
                        "members_nat": "Unknown"
                    },
                    "meshnet_enabled": true
                }
            },
            "name": "libtelio",
            "nordvpnapp": {"version": null},
            "platform": "linux",
            "version": "dev"
        },
     ...
    "body": {
        "connection_duration": "59;0;59",
        "rtt": "4:4:7:7:7,0:0:0:0:0,10:10:11:11:11",
        "rtt_loss": "0:0:0:0:0,0:0:0:0:0,0:0:0:0:0",
        "rtt6": "0:0:0:0:0,0:0:0:0:0,0:0:0:0:0",
        "rtt6_loss": "0:0:0:0:0,0:0:0:0:0,0:0:0:0:0",
        "sent_data": "0:0:32:232:496,0:0:0:0:0,0:0:116:300:5649",
        "received_data": "0:0:32:232:464,0:0:0:0:0,0:0:0:84:3779",
        "heartbeat_interval": 60,
        "derp_connection_duration": 0
    }
}
```

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
