### PR TITLE
Fix persistent keepalive feature in nat-lab

### DIFF
--- a/nat-lab/tests/telio_features.py
+++ b/nat-lab/tests/telio_features.py
@@ -81,11 +81,17 @@ class LinkDetection(DataClassJsonMixin):
 
 @dataclass_json(undefined=Undefined.EXCLUDE)
 @dataclass
-class Wireguard(DataClassJsonMixin):
+class PersistentKeepalive(DataClassJsonMixin):
     proxying: Optional[int] = 25
     direct: Optional[int] = 5
     vpn: Optional[int] = 25
     stun: Optional[int] = 25
+
+
+@dataclass_json(undefined=Undefined.EXCLUDE)
+@dataclass
+class Wireguard(DataClassJsonMixin):
+    persistent_keepalive: PersistentKeepalive
 
 
 @dataclass_json(undefined=Undefined.EXCLUDE)

--- a/nat-lab/tests/test_direct_connection.py
+++ b/nat-lab/tests/test_direct_connection.py
@@ -13,6 +13,7 @@ from telio_features import (
     Wireguard,
     SkipUnresponsivePeers,
     FeatureEndpointProvidersOptimization,
+    PersistentKeepalive,
 )
 from typing import List, Tuple
 from utils import testing
@@ -407,7 +408,9 @@ async def test_direct_working_paths_with_skip_unresponsive_peers(
             param.features.direct.skip_unresponsive_peers = SkipUnresponsivePeers(
                 no_rx_threshold_secs=16
             )
-            param.features.wireguard = Wireguard(proxying=5, direct=5)
+            param.features.wireguard = Wireguard(
+                persistent_keepalive=PersistentKeepalive(proxying=5, direct=5)
+            )
 
         env = await setup_mesh_nodes(exit_stack, setup_params)
         api = env.api

--- a/nat-lab/tests/test_events_link_state.py
+++ b/nat-lab/tests/test_events_link_state.py
@@ -3,7 +3,7 @@ import pytest
 from contextlib import AsyncExitStack
 from helpers import SetupParameters, setup_mesh_nodes
 from telio import AdapterType, LinkState
-from telio_features import TelioFeatures, LinkDetection, Wireguard
+from telio_features import TelioFeatures, LinkDetection, Wireguard, PersistentKeepalive
 from typing import List, Tuple
 from utils import testing
 from utils.connection_util import ConnectionTag
@@ -11,7 +11,11 @@ from utils.ping import Ping
 
 
 def long_persistent_keepalive_periods() -> Wireguard:
-    return Wireguard(proxying=3600, direct=3600, vpn=3600, stun=3600)
+    return Wireguard(
+        persistent_keepalive=PersistentKeepalive(
+            proxying=3600, direct=3600, vpn=3600, stun=3600
+        )
+    )
 
 
 def _generate_setup_paramete_pair(


### PR DESCRIPTION
Persistent keepalive periods feature was not working and left with default values in tests because there was a mistake in the format.

Previous/wrong version was like: "wireguard": {"proxy": 25, "direct": 5, etc}

The correct version is: "wireguard: {"persistent_keepalive": {"proxy":
25, "direct": 5, etc}}"


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
