### PR TITLE
[LLT-4916] Allow any case nickname

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 * LLT-4908: Lowered DNS TTL time for nicknames and NXDomain responses
 * LLT-4915: Update the moose tracker to v1.0.0-libtelioApp
 * LLT-4913: Skip qos analytics ping for unconnected peers
+* LLT-4916: Allow any case nicknames
 
 <br>
 

--- a/crates/telio-model/src/validation.rs
+++ b/crates/telio-model/src/validation.rs
@@ -36,9 +36,5 @@ pub fn validate_nickname(name: &str) -> bool {
         telio_log_debug!("Nickname starts with a hyphen");
         return false;
     }
-    if !name.eq(name.to_lowercase().as_str()) {
-        telio_log_debug!("Nickname is not in lowercase");
-        return false;
-    }
     true
 }

--- a/nat-lab/tests/mesh_api.py
+++ b/nat-lab/tests/mesh_api.py
@@ -240,8 +240,6 @@ class API:
             raise NicknameInvalidError(nickname)
         if nickname.startswith("-"):
             raise NicknameInvalidError(nickname)
-        if not nickname.islower():
-            raise NicknameInvalidError(nickname)
 
         for _, node in self.nodes.items():
             if nickname == node.nickname:

--- a/nat-lab/tests/test_events.py
+++ b/nat-lab/tests/test_events.py
@@ -96,7 +96,7 @@ async def test_event_content_meshnet(
         api = env.api
         alpha, beta = env.nodes
         alpha.nickname = "alpha"
-        beta.nickname = "beta"
+        beta.nickname = "BETA"
         client_alpha, client_beta = env.clients
         connection_alpha, connection_beta = [
             conn.connection for conn in env.connections
@@ -115,7 +115,7 @@ async def test_event_content_meshnet(
             is_vpn=False,
             ip_addresses=beta.ip_addresses,
             allowed_ips=env.api.get_allowed_ip_list(beta.ip_addresses),
-            nickname="beta",
+            nickname="BETA",
             endpoint=None,
             hostname=beta.name + ".nord",
             allow_incoming_connections=True,
@@ -157,7 +157,7 @@ async def test_event_content_meshnet(
             is_vpn=False,
             ip_addresses=beta.ip_addresses,
             allowed_ips=env.api.get_allowed_ip_list(beta.ip_addresses),
-            nickname="beta",
+            nickname="BETA",
             endpoint=None,
             hostname=beta.name + ".nord",
             allow_incoming_connections=True,
@@ -397,7 +397,7 @@ async def test_event_content_exit_through_peer(
             [(False, IPStack.IPv4v6), (False, IPStack.IPv4v6)]
         )
         alpha.nickname = "alpha"
-        beta.nickname = "beta"
+        beta.nickname = "BETA"
         alpha.set_peer_firewall_settings(beta.id)
         env = await setup_mesh_nodes(
             exit_stack, [alpha_setup_params, beta_setup_params], provided_api=api
@@ -418,7 +418,7 @@ async def test_event_content_exit_through_peer(
             is_vpn=False,
             ip_addresses=beta.ip_addresses,
             allowed_ips=env.api.get_allowed_ip_list(beta.ip_addresses),
-            nickname="beta",
+            nickname="BETA",
             endpoint=None,
             hostname=beta.name + ".nord",
             allow_incoming_connections=False,
@@ -447,7 +447,7 @@ async def test_event_content_exit_through_peer(
             is_vpn=False,
             ip_addresses=beta.ip_addresses,
             allowed_ips=["0.0.0.0/0", "::/0"],
-            nickname="beta",
+            nickname="BETA",
             endpoint=None,
             hostname=beta.name + ".nord",
             allow_incoming_connections=False,
@@ -556,7 +556,7 @@ async def test_event_content_meshnet_node_upgrade_direct(
         api = env.api
         alpha, beta = env.nodes
         alpha.nickname = "alpha"
-        beta.nickname = "beta"
+        beta.nickname = "BETA"
         connection_alpha, connection_beta = [
             conn.connection for conn in env.connections
         ]
@@ -577,7 +577,7 @@ async def test_event_content_meshnet_node_upgrade_direct(
             is_vpn=False,
             ip_addresses=beta.ip_addresses,
             allowed_ips=env.api.get_allowed_ip_list(beta.ip_addresses),
-            nickname="beta",
+            nickname="BETA",
             endpoint=None,
             hostname=beta.name + ".nord",
             allow_incoming_connections=True,
@@ -647,7 +647,7 @@ async def test_event_content_meshnet_node_upgrade_direct(
             is_vpn=False,
             ip_addresses=beta.ip_addresses,
             allowed_ips=env.api.get_allowed_ip_list(beta.ip_addresses),
-            nickname="beta",
+            nickname="BETA",
             endpoint=None,
             hostname=beta.name + ".nord",
             allow_incoming_connections=True,

--- a/nat-lab/tests/test_mesh_api.py
+++ b/nat-lab/tests/test_mesh_api.py
@@ -191,8 +191,6 @@ class TestMeshApi:
             api.assign_nickname("id1", "johnsomethingsomethingsomething")
         with pytest.raises(mesh_api.NicknameInvalidError):
             api.assign_nickname("id1", "joh--n")
-        with pytest.raises(mesh_api.NicknameInvalidError):
-            api.assign_nickname("id1", "jOhN")
         with pytest.raises(mesh_api.NicknameCollisionError):
             api.assign_nickname("id1", "alpha")
         with pytest.raises(mesh_api.NicknameCollisionError):

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -2131,7 +2131,7 @@ mod tests {
                 Some("bond-jamesbond".to_owned()),
             ),
             build_peer(
-                String::from("gamma.nord"),
+                String::from("gaMMa.nord"),
                 Some(vec![IpAddr::V6(gamma_ipv6)]),
                 None,
             ),
@@ -2157,7 +2157,7 @@ mod tests {
             vec![IpAddr::V4(beta_ipv4)]
         );
 
-        assert_eq!(records["gamma.nord"].clone(), vec![IpAddr::V6(gamma_ipv6)]);
+        assert_eq!(records["gaMMa.nord"].clone(), vec![IpAddr::V6(gamma_ipv6)]);
 
         assert!(!records.contains_key("theta.nord"));
 
@@ -2206,12 +2206,6 @@ mod tests {
                     valid_hostname.to_owned(),
                     valid_ipv4.clone(),
                     Some("johnny--rotten".to_owned()),
-                ),
-                // Contains a uppercase char
-                build_peer(
-                    valid_hostname.to_owned(),
-                    valid_ipv4.clone(),
-                    Some("jOhnnyrotten".to_owned()),
                 ),
                 // Ends with "."
                 build_peer(


### PR DESCRIPTION
### Problem

Nickname RFC allows nicknames to be passed
in any case. So there is no valid reason
to filter out nicknames that are only in
lowercase.

It was also agreed that nickname passed
with node event should be identical to one
passed via meshnet config.

### Solution

Remove validation that expects nicknames to be only in lowercase.
TrustDNS already handles these cases in an expected
manner. After passing a domain name, we can
query in any case.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests