### PR TITLE
Fix spammy logs in telio-proxy

### DIFF
--- a/crates/telio-proxy/src/proxy.rs
+++ b/crates/telio-proxy/src/proxy.rs
@@ -304,7 +304,7 @@ impl StateEgress {
     }
 
     async fn handle_error(&mut self, err: std::io::Error, pk: Option<PublicKey>) {
-        telio_log_error!("StateEgress: handling error {err:?} for {pk:?}");
+        telio_log_warn!("StateEgress: handling error {err:?} for {pk:?}");
 
         match self.conn_state {
             Ok(()) => telio_log_error!("Unable to send. {}", err),
@@ -398,8 +398,11 @@ impl Runtime for StateIngress {
                         });
                         let _ = permit.send((pk, msg));
                     }
+                    Err(e) if e.kind() == ErrorKind::WouldBlock => {
+                        // Blocking error is not an issue here
+                    }
                     Err(e) => {
-                        telio_log_error!("StateIngress: received error {e:?} for {pk:?}");
+                        telio_log_warn!("StateIngress: received error {e:?} for {pk:?}");
                     }
                 }
             }


### PR DESCRIPTION
### Problem
New telio-proxy error logging is to spamy

### Solution
Switch to warn, don't treat would block as a reportable error on ingress


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
