### PR TITLE
Prepare v4.2.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4099,6 +4099,7 @@ dependencies = [
 name = "telio-proxy"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "async-trait",
  "crypto_box",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3866,7 +3866,7 @@ dependencies = [
 
 [[package]]
 name = "telio"
-version = "4.2.4"
+version = "4.2.5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "telio"
-version = "4.2.4"
+version = "4.2.5"
 authors = ["info@nordvpn.com"]
 edition = "2018"
 license = "GPL-3.0-only"

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-### UNRELEASED
+### v4.2.5
 ---
 * LLT-4908: Lowered DNS TTL time for nicknames and NXDomain responses
 * LLT-4916: Allow any case nicknames
@@ -8,6 +8,7 @@
 * LLT-4968: Make the default nurse initial_heartbeat_interval to be 5 minutes
 * LLT-4850: Add missing VPN meshnet address to analytics
 * LLT-4917: Fix the issue with wireguard-go failing to bind to a port on some devices
+* LLT-4870: Bring back PQ
 
 <br>
 

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 * LLT-4967: Clear leftover STUN peer after meshnet is turned off
 * LLT-4913: Skip qos analytics ping for unconnected peers
 * LLT-4968: Make the default nurse initial_heartbeat_interval to be 5 minutes
+* LLT-4850: Add missing VPN meshnet address to analytics
 
 <br>
 

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@
 * LLT-4850: Add missing VPN meshnet address to analytics
 * LLT-4917: Fix the issue with wireguard-go failing to bind to a port on some devices
 * LLT-4870: Bring back PQ
+* LLT-4406: Implement error handling for proxy egress
 
 <br>
 

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@
 * LLT-4913: Skip qos analytics ping for unconnected peers
 * LLT-4968: Make the default nurse initial_heartbeat_interval to be 5 minutes
 * LLT-4850: Add missing VPN meshnet address to analytics
+* LLT-4917: Fix the issue with wireguard-go failing to bind to a port on some devices
 
 <br>
 

--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@
 * LLT-4917: Fix the issue with wireguard-go failing to bind to a port on some devices
 * LLT-4870: Bring back PQ
 * LLT-4406: Implement error handling for proxy egress
+* LLT-4980: Introduce synchronization for the endpoint map in telio-proxy
 
 <br>
 

--- a/crates/telio-model/src/constants.rs
+++ b/crates/telio-model/src/constants.rs
@@ -1,0 +1,8 @@
+//! Telio constants definition
+
+/// VPN IPv4 Meshnet Address
+pub const VPN_INTERNAL_IPV4: [u8; 4] = [100, 64, 0, 1];
+/// VPN IPv6 Meshnet Address
+pub const VPN_INTERNAL_IPV6: [u16; 8] = [64884, 64884, 26991, 0, 0, 0, 0, 1];
+/// VPN IPv4 Non-Meshnet Address
+pub const VPN_EXTERNAL_IPV4: [u8; 4] = [10, 5, 0, 1];

--- a/crates/telio-model/src/lib.rs
+++ b/crates/telio-model/src/lib.rs
@@ -2,6 +2,7 @@
 //! Crate containing models of various components
 pub mod api_config;
 pub mod config;
+pub mod constants;
 pub mod event;
 pub mod mesh;
 pub mod validation;

--- a/crates/telio-nurse/src/rtt/ping.rs
+++ b/crates/telio-nurse/src/rtt/ping.rs
@@ -6,7 +6,6 @@ use std::{convert::TryInto, net::IpAddr};
 use surge_ping::{
     Client, Config as PingerConfig, ConfigBuilder, PingIdentifier, PingSequence, ICMP,
 };
-use tokio::sync::mpsc;
 
 use telio_crypto::PublicKey;
 use telio_utils::{telio_log_debug, telio_log_error, DualTarget};
@@ -55,16 +54,11 @@ impl Ping {
     /// # Arguments
     ///
     /// * `node` - `NodeInfo` instance to get endpoint to ping and to store RTT information.
-    pub async fn perform(
-        &self,
-        target: (PublicKey, DualTarget),
-        results_tx: mpsc::Sender<(PublicKey, DualPingResults)>,
-    ) {
+    pub async fn perform(&self, target: (PublicKey, DualTarget)) -> DualPingResults {
         let dpr = self.perform_average_rtt(&target.1).await;
-
         telio_log_debug!("{:?}, no_of_tries: {}", dpr, self.no_of_tries);
 
-        let _ = results_tx.send((target.0, dpr)).await;
+        dpr
     }
 
     async fn perform_average_rtt(&self, target: &DualTarget) -> DualPingResults {

--- a/crates/telio-proxy/Cargo.toml
+++ b/crates/telio-proxy/Cargo.toml
@@ -25,6 +25,7 @@ telio-utils.workspace = true
 [dev-dependencies]
 mockall.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "test-util", "time"] }
+anyhow.workspace = true
 
 telio-task = { workspace = true, features = ["test-util"] }
 telio-test.workspace = true

--- a/crates/telio-proxy/src/proxy.rs
+++ b/crates/telio-proxy/src/proxy.rs
@@ -304,7 +304,7 @@ impl StateEgress {
     }
 
     async fn handle_error(&mut self, err: std::io::Error, pk: Option<PublicKey>) {
-        telio_log_error!("StateEgress: handling error {err:?} for {pk:?}");
+        telio_log_warn!("StateEgress: handling error {err:?} for {pk:?}");
 
         match self.conn_state {
             Ok(()) => telio_log_error!("Unable to send. {}", err),
@@ -398,8 +398,11 @@ impl Runtime for StateIngress {
                         });
                         let _ = permit.send((pk, msg));
                     }
+                    Err(e) if e.kind() == ErrorKind::WouldBlock => {
+                        // Blocking error is not an issue here
+                    }
                     Err(e) => {
-                        telio_log_error!("StateIngress: received error {e:?} for {pk:?}");
+                        telio_log_warn!("StateIngress: received error {e:?} for {pk:?}");
                     }
                 }
             }

--- a/crates/telio-utils/src/dual_target.rs
+++ b/crates/telio-utils/src/dual_target.rs
@@ -15,9 +15,10 @@ pub type Result<T> = std::result::Result<T, DualTargetError>;
 pub type Target = (Option<Ipv4Addr>, Option<Ipv6Addr>);
 
 /// DualTarget wrapper
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct DualTarget {
-    target: Target,
+    /// Ipv4/Ipv6 tuple
+    pub target: Target,
 }
 
 impl DualTarget {

--- a/crates/telio-wg/src/adapter/mod.rs
+++ b/crates/telio-wg/src/adapter/mod.rs
@@ -149,6 +149,10 @@ pub enum Error {
     /// Parsing AdapterType from string failed
     #[error("Parsing AdapterType from string failed")]
     AdapterTypeParsingError,
+
+    /// Internal Error
+    #[error("Internal error: {0}")]
+    InternalError(&'static str),
 }
 
 /// Enumeration of types for `Adapter` struct

--- a/crates/telio-wg/src/uapi.rs
+++ b/crates/telio-wg/src/uapi.rs
@@ -11,7 +11,7 @@ use std::{
     collections::BTreeMap,
     fmt::{self, Display, Formatter},
     io::{BufRead, BufReader, Read},
-    net::{AddrParseError, SocketAddr},
+    net::{AddrParseError, IpAddr, SocketAddr},
     num::ParseIntError,
     panic,
     str::FromStr,
@@ -34,6 +34,8 @@ pub struct Peer {
     pub public_key: PublicKey,
     /// Peer's endpoint with `IP address` and `UDP port` number
     pub endpoint: Option<SocketAddr>,
+    /// Mesh's IP addresses of peer
+    pub ip_addresses: Vec<IpAddr>,
     /// Keep alive interval, `seconds` or `None`
     pub persistent_keepalive_interval: Option<u32>,
     /// Vector of allowed IPs
@@ -54,6 +56,7 @@ impl From<get::Peer> for Peer {
         Self {
             public_key: PublicKey(item.public_key),
             endpoint: item.endpoint,
+            ip_addresses: Default::default(),
             persistent_keepalive_interval: Some(item.persistent_keepalive_interval.into()),
             allowed_ips: item
                 .allowed_ips
@@ -242,12 +245,12 @@ pub struct Event {
 }
 
 /// Analytics information to be conveyed
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 pub struct AnalyticsEvent {
     /// Public key of the Peer
     pub public_key: PublicKey,
     /// Mesh's IP target of peer
-    pub endpoint: DualTarget,
+    pub dual_ip_addresses: Vec<DualTarget>,
     /// Number of transmitted bytes
     pub tx_bytes: u64,
     /// Number of recieved bytes

--- a/crates/telio-wg/src/wg.rs
+++ b/crates/telio-wg/src/wg.rs
@@ -573,6 +573,23 @@ impl State {
         true
     }
 
+    fn update_calculate_set_listen_port(
+        from_listen_port: Option<u16>,
+        to_listen_port: Option<u16>,
+    ) -> Option<u16> {
+        match (from_listen_port, to_listen_port) {
+            (Some(from), Some(to)) => {
+                if from != to {
+                    Some(to)
+                } else {
+                    None
+                }
+            }
+            (None, Some(to)) => Some(to),
+            _ => None,
+        }
+    }
+
     fn update_construct_set_device(
         &self,
         to: &uapi::Interface,
@@ -598,7 +615,10 @@ impl State {
 
         set::Device {
             private_key: to.private_key.map(|key| key.into_bytes()),
-            listen_port: to.listen_port,
+            listen_port: Self::update_calculate_set_listen_port(
+                self.interface.listen_port,
+                to.listen_port,
+            ),
             fwmark: match to.fwmark {
                 0 => None,
                 x => Some(x),
@@ -1438,5 +1458,23 @@ pub mod tests {
 
         adapter.lock().await.expect_stop().return_once(|| ());
         wg.stop().await;
+    }
+
+    #[test]
+    fn test_update_calculate_set_listen_port() {
+        assert_eq!(State::update_calculate_set_listen_port(None, None), None);
+        assert_eq!(State::update_calculate_set_listen_port(Some(1), None), None);
+        assert_eq!(
+            State::update_calculate_set_listen_port(Some(1), Some(1)),
+            None
+        );
+        assert_eq!(
+            State::update_calculate_set_listen_port(None, Some(1)),
+            Some(1)
+        );
+        assert_eq!(
+            State::update_calculate_set_listen_port(Some(1), Some(2)),
+            Some(2)
+        );
     }
 }

--- a/crates/telio-wg/src/wg.rs
+++ b/crates/telio-wg/src/wg.rs
@@ -4,12 +4,13 @@ use ipnetwork::{IpNetwork, IpNetworkError};
 use slog::{o, Drain, Logger, Never};
 use std::{
     collections::HashMap,
-    net::{Ipv4Addr, SocketAddr},
+    net::{IpAddr, Ipv4Addr, SocketAddr},
 };
 use telio_model::mesh::ExitNode;
 use telio_sockets::{NativeProtector, SocketPool};
 use telio_utils::{
-    dual_target, telio_err_with_log, telio_log_debug, telio_log_trace, telio_log_warn,
+    dual_target::{DualTarget, DualTargetError},
+    telio_err_with_log, telio_log_debug, telio_log_trace, telio_log_warn,
 };
 use thiserror::Error as TError;
 use tokio::time::{self, sleep, Instant, Interval, MissedTickBehavior};
@@ -300,7 +301,7 @@ impl WireGuard for DynamicWg {
         Ok(task_exec!(&self.task, async move |s| {
             let mut to = s.interface.clone();
             to.private_key = Some(key);
-            s.update(&to, true).await;
+            let _ = s.update(to, true).await;
             Ok(())
         })
         .await?)
@@ -310,7 +311,7 @@ impl WireGuard for DynamicWg {
         Ok(task_exec!(&self.task, async move |s| {
             let mut to = s.interface.clone();
             to.fwmark = fwmark;
-            s.update(&to, true).await;
+            let _ = s.update(to, true).await;
             Ok(())
         })
         .await?)
@@ -351,7 +352,7 @@ impl WireGuard for DynamicWg {
             }
 
             to.peers.insert(new_peer.public_key, new_peer);
-            s.update(&to, true).await;
+            let _ = s.update(to, true).await;
             Ok(())
         })
         .await?)
@@ -361,7 +362,7 @@ impl WireGuard for DynamicWg {
         Ok(task_exec!(&self.task, async move |s| {
             let mut to = s.interface.clone();
             to.peers.remove(&key);
-            s.update(&to, true).await;
+            let _ = s.update(to, true).await;
             Ok(())
         })
         .await?)
@@ -450,7 +451,7 @@ struct DiffKeys {
 impl State {
     async fn sync(&mut self) -> Result<(), Error> {
         if let Some(to) = self.uapi_request(&uapi::Cmd::Get).await?.interface {
-            let _ = self.update(&to, false).await;
+            let _ = self.update(to, false).await;
         }
 
         Ok(())
@@ -632,35 +633,38 @@ impl State {
     }
 
     #[allow(mpsc_blocking_send)]
-    async fn update(&mut self, to: &uapi::Interface, push: bool) -> bool {
+    async fn update(&mut self, mut to: uapi::Interface, push: bool) -> Result<bool, Error> {
         // Diff and report events
 
-        //
+        // Adapter doesn't keep track of mesh addresses, therefore they are not retrieved from UAPI requests
+        // so we need to keep track of it.
+        for (pk, peer) in &mut to.peers {
+            if peer.ip_addresses.is_empty() {
+                if let Some(old_peer) = self.interface.peers.get(pk) {
+                    peer.ip_addresses = old_peer.ip_addresses.clone();
+                }
+            }
+        }
+
         // We need to track failed driver calls in uapi_request().
         // Because uapi_request() now needs a mut self, the mut borrow for self.uapi_request()
         // would collide with HashSet<&PublicKey> and with from=&self.interface,
         // which was used throughout this function for better readability.
-        //
-        // "from" was eliminated, the HashSets now contain PublicKeys instead of a ref
-        // and this function was split into multiple parts retaining the original semantics.
-        //
-        // PLEASE NOTE the alias: let from = &self.interface;
-        //
-        if &self.interface == to {
-            return false;
+        if self.interface == to {
+            return Err(Error::InternalError(
+                "Same interface received in update function",
+            ));
         }
 
-        let diff_keys = self.update_calculate_changes(to);
+        let diff_keys = self.update_calculate_changes(&to);
 
-        self.update_endpoint_change_timestamps(&diff_keys, to);
+        self.update_endpoint_change_timestamps(&diff_keys, &to);
 
-        if !self.update_send_notification_events(to, &diff_keys).await {
-            return false;
-        }
+        self.update_send_notification_events(&to, &diff_keys).await;
 
         let mut success = true;
         if push {
-            let dev = self.update_construct_set_device(to, &diff_keys);
+            let dev = self.update_construct_set_device(&to, &diff_keys);
             // mut self required here
             success = self
                 .uapi_request(&Cmd::Set(dev))
@@ -709,30 +713,44 @@ impl State {
                         PeerState::Connecting
                     };
 
+                    let mut dual_ip_addresses: Vec<DualTarget> = vec![];
                     let mut target = (None, None);
-                    for net in &peer.allowed_ips {
-                        match net {
-                            IpNetwork::V4(net4) => {
-                                if net4.prefix() == 32 && target.0.is_none() {
-                                    target.0 = Some(net4.ip());
+                    for ip in &peer.ip_addresses {
+                        match ip {
+                            IpAddr::V4(ipv4) => {
+                                if target.0.is_none() {
+                                    target.0 = Some(ipv4.to_owned());
+                                } else {
+                                    dual_ip_addresses.push(match DualTarget::new(target) {
+                                        Ok(dt) => dt,
+                                        Err(DualTargetError::NoTarget) => DualTarget::default(),
+                                    });
+                                    target = (Some(ipv4.to_owned()), None);
                                 }
                             }
-                            IpNetwork::V6(net6) => {
-                                if net6.prefix() == 128 && target.1.is_none() {
-                                    target.1 = Some(net6.ip());
+                            IpAddr::V6(ipv6) => {
+                                if target.1.is_none() {
+                                    target.1 = Some(ipv6.to_owned());
+                                } else {
+                                    dual_ip_addresses.push(match DualTarget::new(target) {
+                                        Ok(dt) => dt,
+                                        Err(DualTargetError::NoTarget) => DualTarget::default(),
+                                    });
+                                    target = (None, Some(ipv6.to_owned()));
                                 }
                             }
                         }
                     }
-
-                    let endpoint = match dual_target::DualTarget::new(target) {
-                        Ok(dt) => dt,
-                        Err(_) => continue,
-                    };
+                    if target != (None, None) {
+                        dual_ip_addresses.push(match DualTarget::new(target) {
+                            Ok(dt) => dt,
+                            Err(DualTargetError::NoTarget) => DualTarget::default(),
+                        });
+                    }
 
                     let event = AnalyticsEvent {
                         public_key: *pubkey,
-                        endpoint,
+                        dual_ip_addresses,
                         tx_bytes,
                         rx_bytes,
                         peer_state,
@@ -745,9 +763,9 @@ impl State {
             }
         }
 
-        self.interface = to.clone();
+        self.interface = to;
 
-        success
+        Ok(success)
     }
 }
 
@@ -802,7 +820,7 @@ pub mod tests {
             Ok(task_exec!(&self.task, async move |s| {
                 let mut ifc = s.interface.clone();
                 ifc.listen_port = Some(port);
-                s.update(&ifc, true).await;
+                let _ = s.update(ifc, true).await;
                 Ok(())
             })
             .await?)

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -1,6 +1,7 @@
 mod wg_controller;
 
 use async_trait::async_trait;
+use futures::FutureExt;
 use telio_crypto::{PublicKey, SecretKey};
 use telio_firewall::firewall::{Firewall, StatefullFirewall};
 use telio_lana::init_lana;
@@ -605,7 +606,7 @@ impl Device {
         self.art()?.block_on(async {
             let node = node.clone();
             let _wireguard_interface: Arc<DynamicWg> = task_exec!(self.rt()?, async move |rt| {
-                rt.connect_exit_node(&node).await?;
+                rt.connect_exit_node(&node).boxed().await?;
                 Ok(rt.entities.wireguard_interface.clone())
             })
             .await?;


### PR DESCRIPTION
Prepartion for release, backports of:
* LLT-4850: Add missing VPN meshnet address to analytics
* LLT-4917: Fix the issue with wireguard-go failing to bind to a port on some devices
* LLT-4406: Implement error handling for proxy egress
* LLT-4980: Introduce synchronization for the endpoint map in telio-proxy

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
