### PR TITLE
LLT-3475: Migrate natlab tests to uniffi bindings

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -3,6 +3,19 @@ on: [workflow_call]
 permissions: {}
 
 jobs:
+  uniffi-bindings:
+      runs-on: ubuntu-22.04
+      container:
+          image: ghcr.io/nordsecurity/uniffi-generators:v0.25.0-8
+      steps:
+        - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        - run: uniffi-bindgen generate src/libtelio.udl --language python
+        - run: mkdir -p dist/bindings/
+        - run: cp src/telio.py dist/bindings/telio_bindings.py
+        - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+          with:
+            name: telio_bindings.py
+            path: dist/bindings
   check:
       runs-on: ubuntu-22.04
       steps:
@@ -105,19 +118,31 @@ jobs:
         - run: autoflake --check .
           working-directory: nat-lab
   python-lint:
+      needs: uniffi-bindings
       runs-on: ubuntu-22.04
       steps:
         - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+          with:
+            name: telio_bindings.py
+            path: dist/bindings
+        - run: cp dist/bindings/telio_bindings.py nat-lab/tests/uniffi/telio_bindings.py
         - run: pip3 install --no-deps -r requirements.txt
         - run: pipenv install --system
         - run: pipenv install --system
           working-directory: nat-lab
-        - run: pylint -f colorized .
+        - run: pylint -f colorized . --ignore telio_bindings.py
           working-directory: nat-lab
   natlab-typecheck:
+      needs: uniffi-bindings
       runs-on: ubuntu-22.04
       steps:
         - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+          with:
+            name: telio_bindings.py
+            path: dist/bindings
+        - run: cp dist/bindings/telio_bindings.py nat-lab/tests/uniffi/telio_bindings.py
         - run: pip3 install --no-deps -r requirements.txt
         - run: pipenv install --system
         - run: pipenv install --system

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ tcli.log
 /3rd-party/nordderper
 /nat-lab/3rd-party/iptables
 /nat-lab/3rd-party/netfilter-full-cone-nat
+/nat-lab/tests/uniffi/telio_bindings.py
+/nat-lab/tests/uniffi/libtelio.so
+/src/telio.py
 /3rd-party/wireguard-go/*.lib
 /3rd-party/wireguard-go/*.h
 /3rd-party/wireguard-go/*.a

--- a/.unreleased/LLT-3475
+++ b/.unreleased/LLT-3475
@@ -1,0 +1,1 @@
+Migrate natlab to UniFFI-generated python bindings

--- a/nat-lab/Pipfile
+++ b/nat-lab/Pipfile
@@ -35,14 +35,15 @@ pluggy = "*"
 protobuf = "==3.20.3"
 py = "*"
 pycparser = "*"
+pyro5 = "==5.15"
 pytest-metadata = "*"
+pytest-repeat = "*"
 six = "*"
 tomli = "*"
 types-protobuf = "==3.19.21"
 typing-extensions = "*"
 typing-inspect = "*"
 yarl = "*"
-pytest-repeat = "*"
 
 [dev-packages]
 

--- a/nat-lab/Pipfile.lock
+++ b/nat-lab/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "1ca0bc2d37ce34b284babd76a83742b58fd1f06d4b56aa8dcce74b23bf72a7d9"
+            "sha256": "4a95b7874669bcd26a8cf9f906bc6f38bae84cc4e80798f04c42d1b9f15dcfd2"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -300,60 +300,60 @@
         },
         "cryptography": {
             "hashes": [
-                "sha256:00c0faa5b021457848d031ecff041262211cc1e2bce5f6e6e6c8108018f6b44a",
-                "sha256:073104df012fc815eed976cd7d0a386c8725d0d0947cf9c37f6c36a6c20feb1b",
-                "sha256:076c92b08dd1ab88108bc84545187e10d3693a9299c593f98c4ea195a0b0ead7",
-                "sha256:089aeb297ff89615934b22c7631448598495ffd775b7d540a55cfee35a677bf4",
-                "sha256:3b750279f3e7715df6f68050707a0cee7cbe81ba2eeb2f21d081bd205885ffed",
-                "sha256:43e521f21c2458038d72e8cdfd4d4d9f1d00906a7b6636c4272e35f650d1699b",
-                "sha256:4bdb39ecbf05626e4bfa1efd773bb10346af297af14fb3f4c7cb91a1d2f34a46",
-                "sha256:5967e3632f42b0c0f9dc2c9da88c79eabdda317860b246d1fbbde4a8bbbc3b44",
-                "sha256:65d529c31bd65d54ce6b926a01e1b66eacf770b7e87c0622516a840e400ec732",
-                "sha256:6981acac509cc9415344cb5bfea8130096ea6ebcc917e75503143a1e9e829160",
-                "sha256:81dbe47e28b703bc4711ac74a64ef8b758a0cf056ce81d08e39116ab4bc126fa",
-                "sha256:8b90c57b3cd6128e0863b894ce77bd36fcb5f430bf2377bc3678c2f56e232316",
-                "sha256:9184aff0856261ecb566a3eb26a05dfe13a292c85ce5c59b04e4aa09e5814187",
-                "sha256:945a43ebf036dd4b43ebfbbd6b0f2db29ad3d39df824fb77476ca5777a9dde33",
-                "sha256:97eeacae9aa526ddafe68b9202a535f581e21d78f16688a84c8dcc063618e121",
-                "sha256:9f1a3bc2747166b0643b00e0b56cd9b661afc9d5ff963acaac7a9c7b2b1ef638",
-                "sha256:9ff75b88a4d273c06d968ad535e6cb6a039dd32db54fe36f05ed62ac3ef64a44",
-                "sha256:aeb6f56b004e898df5530fa873e598ec78eb338ba35f6fa1449970800b1d97c2",
-                "sha256:b16b90605c62bcb3aa7755d62cf5e746828cfc3f965a65211849e00c46f8348d",
-                "sha256:b99831397fdc6e6e0aa088b060c278c6e635d25c0d4d14bdf045bf81792fda0a",
-                "sha256:bc954251edcd8a952eeaec8ae989fec7fe48109ab343138d537b7ea5bb41071a",
-                "sha256:c05230d8aaaa6b8ab3ab41394dc06eb3d916131df1c9dcb4c94e8f041f704b74",
-                "sha256:d16a310c770cc49908c500c2ceb011f2840674101a587d39fa3ea828915b7e83",
-                "sha256:d93080d2b01b292e7ee4d247bf93ed802b0100f5baa3fa5fd6d374716fa480d4",
-                "sha256:e1f5f15c5ddadf6ee4d1d624a2ae940f14bd74536230b0056ccb28bb6248e42a",
-                "sha256:e3442601d276bd9e961d618b799761b4e5d892f938e8a4fe1efbe2752be90455",
-                "sha256:e85f433230add2aa26b66d018e21134000067d210c9c68ef7544ba65fc52e3eb",
-                "sha256:eecca86813c6a923cabff284b82ff4d73d9e91241dc176250192c3a9b9902a54",
-                "sha256:f1e933b238978ccfa77b1fee0a297b3c04983f4cb84ae1c33b0ea4ae08266cc9",
-                "sha256:f4cece02478d73dacd52be57a521d168af64ae03d2a567c0c4eb6f189c3b9d79",
-                "sha256:f567a82b7c2b99257cca2a1c902c1b129787278ff67148f188784245c7ed5495",
-                "sha256:f987a244dfb0333fbd74a691c36000a2569eaf7c7cc2ac838f85f59f0588ddc9"
+                "sha256:02c0eee2d7133bdbbc5e24441258d5d2244beb31da5ed19fbb80315f4bbbff55",
+                "sha256:0d563795db98b4cd57742a78a288cdbdc9daedac29f2239793071fe114f13785",
+                "sha256:16268d46086bb8ad5bf0a2b5544d8a9ed87a0e33f5e77dd3c3301e63d941a83b",
+                "sha256:1a58839984d9cb34c855197043eaae2c187d930ca6d644612843b4fe8513c886",
+                "sha256:2954fccea107026512b15afb4aa664a5640cd0af630e2ee3962f2602693f0c82",
+                "sha256:2e47577f9b18723fa294b0ea9a17d5e53a227867a0a4904a1a076d1646d45ca1",
+                "sha256:31adb7d06fe4383226c3e963471f6837742889b3c4caa55aac20ad951bc8ffda",
+                "sha256:3577d029bc3f4827dd5bf8bf7710cac13527b470bbf1820a3f394adb38ed7d5f",
+                "sha256:36017400817987670037fbb0324d71489b6ead6231c9604f8fc1f7d008087c68",
+                "sha256:362e7197754c231797ec45ee081f3088a27a47c6c01eff2ac83f60f85a50fe60",
+                "sha256:3de9a45d3b2b7d8088c3fbf1ed4395dfeff79d07842217b38df14ef09ce1d8d7",
+                "sha256:4f698edacf9c9e0371112792558d2f705b5645076cc0aaae02f816a0171770fd",
+                "sha256:5482e789294854c28237bba77c4c83be698be740e31a3ae5e879ee5444166582",
+                "sha256:5e44507bf8d14b36b8389b226665d597bc0f18ea035d75b4e53c7b1ea84583cc",
+                "sha256:779245e13b9a6638df14641d029add5dc17edbef6ec915688f3acb9e720a5858",
+                "sha256:789caea816c6704f63f6241a519bfa347f72fbd67ba28d04636b7c6b7da94b0b",
+                "sha256:7f8b25fa616d8b846aef64b15c606bb0828dbc35faf90566eb139aa9cff67af2",
+                "sha256:8cb8ce7c3347fcf9446f201dc30e2d5a3c898d009126010cbd1f443f28b52678",
+                "sha256:93a3209f6bb2b33e725ed08ee0991b92976dfdcf4e8b38646540674fc7508e13",
+                "sha256:a3a5ac8b56fe37f3125e5b72b61dcde43283e5370827f5233893d461b7360cd4",
+                "sha256:a47787a5e3649008a1102d3df55424e86606c9bae6fb77ac59afe06d234605f8",
+                "sha256:a79165431551042cc9d1d90e6145d5d0d3ab0f2d66326c201d9b0e7f5bf43604",
+                "sha256:a987f840718078212fdf4504d0fd4c6effe34a7e4740378e59d47696e8dfb477",
+                "sha256:a9bc127cdc4ecf87a5ea22a2556cab6c7eda2923f84e4f3cc588e8470ce4e42e",
+                "sha256:bd13b5e9b543532453de08bcdc3cc7cebec6f9883e886fd20a92f26940fd3e7a",
+                "sha256:c65f96dad14f8528a447414125e1fc8feb2ad5a272b8f68477abbcc1ea7d94b9",
+                "sha256:d8e3098721b84392ee45af2dd554c947c32cc52f862b6a3ae982dbb90f577f14",
+                "sha256:e6b79d0adb01aae87e8a44c2b64bc3f3fe59515280e00fb6d57a7267a2583cda",
+                "sha256:e6b8f1881dac458c34778d0a424ae5769de30544fc678eac51c1c8bb2183e9da",
+                "sha256:e9b2a6309f14c0497f348d08a065d52f3020656f675819fc405fb63bbcd26562",
+                "sha256:ecbfbc00bf55888edda9868a4cf927205de8499e7fabe6c050322298382953f2",
+                "sha256:efd0bf5205240182e0f13bcaea41be4fdf5c22c5129fc7ced4a0282ac86998c9"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.7'",
-            "version": "==42.0.6"
+            "version": "==42.0.7"
         },
         "dataclasses-json": {
             "hashes": [
-                "sha256:35cb40aae824736fdf959801356641836365219cfe14caeb115c39136f775d2a",
-                "sha256:4aeb343357997396f6bca1acae64e486c3a723d8f5c76301888abeccf0c45176"
+                "sha256:1c287594d9fcea72dc42d6d3836cf14848c2dc5ce88f65ed61b36b57f515fe26",
+                "sha256:f49c77aa3a85cac5bf5b7f65f4790ca0d2be8ef4d92c75e91ba0103072788a39"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.7' and python_version < '4.0'",
-            "version": "==0.6.3"
+            "version": "==0.6.5"
         },
         "exceptiongroup": {
             "hashes": [
-                "sha256:4bfd3996ac73b41e9b9628b04e079f193850720ea5945fc96a08633c66912f14",
-                "sha256:91f5c769735f051a4290d52edd0858999b57e5876e9f85937691bd4c9fa3ed68"
+                "sha256:5258b9ed329c5bbdd31a309f53cbfb0b155341807f6ff7606a1e801a891b29ad",
+                "sha256:a4785e48b045528f5bfe627b6ad554ff32def154f42372786903b7abcfe1aa16"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.7'",
-            "version": "==1.2.0"
+            "version": "==1.2.1"
         },
         "flatten-json": {
             "hashes": [
@@ -467,86 +467,86 @@
         },
         "jinja2": {
             "hashes": [
-                "sha256:7d6d50dd97d52cbc355597bd845fabfbac3f551e1f99619e39a35ce8c370b5fa",
-                "sha256:ac8bd6544d4bb2c9792bf3a159e80bba8fda7f07e81bc3aed565432d5925ba90"
+                "sha256:4a3aee7acbbe7303aede8e9648d13b8bf88a429282aa6122a993f0ac800cb369",
+                "sha256:bc5dd2abb727a5319567b7a813e6a2e7318c39f4f487cfe6c89c6f9c7d25197d"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==3.1.3"
+            "version": "==3.1.4"
         },
         "markupsafe": {
             "hashes": [
-                "sha256:0042d6a9880b38e1dd9ff83146cc3c9c18a059b9360ceae207805567aacccc69",
-                "sha256:0c26f67b3fe27302d3a412b85ef696792c4a2386293c53ba683a89562f9399b0",
-                "sha256:0fbad3d346df8f9d72622ac71b69565e621ada2ce6572f37c2eae8dacd60385d",
-                "sha256:15866d7f2dc60cfdde12ebb4e75e41be862348b4728300c36cdf405e258415ec",
-                "sha256:1c98c33ffe20e9a489145d97070a435ea0679fddaabcafe19982fe9c971987d5",
-                "sha256:21e7af8091007bf4bebf4521184f4880a6acab8df0df52ef9e513d8e5db23411",
-                "sha256:23984d1bdae01bee794267424af55eef4dfc038dc5d1272860669b2aa025c9e3",
-                "sha256:31f57d64c336b8ccb1966d156932f3daa4fee74176b0fdc48ef580be774aae74",
-                "sha256:3583a3a3ab7958e354dc1d25be74aee6228938312ee875a22330c4dc2e41beb0",
-                "sha256:36d7626a8cca4d34216875aee5a1d3d654bb3dac201c1c003d182283e3205949",
-                "sha256:396549cea79e8ca4ba65525470d534e8a41070e6b3500ce2414921099cb73e8d",
-                "sha256:3a66c36a3864df95e4f62f9167c734b3b1192cb0851b43d7cc08040c074c6279",
-                "sha256:3aae9af4cac263007fd6309c64c6ab4506dd2b79382d9d19a1994f9240b8db4f",
-                "sha256:3ab3a886a237f6e9c9f4f7d272067e712cdb4efa774bef494dccad08f39d8ae6",
-                "sha256:47bb5f0142b8b64ed1399b6b60f700a580335c8e1c57f2f15587bd072012decc",
-                "sha256:49a3b78a5af63ec10d8604180380c13dcd870aba7928c1fe04e881d5c792dc4e",
-                "sha256:4df98d4a9cd6a88d6a585852f56f2155c9cdb6aec78361a19f938810aa020954",
-                "sha256:5045e892cfdaecc5b4c01822f353cf2c8feb88a6ec1c0adef2a2e705eef0f656",
-                "sha256:5244324676254697fe5c181fc762284e2c5fceeb1c4e3e7f6aca2b6f107e60dc",
-                "sha256:54635102ba3cf5da26eb6f96c4b8c53af8a9c0d97b64bdcb592596a6255d8518",
-                "sha256:54a7e1380dfece8847c71bf7e33da5d084e9b889c75eca19100ef98027bd9f56",
-                "sha256:55d03fea4c4e9fd0ad75dc2e7e2b6757b80c152c032ea1d1de487461d8140efc",
-                "sha256:698e84142f3f884114ea8cf83e7a67ca8f4ace8454e78fe960646c6c91c63bfa",
-                "sha256:6aa5e2e7fc9bc042ae82d8b79d795b9a62bd8f15ba1e7594e3db243f158b5565",
-                "sha256:7653fa39578957bc42e5ebc15cf4361d9e0ee4b702d7d5ec96cdac860953c5b4",
-                "sha256:765f036a3d00395a326df2835d8f86b637dbaf9832f90f5d196c3b8a7a5080cb",
-                "sha256:78bc995e004681246e85e28e068111a4c3f35f34e6c62da1471e844ee1446250",
-                "sha256:7a07f40ef8f0fbc5ef1000d0c78771f4d5ca03b4953fc162749772916b298fc4",
-                "sha256:8b570a1537367b52396e53325769608f2a687ec9a4363647af1cded8928af959",
-                "sha256:987d13fe1d23e12a66ca2073b8d2e2a75cec2ecb8eab43ff5624ba0ad42764bc",
-                "sha256:9896fca4a8eb246defc8b2a7ac77ef7553b638e04fbf170bff78a40fa8a91474",
-                "sha256:9e9e3c4020aa2dc62d5dd6743a69e399ce3de58320522948af6140ac959ab863",
-                "sha256:a0b838c37ba596fcbfca71651a104a611543077156cb0a26fe0c475e1f152ee8",
-                "sha256:a4d176cfdfde84f732c4a53109b293d05883e952bbba68b857ae446fa3119b4f",
-                "sha256:a76055d5cb1c23485d7ddae533229039b850db711c554a12ea64a0fd8a0129e2",
-                "sha256:a76cd37d229fc385738bd1ce4cba2a121cf26b53864c1772694ad0ad348e509e",
-                "sha256:a7cc49ef48a3c7a0005a949f3c04f8baa5409d3f663a1b36f0eba9bfe2a0396e",
-                "sha256:abf5ebbec056817057bfafc0445916bb688a255a5146f900445d081db08cbabb",
-                "sha256:b0fe73bac2fed83839dbdbe6da84ae2a31c11cfc1c777a40dbd8ac8a6ed1560f",
-                "sha256:b6f14a9cd50c3cb100eb94b3273131c80d102e19bb20253ac7bd7336118a673a",
-                "sha256:b83041cda633871572f0d3c41dddd5582ad7d22f65a72eacd8d3d6d00291df26",
-                "sha256:b835aba863195269ea358cecc21b400276747cc977492319fd7682b8cd2c253d",
-                "sha256:bf1196dcc239e608605b716e7b166eb5faf4bc192f8a44b81e85251e62584bd2",
-                "sha256:c669391319973e49a7c6230c218a1e3044710bc1ce4c8e6eb71f7e6d43a2c131",
-                "sha256:c7556bafeaa0a50e2fe7dc86e0382dea349ebcad8f010d5a7dc6ba568eaaa789",
-                "sha256:c8f253a84dbd2c63c19590fa86a032ef3d8cc18923b8049d91bcdeeb2581fbf6",
-                "sha256:d18b66fe626ac412d96c2ab536306c736c66cf2a31c243a45025156cc190dc8a",
-                "sha256:d5291d98cd3ad9a562883468c690a2a238c4a6388ab3bd155b0c75dd55ece858",
-                "sha256:d5c31fe855c77cad679b302aabc42d724ed87c043b1432d457f4976add1c2c3e",
-                "sha256:d6e427c7378c7f1b2bef6a344c925b8b63623d3321c09a237b7cc0e77dd98ceb",
-                "sha256:dac1ebf6983148b45b5fa48593950f90ed6d1d26300604f321c74a9ca1609f8e",
-                "sha256:de8153a7aae3835484ac168a9a9bdaa0c5eee4e0bc595503c95d53b942879c84",
-                "sha256:e1a0d1924a5013d4f294087e00024ad25668234569289650929ab871231668e7",
-                "sha256:e7902211afd0af05fbadcc9a312e4cf10f27b779cf1323e78d52377ae4b72bea",
-                "sha256:e888ff76ceb39601c59e219f281466c6d7e66bd375b4ec1ce83bcdc68306796b",
-                "sha256:f06e5a9e99b7df44640767842f414ed5d7bedaaa78cd817ce04bbd6fd86e2dd6",
-                "sha256:f6be2d708a9d0e9b0054856f07ac7070fbe1754be40ca8525d5adccdbda8f475",
-                "sha256:f9917691f410a2e0897d1ef99619fd3f7dd503647c8ff2475bf90c3cf222ad74",
-                "sha256:fc1a75aa8f11b87910ffd98de62b29d6520b6d6e8a3de69a70ca34dea85d2a8a",
-                "sha256:fe8512ed897d5daf089e5bd010c3dc03bb1bdae00b35588c49b98268d4a01e00"
+                "sha256:00e046b6dd71aa03a41079792f8473dc494d564611a8f89bbbd7cb93295ebdcf",
+                "sha256:075202fa5b72c86ad32dc7d0b56024ebdbcf2048c0ba09f1cde31bfdd57bcfff",
+                "sha256:0e397ac966fdf721b2c528cf028494e86172b4feba51d65f81ffd65c63798f3f",
+                "sha256:17b950fccb810b3293638215058e432159d2b71005c74371d784862b7e4683f3",
+                "sha256:1f3fbcb7ef1f16e48246f704ab79d79da8a46891e2da03f8783a5b6fa41a9532",
+                "sha256:2174c595a0d73a3080ca3257b40096db99799265e1c27cc5a610743acd86d62f",
+                "sha256:2b7c57a4dfc4f16f7142221afe5ba4e093e09e728ca65c51f5620c9aaeb9a617",
+                "sha256:2d2d793e36e230fd32babe143b04cec8a8b3eb8a3122d2aceb4a371e6b09b8df",
+                "sha256:30b600cf0a7ac9234b2638fbc0fb6158ba5bdcdf46aeb631ead21248b9affbc4",
+                "sha256:397081c1a0bfb5124355710fe79478cdbeb39626492b15d399526ae53422b906",
+                "sha256:3a57fdd7ce31c7ff06cdfbf31dafa96cc533c21e443d57f5b1ecc6cdc668ec7f",
+                "sha256:3c6b973f22eb18a789b1460b4b91bf04ae3f0c4234a0a6aa6b0a92f6f7b951d4",
+                "sha256:3e53af139f8579a6d5f7b76549125f0d94d7e630761a2111bc431fd820e163b8",
+                "sha256:4096e9de5c6fdf43fb4f04c26fb114f61ef0bf2e5604b6ee3019d51b69e8c371",
+                "sha256:4275d846e41ecefa46e2015117a9f491e57a71ddd59bbead77e904dc02b1bed2",
+                "sha256:4c31f53cdae6ecfa91a77820e8b151dba54ab528ba65dfd235c80b086d68a465",
+                "sha256:4f11aa001c540f62c6166c7726f71f7573b52c68c31f014c25cc7901deea0b52",
+                "sha256:5049256f536511ee3f7e1b3f87d1d1209d327e818e6ae1365e8653d7e3abb6a6",
+                "sha256:58c98fee265677f63a4385256a6d7683ab1832f3ddd1e66fe948d5880c21a169",
+                "sha256:598e3276b64aff0e7b3451b72e94fa3c238d452e7ddcd893c3ab324717456bad",
+                "sha256:5b7b716f97b52c5a14bffdf688f971b2d5ef4029127f1ad7a513973cfd818df2",
+                "sha256:5dedb4db619ba5a2787a94d877bc8ffc0566f92a01c0ef214865e54ecc9ee5e0",
+                "sha256:619bc166c4f2de5caa5a633b8b7326fbe98e0ccbfacabd87268a2b15ff73a029",
+                "sha256:629ddd2ca402ae6dbedfceeba9c46d5f7b2a61d9749597d4307f943ef198fc1f",
+                "sha256:656f7526c69fac7f600bd1f400991cc282b417d17539a1b228617081106feb4a",
+                "sha256:6ec585f69cec0aa07d945b20805be741395e28ac1627333b1c5b0105962ffced",
+                "sha256:72b6be590cc35924b02c78ef34b467da4ba07e4e0f0454a2c5907f473fc50ce5",
+                "sha256:7502934a33b54030eaf1194c21c692a534196063db72176b0c4028e140f8f32c",
+                "sha256:7a68b554d356a91cce1236aa7682dc01df0edba8d043fd1ce607c49dd3c1edcf",
+                "sha256:7b2e5a267c855eea6b4283940daa6e88a285f5f2a67f2220203786dfa59b37e9",
+                "sha256:823b65d8706e32ad2df51ed89496147a42a2a6e01c13cfb6ffb8b1e92bc910bb",
+                "sha256:8590b4ae07a35970728874632fed7bd57b26b0102df2d2b233b6d9d82f6c62ad",
+                "sha256:8dd717634f5a044f860435c1d8c16a270ddf0ef8588d4887037c5028b859b0c3",
+                "sha256:8dec4936e9c3100156f8a2dc89c4b88d5c435175ff03413b443469c7c8c5f4d1",
+                "sha256:97cafb1f3cbcd3fd2b6fbfb99ae11cdb14deea0736fc2b0952ee177f2b813a46",
+                "sha256:a17a92de5231666cfbe003f0e4b9b3a7ae3afb1ec2845aadc2bacc93ff85febc",
+                "sha256:a549b9c31bec33820e885335b451286e2969a2d9e24879f83fe904a5ce59d70a",
+                "sha256:ac07bad82163452a6884fe8fa0963fb98c2346ba78d779ec06bd7a6262132aee",
+                "sha256:ae2ad8ae6ebee9d2d94b17fb62763125f3f374c25618198f40cbb8b525411900",
+                "sha256:b91c037585eba9095565a3556f611e3cbfaa42ca1e865f7b8015fe5c7336d5a5",
+                "sha256:bc1667f8b83f48511b94671e0e441401371dfd0f0a795c7daa4a3cd1dde55bea",
+                "sha256:bec0a414d016ac1a18862a519e54b2fd0fc8bbfd6890376898a6c0891dd82e9f",
+                "sha256:bf50cd79a75d181c9181df03572cdce0fbb75cc353bc350712073108cba98de5",
+                "sha256:bff1b4290a66b490a2f4719358c0cdcd9bafb6b8f061e45c7a2460866bf50c2e",
+                "sha256:c061bb86a71b42465156a3ee7bd58c8c2ceacdbeb95d05a99893e08b8467359a",
+                "sha256:c8b29db45f8fe46ad280a7294f5c3ec36dbac9491f2d1c17345be8e69cc5928f",
+                "sha256:ce409136744f6521e39fd8e2a24c53fa18ad67aa5bc7c2cf83645cce5b5c4e50",
+                "sha256:d050b3361367a06d752db6ead6e7edeb0009be66bc3bae0ee9d97fb326badc2a",
+                "sha256:d283d37a890ba4c1ae73ffadf8046435c76e7bc2247bbb63c00bd1a709c6544b",
+                "sha256:d9fad5155d72433c921b782e58892377c44bd6252b5af2f67f16b194987338a4",
+                "sha256:daa4ee5a243f0f20d528d939d06670a298dd39b1ad5f8a72a4275124a7819eff",
+                "sha256:db0b55e0f3cc0be60c1f19efdde9a637c32740486004f20d1cff53c3c0ece4d2",
+                "sha256:e61659ba32cf2cf1481e575d0462554625196a1f2fc06a1c777d3f48e8865d46",
+                "sha256:ea3d8a3d18833cf4304cd2fc9cbb1efe188ca9b5efef2bdac7adc20594a0e46b",
+                "sha256:ec6a563cff360b50eed26f13adc43e61bc0c04d94b8be985e6fb24b81f6dcfdf",
+                "sha256:f5dfb42c4604dddc8e4305050aa6deb084540643ed5804d7455b5df8fe16f5e5",
+                "sha256:fa173ec60341d6bb97a89f5ea19c85c5643c1e7dedebc22f5181eb73573142c5",
+                "sha256:fa9db3f79de01457b03d4f01b34cf91bc0048eb2c3846ff26f66687c2f6d16ab",
+                "sha256:fce659a462a1be54d2ffcacea5e3ba2d74daa74f30f5f143fe0c58636e355fdd",
+                "sha256:ffee1f21e5ef0d712f9033568f8344d5da8cc2869dbd08d87c84656e6a2d2f68"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.1.4"
+            "version": "==2.1.5"
         },
         "marshmallow": {
             "hashes": [
-                "sha256:4c1daff273513dc5eb24b219a8035559dc573c8f322558ef85f5438ddd1236dd",
-                "sha256:c21d4b98fee747c130e6bc8f45c4b3199ea66bc00c12ee1f639f0aeca034d5e9"
+                "sha256:70b54a6282f4704d12c0a41599682c5c5450e843b9ec406308653b47c59648a1",
+                "sha256:82408deadd8b33d56338d2182d455db632c6313aa2af61916672146bb32edc56"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==3.20.2"
+            "version": "==3.21.2"
         },
         "multidict": {
             "hashes": [
@@ -647,37 +647,37 @@
         },
         "mypy": {
             "hashes": [
-                "sha256:028cf9f2cae89e202d7b6593cd98db6759379f17a319b5faf4f9978d7084cdc6",
-                "sha256:2afecd6354bbfb6e0160f4e4ad9ba6e4e003b767dd80d85516e71f2e955ab50d",
-                "sha256:2b5b6c721bd4aabaadead3a5e6fa85c11c6c795e0c81a7215776ef8afc66de02",
-                "sha256:42419861b43e6962a649068a61f4a4839205a3ef525b858377a960b9e2de6e0d",
-                "sha256:42c6680d256ab35637ef88891c6bd02514ccb7e1122133ac96055ff458f93fc3",
-                "sha256:485a8942f671120f76afffff70f259e1cd0f0cfe08f81c05d8816d958d4577d3",
-                "sha256:4c886c6cce2d070bd7df4ec4a05a13ee20c0aa60cb587e8d1265b6c03cf91da3",
-                "sha256:4e6d97288757e1ddba10dd9549ac27982e3e74a49d8d0179fc14d4365c7add66",
-                "sha256:4ef4be7baf08a203170f29e89d79064463b7fc7a0908b9d0d5114e8009c3a259",
-                "sha256:51720c776d148bad2372ca21ca29256ed483aa9a4cdefefcef49006dff2a6835",
-                "sha256:52825b01f5c4c1c4eb0db253ec09c7aa17e1a7304d247c48b6f3599ef40db8bd",
-                "sha256:538fd81bb5e430cc1381a443971c0475582ff9f434c16cd46d2c66763ce85d9d",
-                "sha256:5c1538c38584029352878a0466f03a8ee7547d7bd9f641f57a0f3017a7c905b8",
-                "sha256:6ff8b244d7085a0b425b56d327b480c3b29cafbd2eff27316a004f9a7391ae07",
-                "sha256:7178def594014aa6c35a8ff411cf37d682f428b3b5617ca79029d8ae72f5402b",
-                "sha256:720a5ca70e136b675af3af63db533c1c8c9181314d207568bbe79051f122669e",
-                "sha256:7f1478736fcebb90f97e40aff11a5f253af890c845ee0c850fe80aa060a267c6",
-                "sha256:855fe27b80375e5c5878492f0729540db47b186509c98dae341254c8f45f42ae",
-                "sha256:8963b83d53ee733a6e4196954502b33567ad07dfd74851f32be18eb932fb1cb9",
-                "sha256:9261ed810972061388918c83c3f5cd46079d875026ba97380f3e3978a72f503d",
-                "sha256:99b00bc72855812a60d253420d8a2eae839b0afa4938f09f4d2aa9bb4654263a",
-                "sha256:ab3c84fa13c04aeeeabb2a7f67a25ef5d77ac9d6486ff33ded762ef353aa5592",
-                "sha256:afe3fe972c645b4632c563d3f3eff1cdca2fa058f730df2b93a35e3b0c538218",
-                "sha256:d19c413b3c07cbecf1f991e2221746b0d2a9410b59cb3f4fb9557f0365a1a817",
-                "sha256:df9824ac11deaf007443e7ed2a4a26bebff98d2bc43c6da21b2b64185da011c4",
-                "sha256:e46f44b54ebddbeedbd3d5b289a893219065ef805d95094d16a0af6630f5d410",
-                "sha256:f5ac9a4eeb1ec0f1ccdc6f326bcdb464de5f80eb07fb38b5ddd7b0de6bc61e55"
+                "sha256:075cbf81f3e134eadaf247de187bd604748171d6b79736fa9b6c9685b4083061",
+                "sha256:12b6bfc1b1a66095ab413160a6e520e1dc076a28f3e22f7fb25ba3b000b4ef99",
+                "sha256:1ec404a7cbe9fc0e92cb0e67f55ce0c025014e26d33e54d9e506a0f2d07fe5de",
+                "sha256:28d0e038361b45f099cc086d9dd99c15ff14d0188f44ac883010e172ce86c38a",
+                "sha256:2b0695d605ddcd3eb2f736cd8b4e388288c21e7de85001e9f85df9187f2b50f9",
+                "sha256:3236a4c8f535a0631f85f5fcdffba71c7feeef76a6002fcba7c1a8e57c8be1ec",
+                "sha256:3be66771aa5c97602f382230165b856c231d1277c511c9a8dd058be4784472e1",
+                "sha256:3d087fcbec056c4ee34974da493a826ce316947485cef3901f511848e687c131",
+                "sha256:3f298531bca95ff615b6e9f2fc0333aae27fa48052903a0ac90215021cdcfa4f",
+                "sha256:4a2b5cdbb5dd35aa08ea9114436e0d79aceb2f38e32c21684dcf8e24e1e92821",
+                "sha256:4cf18f9d0efa1b16478c4c129eabec36148032575391095f73cae2e722fcf9d5",
+                "sha256:8b2cbaca148d0754a54d44121b5825ae71868c7592a53b7292eeb0f3fdae95ee",
+                "sha256:8f55583b12156c399dce2df7d16f8a5095291354f1e839c252ec6c0611e86e2e",
+                "sha256:92f93b21c0fe73dc00abf91022234c79d793318b8a96faac147cd579c1671746",
+                "sha256:9e36fb078cce9904c7989b9693e41cb9711e0600139ce3970c6ef814b6ebc2b2",
+                "sha256:9fd50226364cd2737351c79807775136b0abe084433b55b2e29181a4c3c878c0",
+                "sha256:a781f6ad4bab20eef8b65174a57e5203f4be627b46291f4589879bf4e257b97b",
+                "sha256:a87dbfa85971e8d59c9cc1fcf534efe664d8949e4c0b6b44e8ca548e746a8d53",
+                "sha256:b808e12113505b97d9023b0b5e0c0705a90571c6feefc6f215c1df9381256e30",
+                "sha256:bc6ac273b23c6b82da3bb25f4136c4fd42665f17f2cd850771cb600bdd2ebeda",
+                "sha256:cd777b780312ddb135bceb9bc8722a73ec95e042f911cc279e2ec3c667076051",
+                "sha256:da1cbf08fb3b851ab3b9523a884c232774008267b1f83371ace57f412fe308c2",
+                "sha256:e22e1527dc3d4aa94311d246b59e47f6455b8729f4968765ac1eacf9a4760bc7",
+                "sha256:f8c083976eb530019175aabadb60921e73b4f45736760826aa1689dda8208aee",
+                "sha256:f90cff89eea89273727d8783fef5d4a934be2fdca11b47def50cf5d311aff727",
+                "sha256:fa7ef5244615a2523b56c034becde4e9e3f9b034854c93639adb667ec9ec2976",
+                "sha256:fcfc70599efde5c67862a07a1aaf50e55bce629ace26bb19dc17cece5dd31ca4"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==1.8.0"
+            "version": "==1.10.0"
         },
         "mypy-extensions": {
             "hashes": [
@@ -690,21 +690,21 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:048fb0e9405036518eaaf48a55953c750c11e1a1b68e0dd1a9d62ed0c092cfc5",
-                "sha256:8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7"
+                "sha256:2ddfb553fdf02fb784c234c7ba6ccc288296ceabec964ad2eae3777778130bc5",
+                "sha256:eb82c5e3e56209074766e6885bb04b8c38a0c015d0a30036ebe7ece34c9989e9"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.7'",
-            "version": "==23.2"
+            "version": "==24.0"
         },
         "pluggy": {
             "hashes": [
-                "sha256:7db9f7b503d67d1c5b95f59773ebb58a8c1c288129a88665838012cfb07b8981",
-                "sha256:8c85c2876142a764e5b7548e7d9a0e0ddb46f5185161049a79b7e974454223be"
+                "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1",
+                "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==1.4.0"
+            "version": "==1.5.0"
         },
         "protobuf": {
             "hashes": [
@@ -753,23 +753,32 @@
             "markers": "python_version >= '3.8'",
             "version": "==2.22"
         },
-        "pytest": {
+        "pyro5": {
             "hashes": [
-                "sha256:2cf0005922c6ace4a3e2ec8b4080eb0d9753fdc93107415332f50ce9e7994280",
-                "sha256:b090cdf5ed60bf4c45261be03239c2c1c22df034fbffe691abe93cd80cea01d8"
+                "sha256:4d85428ed75985e63f159d2486ad5680743ea76f766340fd30b65dd20f83d471",
+                "sha256:82c3dfc9860b49f897b28ff24fe6716c841672c600af8fe40d0e3a7fac9a3f5e"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.7'",
-            "version": "==7.4.4"
+            "version": "==5.15"
         },
-        "pytest-asyncio": {
+        "pytest": {
             "hashes": [
-                "sha256:2143d9d9375bf372a73260e4114541485e84fca350b0b6b92674ca56ff5f7ea2",
-                "sha256:b0079dfac14b60cd1ce4691fbfb1748fe939db7d0234b5aba97197d10fbe0fef"
+                "sha256:1733f0620f6cda4095bbf0d9ff8022486e91892245bb9e7d5542c018f612f233",
+                "sha256:d507d4482197eac0ba2bae2e9babf0672eb333017bcedaa5fb1a3d42c1174b3f"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==0.23.4"
+            "version": "==8.2.0"
+        },
+        "pytest-asyncio": {
+            "hashes": [
+                "sha256:68516fdd1018ac57b846c9846b954f0393b26f094764a28c955eabb0536a4e8a",
+                "sha256:ffe523a89c1c222598c76856e76852b787504ddb72dd5d9b6617ffa8aa2cde5f"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==0.23.6"
         },
         "pytest-html": {
             "hashes": [
@@ -782,21 +791,21 @@
         },
         "pytest-metadata": {
             "hashes": [
-                "sha256:769a9c65d2884bd583bc626b0ace77ad15dbe02dd91a9106d47fd46d9c2569ca",
-                "sha256:a17b1e40080401dc23177599208c52228df463db191c1a573ccdffacd885e190"
+                "sha256:c8e0844db684ee1c798cfa38908d20d67d0463ecb6137c72e91f418558dd5f4b",
+                "sha256:d2a29b0355fbc03f168aa96d41ff88b1a3b44a3b02acbe491801c98a048017c8"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
-            "version": "==3.0.0"
+            "markers": "python_version >= '3.8'",
+            "version": "==3.1.1"
         },
         "pytest-order": {
             "hashes": [
-                "sha256:944f86b6d441aa7b1da80f801c6ab65b84bbeba472d0a7a12eb43ba26650101a",
-                "sha256:9d65c3b6dc6d6ee984d6ae2c6c4aa4f1331e5b915116219075c888c8bcbb93b8"
+                "sha256:4451bd8821ba4fa2109455a2fcc882af60ef8e53e09d244d67674be08f56eac3",
+                "sha256:c3082fc73f9ddcf13e4a22dda9bbcc2f39865bf537438a1d50fa241e028dd743"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.6'",
-            "version": "==1.2.0"
+            "version": "==1.2.1"
         },
         "pytest-repeat": {
             "hashes": [
@@ -809,21 +818,21 @@
         },
         "pytest-rerunfailures": {
             "hashes": [
-                "sha256:34919cb3fcb1f8e5d4b940aa75ccdea9661bade925091873b7c6fa5548333069",
-                "sha256:e132dbe420bc476f544b96e7036edd0a69707574209b6677263c950d19b09199"
+                "sha256:4197bdd2eaeffdbf50b5ea6e7236f47ff0e44d1def8dae08e409f536d84e7b32",
+                "sha256:4a400bcbcd3c7a4ad151ab8afac123d90eca3abe27f98725dc4d9702887d2e92"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
-            "version": "==13.0"
+            "markers": "python_version >= '3.8'",
+            "version": "==14.0"
         },
         "pytest-timeout": {
             "hashes": [
-                "sha256:3b0b95dabf3cb50bac9ef5ca912fa0cfc286526af17afc806824df20c2f72c90",
-                "sha256:bde531e096466f49398a59f2dde76fa78429a09a12411466f88a07213e220de2"
+                "sha256:12397729125c6ecbdaca01035b9e5239d4db97352320af155b3f5de1ba5165d9",
+                "sha256:68188cb703edfc6a18fad98dc25a3c61e9f24d644b0b70f33af545219fc7813e"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.7'",
-            "version": "==2.2.0"
+            "version": "==2.3.1"
         },
         "python-wireguard": {
             "hashes": [
@@ -833,13 +842,21 @@
             "index": "pypi",
             "version": "==0.2.2"
         },
+        "serpent": {
+            "hashes": [
+                "sha256:0407035fe3c6644387d48cff1467d5aa9feff814d07372b78677ed0ee3ed7095",
+                "sha256:5fd776b3420441985bc10679564c2c9b4a19f77bea59f018e473441d98ae5dd7"
+            ],
+            "markers": "python_version >= '3.2'",
+            "version": "==1.41"
+        },
         "six": {
             "hashes": [
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
             "index": "pypi",
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
         },
         "tomli": {
@@ -861,12 +878,12 @@
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:23478f88c37f27d76ac8aee6c905017a143b0b1b886c3c9f66bc2fd94f9f5783",
-                "sha256:af72aea155e91adfc61c3ae9e0e342dbc0cba726d6cba4b6c72c1f34e47291cd"
+                "sha256:83f085bd5ca59c80295fc2a82ab5dac679cbe02b9f33f7d83af68e241bea51b0",
+                "sha256:c1f94d72897edaf4ce775bb7558d5b79d8126906a14ea5ed1635921406c0387a"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==4.9.0"
+            "version": "==4.11.0"
         },
         "typing-inspect": {
             "hashes": [

--- a/nat-lab/docker-compose.yml
+++ b/nat-lab/docker-compose.yml
@@ -71,6 +71,8 @@ services:
     networks:
       cone-net-01:
         ipv4_address: 192.168.101.104
+    ports:
+      - "58001:58001"
     environment:
       CLIENT_GATEWAY_PRIMARY: 192.168.101.254
     extra_hosts:
@@ -89,6 +91,8 @@ services:
     networks:
       cone-net-02:
         ipv4_address: 192.168.102.54
+    ports:
+      - "58002:58002"
     environment:
       CLIENT_GATEWAY_PRIMARY: 192.168.102.254
   # Client that shares two cone networks on different interfaces
@@ -100,6 +104,8 @@ services:
         ipv4_address: 192.168.101.67
       cone-net-05:
         ipv4_address: 192.168.113.67
+    ports:
+      - "58003:58003"
     environment:
       CLIENT_GATEWAY_PRIMARY: 192.168.101.254
       CLIENT_GATEWAY_SECONDARY: 192.168.113.254
@@ -111,6 +117,8 @@ services:
     networks:
       internet:
         ipv4_address: 10.0.11.2
+    ports:
+      - "58004:58004"
     environment:
       CLIENT_GATEWAY_PRIMARY: none
   open-internet-client-02:
@@ -119,6 +127,8 @@ services:
     networks:
       internet:
         ipv4_address: 10.0.11.3
+    ports:
+      - "58005:58005"
     environment:
       CLIENT_GATEWAY_PRIMARY: none
   # Open internet client used on ipv6 tests
@@ -129,6 +139,8 @@ services:
       internet:
         ipv4_address: 10.0.11.4
         ipv6_address: 2001:db8:85a4::dead:beef:ceed
+    ports:
+      - "58006:58006"
     environment:
       CLIENT_GATEWAY_PRIMARY: none
     extra_hosts:
@@ -144,6 +156,8 @@ services:
     networks:
       fullcone-net-01:
         ipv4_address: 192.168.109.88
+    ports:
+      - "58007:58007"
     environment:
       CLIENT_GATEWAY_PRIMARY: 192.168.109.254
   fullcone-client-02:
@@ -152,6 +166,8 @@ services:
     networks:
       fullcone-net-02:
         ipv4_address: 192.168.106.88
+    ports:
+      - "58008:58008"
     environment:
       CLIENT_GATEWAY_PRIMARY: 192.168.106.254
 
@@ -161,6 +177,8 @@ services:
     networks:
       upnp-net-01:
         ipv4_address: 192.168.105.88
+    ports:
+      - "58009:58009"
     environment:
       CLIENT_GATEWAY_PRIMARY: 192.168.105.254
   upnp-client-02:
@@ -169,6 +187,8 @@ services:
     networks:
       upnp-net-02:
         ipv4_address: 192.168.112.88
+    ports:
+      - "58010:58010"
     environment:
       CLIENT_GATEWAY_PRIMARY: 192.168.112.254
 
@@ -178,6 +198,8 @@ services:
     networks:
       hsymmetric-net-01:
         ipv4_address: 192.168.103.88
+    ports:
+      - "58011:58011"
     environment:
       CLIENT_GATEWAY_PRIMARY: 192.168.103.254
   symmetric-client-02:
@@ -186,6 +208,8 @@ services:
     networks:
       hsymmetric-net-02:
         ipv4_address: 192.168.104.88
+    ports:
+      - "58012:58012"
     environment:
       CLIENT_GATEWAY_PRIMARY: 192.168.104.254
   internal-symmetric-client-01:
@@ -197,6 +221,8 @@ services:
     networks:
       hsymmetric-internal-net-01:
         ipv4_address: 192.168.114.88
+    ports:
+      - "58013:58013"
 
   udp-block-client-01:
     hostname: udp-block-client-01
@@ -204,6 +230,8 @@ services:
     networks:
       udp-block-net-01:
         ipv4_address: 192.168.110.100
+    ports:
+      - "58014:58014"
     environment:
       CLIENT_GATEWAY_PRIMARY: 192.168.110.254
   udp-block-client-02:
@@ -212,6 +240,8 @@ services:
     networks:
       udp-block-net-02:
         ipv4_address: 192.168.111.100
+    ports:
+      - "58015:58015"
     environment:
       CLIENT_GATEWAY_PRIMARY: 192.168.111.254
 

--- a/nat-lab/tests/config.py
+++ b/nat-lab/tests/config.py
@@ -67,6 +67,9 @@ else:
 LIBTELIO_BINARY_PATH_WINDOWS_VM = "C:/workspace/binaries/".replace("/", "\\")
 LIBTELIO_BINARY_PATH_MAC_VM = "/var/root/workspace/binaries/"
 
+UNIFFI_PATH_WINDOWS_VM = "C:/workspace/uniffi/".replace("/", "\\")
+UNIFFI_PATH_MAC_VM = "/var/root/workspace/uniffi/"
+
 LIBTELIO_IPV6_WG_SUBNET = "fd74:656c:696f"
 LIBTELIO_IPV6_WAN_SUBNET = "2001:db8:85a4"
 LIBTELIO_IPV6_WAN_SUBNET_SZ = "48"

--- a/nat-lab/tests/telio.py
+++ b/nat-lab/tests/telio.py
@@ -4,8 +4,12 @@ import asyncio
 import datetime
 import json
 import os
+import platform
+import random
 import re
 import shlex
+import uniffi.telio_bindings as libtelio  # type: ignore
+import uuid
 from collections import Counter
 from config import DERP_PRIMARY, DERP_SERVERS
 from contextlib import asynccontextmanager
@@ -15,12 +19,16 @@ from enum import Enum
 from mesh_api import Meshmap, Node, start_tcpdump, stop_tcpdump
 from telio_features import TelioFeatures
 from typing import AsyncIterator, List, Optional, Set
+from uniffi.libtelio_proxy import LibtelioProxy, ProxyConnectionError
 from utils import asyncio_util
 from utils.connection import Connection, DockerConnection, TargetOS
-from utils.connection_util import get_libtelio_binary_path
+from utils.connection_util import get_libtelio_binary_path, get_uniffi_path
 from utils.output_notifier import OutputNotifier
 from utils.process import Process
 from utils.router import IPStack, Router, new_router
+from utils.router.linux_router import LinuxRouter, FWMARK_VALUE as LINUX_FWMARK_VALUE
+from utils.router.mac_router import MacRouter
+from utils.router.windows_router import WindowsRouter
 from utils.testing import test_name_safe_for_file_name
 
 
@@ -177,6 +185,19 @@ class AdapterType(Enum):
     WireguardGo = "wireguard-go"
     WindowsNativeWg = "wireguard-nt"
 
+    def convert_adapter_type(self, router: Router) -> libtelio.TelioAdapterType:
+        if self == AdapterType.BoringTun:
+            return libtelio.TelioAdapterType.BORING_TUN
+        if self == AdapterType.LinuxNativeWg:
+            return libtelio.TelioAdapterType.LINUX_NATIVE_TUN
+        if self == AdapterType.WireguardGo:
+            return libtelio.TelioAdapterType.WIREGUARD_GO_TUN
+        if self == AdapterType.WindowsNativeWg:
+            return libtelio.TelioAdapterType.WINDOWS_NATIVE_TUN
+        if isinstance(router, WindowsRouter):
+            return libtelio.TelioAdapterType.WIREGUARD_GO_TUN
+        return libtelio.TelioAdapterType.BORING_TUN
+
 
 class Runtime:
     _output_notifier: OutputNotifier
@@ -328,21 +349,9 @@ class Runtime:
         self._peer_state_events.append(peer)
 
     def _extract_event_tokens(self, line: str, event_type: str) -> Optional[List[str]]:
-        if not line.startswith("event "):
-            return None
-
-        line = line.split("event ")[-1]
-
-        if line.startswith("["):
-            # Includes timestamp
-            line = line.split("] ")[-1]
-
-        if not line.startswith(f"{event_type}: "):
-            return None
-
-        tokens = line.split(f"{event_type}: ")
-
-        return tokens
+        if line.startswith(f'{{"type":"{event_type}","body":'):
+            return line[:-1].split(f'{{"type":"{event_type}","body":')
+        return None
 
     def _handle_node_event(self, line) -> bool:
         def _check_node_event(node_event: PeerInfo):
@@ -511,6 +520,7 @@ class Client:
         self._telio_features = telio_features
         self._quit = False
         self._start_time = datetime.datetime.now()
+        self._libtelio_proxy: Optional[LibtelioProxy] = None
         # Automatically enables IPv6 feature when the IPv6 stack is enabled
         if (
             self._node.ip_stack in (IPStack.IPv4v6, IPStack.IPv6)
@@ -546,11 +556,40 @@ class Client:
                 if self._runtime:
                     self._runtime.handle_output_line(line)
 
-        tcli_path = get_libtelio_binary_path("tcli", self._connection)
-
         self._runtime = Runtime()
         self._events = Events(self._runtime)
         self._router = new_router(self._connection, self._node.ip_stack)
+
+        object_name = str(uuid.uuid4()).replace("-", "")
+        (host_ip, container_ip) = await self._connection.get_ip_address()
+        host_os = platform.system()
+        if host_os == "Linux":
+            host_ip = container_ip
+            port = str(random.randrange(10000, 65000))
+            (host_port, container_port) = (port, port)
+        elif host_os in ("Windows", "Darwin"):
+            (host_port, container_port) = await self._connection.mapped_ports()
+        else:
+            print("Unsupported host OS")
+        object_uri = f"PYRO:{object_name}@{host_ip}:{host_port}"
+        if isinstance(self.get_router(), WindowsRouter):
+            python_cmd = "python"
+        else:
+            python_cmd = "python3"
+        uniffi_path = get_uniffi_path(self._connection)
+
+        if isinstance(self.get_router(), MacRouter):
+            uniprocess = self._connection.create_process(["/bin/sh"])
+        else:
+            uniprocess = self._connection.create_process([
+                python_cmd,
+                uniffi_path,
+                object_name,
+                container_ip,
+                container_port,
+            ])
+
+        tcli_path = get_libtelio_binary_path("tcli", self._connection)
         if telio_v3:
             self._process = self._connection.create_process([
                 "/opt/bin/tcli-3.6",
@@ -563,51 +602,75 @@ class Client:
                 "--less-spam",
                 f"-f {self._telio_features.to_json()}",
             ])
+
         async with self._process.run(
             stdout_callback=on_stdout, stderr_callback=on_stderr
         ):
-            try:
-                await self._process.wait_stdin_ready()
-                await self._write_command(
-                    [
-                        "dev",
-                        "start",
-                        self._adapter_type.value,
-                        self._router.get_interface_name(),
-                        self._node.private_key,
-                    ],
-                )
-                async with asyncio_util.run_async_context(self._event_request_loop()):
-                    if meshmap:
-                        await self.set_meshmap(meshmap)
-                    yield self
-            finally:
-                await self.save_logs()
-                if isinstance(self._connection, DockerConnection):
-                    stop_tcpdump([self._connection.container_name()])
-                await self.save_mac_network_info()
-                if self._process.is_executing():
-                    await self.stop_device()
-                    self._quit = True
-                if self._router:
-                    await self._router.delete_vpn_route()
-                    await self._router.delete_exit_node_route()
-                    await self._router.delete_interface()
+            async with uniprocess.run(
+                stdout_callback=on_stdout, stderr_callback=on_stderr
+            ):
+                try:
+                    await self._process.wait_stdin_ready()
+                    await uniprocess.wait_stdin_ready()
 
-    async def quit(self):
-        self._quit = True
-        await self._write_command(["quit"])
+                    if isinstance(self.get_router(), MacRouter):
+                        await uniprocess.escape_and_write_stdin(
+                            ["source", "/etc/profile"]
+                        )
+                        await uniprocess.escape_and_write_stdin([
+                            python_cmd,
+                            uniffi_path,
+                            object_name,
+                            container_ip,
+                            container_port,
+                        ])
+
+                    try:
+                        self._libtelio_proxy = LibtelioProxy(
+                            object_uri, self._telio_features.to_json()
+                        )
+                    except ProxyConnectionError as err:
+                        print(str(err))
+                        raise err
+
+                    self.get_proxy().start_named(
+                        private_key=self._node.private_key,
+                        adapter=self._adapter_type.convert_adapter_type(
+                            self.get_router()
+                        ),
+                        name=self.get_router().get_interface_name(),
+                    )
+                    if isinstance(self.get_router(), LinuxRouter):
+                        self.get_proxy().set_fwmark(int(LINUX_FWMARK_VALUE))
+
+                    async with asyncio_util.run_async_context(
+                        self._event_request_loop()
+                    ):
+                        if meshmap:
+                            await self.set_meshmap(meshmap)
+                        yield self
+                finally:
+                    await self.save_logs()
+                    if isinstance(self._connection, DockerConnection):
+                        stop_tcpdump([self._connection.container_name()])
+                    await self.save_mac_network_info()
+                    if self._process.is_executing():
+                        await self.stop_device()
+                        self._quit = True
+                    self.get_proxy().shutdown()
+                    if self._router:
+                        await self._router.delete_vpn_route()
+                        await self._router.delete_exit_node_route()
+                        await self._router.delete_interface()
 
     async def simple_start(self):
-        await self._write_command(
-            [
-                "dev",
-                "start",
-                self._adapter_type.value,
-                self.get_router().get_interface_name(),
-                self._node.private_key,
-            ],
+        self.get_proxy().start_named(
+            private_key=self._node.private_key,
+            adapter=self._adapter_type.convert_adapter_type(self.get_router()),
+            name=self.get_router().get_interface_name(),
         )
+        if isinstance(self.get_router(), LinuxRouter):
+            self.get_proxy().set_fwmark(int(LINUX_FWMARK_VALUE))
 
     async def wait_for_state_peer(
         self,
@@ -717,10 +780,10 @@ class Client:
             for peer in peers:
                 self.get_runtime().allowed_pub_keys.add(peer["public_key"])
 
-        await self._write_command(["mesh", "config", json.dumps(meshmap)])
+        self.get_proxy().set_meshnet(json.dumps(meshmap))
 
     async def set_mesh_off(self):
-        await self._write_command(["mesh", "off"])
+        self.get_proxy().set_meshnet_off()
 
     async def receive_ping(self):
         await self._write_command(["mesh", "ping"])
@@ -747,11 +810,19 @@ class Client:
         ) as event:
             self.get_runtime().allowed_pub_keys.add(public_key)
 
-            cmd = ["dev", "con", public_key, f"{ip}:{port}"]
             if pq:
-                cmd.append("--pq")
-
-            await asyncio.gather(self._write_command(cmd), event)
+                self.get_proxy().connect_to_exit_node_pq(
+                    public_key=public_key,
+                    allowed_ips=None,
+                    endpoint=f"{ip}:{port}",
+                )
+            else:
+                self.get_proxy().connect_to_exit_node(
+                    public_key=public_key,
+                    allowed_ips=None,
+                    endpoint=f"{ip}:{port}",
+                )
+            await event
 
     async def disconnect_from_vpn(
         self,
@@ -768,8 +839,8 @@ class Client:
                 timeout=timeout,
             )
         ) as event:
+            self.get_proxy().disconnect_from_exit_nodes()
             await asyncio.gather(
-                self._write_command(["vpn", "off"]),
                 event,
                 self.get_router().delete_vpn_route(),
             )
@@ -784,20 +855,20 @@ class Client:
                 public_key, [State.Connected], list(PathType), timeout=timeout
             )
         ) as event:
+            self.get_proxy().disconnect_from_exit_nodes()
             await asyncio.gather(
-                self._write_command(["vpn", "off"]),
                 event,
                 self.get_router().delete_vpn_route(),
             )
 
     async def enable_magic_dns(self, forward_servers: List[str]) -> None:
-        await self._write_command(["dns", "on"] + forward_servers)
+        self.get_proxy().enable_magic_dns(forward_servers)
 
     async def disable_magic_dns(self) -> None:
-        await self._write_command(["dns", "off"])
+        self.get_proxy().disable_magic_dns()
 
     async def notify_network_change(self) -> None:
-        await self._write_command(["dev", "notify-net-change"])
+        self.get_proxy().notify_network_change()
 
     async def _configure_interface(self) -> bool:
         if not self._interface_configured:
@@ -825,10 +896,10 @@ class Client:
                 timeout=timeout,
             )
         ) as event:
-            await asyncio.gather(
-                self._write_command(["dev", "con", public_key]),
-                event,
+            self.get_proxy().connect_to_exit_node(
+                public_key=public_key, allowed_ips=None, endpoint=None
             )
+            await event
 
     def get_router(self) -> Router:
         assert self._router
@@ -842,6 +913,10 @@ class Client:
         assert self._process
         return self._process
 
+    def get_proxy(self) -> LibtelioProxy:
+        assert self._libtelio_proxy
+        return self._libtelio_proxy
+
     def get_events(self) -> Events:
         assert self._events
         return self._events
@@ -854,15 +929,23 @@ class Client:
         assert self._telio_features
         return self._telio_features
 
-    async def stop_device(self, timeout: Optional[float] = None) -> None:
-        await asyncio.wait_for(self._write_command(["dev", "stop"]), timeout)
+    async def stop_device(self) -> None:
+        self.get_proxy().stop()
         self._interface_configured = False
-        started_tasks = self.get_runtime().get_started_tasks()
-        stopped_tasks = self.get_runtime().get_stopped_tasks()
-        diff = Counter(started_tasks) - Counter(stopped_tasks)
-        assert (
-            diff == Counter()
-        ), f"started tasks and stopped tasks differ! diff: {diff} | started tasks: {started_tasks} | stopped tasks: {stopped_tasks}"
+
+        # Check every .5s, up to maximum 10 seconds, that the started and stopped tasks are the same
+        for i in range(20, -1, -1):
+            started_tasks = self.get_runtime().get_started_tasks()
+            stopped_tasks = self.get_runtime().get_stopped_tasks()
+            diff = Counter(started_tasks) - Counter(stopped_tasks)
+            if diff == Counter():
+                break
+            if i > 0:
+                await asyncio.sleep(0.5)
+            else:
+                assert (
+                    diff == Counter()
+                ), f"started tasks and stopped tasks differ! diff: {diff} | started tasks: {started_tasks} | stopped tasks: {stopped_tasks}"
 
     def get_node_state(self, public_key: str) -> Optional[PeerInfo]:
         return self.get_runtime().get_peer_info(public_key)
@@ -873,7 +956,15 @@ class Client:
     async def _event_request_loop(self) -> None:
         while True:
             try:
-                await self._write_command(["events"])
+                event = self.get_proxy().next_event()
+                while event:
+                    if self._runtime:
+                        print(
+                            f"[{self._node.name}]: event [{datetime.datetime.now()}]:"
+                            f" {event}"
+                        )
+                        self._runtime.handle_output_line(event)
+                        event = self.get_proxy().next_event()
                 await asyncio.sleep(1)
             except:
                 if self._quit:
@@ -908,10 +999,10 @@ class Client:
         await self._write_command(["derp", "send", pk] + data)
 
     async def trigger_event_collection(self) -> None:
-        await self._write_command(["dev", "analytics"])
+        self.get_proxy().trigger_analytics_event()
 
     async def trigger_qos_collection(self) -> None:
-        await self._write_command(["dev", "qos"])
+        self.get_proxy().trigger_qos_collection()
 
     async def _write_command(self, command: List[str]) -> None:
         idx = self._message_idx

--- a/nat-lab/tests/telio_test.py
+++ b/nat-lab/tests/telio_test.py
@@ -148,10 +148,10 @@ class TestRuntime:
         runtime = Runtime()
 
         assert runtime.handle_output_line(
-            'event relay: {"region_code":"test","name":"test","hostname"'
+            '{"type":"relay","body":{"region_code":"test","name":"test","hostname"'
             + ':"test","ipv4":"1.1.1.1","relay_port":1111,"stun_port":1111,'
             + '"stun_plaintext_port":1111,"public_key":"test","weight":1,'
-            + '"use_plain_text":true,"conn_state":"connected"}'
+            + '"use_plain_text":true,"conn_state":"connected"}}'
         )
 
         await runtime.notify_derp_state("1.1.1.1", [State.Connected])
@@ -162,10 +162,10 @@ class TestRuntime:
         runtime.allowed_pub_keys = set(["AAA"])
 
         assert runtime.handle_output_line(
-            "event node: "
-            + ' "{"identifier":"tcli","public_key":"AAA","state":"connected","is_exit":true,'
+            '{"type":"node","body":'
+            + '{"identifier":"tcli","public_key":"AAA","state":"connected","is_exit":true,'
             + '"is_vpn":true,"ip_addresses":[],"allowed_ips":[],"endpoint":null,"hostname":null,'
-            + '"allow_incoming_connections":false,"allow_peer_send_files":false,"path":"relay"}"'
+            + '"allow_incoming_connections":false,"allow_peer_send_files":false,"path":"relay"}}'
         )
 
         await runtime.notify_peer_state(

--- a/nat-lab/tests/test_direct_connection.py
+++ b/nat-lab/tests/test_direct_connection.py
@@ -382,7 +382,7 @@ async def test_direct_working_paths_are_reestablished_and_correctly_reported_in_
             ),
         )
 
-        pred = ".* telio_nurse::aggregator: \\d+: (.* peer state change for .* will be reported)"
+        pred = '.* "telio_nurse::aggregator":\\d+ (.* peer state change for .* will be reported)'
         # We need to compare the decoded forms, not the base64 encoded strings
         if base64.b64decode(alpha.public_key) < base64.b64decode(beta.public_key):
             losing_key = beta.public_key

--- a/nat-lab/tests/test_direct_feature.py
+++ b/nat-lab/tests/test_direct_feature.py
@@ -1,6 +1,6 @@
 import pytest
 from contextlib import AsyncExitStack
-from helpers import setup_environment, SetupParameters
+from helpers import setup_mesh_nodes, SetupParameters
 from telio_features import TelioFeatures, Direct
 
 ALL_DIRECT_FEATURES = ["upnp", "local", "stun"]
@@ -10,45 +10,45 @@ EMPTY_PROVIDER = [""]
 @pytest.mark.asyncio
 async def test_default_direct_features() -> None:
     async with AsyncExitStack() as exit_stack:
-        async with setup_environment(
+        env = await setup_mesh_nodes(
             exit_stack,
             [SetupParameters(features=TelioFeatures(direct=Direct(providers=None)))],
-        ) as env:
-            started_tasks = env.clients[0].get_runtime().get_started_tasks()
-            assert "UpnpEndpointProvider" not in started_tasks
-            assert "LocalInterfacesEndpointProvider" in started_tasks
-            assert "StunEndpointProvider" in started_tasks
+        )
+        started_tasks = env.clients[0].get_runtime().get_started_tasks()
+        assert "UpnpEndpointProvider" not in started_tasks
+        assert "LocalInterfacesEndpointProvider" in started_tasks
+        assert "StunEndpointProvider" in started_tasks
 
 
 @pytest.mark.asyncio
 async def test_enable_all_direct_features() -> None:
     async with AsyncExitStack() as exit_stack:
-        async with setup_environment(
+        env = await setup_mesh_nodes(
             exit_stack,
             [
                 SetupParameters(
                     features=TelioFeatures(direct=Direct(providers=ALL_DIRECT_FEATURES))
                 )
             ],
-        ) as env:
-            started_tasks = env.clients[0].get_runtime().get_started_tasks()
-            assert "UpnpEndpointProvider" in started_tasks
-            assert "LocalInterfacesEndpointProvider" in started_tasks
-            assert "StunEndpointProvider" in started_tasks
+        )
+        started_tasks = env.clients[0].get_runtime().get_started_tasks()
+        assert "UpnpEndpointProvider" in started_tasks
+        assert "LocalInterfacesEndpointProvider" in started_tasks
+        assert "StunEndpointProvider" in started_tasks
 
 
 @pytest.mark.asyncio
 async def test_check_features_with_empty_direct_providers() -> None:
     async with AsyncExitStack() as exit_stack:
-        async with setup_environment(
+        env = await setup_mesh_nodes(
             exit_stack,
             [
                 SetupParameters(
                     features=TelioFeatures(direct=Direct(providers=EMPTY_PROVIDER))
                 )
             ],
-        ) as env:
-            started_tasks = env.clients[0].get_runtime().get_started_tasks()
-            assert "UpnpEndpointProvider" not in started_tasks
-            assert "LocalInterfacesEndpointProvider" not in started_tasks
-            assert "StunEndpointProvider" not in started_tasks
+        )
+        started_tasks = env.clients[0].get_runtime().get_started_tasks()
+        assert "UpnpEndpointProvider" not in started_tasks
+        assert "LocalInterfacesEndpointProvider" not in started_tasks
+        assert "StunEndpointProvider" not in started_tasks

--- a/nat-lab/tests/test_events.py
+++ b/nat-lab/tests/test_events.py
@@ -269,7 +269,7 @@ async def test_event_content_vpn_connection(
             await ping.wait_for_next_ping()
 
         assert client_alpha.get_node_state(str(wg_server["public_key"])) == PeerInfo(
-            identifier="tcli",
+            identifier="natlab",
             public_key=str(wg_server["public_key"]),
             state=State.Connected,
             is_exit=True,
@@ -296,7 +296,7 @@ async def test_event_content_vpn_connection(
         assert ip == alpha_public_ip, f"wrong public IP before connecting to VPN {ip}"
 
         assert client_alpha.get_node_state(str(wg_server["public_key"])) == PeerInfo(
-            identifier="tcli",
+            identifier="natlab",
             public_key=str(wg_server["public_key"]),
             state=State.Disconnected,
             is_exit=True,

--- a/nat-lab/tests/test_vpn.py
+++ b/nat-lab/tests/test_vpn.py
@@ -337,7 +337,7 @@ async def test_vpn_reconnect(
         # IPv4 public server
         pytest.param(
             SetupParameters(
-                connection_tag=ConnectionTag.DOCKER_OPEN_INTERNET_CLIENT_DUAL_STACK,
+                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
                 adapter_type=AdapterType.BoringTun,
                 ip_stack=IPStack.IPv4,
                 features=TelioFeatures(boringtun_reset_connections=True),
@@ -474,7 +474,7 @@ async def test_kill_external_tcp_conn_on_vpn_reconnect(
         # IPv4 public server
         pytest.param(
             SetupParameters(
-                connection_tag=ConnectionTag.DOCKER_OPEN_INTERNET_CLIENT_DUAL_STACK,
+                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
                 adapter_type=AdapterType.BoringTun,
                 ip_stack=IPStack.IPv4,
                 features=TelioFeatures(boringtun_reset_connections=True),

--- a/nat-lab/tests/uniffi/__init__.py
+++ b/nat-lab/tests/uniffi/__init__.py
@@ -1,0 +1,2 @@
+from .libtelio_proxy import *
+from .telio_bindings import *  # type: ignore

--- a/nat-lab/tests/uniffi/libtelio_proxy.py
+++ b/nat-lab/tests/uniffi/libtelio_proxy.py
@@ -1,0 +1,93 @@
+import Pyro5.errors  # type:ignore
+import time
+from Pyro5.api import Proxy  # type: ignore
+
+
+class ProxyConnectionError(Exception):
+    def __init__(self, inner):
+        self._inner = inner
+
+    def __str__(self):
+        return f"ProxyConnectionError: {self._inner}"
+
+
+class LibtelioProxy:
+    def __init__(self, object_uri: str, features: str):
+        self._uri = object_uri
+        iterations = 20
+        for i in range(0, iterations):
+            try:
+                self._create(features)
+                return
+            except Pyro5.errors.CommunicationError as err:
+                if i == iterations - 1:
+                    raise ProxyConnectionError(err) from err
+                time.sleep(0.25)
+
+    def shutdown(self):
+        with Proxy(self._uri) as remote:
+            remote.shutdown()
+
+    def handle_remote_error(self, f):
+        with Proxy(self._uri) as remote:
+            fn_res = f(remote)
+            if fn_res is None:
+                return None
+            (res, err) = fn_res
+            if err is not None:
+                raise Exception(err)
+            return res
+
+    def _create(self, features: str):
+        self.handle_remote_error(lambda r: r.create(features))
+
+    def next_event(self):
+        return self.handle_remote_error(lambda r: r.next_event())
+
+    def stop(self):
+        self.handle_remote_error(lambda r: r.stop())
+
+    def start_named(self, private_key, adapter, name: str):
+        self.handle_remote_error(
+            lambda r: r.start_named(private_key, adapter.value, name)
+        )
+
+    def set_fwmark(self, fwmark: int):
+        self.handle_remote_error(lambda r: r.set_fwmark(fwmark))
+
+    def notify_network_change(self):
+        self.handle_remote_error(lambda r: r.notify_network_change())
+
+    def connect_to_exit_node(self, public_key, allowed_ips, endpoint):
+        self.handle_remote_error(
+            lambda r: r.connect_to_exit_node(public_key, allowed_ips, endpoint)
+        )
+
+    def connect_to_exit_node_pq(self, public_key, allowed_ips, endpoint):
+        self.handle_remote_error(
+            lambda r: r.connect_to_exit_node_pq(public_key, allowed_ips, endpoint)
+        )
+
+    def disconnect_from_exit_nodes(self):
+        self.handle_remote_error(lambda r: r.disconnect_from_exit_nodes())
+
+    def enable_magic_dns(self, forward_servers):
+        self.handle_remote_error(lambda r: r.enable_magic_dns(forward_servers))
+
+    def disable_magic_dns(self):
+        self.handle_remote_error(lambda r: r.disable_magic_dns())
+
+    def set_meshnet(self, cfg: str):
+        self.handle_remote_error(lambda r: r.set_meshnet(cfg))
+
+    def set_meshnet_off(self):
+        self.handle_remote_error(lambda r: r.set_meshnet_off())
+
+    def is_running(self) -> bool:
+        return self.handle_remote_error(lambda r: r.is_running())
+
+    def trigger_analytics_event(self) -> None:
+        self.handle_remote_error(lambda r: r.trigger_analytics_event())
+
+    def trigger_qos_collection(self) -> None:
+        self.handle_remote_error(lambda r: r.trigger_qos_collection())

--- a/nat-lab/tests/uniffi/libtelio_remote.py
+++ b/nat-lab/tests/uniffi/libtelio_remote.py
@@ -1,0 +1,164 @@
+import base64
+import datetime
+import os
+import Pyro5.api  # type: ignore
+import Pyro5.server  # type: ignore
+import sys
+import telio_bindings as libtelio  # type: ignore # pylint: disable=import-error
+from typing import List
+
+REMOTE_LOG = "remote.log"
+TCLI_LOG = "tcli.log"
+
+
+def serialize_error(f):
+    def wrap(*args, **kwargs):
+        with open(REMOTE_LOG, "a", encoding="utf-8") as logfile:
+            fname = str(f).split(" ")[1]
+            args_str = ", ".join(map(str, args[1:]))
+            try:
+                res = f(*args, **kwargs)
+                logfile.write(
+                    f"{datetime.datetime.now()} {fname}({args_str}) => {res}\n"
+                )
+                return (res, None)
+            except libtelio.TelioError as e:
+                logfile.write(
+                    f"{datetime.datetime.now()} {fname}({args_str}) => {str(e)}\n"
+                )
+                return (None, str(e))
+
+    return wrap
+
+
+class TelioEventCbImpl(libtelio.TelioEventCb):
+    def __init__(self):
+        self._events = []
+
+    def event(self, payload):
+        self._events.append(payload)
+
+    def next_event(self):
+        if len(self._events) > 0:
+            return self._events.pop(0)
+        return None
+
+
+class TelioLoggerCbImpl(libtelio.TelioLoggerCb):
+    def log(self, log_level, payload):
+        with open(TCLI_LOG, "a", encoding="utf-8") as logfile:
+            try:
+                logfile.write(f"{datetime.datetime.now()} {log_level} {payload}\n")
+            except IOError as e:
+                logfile.write(
+                    f"{datetime.datetime.now()} Failed to write logline due to error {str(e)}\n"
+                )
+
+
+@Pyro5.api.expose
+@Pyro5.server.behavior(instance_mode="single")
+class LibtelioWrapper:
+    def __init__(self, daemon):
+        try:
+            os.remove(REMOTE_LOG)
+        except:
+            pass
+
+        self._daemon = daemon
+
+        self._libtelio = None
+        self._event_cb = TelioEventCbImpl()
+        self._logger_cb = TelioLoggerCbImpl()
+        libtelio.set_global_logger(libtelio.TelioLogLevel.DEBUG, self._logger_cb)
+
+    def shutdown(self):
+        self._daemon.shutdown()
+
+    @serialize_error
+    def create(self, features: str):
+        features = libtelio.deserialize_feature_config(features)
+        self._libtelio = libtelio.Telio(features, self._event_cb)
+
+    @serialize_error
+    def next_event(self):
+        return self._event_cb.next_event()
+
+    @serialize_error
+    def stop(self):
+        self._libtelio.stop()
+
+    @serialize_error
+    def start_named(self, private_key, adapter, name: str):
+        self._libtelio.start_named(
+            base64.b64decode(private_key), libtelio.TelioAdapterType(adapter), name
+        )
+
+    @serialize_error
+    def set_fwmark(self, fwmark: int):
+        self._libtelio.set_fwmark(fwmark)
+
+    @serialize_error
+    def notify_network_change(self):
+        self._libtelio.notify_network_change("")
+
+    @serialize_error
+    def connect_to_exit_node(self, public_key, allowed_ips: str, endpoint: str):
+        self._libtelio.connect_to_exit_node_with_id(
+            "natlab", base64.b64decode(public_key), allowed_ips, endpoint
+        )
+
+    @serialize_error
+    def connect_to_exit_node_pq(self, public_key, allowed_ips: str, endpoint: str):
+        self._libtelio.connect_to_exit_node_postquantum(
+            "natlabpq", base64.b64decode(public_key), allowed_ips, endpoint
+        )
+
+    @serialize_error
+    def disconnect_from_exit_nodes(self):
+        self._libtelio.disconnect_from_exit_nodes()
+
+    @serialize_error
+    def enable_magic_dns(self, forward_servers: List[str]):
+        self._libtelio.enable_magic_dns(forward_servers)
+
+    @serialize_error
+    def disable_magic_dns(self):
+        self._libtelio.disable_magic_dns()
+
+    @serialize_error
+    def set_meshnet(self, cfg: str):
+        cfg = libtelio.deserialize_meshnet_config(cfg)
+        self._libtelio.set_meshnet(cfg)
+
+    @serialize_error
+    def set_meshnet_off(self):
+        self._libtelio.set_meshnet_off()
+
+    @serialize_error
+    def is_running(self) -> bool:
+        return self._libtelio.is_running()
+
+    @serialize_error
+    def trigger_analytics_event(self) -> None:
+        self._libtelio.trigger_analytics_event()
+
+    @serialize_error
+    def trigger_qos_collection(self) -> None:
+        self._libtelio.trigger_qos_collection()
+
+
+def main():
+    object_name = sys.argv[1]
+    container_ip = sys.argv[2]
+    port = int(sys.argv[3])
+
+    daemon = Pyro5.server.Daemon(host=container_ip, port=port)
+    wrapper = LibtelioWrapper(daemon)
+    daemon.register(wrapper, objectId=object_name)
+
+    daemon.requestLoop()
+    daemon.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/nat-lab/tests/utils/connection/connection.py
+++ b/nat-lab/tests/utils/connection/connection.py
@@ -28,3 +28,10 @@ class Connection(ABC):
     @target_os.setter
     def target_os(self, target_os: TargetOS) -> None:
         self._target_os = target_os
+
+    async def get_ip_address(self) -> tuple[str, str]:
+        ip = "127.0.0.1"
+        return (ip, ip)
+
+    async def mapped_ports(self) -> tuple[str, str]:
+        return ("0", "0")

--- a/nat-lab/tests/utils/connection/docker_connection.py
+++ b/nat-lab/tests/utils/connection/docker_connection.py
@@ -20,3 +20,26 @@ class DockerConnection(Connection):
     def create_process(self, command: List[str]) -> "Process":
         print(datetime.now(), "Executing", command, "on", self._name)
         return DockerProcess(self._container, command)
+
+    async def get_ip_address(self) -> tuple[str, str]:
+        details = await self._container.show()
+        networks = details["NetworkSettings"]["Networks"]
+        if not networks.values():
+            raise Exception(
+                "Docker container '" + self._container["Name"] + "' has no ip addresses"
+            )
+        networks = list(networks.values())
+        ip_address = networks[0]["IPAMConfig"]["IPv4Address"]
+        return ("localhost", ip_address)
+
+    async def mapped_ports(self) -> tuple[str, str]:
+        details = await self._container.show()
+        ports = details["NetworkSettings"]["Ports"]
+        if not ports.items():
+            raise Exception(
+                "Docker container '" + self._container["Name"] + "' has no mapped ports"
+            )
+        mapped_port = list(ports.items())[0]
+        container_port = mapped_port[0].split("/")[0]
+        host_port = mapped_port[1][0]["HostPort"]
+        return (str(host_port), str(container_port))

--- a/nat-lab/tests/utils/connection/ssh_connection.py
+++ b/nat-lab/tests/utils/connection/ssh_connection.py
@@ -1,4 +1,5 @@
 import asyncssh
+import random
 import shlex
 from .connection import Connection, TargetOS
 from datetime import datetime
@@ -24,3 +25,11 @@ class SshConnection(Connection):
             assert False, f"not supported target_os '{self._target_os}'"
 
         return SshProcess(self._connection, command, escape_argument)
+
+    async def get_ip_address(self) -> tuple[str, str]:
+        ip = self._connection._host  # pylint: disable=protected-access
+        return (ip, ip)
+
+    async def mapped_ports(self) -> tuple[str, str]:
+        port = str(random.randrange(10000, 65000))
+        return (port, port)

--- a/nat-lab/tests/utils/connection_util.py
+++ b/nat-lab/tests/utils/connection_util.py
@@ -188,6 +188,17 @@ def get_libtelio_binary_path(path: str, connection: Connection) -> str:
     assert False, f"target_os not supported '{target_os}'"
 
 
+def get_uniffi_path(connection: Connection) -> str:
+    target_os = connection.target_os
+    if target_os == TargetOS.Linux:
+        return "/libtelio/nat-lab/tests/uniffi/libtelio_remote.py"
+    if target_os == TargetOS.Windows:
+        return "C:/workspace/uniffi/libtelio_remote.py".replace("/", "\\")
+    if target_os == TargetOS.Mac:
+        return "/var/root/workspace/uniffi/libtelio_remote.py"
+    assert False, f"target_os not supported '{target_os}'"
+
+
 @asynccontextmanager
 async def new_connection_raw(tag: ConnectionTag) -> AsyncIterator[Connection]:
     if tag in DOCKER_SERVICE_IDS:

--- a/nat-lab/tests/utils/process/docker_process.py
+++ b/nat-lab/tests/utils/process/docker_process.py
@@ -178,6 +178,10 @@ class DockerProcess(Process):
         assert self._stream, "process dead"
         await self._stream.write_in(data.encode("utf-8"))
 
+    async def escape_and_write_stdin(self, data: List[str]) -> None:
+        command_str = " ".join(data) + "\n"
+        await self.write_stdin(command_str)
+
     def get_stdout(self) -> str:
         return self._stdout
 

--- a/nat-lab/tests/utils/process/process.py
+++ b/nat-lab/tests/utils/process/process.py
@@ -47,6 +47,10 @@ class Process(ABC):
         pass
 
     @abstractmethod
+    async def escape_and_write_stdin(self, data: List[str]) -> None:
+        pass
+
+    @abstractmethod
     def get_stdout(self) -> str:
         pass
 

--- a/nat-lab/tests/utils/process/ssh_process.py
+++ b/nat-lab/tests/utils/process/ssh_process.py
@@ -123,6 +123,11 @@ class SshProcess(Process):
         assert self._stdin, "process dead"
         self._stdin.write(data)
 
+    async def escape_and_write_stdin(self, data: List[str]) -> None:
+        escaped = [self._escape_argument(arg) for arg in data]
+        command_str = " ".join(escaped) + "\n"
+        await self.write_stdin(command_str)
+
     def get_stdout(self) -> str:
         return self._stdout
 

--- a/rustdoc/multi-code.html
+++ b/rustdoc/multi-code.html
@@ -79,8 +79,6 @@ class MultiCode extends HTMLElement {
 document.addEventListener("DOMContentLoaded", function() {
   customElements.define('multi-code', MultiCode);
   customElements.define('multi-code-select', MultiCodeSelect);
-
-  console.log("multi-code loaded");
 });
 
 </script>

--- a/src/doc/integrating_telio.md
+++ b/src/doc/integrating_telio.md
@@ -21,8 +21,9 @@ use telio::{ffi::*, types::*};
 #[derive(Debug)]
 struct Logger;
 impl TelioLoggerCb for Logger {
-    fn log(&self, log_level: TelioLogLevel, payload: String) {
+    fn log(&self, log_level: TelioLogLevel, payload: String) -> FFIResult<()> {
         // report log level and payload to the app
+        Ok(())
     }
 }
 // Global function
@@ -34,7 +35,7 @@ import github.com/nordsecurity/telio
 
 type Logger struct {}
 
-func (l Logger) Log(logLevel TelioLogLevel, payload string) {
+func (l Logger) Log(logLevel TelioLogLevel, payload string) *TelioError {
     // report log level and payload to the app
 }
 
@@ -45,7 +46,7 @@ SetGlobalLogger(TelioLogLevel.Debug, Logger{})
 import libtelio
 
 class Logger: TelioLoggerCb {
-    func log(logLevel: TelioLogLevel, payload: String) {
+    func log(logLevel: TelioLogLevel, payload: String) throws {
         // report log level and payload to the app
     }
 }
@@ -94,7 +95,9 @@ use telio::{ffi::*, types::*};
 #[derive(Debug)]
 struct EventHandler;
 impl TelioEventCb for EventHandler {
-    fn event(&self, payload: String) {}
+    fn event(&self, payload: String) -> FFIResult<()> {
+        Ok(())
+    }
 }
 
 let telio = Telio::new(Default::default(), Box::new(EventHandler)).unwrap();
@@ -155,7 +158,9 @@ if let Some(nurse) = &mut feature_config.nurse {
 #[derive(Debug)]
 struct EventHandler;
 impl TelioEventCb for EventHandler {
-    fn event(&self, payload: String) {}
+    fn event(&self, payload: String) -> FFIResult<()> {
+        Ok(())
+    }
 }
 
 let telio = Telio::new(feature_config, Box::new(EventHandler)).unwrap();
@@ -237,9 +242,10 @@ use telio::{ffi::*, types::*};
 #[derive(Debug)]
 struct EventHandler;
 impl TelioEventCb for EventHandler {
-    fn event(&self, payload: String) {
+    fn event(&self, payload: String) -> FFIResult<()> {
         // deserialize json payload
         // pass deserialized event to app
+        Ok(())
     }
 }
 
@@ -251,7 +257,7 @@ import github.com/nordsecurity/telio
 
 type EventHandler struct {}
 
-func (eh EventHandler) Event(payload String) {
+func (eh EventHandler) Event(payload String) *TelioError {
     // deserialize json payload
     // pass deserialized event to app
 }
@@ -266,7 +272,7 @@ _, err = Telio {
 import libtelio
 
 class EventHandler: TelioEventCb {
-    func event(payload: string) {
+    func event(payload: string) throws {
         // deserialize json payload
         // pass deserialized event to app
     }
@@ -321,7 +327,9 @@ use telio::{ffi::*, types::*};
 #[derive(Debug)]
 struct EventHandler;
 impl TelioEventCb for EventHandler {
-    fn event(&self, payload: String) {}
+    fn event(&self, payload: String) -> FFIResult<()> {
+        Ok(())
+    }
 }
 
 let sk = generate_secret_key();
@@ -429,7 +437,9 @@ use telio_crypto::PublicKey;
 #[derive(Debug)]
 struct EventHandler;
 impl TelioEventCb for EventHandler {
-    fn event(&self, payload: String) {}
+    fn event(&self, payload: String) -> FFIResult<()> {
+        Ok(())
+    }
 }
 
 let sk = generate_secret_key();
@@ -575,7 +585,9 @@ use telio::{ffi::*, types::*};
 #[derive(Debug)]
 struct EventHandler;
 impl TelioEventCb for EventHandler {
-    fn event(&self, payload: String) {}
+    fn event(&self, payload: String) -> FFIResult<()> {
+        Ok(())
+    }
 }
 
 let sk = generate_secret_key();
@@ -718,7 +730,9 @@ use telio::{ffi::*, types::*};
 #[derive(Debug)]
 struct EventHandler;
 impl TelioEventCb for EventHandler {
-    fn event(&self, payload: String) {}
+    fn event(&self, payload: String) -> FFIResult<()> {
+        Ok(())
+    }
 }
 
 let sk = generate_secret_key();
@@ -850,7 +864,9 @@ use telio_crypto::PublicKey;
 #[derive(Debug)]
 struct EventHandler;
 impl TelioEventCb for EventHandler {
-    fn event(&self, payload: String) {}
+    fn event(&self, payload: String) -> FFIResult<()> {
+        Ok(())
+    }
 }
 
 let sk = generate_secret_key();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,16 @@ mod uniffi_libtelio {
     use telio_model::mesh::*;
     use telio_utils::{Hidden, HiddenString};
 
+    impl From<uniffi::UnexpectedUniFFICallbackError> for TelioError {
+        fn from(err: uniffi::UnexpectedUniFFICallbackError) -> Self {
+            let err_string = err.to_string();
+            let err_reason = err.reason;
+            Self::UnknownError {
+                inner: format!("{err_string} - {err_reason}"),
+            }
+        }
+    }
+
     impl UniffiCustomTypeConverter for PublicKey {
         type Builtin = Vec<u8>;
 
@@ -109,8 +119,8 @@ mod uniffi_libtelio {
         type Builtin = String;
 
         fn into_custom(val: Self::Builtin) -> uniffi::Result<Self> {
-            Ok(val.parse().map_err(|_| {
-                TelioError::UnknownError(anyhow::anyhow!("Invalid IP address".to_owned()))
+            Ok(val.parse().map_err(|_| TelioError::UnknownError {
+                inner: "Invalid IP address".to_owned(),
             })?)
         }
 
@@ -123,8 +133,8 @@ mod uniffi_libtelio {
         type Builtin = String;
 
         fn into_custom(val: Self::Builtin) -> uniffi::Result<Self> {
-            Ok(val.parse().map_err(|_| {
-                TelioError::UnknownError(anyhow::anyhow!("Invalid IP address".to_owned()))
+            Ok(val.parse().map_err(|_| TelioError::UnknownError {
+                inner: "Invalid IP address".to_owned(),
             })?)
         }
 
@@ -150,8 +160,8 @@ mod uniffi_libtelio {
         type Builtin = String;
 
         fn into_custom(val: Self::Builtin) -> uniffi::Result<Self> {
-            Ok(val.parse().map_err(|_| {
-                TelioError::UnknownError(anyhow::anyhow!("Invalid IP address".to_owned()))
+            Ok(val.parse().map_err(|_| TelioError::UnknownError {
+                inner: "Invalid IP address".to_owned(),
             })?)
         }
 
@@ -168,7 +178,7 @@ mod uniffi_libtelio {
         }
 
         fn from_custom(obj: Self) -> Self::Builtin {
-            obj.to_string()
+            obj.0.clone()
         }
     }
 

--- a/src/libtelio.udl
+++ b/src/libtelio.udl
@@ -23,14 +23,14 @@ enum RttType {
 };
 
 [Error]
-enum TelioError {
-    "UnknownError",
-    "InvalidKey",
-    "BadConfig",
-    "LockError",
-    "InvalidString",
-    "AlreadyStarted",
-    "NotStarted"
+interface TelioError {
+    UnknownError(string inner);
+    InvalidKey();
+    BadConfig();
+    LockError();
+    InvalidString();
+    AlreadyStarted();
+    NotStarted();
 };
 
 /// Possible adapters.
@@ -370,6 +370,13 @@ interface Telio {
 
     /// Get last error's message length, including trailing null
     string get_last_error();
+    
+    [Throws=TelioError]
+    boolean is_running();
+    [Throws=TelioError]
+    void trigger_analytics_event();
+    [Throws=TelioError]
+    void trigger_qos_collection();
 
     /// For testing only.
     [Throws=TelioError]
@@ -381,14 +388,17 @@ interface Telio {
 };
 
 callback interface TelioEventCb {
+    [Throws=TelioError]
     void event(string payload);
 };
 
 callback interface TelioLoggerCb {
+    [Throws=TelioError]
     void log(TelioLogLevel log_level, string payload);
 };
 
 callback interface TelioProtectCb {
+    [Throws=TelioError]
     void protect(i32 payload);
 };
 

--- a/tests/logger.rs
+++ b/tests/logger.rs
@@ -7,7 +7,7 @@ mod test_module {
         Arc,
     };
 
-    use telio::ffi_types::TelioLoggerCb;
+    use telio::ffi_types::{FFIResult, TelioLoggerCb};
 
     use super::*;
 
@@ -20,10 +20,15 @@ mod test_module {
             call_count: Arc<AtomicUsize>,
         }
         impl TelioLoggerCb for TestLogger {
-            fn log(&self, log_level: telio::ffi_types::TelioLogLevel, payload: String) {
+            fn log(
+                &self,
+                log_level: telio::ffi_types::TelioLogLevel,
+                payload: String,
+            ) -> FFIResult<()> {
                 assert!(matches!(log_level, telio::ffi_types::TelioLogLevel::Info));
-                assert_eq!(r#""logger::test_module":38 test message"#, payload);
+                assert_eq!(r#""logger::test_module":43 test message"#, payload);
                 assert_eq!(0, self.call_count.fetch_add(1, Ordering::Relaxed));
+                Ok(())
             }
         }
 


### PR DESCRIPTION
### Problem
We want to migrate natlab tests to using UniFFI-generated bindings.

### Solution
Generated python bindings and a dynamically linked binary is now used instead of tcli for interacting with libtelio. Pyro5, a python remote object framework, will allow the host to control the container(s) and VM(s) instead of writing to a docker process' stdin. 

The Pyro5 code here consists of two parts: `libtelio_remote.py` and `libtelio_proxy.py`. `libtelio_remote.py` runs on the container(s) and VM(s), has a telio instance, and exposes what the natlab tests needs. `libtelio_proxy.py` has a class `LibtelioProxy`, that can communicate with the object exposed from `libtelio_remote.py`. `Client` now has an instance of `LibtelioProxy` that allows the host to interact with telio.

The build repo needs to be updated before the tests can run, since this requires some plumbing. The associated build repo MR shows all tests passing.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
