### PR TITLE
Update gradle dependencies for build scripts

### DIFF
--- a/android/templates/build.gradle
+++ b/android/templates/build.gradle
@@ -10,9 +10,9 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.1'
-        classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.18.2"
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.21"
+        classpath 'com.android.tools.build:gradle:8.3.0'
+        classpath "org.jfrog.buildinfo:build-info-extractor-gradle:5.2.0"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.23"
     }
 }
 


### PR DESCRIPTION
Update com.android.tools.build:gradle to v4.2.2
Update org.jfro.buildinfo:build-info-extractor-gradle:4.33.13 Due to reported vulnerabilities.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
