### PR TITLE
Use null terminated strings in uniffi test for path length

### DIFF
--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -1914,14 +1914,14 @@ mod tests {
             id: rand::thread_rng().gen::<usize>(),
         };
 
-        let cfg = "a".repeat(MAX_CONFIG_LENGTH);
+        let cfg = CString::new("a".repeat(MAX_CONFIG_LENGTH)).unwrap();
         assert_eq!(
-            telio_set_meshnet(&telio_dev, cfg.as_bytes().as_ptr() as *const c_char),
+            telio_set_meshnet(&telio_dev, cfg.as_ptr()),
             TELIO_RES_BAD_CONFIG
         );
-        let cfg = "a".repeat(MAX_CONFIG_LENGTH + 1);
+        let cfg = CString::new("a".repeat(MAX_CONFIG_LENGTH + 2)).unwrap();
         assert_eq!(
-            telio_set_meshnet(&telio_dev, cfg.as_bytes().as_ptr() as *const c_char),
+            telio_set_meshnet(&telio_dev, cfg.as_ptr()),
             TELIO_RES_INVALID_STRING
         );
         Ok(())


### PR DESCRIPTION
### Problem
`String` was converted to a slice of bytes, from which a point was created. This doesn't guarantee that a resulting pointer points to an array ending with a nul byte.

Printing that string in lldb shows that it can end with 'random' bytes:

```
(lldb) set set target.max-string-summary-length 100000000
(lldb) p ptr
"aaa(...)aaaaa\xe8$N%\U00000002"
```

### Solution
Use `CString` to have a guaranteed null terminated c style string.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
