### PR TITLE
Backport Make initial_heartbeat_interval to default at 5 minutes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 * LLT-4948: Change missed tick behavior from burst to delay
 * LLT-4967: Clear leftover STUN peer after meshnet is turned off
 * LLT-4913: Skip qos analytics ping for unconnected peers
+* LLT-4968: Make the default nurse initial_heartbeat_interval to be 5 minutes
 
 <br>
 

--- a/crates/telio-model/src/api_config.rs
+++ b/crates/telio-model/src/api_config.rs
@@ -1,7 +1,7 @@
 //! Object descriptions of various
 //! telio configurable features via API
 
-use std::{collections::HashSet, fmt};
+use std::{collections::HashSet, fmt, time::Duration};
 
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 use serde::{de::IntoDeserializer, Deserialize, Deserializer, Serialize};
@@ -94,13 +94,32 @@ pub struct FeatureNurse {
     /// The unique identifier of the device, used for meshnet ID
     pub fingerprint: String,
     /// Heartbeat interval in seconds. Default value is 3600.
+    #[serde(default = "FeatureNurse::get_default_heartbeat_interval")]
     pub heartbeat_interval: Option<u32>,
-    /// Initial heartbeat interval in seconds. Default value is None.
+    /// Initial heartbeat interval in seconds. Default value is 300.
+    #[serde(default = "FeatureNurse::get_default_initial_heartbeat_interval")]
     pub initial_heartbeat_interval: Option<u32>,
     /// QoS configuration for Nurse
     pub qos: Option<FeatureQoS>,
     /// Enable/disable collecting nat type
     pub enable_nat_type_collection: Option<bool>,
+}
+
+impl FeatureNurse {
+    /// One hour
+    pub const DEFAULT_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(3600);
+    /// 5 minutes
+    pub const DEFAULT_INITIAL_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(300);
+
+    fn get_default_heartbeat_interval() -> Option<u32> {
+        // 3600 seconds
+        Some(Self::DEFAULT_HEARTBEAT_INTERVAL.as_secs() as u32)
+    }
+
+    fn get_default_initial_heartbeat_interval() -> Option<u32> {
+        // 300 seconds
+        Some(Self::DEFAULT_INITIAL_HEARTBEAT_INTERVAL.as_secs() as u32)
+    }
 }
 
 /// Configurable features for Lana module
@@ -493,8 +512,8 @@ mod tests {
         },
         nurse: Some(FeatureNurse {
             fingerprint: "fingerprint_test".to_string(),
-            heartbeat_interval: None,
-            initial_heartbeat_interval: None,
+            heartbeat_interval: Some(3600),
+            initial_heartbeat_interval: Some(300),
             qos: None,
             enable_nat_type_collection: None,
         }),
@@ -549,8 +568,8 @@ mod tests {
         },
         nurse: Some(FeatureNurse {
             fingerprint: "fingerprint_test".to_string(),
-            heartbeat_interval: None,
-            initial_heartbeat_interval: None,
+            heartbeat_interval: Some(3600),
+            initial_heartbeat_interval: Some(300),
             qos: None,
             enable_nat_type_collection: None,
         }),
@@ -705,6 +724,7 @@ mod tests {
             "nurse": {
                 "fingerprint": "fingerprint_test",
                 "heartbeat_interval": 3600,
+                "initial_heartbeat_interval": 300,
                 "qos": {
                     "rtt_interval": 3600,
                     "rtt_tries": 5,
@@ -734,7 +754,7 @@ mod tests {
             nurse: Some(FeatureNurse {
                 fingerprint: String::from("fingerprint_test"),
                 heartbeat_interval: Some(3600),
-                initial_heartbeat_interval: None,
+                initial_heartbeat_interval: Some(300),
                 qos: Some(FeatureQoS {
                     rtt_interval: Some(3600),
                     rtt_tries: Some(5),
@@ -763,8 +783,8 @@ mod tests {
             wireguard: Default::default(),
             nurse: Some(FeatureNurse {
                 fingerprint: String::from("fingerprint_test"),
-                heartbeat_interval: None,
-                initial_heartbeat_interval: None,
+                heartbeat_interval: Some(3600),
+                initial_heartbeat_interval: Some(300),
                 qos: Some(FeatureQoS {
                     rtt_interval: None,
                     rtt_tries: None,
@@ -793,8 +813,8 @@ mod tests {
             wireguard: Default::default(),
             nurse: Some(FeatureNurse {
                 fingerprint: String::from("fingerprint_test"),
-                heartbeat_interval: None,
-                initial_heartbeat_interval: None,
+                heartbeat_interval: Some(3600),
+                initial_heartbeat_interval: Some(300),
                 qos: None,
                 enable_nat_type_collection: None,
             }),

--- a/crates/telio-nurse/src/config.rs
+++ b/crates/telio-nurse/src/config.rs
@@ -25,7 +25,7 @@ impl Config {
 /// Configuration for Heartbeat component from Nurse
 pub struct HeartbeatConfig {
     /// Initial time period to wait until the first collection happens in seconds, if none, defaults to 'send_interval'
-    pub initial_collect_interval: Option<Duration>,
+    pub initial_collect_interval: Duration,
 
     /// How often to collect data, in seconds
     pub collect_interval: Duration,
@@ -41,19 +41,18 @@ pub struct HeartbeatConfig {
 }
 
 impl HeartbeatConfig {
-    const DEFAULT_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(3600); // 60 minutes
-
     /// Create a new Heartbeat config
     fn new(features: &FeatureNurse) -> Self {
         let collect_interval = features
             .heartbeat_interval
-            .map(|interval| Duration::from_secs(interval.into()))
-            .unwrap_or(Self::DEFAULT_HEARTBEAT_INTERVAL);
+            .map_or(FeatureNurse::DEFAULT_HEARTBEAT_INTERVAL, |interval| {
+                Duration::from_secs(interval.into())
+            });
 
-        let initial_collect_interval = features
-            .initial_heartbeat_interval
-            .map(|interval| Some(Duration::from_secs(interval.into())))
-            .unwrap_or_default();
+        let initial_collect_interval = features.initial_heartbeat_interval.map_or(
+            FeatureNurse::DEFAULT_INITIAL_HEARTBEAT_INTERVAL,
+            |interval| Duration::from_secs(interval.into()),
+        );
 
         Self {
             initial_collect_interval,
@@ -68,8 +67,8 @@ impl HeartbeatConfig {
 impl Default for HeartbeatConfig {
     fn default() -> Self {
         Self {
-            initial_collect_interval: None,
-            collect_interval: Duration::from_secs(3600),
+            initial_collect_interval: FeatureNurse::DEFAULT_INITIAL_HEARTBEAT_INTERVAL,
+            collect_interval: FeatureNurse::DEFAULT_HEARTBEAT_INTERVAL,
             collect_answer_timeout: Duration::from_secs(10),
             fingerprint: String::new(),
             is_nat_type_collection_enabled: true,

--- a/crates/telio-nurse/src/heartbeat.rs
+++ b/crates/telio-nurse/src/heartbeat.rs
@@ -378,13 +378,7 @@ impl Analytics {
     ///
     /// An empty Analytics instance with the given config
     pub fn new(public_key: PublicKey, meshnet_id: Uuid, config: HeartbeatConfig, io: Io) -> Self {
-        let start_time = if let Some(initial_timeout) = config.initial_collect_interval {
-            Instant::now() + initial_timeout
-        } else {
-            // Adjust the time when the first event will be generated.
-            // This way, the interval between events will be constant.
-            Instant::now() + config.collect_interval - config.collect_answer_timeout
-        };
+        let start_time = Instant::now() + config.initial_collect_interval;
 
         let mut interval: Interval = interval_at(start_time, config.collect_interval);
         interval.set_missed_tick_behavior(MissedTickBehavior::Skip);


### PR DESCRIPTION
BACKPORT

initial_heartbeat_interval represents the time between the start of libtelio and the first analytics event. Until now, when it was missing from the config, it defaulted to None and the first event was generated after heartbeat_interval time which by default is 1 hour. It was requested that we use a default value of 5 minutes for initial_heartbeat_interval.



### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
