### PR TITLE
Do not update wg listen_port when not needed

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@
 * LLT-4406: Implement error handling for proxy egress
 * LLT-4948: Change missed tick behavior from burst to delay
 * LLT-4855: Add Aggregator struct for connectivity events gathering
+* LLT-4917: Fix the issue with wireguard-go failing to bind to a port on some devices
 
 <br>
 

--- a/crates/telio-wg/src/wg.rs
+++ b/crates/telio-wg/src/wg.rs
@@ -620,6 +620,23 @@ impl State {
         Ok(())
     }
 
+    fn update_calculate_set_listen_port(
+        from_listen_port: Option<u16>,
+        to_listen_port: Option<u16>,
+    ) -> Option<u16> {
+        match (from_listen_port, to_listen_port) {
+            (Some(from), Some(to)) => {
+                if from != to {
+                    Some(to)
+                } else {
+                    None
+                }
+            }
+            (None, Some(to)) => Some(to),
+            _ => None,
+        }
+    }
+
     fn update_construct_set_device(
         &self,
         to: &uapi::Interface,
@@ -645,7 +662,10 @@ impl State {
 
         set::Device {
             private_key: to.private_key.map(|key| key.into_bytes()),
-            listen_port: to.listen_port,
+            listen_port: Self::update_calculate_set_listen_port(
+                self.interface.listen_port,
+                to.listen_port,
+            ),
             fwmark: match to.fwmark {
                 0 => None,
                 x => Some(x),
@@ -1449,5 +1469,23 @@ pub mod tests {
 
         adapter.lock().await.expect_stop().return_once(|| ());
         wg.stop().await;
+    }
+
+    #[test]
+    fn test_update_calculate_set_listen_port() {
+        assert_eq!(State::update_calculate_set_listen_port(None, None), None);
+        assert_eq!(State::update_calculate_set_listen_port(Some(1), None), None);
+        assert_eq!(
+            State::update_calculate_set_listen_port(Some(1), Some(1)),
+            None
+        );
+        assert_eq!(
+            State::update_calculate_set_listen_port(None, Some(1)),
+            Some(1)
+        );
+        assert_eq!(
+            State::update_calculate_set_listen_port(Some(1), Some(2)),
+            Some(2)
+        );
     }
 }


### PR DESCRIPTION
Do not configure listen_port in wireguard adapter if it is already configured to the same value. At least in some implementations it is not a no-op and reconfiguring it causes the underlying socket to be closed and recreated


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
