### PR TITLE
LLT-4948: Set missing tick behavior for tokio intervals

### DIFF
--- a/crates/telio-nurse/src/qos.rs
+++ b/crates/telio-nurse/src/qos.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use tokio::sync::mpsc;
-use tokio::time::{interval_at, Duration, Interval};
+use tokio::time::{interval_at, Duration, Interval, MissedTickBehavior};
 
 use telio_crypto::PublicKey;
 use telio_task::{io::mc_chan, Runtime, RuntimeExt, WaitResponse};
@@ -233,9 +233,11 @@ impl Analytics {
         } else {
             Arc::new(None)
         };
+        let mut rtt_interval = interval_at(tokio::time::Instant::now(), config.rtt_interval);
+        rtt_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
         Self {
-            rtt_interval: interval_at(tokio::time::Instant::now(), config.rtt_interval),
+            rtt_interval,
             io,
             nodes: HashMap::new(),
             ping_backend,

--- a/crates/telio-utils/src/repeated_actions.rs
+++ b/crates/telio-utils/src/repeated_actions.rs
@@ -10,7 +10,7 @@ use futures::{
     stream::{FuturesUnordered, StreamExt},
     FutureExt,
 };
-use tokio::time::{interval, interval_at, Duration, Instant, Interval};
+use tokio::time::{interval, interval_at, Duration, Instant, Interval, MissedTickBehavior};
 
 /// Possible [RepeatedAction] errors.
 #[derive(ThisError, Debug)]
@@ -84,7 +84,9 @@ where
         self.actions.get_mut(key).map_or_else(
             || Err(RepeatedActionError::RepeatedActionNotFound),
             |a| {
-                a.0 = interval_at(Instant::now() + dur, dur);
+                let mut interval = interval_at(Instant::now() + dur, dur);
+                interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+                a.0 = interval;
                 Ok(())
             },
         )

--- a/crates/telio-wg/src/wg.rs
+++ b/crates/telio-wg/src/wg.rs
@@ -12,7 +12,7 @@ use telio_utils::{
     dual_target, telio_err_with_log, telio_log_debug, telio_log_trace, telio_log_warn,
 };
 use thiserror::Error as TError;
-use tokio::time::{self, sleep, Instant, Interval};
+use tokio::time::{self, sleep, Instant, Interval, MissedTickBehavior};
 use wireguard_uapi::xplatform::set;
 
 use telio_crypto::{PublicKey, SecretKey};
@@ -231,7 +231,8 @@ impl DynamicWg {
         no_link_detection: Option<FeatureLinkDetection>,
         #[cfg(unix)] cfg: Config,
     ) -> Self {
-        let interval = time::interval(Duration::from_millis(POLL_MILLIS));
+        let mut interval = time::interval(Duration::from_millis(POLL_MILLIS));
+        interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
         Self {
             task: Task::start(State {

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -39,7 +39,7 @@ use thiserror::Error as TError;
 use tokio::{
     runtime::{Builder, Runtime as AsyncRuntime},
     sync::Mutex,
-    time::{interval_at, Interval},
+    time::{interval_at, Interval, MissedTickBehavior},
 };
 
 use telio_dns::{DnsResolver, LocalDnsResolver, Records};
@@ -1002,6 +1002,9 @@ impl Runtime {
             .post_quantum_vpn
             .map(|pq_features| telio_pq::Entity::new(pq_features, socket_pool.clone()));
 
+        let mut polling_interval = interval_at(tokio::time::Instant::now(), Duration::from_secs(5));
+        polling_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+
         Ok(Runtime {
             features,
             requested_state,
@@ -1032,7 +1035,7 @@ impl Runtime {
                 derp_events_publisher: derp_events.tx,
                 post_quantum_publisher: post_quantum.tx,
             },
-            polling_interval: interval_at(tokio::time::Instant::now(), Duration::from_secs(5)),
+            polling_interval,
             #[cfg(test)]
             test_env: wg::tests::Env {
                 analytics: analytics_ch,


### PR DESCRIPTION
### Problem
We were, for our purposes, incorrectly handling the cases where tokio misses one or more ticks when doing work based on an interval.

### Solution
We now set the missed tick behavior to delay, instead of the default burst. For more info, see:
https://docs.rs/tokio/latest/tokio/time/enum.MissedTickBehavior.html


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
