### PR TITLE
Fix gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 Cargo.lock
 tcli.log
-.*
+./*/
+!/.cargo
+!/.github
+!/.gitlab
 *.pyc
 *.box
 *.deb


### PR DESCRIPTION
Do not ignore all files and directories starting with . because we are actually tracking some of them.
Instead ignore only directories in the root folder starting with . except for a few that we track.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
