### PR TITLE
LLT-4980: Missing sync in telio-proxy

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,7 @@
 * LLT-4978: Bump moose tracker to v2.0.0-libtelioApp
 * LLT-4968: Make the default nurse initial_heartbeat_interval to be 5 minutes
 * LLT-4850: Add missing VPN meshnet address to analytics
+* LLT-4980: Introduce synchronization for the endpoint map in telio-proxy
 
 <br>
 

--- a/nat-lab/run_local.py
+++ b/nat-lab/run_local.py
@@ -35,6 +35,9 @@ def main() -> int:
         "-m", type=str, help="Pass the name of mark to pytest (pytest -m)"
     )
     parser.add_argument(
+        "-x", action="store_true", help="Stop tests on first failure or error"
+    )
+    parser.add_argument(
         "-v",
         action="store_true",
         help="Show stdout (by default stdout is captured and not shown)",
@@ -113,6 +116,9 @@ def get_pytest_arguments(options) -> List[str]:
 
     if options.k:
         args.extend(["-k", options.k])
+
+    if options.x:
+        args.extend(["-x"])
 
     if options.m:
         args.extend(["-m", options.m])


### PR DESCRIPTION
### Problem
We were getting the wrong endpoint map from the proxy when trying to configure the wg controller. There was recently some error handling added which made the problem visible, but the problem was there for longer. The root of the issue was that if there was a socket error, StateIngress would swallow the error while StateEgress would actually handle it, yet when we were fetching the endpoint map for the wg controller, we would get it from StateIngress. As a result, if there was a socket error, ingress and egress could be out of sync, and we would get the wrong values passed to the wg controller.

### Solution
There is now synchronization logic added for ingress and egress, and the endpoint map is fetched from egress

Also, with this PR, it's possible to pass the `-x` flag to `run_local.py` and have that be propagated to pytest



### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
