### PR TITLE
Fix (backport) leftover stun peer after meshnet is set off

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 * LLT-4908: Lowered DNS TTL time for nicknames and NXDomain responses
 * LLT-4916: Allow any case nicknames
 * LLT-4948: Change missed tick behavior from burst to delay
+* LLT-4967: Clear leftover STUN peer after meshnet is turned off
 
 <br>
 

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -1528,6 +1528,8 @@ impl Runtime {
                 meshnet_entities.stop().await;
             }
 
+            self.requested_state.wg_stun_server = None;
+
             self.upsert_dns_peers().await?;
         }
 


### PR DESCRIPTION
### Problem
There is a leftover stun peer after meshnet is set off, but it's already fixed in main

### Solution
Backport the fix from main into release v4.2


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
