### PR TITLE
Add UpgradeDecision message and session field to Upgrade message

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,7 @@
 * LLT-4850: Add missing VPN meshnet address to analytics
 * LLT-4980: Introduce synchronization for the endpoint map in telio-proxy
 * LLT-4970: PQ VPN is enabled by calling `telio_connect_to_exit_node_postquantum()`
+* LLT-4981: Add upgrade decision message
 
 <br>
 

--- a/crates/telio-proto/protos/upgrade.proto
+++ b/crates/telio-proto/protos/upgrade.proto
@@ -1,5 +1,17 @@
 syntax = "proto3";
 
+enum Decision {
+	Accepted = 0;
+	RejectedDueToUnknownSession = 1;
+	RejectedDueToConcurrentUpgrade = 2;
+}
+
 message Upgrade {
 	string endpoint = 1;
+	fixed64 session = 2;
+}
+
+message UpgradeDecision {
+	Decision decision = 1;
+	fixed64 session = 2;
 }

--- a/crates/telio-proto/src/packet/relayed/upgrade.rs
+++ b/crates/telio-proto/src/packet/relayed/upgrade.rs
@@ -2,7 +2,7 @@ use std::net::SocketAddr;
 
 use crate::{
     messages::upgrade::*, Codec, CodecError, CodecResult, DowncastPacket, PacketRelayed,
-    PacketTypeRelayed, MAX_PACKET_SIZE,
+    PacketTypeRelayed, Session, MAX_PACKET_SIZE,
 };
 
 use bytes::BufMut;
@@ -13,6 +13,8 @@ use protobuf::Message;
 pub struct UpgradeMsg {
     /// Endpoint which message sender is requesting to upgrade to
     pub endpoint: SocketAddr,
+    /// Session id created by CrossPingCheck
+    pub session: Session,
 }
 
 impl Codec<PacketTypeRelayed> for UpgradeMsg {
@@ -36,7 +38,9 @@ impl Codec<PacketTypeRelayed> for UpgradeMsg {
                     .get_endpoint()
                     .parse()
                     .map_err(|_| CodecError::DecodeFailed)?;
-                Ok(Self { endpoint })
+                let session: Session = proto_upgrade.session;
+
+                Ok(Self { endpoint, session })
             }
             _ => Err(CodecError::DecodeFailed),
         }
@@ -46,6 +50,7 @@ impl Codec<PacketTypeRelayed> for UpgradeMsg {
         let mut bytes = Vec::with_capacity(MAX_PACKET_SIZE);
         let mut msg = Upgrade::new();
         msg.set_endpoint(self.endpoint.to_string());
+        msg.set_session(self.session);
 
         bytes.put_u8(PacketTypeRelayed::Upgrade as u8);
         msg.write_to_vec(&mut bytes)
@@ -71,42 +76,188 @@ impl DowncastPacket<PacketRelayed> for UpgradeMsg {
     }
 }
 
+/// Decision of the other node if the upgrade request was accepted and performed
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum Decision {
+    /// Upgrade request was accepted and performed
+    Accepted = 0,
+    /// Upgrade request was rejected because it contained unknown session id
+    RejectedDueToUnknownSession = 1,
+    /// Upgrade request was rejected because it was sent when the other node has
+    /// already also sent an upgrade request to us, and they have a winning pub key.
+    RejectedDueToConcurrentUpgrade = 2,
+}
+
+impl From<crate::messages::upgrade::Decision> for Decision {
+    fn from(value: crate::messages::upgrade::Decision) -> Self {
+        match value {
+            crate::messages::upgrade::Decision::Accepted => Decision::Accepted,
+            crate::messages::upgrade::Decision::RejectedDueToUnknownSession => {
+                Decision::RejectedDueToUnknownSession
+            }
+            crate::messages::upgrade::Decision::RejectedDueToConcurrentUpgrade => {
+                Decision::RejectedDueToConcurrentUpgrade
+            }
+        }
+    }
+}
+
+impl From<Decision> for crate::messages::upgrade::Decision {
+    fn from(value: Decision) -> Self {
+        use crate::messages::upgrade::Decision::*;
+        match value {
+            Decision::Accepted => Accepted,
+            Decision::RejectedDueToUnknownSession => RejectedDueToUnknownSession,
+            Decision::RejectedDueToConcurrentUpgrade => RejectedDueToConcurrentUpgrade,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+/// Result of previously sent upgrade request
+pub struct UpgradeDecisionMsg {
+    /// Decision if the upgrade was accepted and processed
+    pub decision: Decision,
+    /// Session identifing request for which this result in an answer
+    pub session: Session,
+}
+
+impl Codec<PacketTypeRelayed> for UpgradeDecisionMsg {
+    const TYPES: &'static [PacketTypeRelayed] = &[PacketTypeRelayed::UpgradeDecision];
+
+    fn decode(bytes: &[u8]) -> CodecResult<Self>
+    where
+        Self: Sized,
+    {
+        let Some((first, rest)) = bytes.split_first() else {
+            return Err(CodecError::InvalidLength);
+        };
+        match PacketTypeRelayed::from(*first) {
+            PacketTypeRelayed::UpgradeDecision => {
+                let proto_upgrade_decision = UpgradeDecision::parse_from_bytes(rest)
+                    .map_err(|_| CodecError::DecodeFailed)?;
+                let decision: Decision = proto_upgrade_decision.get_decision().into();
+                let session: Session = proto_upgrade_decision.session;
+
+                Ok(Self { decision, session })
+            }
+            _ => Err(CodecError::DecodeFailed),
+        }
+    }
+
+    fn encode(self) -> CodecResult<Vec<u8>>
+    where
+        Self: Sized,
+    {
+        let mut bytes = Vec::with_capacity(MAX_PACKET_SIZE);
+        let mut msg = UpgradeDecision::new();
+        msg.set_decision(self.decision.into());
+        msg.set_session(self.session);
+
+        bytes.put_u8(PacketTypeRelayed::UpgradeDecision as u8);
+        msg.write_to_vec(&mut bytes)
+            .map_err(|_| CodecError::Encode)?;
+
+        Ok(bytes)
+    }
+
+    fn packet_type(&self) -> PacketTypeRelayed {
+        PacketTypeRelayed::UpgradeDecision
+    }
+}
+
+impl DowncastPacket<PacketRelayed> for UpgradeDecisionMsg {
+    fn downcast(packet: PacketRelayed) -> Result<Self, PacketRelayed>
+    where
+        Self: Sized,
+    {
+        match packet {
+            PacketRelayed::UpgradeDecision(upgrade_decision) => Ok(upgrade_decision),
+            packet => Err(packet),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn decode_packet() {
+    fn decode_upgrade_packet() {
         let upgrade_bytes = &[
-            8, 10, 14, 49, 50, 55, 46, 48, 46, 48, 46, 49, 58, 49, 50, 51, 52,
+            8, 10, 14, 49, 50, 55, 46, 48, 46, 48, 46, 49, 58, 49, 50, 51, 52, 17, 42, 0, 0, 0, 0,
+            0, 0, 0,
         ];
         let upgrade_msg = UpgradeMsg::decode(upgrade_bytes).expect("Failed to parse upgrade msg");
         assert_eq!(upgrade_msg.endpoint, "127.0.0.1:1234".parse().unwrap());
+        assert_eq!(upgrade_msg.session, 42);
     }
 
     #[test]
-    fn fail_to_decode_small_packet() {
+    fn fail_to_decode_small_upgrade_packet() {
         let bytes = &[6];
         let data = UpgradeMsg::decode(bytes);
         assert_eq!(data, Err(CodecError::DecodeFailed));
     }
 
     #[test]
-    fn fail_to_decode_packet_of_wrong_type() {
+    fn fail_to_decode_upgrade_packet_of_wrong_type() {
         let bytes = &[PacketTypeRelayed::Invalid as u8];
         let data = UpgradeMsg::decode(bytes);
         assert_eq!(data, Err(CodecError::DecodeFailed));
     }
 
     #[test]
-    fn encode_packet() {
+    fn encode_upgrade_packet() {
         let upgrade_msg = UpgradeMsg {
             endpoint: "127.0.0.1:1234".parse().unwrap(),
+            session: 42,
         };
         let expected_upgrade_bytes: &[u8] = &[
-            8, 10, 14, 49, 50, 55, 46, 48, 46, 48, 46, 49, 58, 49, 50, 51, 52,
+            8, 10, 14, 49, 50, 55, 46, 48, 46, 48, 46, 49, 58, 49, 50, 51, 52, 17, 42, 0, 0, 0, 0,
+            0, 0, 0,
         ];
         let actual_upgrade_bytes = upgrade_msg.encode().unwrap();
         assert_eq!(expected_upgrade_bytes, actual_upgrade_bytes);
+    }
+
+    #[test]
+    fn decode_upgrade_decision_packet() {
+        let upgrade_bytes = &[10, 17, 42, 0, 0, 0, 0, 0, 0, 0];
+        let upgrade_msg =
+            UpgradeDecisionMsg::decode(upgrade_bytes).expect("Failed to parse upgrade msg");
+        assert_eq!(upgrade_msg.decision, Decision::Accepted);
+        assert_eq!(upgrade_msg.session, 42);
+    }
+
+    #[test]
+    fn fail_to_decode_small_upgrade_decision_packet() {
+        let bytes = &[6];
+        let data = UpgradeDecisionMsg::decode(bytes);
+        assert_eq!(data, Err(CodecError::DecodeFailed));
+    }
+
+    #[test]
+    fn fail_to_decode_upgrade_decision_packet_of_wrong_type() {
+        let bytes = &[PacketTypeRelayed::Invalid as u8];
+        let data = UpgradeDecisionMsg::decode(bytes);
+        assert_eq!(data, Err(CodecError::DecodeFailed));
+    }
+
+    #[test]
+    fn encode_upgrade_decision_packet() {
+        let upgrade_msg = UpgradeDecisionMsg {
+            decision: crate::Decision::RejectedDueToUnknownSession,
+            session: 42,
+        };
+        let expected_upgrade_bytes: &[u8] = &[10, 8, 1, 17, 42, 0, 0, 0, 0, 0, 0, 0];
+
+        let actual_upgrade_bytes = upgrade_msg.clone().encode().unwrap();
+        assert_eq!(expected_upgrade_bytes, actual_upgrade_bytes);
+
+        assert_eq!(
+            upgrade_msg,
+            UpgradeDecisionMsg::decode(&actual_upgrade_bytes).unwrap()
+        );
     }
 }

--- a/crates/telio-traversal/src/connectivity_check/cross_ping_check.rs
+++ b/crates/telio-traversal/src/connectivity_check/cross_ping_check.rs
@@ -24,12 +24,13 @@ use telio_proto::{CallMeMaybeMsg, CallMeMaybeType, Session};
 use telio_task::{io::chan, io::Chan, task_exec, BoxAction, Runtime, Task};
 use telio_utils::{
     exponential_backoff::{Backoff, ExponentialBackoff, ExponentialBackoffBounds},
-    telio_log_debug, telio_log_info, telio_log_trace, telio_log_warn,
+    telio_log_debug, telio_log_info, telio_log_trace, telio_log_warn, LruCache,
 };
 use tokio::time::{interval_at, Instant, Interval};
 use tokio::{sync::Mutex, time::MissedTickBehavior};
 
 const CPC_TIMEOUT: Duration = Duration::from_secs(10);
+const UPGRADE_TIMEOUT: Duration = Duration::from_secs(60);
 
 // Cross ping state machine definintion
 sm! {
@@ -83,16 +84,54 @@ macro_rules! do_state_transition {
 
 #[cfg_attr(any(test, feature = "mockall"), mockall::automock)]
 #[async_trait]
-pub trait CrossPingCheckTrait {
+pub trait UpgradeController: Send + Sync {
+    async fn check_if_upgrade_is_allowed(
+        &self,
+        session: Session,
+        public_key: PublicKey,
+    ) -> Result<bool, Error>;
+    async fn notify_failed_wg_connection(&self, public_key: PublicKey) -> Result<(), Error>;
+}
+
+#[async_trait]
+pub trait CrossPingCheckTrait: UpgradeController {
     async fn configure(&self, config: Option<Config>) -> Result<(), Error>;
     async fn get_validated_endpoints(
         &self,
     ) -> Result<HashMap<PublicKey, WireGuardEndpointCandidateChangeEvent>, Error>;
-    async fn notify_failed_wg_connection(&self, public_key: PublicKey) -> Result<(), Error>;
     async fn notify_successfull_wg_connection_upgrade(
         &self,
         public_key: PublicKey,
     ) -> Result<(), Error>;
+    async fn session_for_key(&self, pk: PublicKey) -> Result<Option<Session>, Error>;
+}
+
+#[cfg(any(test, feature = "mockall"))]
+mockall::mock! {
+    pub CrossPingCheckTrait {}
+
+    #[async_trait]
+    impl CrossPingCheckTrait for CrossPingCheckTrait {
+        async fn configure(&self, config: Option<Config>) -> Result<(), Error>;
+        async fn get_validated_endpoints(
+            &self,
+        ) -> Result<HashMap<PublicKey, WireGuardEndpointCandidateChangeEvent>, Error>;
+        async fn notify_successfull_wg_connection_upgrade(
+            &self,
+            public_key: PublicKey,
+        ) -> Result<(), Error>;
+        async fn session_for_key(&self, pk: PublicKey) -> Result<Option<Session>, Error>;
+    }
+
+    #[async_trait]
+    impl UpgradeController for CrossPingCheckTrait {
+        async fn check_if_upgrade_is_allowed(
+            &self,
+            session: Session,
+            public_key: PublicKey,
+        ) -> Result<bool, Error>;
+        async fn notify_failed_wg_connection(&self, public_key: PublicKey) -> Result<(), Error>;
+    }
 }
 
 pub struct CrossPingCheck<E: Backoff = ExponentialBackoff> {
@@ -169,6 +208,9 @@ pub struct State<E: Backoff> {
     ///
     /// A closure which produces exponential backoff helpers for the cross ping check sessions.
     exponential_backoff_helper_provider: ExponentialBackoffProvider<E>,
+
+    /// Session IDs received from other nodes in CMM requests
+    session_id_candidates: LruCache<Session, PublicKey>,
 }
 
 impl<E: Backoff> CrossPingCheck<E> {
@@ -193,6 +235,7 @@ impl<E: Backoff> CrossPingCheck<E> {
                 poll_timer,
                 ping_pong_handler,
                 exponential_backoff_helper_provider,
+                session_id_candidates: LruCache::new(UPGRADE_TIMEOUT, 512),
             }),
         }
     }
@@ -254,32 +297,6 @@ impl CrossPingCheckTrait for CrossPingCheck {
         res
     }
 
-    async fn notify_failed_wg_connection(&self, public_key: PublicKey) -> Result<(), Error> {
-        let res: Result<(), Error> = task_exec!(&self.task, async move |s| {
-            let sessions = s
-                .endpoint_connectivity_check_state
-                .values_mut()
-                .filter(|v| v.public_key == public_key);
-            for session in sessions {
-                session.handle_endpoint_gone_notification().await?;
-
-                for e in s.endpoint_providers.iter() {
-                    if let Some(current_endpoints) = e.get_current_endpoints().await {
-                        if current_endpoints.iter().any(|current_endpoint| {
-                            *current_endpoint == session.local_endpoint_candidate
-                        }) {
-                            e.handle_endpoint_gone_notification().await;
-                        }
-                    }
-                }
-            }
-            Ok(())
-        })
-        .await
-        .map_err(|e| e.into());
-        res
-    }
-
     async fn notify_successfull_wg_connection_upgrade(
         &self,
         public_key: PublicKey,
@@ -309,6 +326,12 @@ impl CrossPingCheckTrait for CrossPingCheck {
         })
         .await;
         Ok(())
+    }
+
+    async fn session_for_key(&self, pk: PublicKey) -> Result<Option<Session>, Error> {
+        task_exec!(&self.task, async move |s| Ok(s.session_for_key(pk)))
+            .await
+            .map_err(|e| e.into())
     }
 }
 
@@ -507,6 +530,8 @@ impl<E: Backoff> State<E> {
                 }
 
                 let remote_session_id = message.get_session();
+                self.session_id_candidates
+                    .insert(remote_session_id, public_key);
 
                 // Next format and exchange CallMeMabe response message
                 let call_me_maybe_response = CallMeMaybeMsg::new(
@@ -576,6 +601,61 @@ impl<E: Backoff> State<E> {
         }
 
         Ok(())
+    }
+
+    pub fn session_for_key(&self, pk: PublicKey) -> Option<Session> {
+        self.endpoint_connectivity_check_state
+            .iter()
+            .find(|(_, state)| state.public_key == pk)
+            .map(|(session, _)| *session)
+    }
+
+    pub fn check_if_upgrade_is_allowed(&mut self, session: Session, public_key: PublicKey) -> bool {
+        match self.session_id_candidates.remove(&session) {
+            Some(pk) => pk == public_key,
+            None => false,
+        }
+    }
+}
+
+#[async_trait]
+impl UpgradeController for CrossPingCheck {
+    async fn check_if_upgrade_is_allowed(
+        &self,
+        session: Session,
+        public_key: PublicKey,
+    ) -> Result<bool, Error> {
+        task_exec!(&self.task, async move |s| Ok(
+            s.check_if_upgrade_is_allowed(session, public_key)
+        ))
+        .await
+        .map_err(|e| e.into())
+    }
+
+    async fn notify_failed_wg_connection(&self, public_key: PublicKey) -> Result<(), Error> {
+        let res: Result<(), Error> = task_exec!(&self.task, async move |s| {
+            let sessions = s
+                .endpoint_connectivity_check_state
+                .values_mut()
+                .filter(|v| v.public_key == public_key);
+            for session in sessions {
+                session.handle_endpoint_gone_notification().await?;
+
+                for e in s.endpoint_providers.iter() {
+                    if let Some(current_endpoints) = e.get_current_endpoints().await {
+                        if current_endpoints.iter().any(|current_endpoint| {
+                            *current_endpoint == session.local_endpoint_candidate
+                        }) {
+                            e.handle_endpoint_gone_notification().await;
+                        }
+                    }
+                }
+            }
+            Ok(())
+        })
+        .await
+        .map_err(|e| e.into());
+        res
     }
 }
 
@@ -1432,7 +1512,6 @@ mod tests {
             SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)), 8080),
             last_rx_time_provider_mock.clone(),
         );
-        let pk = endpoint_connectivity_check_state.public_key;
         last_rx_time_provider_mock
             .lock()
             .await
@@ -1497,5 +1576,100 @@ mod tests {
         intercoms_rx
             .try_recv()
             .expect_err("CMM message should not be sent");
+    }
+
+    #[tokio::test]
+    async fn upgrade_is_allowed_only_for_sessions_received_in_cmm() {
+        let (checker, channels) = prepare_checker_test().unwrap();
+        let addrs = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)), 8080);
+        let session: Session = 42;
+        let pub_key = PublicKey(*b"ABBBBBBBBBBBBBBBBBBBAAAAAAAAAAAA");
+        assert!(!checker
+            .check_if_upgrade_is_allowed(session, pub_key)
+            .await
+            .unwrap());
+        channels
+            .endpoint_change_subscriber
+            .send((
+                EndpointProviderType::LocalInterfaces,
+                vec![EndpointCandidate {
+                    wg: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 1234),
+                    udp: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 1234),
+                }],
+            ))
+            .await
+            .unwrap();
+
+        wait_for_tick().await;
+
+        let mut peer = Peer::default();
+
+        peer.base.public_key = pub_key;
+
+        checker
+            .configure(Some(Config {
+                this: PeerBase::default(),
+                peers: Some(vec![peer]),
+                derp_servers: None,
+                dns: None,
+            }))
+            .await
+            .unwrap();
+
+        let msg = CallMeMaybeMsg::new(true, [addrs].iter().cloned(), session);
+        channels.intercoms.tx.send((pub_key, msg)).await.unwrap();
+        wait_for_tick().await;
+        assert!(checker
+            .check_if_upgrade_is_allowed(session, pub_key)
+            .await
+            .unwrap());
+    }
+
+    #[tokio::test]
+    async fn upgrade_is_rejected_when_session_is_correct_but_key_is_wrong() {
+        let (checker, channels) = prepare_checker_test().unwrap();
+        let addrs = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)), 8080);
+        let session: Session = 42;
+        let pub_key = PublicKey(*b"ABBBBBBBBBBBBBBBBBBBAAAAAAAAAAAA");
+        assert!(!checker
+            .check_if_upgrade_is_allowed(session, pub_key)
+            .await
+            .unwrap());
+        channels
+            .endpoint_change_subscriber
+            .send((
+                EndpointProviderType::LocalInterfaces,
+                vec![EndpointCandidate {
+                    wg: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 1234),
+                    udp: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 1234),
+                }],
+            ))
+            .await
+            .unwrap();
+
+        wait_for_tick().await;
+
+        let mut peer = Peer::default();
+
+        peer.base.public_key = pub_key;
+
+        checker
+            .configure(Some(Config {
+                this: PeerBase::default(),
+                peers: Some(vec![peer]),
+                derp_servers: None,
+                dns: None,
+            }))
+            .await
+            .unwrap();
+
+        let msg = CallMeMaybeMsg::new(true, [addrs].iter().cloned(), session);
+        channels.intercoms.tx.send((pub_key, msg)).await.unwrap();
+        wait_for_tick().await;
+        let other_pub_key = PublicKey(*b"CCCCBBBBBBBBBBBBBBBBAAAAAAAAAAAA");
+        assert!(!checker
+            .check_if_upgrade_is_allowed(session, other_pub_key)
+            .await
+            .unwrap());
     }
 }

--- a/crates/telio-traversal/src/connectivity_check/mod.rs
+++ b/crates/telio-traversal/src/connectivity_check/mod.rs
@@ -7,7 +7,7 @@ use thiserror::Error as TError;
 use telio_model::SocketAddr;
 
 use telio_crypto::PublicKey;
-use telio_proto::CallMeMaybeMsg;
+use telio_proto::{CallMeMaybeMsg, Session};
 
 #[derive(Debug, TError)]
 pub enum Error {
@@ -36,4 +36,5 @@ pub struct WireGuardEndpointCandidateChangeEvent {
     pub public_key: PublicKey,
     pub remote_endpoint: SocketAddr,
     pub local_endpoint: SocketAddr,
+    pub session: Session,
 }

--- a/crates/telio-traversal/src/upgrade_sync.rs
+++ b/crates/telio-traversal/src/upgrade_sync.rs
@@ -1,16 +1,18 @@
 use async_trait::async_trait;
 use futures::Future;
-use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::time::Duration;
+use std::{collections::HashMap, sync::Arc};
 use telio_crypto::PublicKey;
-use telio_proto::UpgradeMsg;
+use telio_proto::{Decision, Session, UpgradeDecisionMsg, UpgradeMsg};
 use telio_task::{io::chan, io::Chan, task_exec, BoxAction, Runtime, Task};
-use telio_utils::{telio_log_info, telio_log_warn};
+use telio_utils::{telio_log_debug, telio_log_info, telio_log_warn};
 use tokio::{
     sync::mpsc::error::SendError,
     time::{interval_at, Instant, Interval, MissedTickBehavior},
 };
+
+use crate::cross_ping_check::UpgradeController;
 
 /// Possible [UpgradeSync] errors.
 #[derive(thiserror::Error, Debug)]
@@ -18,12 +20,16 @@ pub enum Error {
     /// Channel error
     #[error(transparent)]
     SendUpgradeMsgErr(#[from] SendError<(PublicKey, UpgradeMsg)>),
+    #[error(transparent)]
+    SendUpgradeDecisionMsgErr(#[from] SendError<(PublicKey, UpgradeDecisionMsg)>),
     /// Channel error
     #[error(transparent)]
     SendUpgradeRequestChangeEventErr(#[from] SendError<UpgradeRequestChangeEvent>),
     /// Task encountered an error while running
     #[error(transparent)]
     Task(#[from] telio_task::ExecError),
+    #[error("Upgrade request rejected")]
+    Rejected,
     #[error("Upgrade request not found or expired")]
     NotFound,
 }
@@ -34,13 +40,11 @@ pub type Result<T> = std::result::Result<T, Error>;
 pub struct UpgradeRequest {
     pub endpoint: SocketAddr,
     pub requested_at: Instant,
+    pub session: Session,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
-pub struct UpgradeRequestChangeEvent {
-    old_request: Option<UpgradeRequest>,
-    new_request: Option<UpgradeRequest>,
-}
+pub struct UpgradeRequestChangeEvent {}
 
 #[cfg_attr(any(test, feature = "mockall"), mockall::automock)]
 #[async_trait]
@@ -51,8 +55,8 @@ pub trait UpgradeSyncTrait {
         public_key: &PublicKey,
         remote_endpoint: SocketAddr,
         local_endpoint: SocketAddr,
+        session: Session,
     ) -> Result<()>;
-    async fn remove_upgrade(&self, public_key: &PublicKey) -> Result<()>;
 }
 
 pub struct UpgradeSync {
@@ -61,17 +65,21 @@ pub struct UpgradeSync {
 
 pub struct State {
     upgrade_request_publisher: chan::Tx<UpgradeRequestChangeEvent>,
-    intercoms: Chan<(PublicKey, UpgradeMsg)>,
+    upgrade_intercoms: Chan<(PublicKey, UpgradeMsg)>,
     upgrade_requests: HashMap<PublicKey, UpgradeRequest>,
     expiration_period: Duration,
+    upgrade_controller: Arc<dyn UpgradeController>,
     poll_timer: Interval,
+    upgrade_decision_intercoms: Chan<(PublicKey, UpgradeDecisionMsg)>,
 }
 
 impl UpgradeSync {
     pub fn new(
         upgrade_request_publisher: chan::Tx<UpgradeRequestChangeEvent>,
-        intercoms: Chan<(PublicKey, UpgradeMsg)>,
+        upgrade_intercoms: Chan<(PublicKey, UpgradeMsg)>,
         expiration_period: Duration,
+        upgrade_verifier: Arc<dyn UpgradeController>,
+        upgrade_decision_intercoms: Chan<(PublicKey, UpgradeDecisionMsg)>,
     ) -> Result<Self> {
         telio_log_info!("Starting Upgrade sync module");
         let mut poll_timer = interval_at(Instant::now(), expiration_period / 2);
@@ -79,10 +87,12 @@ impl UpgradeSync {
         Ok(Self {
             task: Task::start(State {
                 upgrade_request_publisher,
-                intercoms,
+                upgrade_intercoms,
                 upgrade_requests: Default::default(),
                 expiration_period,
+                upgrade_controller: upgrade_verifier,
                 poll_timer,
+                upgrade_decision_intercoms,
             }),
         })
     }
@@ -110,11 +120,12 @@ impl UpgradeSyncTrait for UpgradeSync {
         remote_endpoint: SocketAddr, // The endpoint which will be added to local WG and points to
         // remote node
         local_endpoint: SocketAddr, // The endpoint which will be added to remote WG and points to
-                                    // our local node
+        // our local node
+        session: Session,
     ) -> Result<()> {
         let public_key = *public_key;
         task_exec!(&self.task, async move |s| {
-            s.request_upgrade(&public_key, remote_endpoint, local_endpoint)
+            s.request_upgrade(&public_key, remote_endpoint, local_endpoint, session)
                 .await
                 .unwrap_or_else(|e| {
                     telio_log_warn!("Failed to send ping {:?}", e);
@@ -124,18 +135,6 @@ impl UpgradeSyncTrait for UpgradeSync {
         .await
         .map_err(Error::Task)
     }
-
-    async fn remove_upgrade(&self, public_key: &PublicKey) -> Result<()> {
-        // TODO: error handling with task_exec! seems to suck a lot. Need to fix that.
-        let public_key = *public_key;
-        task_exec!(&self.task, async move |s| {
-            Ok(s.upgrade_requests.remove(&public_key))
-        })
-        .await
-        .map_err(Error::Task)?
-        .ok_or(Error::NotFound)
-        .map(|_| ())
-    }
 }
 
 impl State {
@@ -144,9 +143,10 @@ impl State {
         public_key: &PublicKey,
         remote_endpoint: SocketAddr,
         local_endpoint: SocketAddr,
+        session: Session,
     ) -> Result<()> {
         telio_log_info!(
-            "Requesting {:?} to upgrade endpoint to local WG: {:?}, remote WG: {:?}",
+            "Requesting {:?} to upgrade endpoint to local WG: {:?}, remote WG: {:?}, for session: {session}",
             public_key,
             remote_endpoint,
             local_endpoint,
@@ -154,12 +154,13 @@ impl State {
 
         // Send message to remote end
         #[allow(mpsc_blocking_send)]
-        self.intercoms
+        self.upgrade_intercoms
             .tx
             .send((
                 *public_key,
                 UpgradeMsg {
                     endpoint: local_endpoint,
+                    session,
                 },
             ))
             .await
@@ -171,6 +172,7 @@ impl State {
             UpgradeRequest {
                 endpoint: remote_endpoint,
                 requested_at: Instant::now(),
+                session,
             },
         );
 
@@ -183,21 +185,89 @@ impl State {
         upgrade_msg: &UpgradeMsg,
     ) -> Result<()> {
         telio_log_info!(
-            "{:?} has requested us to upgrade endpoint to {:?}",
+            "{:?} has requested us to upgrade endpoint to {:?} for session {}",
             public_key,
-            upgrade_msg.endpoint
+            upgrade_msg.endpoint,
+            upgrade_msg.session,
         );
+
+        match self
+            .upgrade_controller
+            .check_if_upgrade_is_allowed(upgrade_msg.session, *public_key)
+            .await
+        {
+            Ok(true) => {
+                // TODO: in LLT-4858 check if we have already sent our own upgrade request
+                // and if so compare keys to decide who should win
+
+                telio_log_debug!("sending upgrade decision: Accepted");
+
+                #[allow(mpsc_blocking_send)]
+                self.upgrade_decision_intercoms
+                    .tx
+                    .send((
+                        *public_key,
+                        UpgradeDecisionMsg {
+                            decision: telio_proto::Decision::Accepted,
+                            session: upgrade_msg.session,
+                        },
+                    ))
+                    .await
+                    .map_err(Error::SendUpgradeDecisionMsgErr)?;
+            }
+            Ok(false) => {
+                // We might have restarted in the middle of upgrade procedure and have
+                // lost the state needed to verify the incoming request. Not a big deal,
+                // upgrade procedure will be restarted shortly either way.
+                telio_log_warn!(
+                    "Upgrade request from {public_key} for unknown session {} rejected",
+                    upgrade_msg.session
+                );
+
+                #[allow(mpsc_blocking_send)]
+                self.upgrade_decision_intercoms
+                    .tx
+                    .send((
+                        *public_key,
+                        UpgradeDecisionMsg {
+                            decision: telio_proto::Decision::RejectedDueToUnknownSession,
+                            session: upgrade_msg.session,
+                        },
+                    ))
+                    .await
+                    .map_err(Error::SendUpgradeDecisionMsgErr)?;
+                return Err(Error::Rejected);
+            }
+            Err(e) => {
+                telio_log_warn!(
+                    "Upgrade request from {public_key} for session {} rejected: {e}",
+                    upgrade_msg.session
+                );
+
+                #[allow(mpsc_blocking_send)]
+                self.upgrade_decision_intercoms
+                    .tx
+                    .send((
+                        *public_key,
+                        UpgradeDecisionMsg {
+                            decision: telio_proto::Decision::RejectedDueToUnknownSession,
+                            session: upgrade_msg.session,
+                        },
+                    ))
+                    .await
+                    .map_err(Error::SendUpgradeDecisionMsgErr)?;
+                return Err(Error::Rejected);
+            }
+        }
 
         let new_request = UpgradeRequest {
             endpoint: upgrade_msg.endpoint,
+            session: upgrade_msg.session,
             requested_at: Instant::now(),
         };
 
         // Format upgrade request event
-        let upgrade_req_event = UpgradeRequestChangeEvent {
-            old_request: self.upgrade_requests.get(public_key).cloned(),
-            new_request: Some(new_request.clone()),
-        };
+        let upgrade_req_event = UpgradeRequestChangeEvent {};
 
         // Store the upgrade request
         self.upgrade_requests.insert(*public_key, new_request);
@@ -227,10 +297,7 @@ impl State {
             );
             #[allow(mpsc_blocking_send)]
             self.upgrade_request_publisher
-                .send(UpgradeRequestChangeEvent {
-                    old_request: Some(expired_request.clone()),
-                    new_request: None,
-                })
+                .send(UpgradeRequestChangeEvent {})
                 .await
                 .map_err(Error::SendUpgradeRequestChangeEventErr)?;
         }
@@ -252,13 +319,27 @@ impl Runtime for State {
         F: Future<Output = BoxAction<Self, std::result::Result<(), Self::Err>>> + Send,
     {
         tokio::select! {
-            Some((public_key, upgrade_msg)) = self.intercoms.rx.recv() => {
+            Some((public_key, upgrade_msg)) = self.upgrade_intercoms.rx.recv() => {
                 self.handle_upgrade_request_msg(&public_key, &upgrade_msg)
                     .await
                     .unwrap_or_else(
                         |e| {
                             telio_log_warn!("Failed to parse upgrade request: {:?}", e);
                         });
+            }
+            Some((_pk, msg)) = self.upgrade_decision_intercoms.rx.recv() => {
+                telio_log_debug!("Upgrade decision received: {msg:?}");
+                match msg.decision {
+                    Decision::Accepted => {},
+                    Decision::RejectedDueToUnknownSession => {
+                        if let Some(pk) = self.upgrade_requests.iter().find(|(_, req)| req.session == msg.session).map(|(pk,_)| *pk) {
+                            let _ = self.upgrade_controller.notify_failed_wg_connection(pk).await;
+                        }
+                    }
+                    Decision::RejectedDueToConcurrentUpgrade => {
+                        // TODO: in LLT-4858
+                    }
+                }
             }
             _ = self.poll_timer.tick() => {
                 self.handle_tick()
@@ -281,25 +362,98 @@ impl Runtime for State {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
-    use tokio::time;
+    use telio_proto::Decision;
+    use tokio::{
+        sync::{
+            mpsc::{channel, Receiver, Sender},
+            Mutex,
+        },
+        time,
+    };
+
+    struct KnowsAllSessions {
+        notifications_sender: Sender<PublicKey>,
+        notifications_receiver: Mutex<Receiver<PublicKey>>,
+    }
+
+    impl KnowsAllSessions {
+        fn new() -> Self {
+            let (sender, receiver) = channel(1);
+            Self {
+                notifications_sender: sender,
+                notifications_receiver: Mutex::new(receiver),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl UpgradeController for KnowsAllSessions {
+        async fn check_if_upgrade_is_allowed(
+            &self,
+            _session: Session,
+            _public_key: PublicKey,
+        ) -> std::result::Result<bool, crate::connectivity_check::Error> {
+            Ok(true)
+        }
+
+        async fn notify_failed_wg_connection(
+            &self,
+            public_key: PublicKey,
+        ) -> std::result::Result<(), crate::connectivity_check::Error> {
+            self.notifications_sender.send(public_key).await.unwrap();
+            Ok(())
+        }
+    }
+
+    struct KnowsNoSessions;
+
+    #[async_trait]
+    impl UpgradeController for KnowsNoSessions {
+        async fn check_if_upgrade_is_allowed(
+            &self,
+            _session: Session,
+            _public_key: PublicKey,
+        ) -> std::result::Result<bool, crate::connectivity_check::Error> {
+            Ok(false)
+        }
+
+        async fn notify_failed_wg_connection(
+            &self,
+            _public_key: PublicKey,
+        ) -> std::result::Result<(), crate::connectivity_check::Error> {
+            Ok(())
+        }
+    }
 
     fn setup(
         expiry: Duration,
+        upgrade_verifier: Arc<dyn UpgradeController>,
     ) -> (
         UpgradeSync,
         chan::Rx<UpgradeRequestChangeEvent>,
         Chan<(PublicKey, UpgradeMsg)>,
+        Chan<(PublicKey, UpgradeDecisionMsg)>,
     ) {
         let (intercoms_them, intercoms_us) = Chan::pipe();
         let Chan {
             tx: upg_rq_tx,
             rx: upg_rq_rx,
         } = Chan::default();
+        let (upg_decision_them, upg_decision_us) = Chan::pipe();
 
-        let upg_sync = UpgradeSync::new(upg_rq_tx, intercoms_us, expiry).unwrap();
+        let upg_sync = UpgradeSync::new(
+            upg_rq_tx,
+            intercoms_us,
+            expiry,
+            upgrade_verifier,
+            upg_decision_us,
+        )
+        .unwrap();
 
-        (upg_sync, upg_rq_rx, intercoms_them)
+        (upg_sync, upg_rq_rx, intercoms_them, upg_decision_them)
     }
 
     #[ignore]
@@ -307,10 +461,12 @@ mod tests {
     async fn handle_request_expiration() {
         const EXPIRY: Duration = Duration::from_millis(100);
 
-        let (upg_sync, mut upg_rq_rx, mut intercoms_them) = setup(EXPIRY);
+        let (upg_sync, mut upg_rq_rx, mut intercoms_them, _) =
+            setup(EXPIRY, Arc::new(KnowsAllSessions::new()));
 
         let upg_msg = UpgradeMsg {
             endpoint: "127.0.0.1:6666".parse().unwrap(),
+            session: 42,
         };
 
         let pk = "REjdn4zY2TFx2AMujoNGPffo9vDiRDXpGG4jHPtx2AY="
@@ -332,16 +488,12 @@ mod tests {
                     _ = intercoms_them.rx.recv() => {
                         assert!(false, "Should not rx here");
                     }
-                    Some(upg_rq) = upg_rq_rx.recv() => {
+                    Some(_upg_rq) = upg_rq_rx.recv() => {
                         if !expecting_old_rq {
-                            assert!(upg_rq.old_request.is_none());
-                            assert_eq!(upg_rq.new_request.unwrap().endpoint, upg_msg.endpoint);
                             expecting_old_rq = true;
                             start = Some(Instant::now());
                             continue;
                         } else {
-                            assert!(upg_rq.new_request.is_none());
-                            assert_eq!(upg_rq.old_request.unwrap().endpoint, upg_msg.endpoint);
                             let elapsed_time = start.unwrap().elapsed();
                             assert!(elapsed_time >= EXPIRY, "Elapsed time: {:?} EXPIRY: {:?}", elapsed_time, EXPIRY);
                             break;
@@ -362,10 +514,12 @@ mod tests {
     #[tokio::test]
     async fn handle_request_and_removal() {
         const EXPIRY: Duration = Duration::from_millis(100);
-        let (upg_sync, mut upg_rq_rx, mut intercoms_them) = setup(EXPIRY);
+        let (upg_sync, mut upg_rq_rx, mut intercoms_them, mut upgrade_decision_them) =
+            setup(EXPIRY, Arc::new(KnowsAllSessions::new()));
 
         let upg_msg = UpgradeMsg {
             endpoint: "127.0.0.1:6666".parse().unwrap(),
+            session: 42,
         };
 
         let pk = "REjdn4zY2TFx2AMujoNGPffo9vDiRDXpGG4jHPtx2AY="
@@ -385,18 +539,16 @@ mod tests {
 
             loop {
                 tokio::select! {
-                    _ = intercoms_them.rx.recv() => {
+                    _msg = intercoms_them.rx.recv() => {
                         assert!(false, "Should not rx here");
                     }
-                    Some(upg_rq) = upg_rq_rx.recv() => {
-                        assert!(upg_rq.old_request.is_none());
-                        assert_eq!(upg_rq.new_request.unwrap().endpoint, upg_msg.endpoint);
-
-                        time::sleep(EXPIRY / 2).await;
-
-                        let _ = upg_sync.remove_upgrade(&pk).await;
-                        assert!(upg_sync.get_upgrade_requests().await.unwrap().is_empty());
+                    Some(_upg_rq) = upg_rq_rx.recv() => {
                         break;
+                    }
+                    Some(decision_msg) = upgrade_decision_them.rx.recv() => {
+                        assert_eq!(decision_msg.0, pk);
+                        assert_eq!(decision_msg.1.decision, telio_proto::Decision::Accepted);
+                        continue;
                     }
                     _ = &mut timeout => {
                         assert!(false, "Timeout!");
@@ -408,5 +560,72 @@ mod tests {
         })
         .await
         .unwrap();
+    }
+
+    #[tokio::test]
+    async fn handle_upgrade_rejection_due_to_unknown_session() {
+        const EXPIRY: Duration = Duration::from_millis(100);
+        let upgrade_controller = Arc::new(KnowsAllSessions::new());
+        let (upg_sync, _upg_rq_rx, _intercoms_them, upgrade_decision_them) =
+            setup(EXPIRY, upgrade_controller.clone());
+
+        let public_key = "REjdn4zY2TFx2AMujoNGPffo9vDiRDXpGG4jHPtx2AY="
+            .parse::<PublicKey>()
+            .unwrap();
+        let endpoint = "127.0.0.1:6666".parse().unwrap();
+        let session: Session = 42;
+
+        upg_sync
+            .request_upgrade(&public_key, endpoint, endpoint, session)
+            .await
+            .unwrap();
+
+        upgrade_decision_them
+            .tx
+            .send((
+                public_key,
+                UpgradeDecisionMsg {
+                    decision: Decision::RejectedDueToUnknownSession,
+                    session,
+                },
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            public_key,
+            upgrade_controller
+                .notifications_receiver
+                .lock()
+                .await
+                .recv()
+                .await
+                .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn unknown_requests_are_rejected() {
+        const EXPIRY: Duration = Duration::from_millis(100);
+        let (_upg_sync, mut _upg_rq_rx, intercoms_them, mut upgrade_decision_them) =
+            setup(EXPIRY, Arc::new(KnowsNoSessions));
+        let public_key = "REjdn4zY2TFx2AMujoNGPffo9vDiRDXpGG4jHPtx2AY="
+            .parse::<PublicKey>()
+            .unwrap();
+        let upgrade_msg = UpgradeMsg {
+            endpoint: "127.0.0.1:6666".parse().unwrap(),
+            session: 42,
+        };
+
+        intercoms_them
+            .tx
+            .send((public_key, upgrade_msg))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            upgrade_decision_them.rx.recv().await.unwrap().1.decision,
+            Decision::RejectedDueToUnknownSession
+        );
     }
 }

--- a/nat-lab/tests/telio.py
+++ b/nat-lab/tests/telio.py
@@ -523,6 +523,7 @@ class Client:
                         await self.set_meshmap(meshmap)
                     yield self
             finally:
+                await self.save_logs()
                 await self.save_mac_network_info()
                 if self._process.is_executing():
                     await self.stop_device()
@@ -531,7 +532,6 @@ class Client:
                     await self._router.delete_vpn_route()
                     await self._router.delete_exit_node_route()
                     await self._router.delete_interface()
-                await self.save_logs()
 
     async def quit(self):
         self._quit = True

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -154,6 +154,8 @@ pub enum Error {
     MeshnetUnavailableWithPQ,
     #[error(transparent)]
     PmtuProbe(std::io::Error),
+    #[error("Connection upgrade failed - there is no session for key {0:?}")]
+    NoSessionForKey(PublicKey),
 }
 
 pub type Result<T = ()> = std::result::Result<T, Error>;
@@ -651,7 +653,7 @@ impl Device {
         self.art()?.block_on(async {
             let node_key = *node_key;
             task_exec!(self.rt()?, async move |rt| {
-                Ok(rt.disconnect_exit_node(&node_key).await)
+                Ok(Box::pin(rt.disconnect_exit_node(&node_key)).await)
             })
             .await?
             .map_err(Error::from)
@@ -687,7 +689,7 @@ impl Device {
         self.art()?.block_on(async {
             let upstream_servers = upstream_servers.to_vec();
             task_exec!(self.rt()?, async move |rt| {
-                Ok(rt.start_dns(&upstream_servers).await)
+                Ok(Box::pin(rt.start_dns(&upstream_servers)).await)
             })
             .await?
         })
@@ -867,6 +869,8 @@ impl MeshnetEntites {
         }
 
         if let Some(direct) = self.direct.take() {
+            // Arc dependency on CrossPingCheck
+            stop_arc_entity!(direct.upgrade_sync, "UpgradeSync");
             // Arc dependency on endpoint providers
             stop_arc_entity!(direct.cross_ping_check, "CrossPingCheck");
             drop(direct.endpoint_providers);
@@ -883,7 +887,6 @@ impl MeshnetEntites {
             }
 
             stop_arc_entity!(direct.session_keeper, "SessionKeeper");
-            stop_arc_entity!(direct.upgrade_sync, "UpgradeSync");
         }
 
         stop_arc_entity!(self.multiplexer, "Multiplexer");
@@ -1295,6 +1298,8 @@ impl Runtime {
                     .clone(),
                 multiplexer.get_channel().await?,
                 Duration::from_secs(5),
+                cross_ping_check.clone(),
+                multiplexer.get_channel().await?,
             )?);
 
             let session_keeper = Arc::new(SessionKeeper::start(self.entities.socket_pool.clone())?);
@@ -2002,6 +2007,7 @@ impl TaskRuntime for Runtime {
                         |e| {
                             telio_log_warn!("WireGuard controller failure: {:?}. Ignoring", e);
                         });
+
                 Ok(())
             },
 


### PR DESCRIPTION
This will be used to decide if upgrade is accepted or rejected in LLT-4858. For now it is used to detect situations when the recipient of Upgrade message is unaware of the associated session id, most likely due to restart.

### Problem
Currently there is no way to distinguish initiators in a upgrade procedures when 2 procedures start at the same time. Furthermore when the other side is restarted after it sent CMM response, it will accept any update request as valid.

### Solution
Implement RFC LLT-0058 which prepares us for detecting initiator and solves the rejection of unknown update requests (e.g. after a restart).

`Upgrade` message is extended with a `session` field and a new message `UpgradeDecision` is added to be sent as a reply for the `Upgrade. The decision let's the other side reject unknown requests.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
