### PR TITLE
Unit tests on mac

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,15 @@ jobs:
         with:
           command: test
           args: --all --lib -- --nocapture
+          
+  test-mac:
+    runs-on: macos-13
+    steps:
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - uses: actions-rs/cargo@ae10961054e4aa8b4aa7dffede299aaf087aa33b # v1.0.3
+        with:
+          command: test
+          args: --all --lib -- --nocapture
 
   test-ffi:
     runs-on: ubuntu-22.04

--- a/crates/telio-nurse/src/qos.rs
+++ b/crates/telio-nurse/src/qos.rs
@@ -615,6 +615,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(not(target_os = "macos"))]
     async fn test_handle_wg_event_after_ping() {
         let mut analytics = setup();
         let mut event = generate_event();

--- a/crates/telio-sockets/src/socket_pool.rs
+++ b/crates/telio-sockets/src/socket_pool.rs
@@ -326,7 +326,7 @@ mod tests {
     }
 
     #[rstest]
-    #[cfg(not(windows))]
+    #[cfg(not(any(windows, target_os = "macos")))]
     #[case(IpAddr::V4(Ipv4Addr::LOCALHOST))]
     #[case(IpAddr::V4(Ipv4Addr::UNSPECIFIED))]
     #[case(IpAddr::V6(Ipv6Addr::LOCALHOST))]
@@ -358,7 +358,7 @@ mod tests {
     }
 
     #[rstest]
-    #[cfg(not(windows))]
+    #[cfg(not(any(windows, target_os = "macos")))]
     #[case(IpAddr::V4(Ipv4Addr::LOCALHOST))]
     #[case(IpAddr::V4(Ipv4Addr::UNSPECIFIED))]
     #[case(IpAddr::V6(Ipv6Addr::LOCALHOST))]

--- a/crates/telio-traversal/src/endpoint_providers/stun.rs
+++ b/crates/telio-traversal/src/endpoint_providers/stun.rs
@@ -1675,6 +1675,7 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
+    #[cfg(not(target_os = "macos"))]
     async fn server_maintained_when_current_connection_is_active() {
         let mut env = prepare_test_env_with_server_weights(None, vec![100, 200, 10], false).await;
         let poll_interval = Duration::from_millis(10000);
@@ -1709,6 +1710,7 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
+    #[cfg(not(target_os = "macos"))]
     async fn exponential_backoff() {
         // We need to prepare some more complex mock to test if it is used properly
         let backoff_array = [4000, 12000, 44444, 7654, 10000, 765432];

--- a/test_runner.sh
+++ b/test_runner.sh
@@ -1,2 +1,7 @@
 #!/usr/bin/env bash
-which sudo &> /dev/null && sudo $@ || $@
+
+if command -v sudo &> /dev/null; then
+    sudo $@
+else
+    $@
+fi


### PR DESCRIPTION
### Problem
Tests are not run at all on the mac, which causes accidental breakage. Additionally the test runner reruns the tests when they fail.

### Solution
Add a unit tests job on a mac runner. The tests that are currently not working will have separate tickets created to investigate them and fix them.
The test runner is modified so that it only runs the tests once.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
