### PR TITLE
Remove unnecessary Wireguard() from test params

### DIFF
--- a/nat-lab/tests/test_pinging.py
+++ b/nat-lab/tests/test_pinging.py
@@ -4,7 +4,7 @@ import telio
 from contextlib import AsyncExitStack
 from helpers import setup_mesh_nodes, SetupParameters
 from telio import PathType, State
-from telio_features import TelioFeatures, Direct, Wireguard, Nurse, Qos, Lana
+from telio_features import TelioFeatures, Direct, Nurse, Qos, Lana
 from typing import Tuple, List
 from utils import testing
 from utils.connection import Connection
@@ -58,7 +58,6 @@ async def get_in_node_tracker(
                 ),
                 features=TelioFeatures(
                     direct=Direct(providers=["stun"]),
-                    wireguard=Wireguard(),
                     ipv6=True,
                 ),
             )
@@ -73,7 +72,6 @@ async def get_in_node_tracker(
                 ),
                 features=TelioFeatures(
                     direct=Direct(providers=["stun"]),
-                    wireguard=Wireguard(),
                     ipv6=True,
                 ),
             ),
@@ -99,7 +97,6 @@ async def get_in_node_tracker(
                 ip_stack=IPStack.IPv4v6,
                 features=TelioFeatures(
                     direct=Direct(providers=["stun"]),
-                    wireguard=Wireguard(),
                     ipv6=True,
                 ),
             )


### PR DESCRIPTION
### Problem
Leftovers from [368](https://github.com/NordSecurity/libtelio/pull/368), that fails python lints.

### Solution
Remove leftovers.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
