### PR TITLE
Fix leftover stun peer after meshnet is set off

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@
 * LLT-4917: Fix the issue with wireguard-go failing to bind to a port on some devices
 * LLT-2515: Implement PMTU discovery for VPN connection paths on Linux/Android
 * LLT-4978: Bump moose tracker to v2.0.0-libtelioApp
+* LLT-4967: Clear leftover STUN peer after meshnet is turned off
 
 <br>
 

--- a/nat-lab/tests/telio_features.py
+++ b/nat-lab/tests/telio_features.py
@@ -91,7 +91,7 @@ class PersistentKeepalive(DataClassJsonMixin):
 @dataclass_json(undefined=Undefined.EXCLUDE)
 @dataclass
 class Wireguard(DataClassJsonMixin):
-    persistent_keepalive: PersistentKeepalive
+    persistent_keepalive: PersistentKeepalive = PersistentKeepalive()
 
 
 @dataclass_json(undefined=Undefined.EXCLUDE)

--- a/nat-lab/tests/telio_features.py
+++ b/nat-lab/tests/telio_features.py
@@ -91,7 +91,7 @@ class PersistentKeepalive(DataClassJsonMixin):
 @dataclass_json(undefined=Undefined.EXCLUDE)
 @dataclass
 class Wireguard(DataClassJsonMixin):
-    persistent_keepalive: PersistentKeepalive = PersistentKeepalive()
+    persistent_keepalive: PersistentKeepalive
 
 
 @dataclass_json(undefined=Undefined.EXCLUDE)

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -1599,6 +1599,8 @@ impl Runtime {
                 meshnet_entities.stop().await;
             }
 
+            self.requested_state.wg_stun_server = None;
+
             self.upsert_dns_peers().await?;
         }
 


### PR DESCRIPTION
### Problem
A leftover STUN peer remains after meshnet is turned off causing issues

### Solution
Added code to properly clear the wg stun server config when stopping meshnet 


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
