### PR TITLE
LLT-4980: Improve proxy endpoint update logic

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -27,6 +27,7 @@
 * LLT-4996: nurse: Stop adding virtual peers to qos
 * LLT-4687: Add PQ VPN nat-lab tests
 * LLT-5009: Enable QoS feature by default
+* LLT-4980: Add exponential backoff for socket updates on error
 
 <br>
 

--- a/crates/telio-model/src/lib.rs
+++ b/crates/telio-model/src/lib.rs
@@ -12,4 +12,4 @@ pub use std::net::SocketAddr;
 pub use telio_crypto::PublicKey;
 
 /// Hashmap of public key of the endpoint with its socket information
-pub type EndpointMap = HashMap<PublicKey, SocketAddr>;
+pub type EndpointMap = HashMap<PublicKey, Vec<SocketAddr>>;

--- a/crates/telio-model/src/mesh.rs
+++ b/crates/telio-model/src/mesh.rs
@@ -157,7 +157,7 @@ impl Map {
             // TODO: check if endpoint already contains primary, assume it should stay primary
             //      think, how to check for old derp endpoint.
             if let Some(node) = self.nodes.get_mut(&key) {
-                node.endpoint = Some(endpoint);
+                node.endpoint = endpoint.get(0).copied();
             }
         }
     }

--- a/nat-lab/tests/test_proxy.py
+++ b/nat-lab/tests/test_proxy.py
@@ -1,0 +1,52 @@
+import asyncio
+import pytest
+from contextlib import AsyncExitStack
+from helpers import SetupParameters, setup_mesh_nodes
+from telio import PeerInfo
+from typing import Optional
+from utils import testing
+from utils.connection_util import ConnectionTag
+from utils.ping import Ping
+
+
+@pytest.mark.asyncio
+async def test_proxy_endpoint_map_update() -> None:
+    setup_params = [
+        SetupParameters(connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1),
+        SetupParameters(connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2),
+    ]
+
+    async with AsyncExitStack() as exit_stack:
+        env = await setup_mesh_nodes(exit_stack, setup_params)
+        alpha, beta = env.nodes
+        alpha_connection, beta_connection = [
+            conn.connection for conn in env.connections
+        ]
+        alpha_client, _ = env.clients
+
+        port = node_port(alpha_client.get_node_state(beta.public_key))
+
+        await exit_stack.enter_async_context(
+            alpha_client.get_router().block_udp_port(port)
+        )
+
+        async with Ping(alpha_connection, beta.ip_addresses[0]).run() as ping:
+            await testing.wait_long(ping.wait_for_next_ping())
+        async with Ping(beta_connection, alpha.ip_addresses[0]).run() as ping:
+            await testing.wait_long(ping.wait_for_next_ping())
+
+        for _ in range(0, 5):
+            new_port = node_port(alpha_client.get_node_state(beta.public_key))
+            if port != new_port:
+                break
+            await asyncio.sleep(1)
+        else:
+            assert False, "Endpoint wasn't successfully updated"
+
+
+def node_port(peer_info: Optional[PeerInfo]) -> int:
+    assert peer_info
+    endpoint = peer_info.endpoint
+    assert endpoint
+    port = endpoint.split(":")[1]
+    return int(port)

--- a/nat-lab/tests/utils/router/linux_router.py
+++ b/nat-lab/tests/utils/router/linux_router.py
@@ -429,6 +429,37 @@ class LinuxRouter(Router):
                 "icmp-host-unreachable",
             ]).execute()
 
+    # This function blocks outgoing data for a specific port to simulate permission denied error for the socket bound to that port.
+    # It was added for LLT-4980, to test a specific code path in proxy.rs
+    @asynccontextmanager
+    async def block_udp_port(self, port: int) -> AsyncIterator:
+        await self._connection.create_process([
+            "iptables",
+            "-A",
+            "OUTPUT",
+            "-p",
+            "udp",
+            "--sport",
+            str(port),
+            "-j",
+            "DROP",
+        ]).execute()
+
+        try:
+            yield
+        finally:
+            await self._connection.create_process([
+                "iptables",
+                "-D",
+                "OUTPUT",
+                "-p",
+                "udp",
+                "--sport",
+                str(port),
+                "-j",
+                "DROP",
+            ]).execute()
+
     @asynccontextmanager
     async def reset_upnpd(self) -> AsyncIterator:
         await self._connection.create_process(["killall", "upnpd"]).execute()

--- a/nat-lab/tests/utils/router/mac_router.py
+++ b/nat-lab/tests/utils/router/mac_router.py
@@ -143,5 +143,11 @@ class MacRouter(Router):
         yield
 
     @asynccontextmanager
+    async def block_udp_port(
+        self, port: int  # pylint: disable=unused-argument
+    ) -> AsyncIterator:
+        yield
+
+    @asynccontextmanager
     async def reset_upnpd(self) -> AsyncIterator:
         yield

--- a/nat-lab/tests/utils/router/router.py
+++ b/nat-lab/tests/utils/router/router.py
@@ -115,6 +115,11 @@ class Router(ABC):
 
     @abstractmethod
     @asynccontextmanager
+    async def block_udp_port(self, port: int) -> AsyncIterator:
+        yield
+
+    @abstractmethod
+    @asynccontextmanager
     async def reset_upnpd(self) -> AsyncIterator:
         yield
 

--- a/nat-lab/tests/utils/router/windows_router.py
+++ b/nat-lab/tests/utils/router/windows_router.py
@@ -181,5 +181,11 @@ class WindowsRouter(Router):
         yield
 
     @asynccontextmanager
+    async def block_udp_port(
+        self, port: int  # pylint: disable=unused-argument
+    ) -> AsyncIterator:
+        yield
+
+    @asynccontextmanager
     async def reset_upnpd(self) -> AsyncIterator:
         yield

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -460,12 +460,13 @@ impl Device {
 
         self.rt = Some(self.art()?.block_on(async {
             let t = Task::start(
-                Box::pin(Runtime::start(
+                Runtime::start(
                     self.event.clone(),
                     config,
                     self.features.clone(),
                     self.protect.clone(),
-                ))
+                )
+                .boxed()
                 .await?,
             );
             Ok::<Task<Runtime>, Error>(t)
@@ -582,10 +583,10 @@ impl Device {
     pub fn set_config(&self, config: &Option<Config>) -> Result {
         let config = config.clone();
         self.art()?.block_on(async {
-            task_exec!(self.rt()?, async move |rt| Ok(Box::pin(
-                rt.set_config(&config)
-            )
-            .await))
+            task_exec!(self.rt()?, async move |rt| Ok(rt
+                .set_config(&config)
+                .boxed()
+                .await))
             .await?
         })
     }
@@ -656,7 +657,7 @@ impl Device {
         self.art()?.block_on(async {
             let node_key = *node_key;
             task_exec!(self.rt()?, async move |rt| {
-                Ok(Box::pin(rt.disconnect_exit_node(&node_key)).await)
+                Ok(rt.disconnect_exit_node(&node_key).boxed().await)
             })
             .await?
             .map_err(Error::from)
@@ -668,7 +669,7 @@ impl Device {
     pub fn disconnect_exit_nodes(&self) -> Result {
         self.art()?.block_on(async {
             task_exec!(self.rt()?, async move |rt| {
-                Ok(rt.disconnect_exit_nodes().await)
+                Ok(rt.disconnect_exit_nodes().boxed().await)
             })
             .await?
             .map_err(Error::from)
@@ -692,7 +693,7 @@ impl Device {
         self.art()?.block_on(async {
             let upstream_servers = upstream_servers.to_vec();
             task_exec!(self.rt()?, async move |rt| {
-                Ok(Box::pin(rt.start_dns(&upstream_servers)).await)
+                Ok(rt.start_dns(&upstream_servers).boxed().await)
             })
             .await?
         })
@@ -1435,6 +1436,7 @@ impl Runtime {
             .await?;
 
         if let Some(meshnet_entities) = self.entities.meshnet.as_ref() {
+            meshnet_entities.proxy.on_network_change().await;
             if let Some(direct) = &meshnet_entities.direct {
                 if let Some(stun) = &direct.stun_endpoint_provider {
                     // this unpauses provider if paused
@@ -1719,7 +1721,7 @@ impl Runtime {
         };
 
         // This is required to silence the dylint error "error: large future with a size of 2048 bytes"
-        Box::pin(self.connect_exit_node(exit_node)).await?;
+        self.connect_exit_node(exit_node).boxed().await?;
 
         self.entities.postquantum_wg.start(
             addr,
@@ -1812,7 +1814,7 @@ impl Runtime {
                 self.entities
                     .firewall
                     .remove_from_peer_whitelist(exit_node.public_key);
-                self.disconnect_exit_nodes().await
+                self.disconnect_exit_nodes().boxed().await
             }
             _ => Err(Error::InvalidNode),
         }
@@ -1901,7 +1903,7 @@ impl Runtime {
                         Default::default()
                     })
                     .get(&peer.public_key)
-                    .and_then(|proxy| endpoint.filter(|actual| proxy == actual))
+                    .and_then(|proxy| endpoint.filter(|actual| proxy.contains(actual)))
                     .map_or(PathType::Direct, |_| PathType::Relay)
             }
             .await

--- a/src/device/wg_controller.rs
+++ b/src/device/wg_controller.rs
@@ -605,7 +605,10 @@ async fn build_requested_meshnet_peers_list<
             // Retrieve public key
             let public_key = p.base.public_key;
             let persistent_keepalive_interval = requested_state.keepalive_periods.proxying;
-            let endpoint = proxy_endpoints.get(&public_key).cloned();
+            let endpoint = proxy_endpoints
+                .get(&public_key)
+                .and_then(|eps| eps.get(0))
+                .cloned();
 
             // Keep track of meshnet IP needed for instance for QoS analytics
             let ip_addresses = match deduplicated_peer_ips.get(&public_key) {
@@ -691,7 +694,10 @@ async fn build_requested_meshnet_peers_list<
             actual_peer,
             time_since_last_rx_or_handshake.as_ref(),
             time_since_last_endpoint_change.as_ref(),
-            proxy_endpoint,
+            match proxy_endpoint {
+                Some(eps) => eps,
+                None => &[],
+            },
             requested_state,
         );
 
@@ -710,7 +716,10 @@ async fn build_requested_meshnet_peers_list<
             &time_since_last_rx_or_handshake,
             peer_state,
             &checked_endpoint.cloned(),
-            &proxy_endpoint.cloned(),
+            match proxy_endpoint {
+                Some(eps) => eps,
+                None => &[],
+            },
             &upgrade_request_endpoint,
         )
         .await?;
@@ -788,7 +797,7 @@ async fn select_endpoint_for_peer<'a>(
     time_since_last_rx: &Option<Duration>,
     peer_state: PeerState,
     checked_endpoint: &Option<WireGuardEndpointCandidateChangeEvent>,
-    proxy_endpoint: &Option<SocketAddr>,
+    proxy_endpoint: &[SocketAddr],
     upgrade_request_endpoint: &Option<SocketAddr>,
 ) -> Result<(Option<SocketAddr>, Option<(SocketAddr, Session)>)> {
     // Retrieve some helper information
@@ -807,9 +816,12 @@ async fn select_endpoint_for_peer<'a>(
                 telio_log_debug!("Our actual endpoint is: {:?}", peer.endpoint);
             }
 
+            #[allow(clippy::expect_used)]
             if (peer_state == PeerState::Upgrading || peer_state == PeerState::Direct)
                 && actual_endpoint.is_some()
-                && actual_endpoint != *proxy_endpoint
+                && !proxy_endpoint.contains(
+                    &actual_endpoint.expect("Previous check mandates there be an endpoint here"),
+                )
             {
                 telio_log_debug!("Keeping the current direct endpoint: {:?}", actual_endpoint);
                 Ok((actual_endpoint, None))
@@ -831,7 +843,7 @@ async fn select_endpoint_for_peer<'a>(
                 public_key,
                 time_since_last_rx,
             );
-            Ok((*proxy_endpoint, None))
+            Ok((proxy_endpoint.get(0).copied(), None))
         }
 
         // Just proxying, nothing to upgrade to...
@@ -841,7 +853,7 @@ async fn select_endpoint_for_peer<'a>(
                 public_key,
                 time_since_last_rx,
             );
-            Ok((*proxy_endpoint, None))
+            Ok((proxy_endpoint.get(0).copied(), None))
         }
 
         // Proxying, but we have something to upgrade to. Lets try to upgrade.
@@ -891,26 +903,25 @@ fn compare_peers(a: &telio_wg::uapi::Peer, b: &telio_wg::uapi::Peer) -> bool {
         && a.preshared_key == b.preshared_key
 }
 
-fn is_peer_proxying(
-    peer: &telio_wg::uapi::Peer,
-    proxy_endpoints: &HashMap<PublicKey, SocketAddr>,
-) -> bool {
+fn is_peer_proxying(peer: &telio_wg::uapi::Peer, proxy_endpoints: &EndpointMap) -> bool {
     // If proxy has no knowledge of the public key -> the node definitely does not proxy
-    let proxy_endpoint = if let Some(proxy_endpoint) = proxy_endpoints.get(&peer.public_key) {
-        proxy_endpoint
+    let proxy_endpoints = if let Some(proxy_endpoints) = proxy_endpoints.get(&peer.public_key) {
+        proxy_endpoints
     } else {
         return false;
     };
 
     // Otherwise, we are only proxying if peer endpoint matches proxy endpoint
-    peer.endpoint == Some(*proxy_endpoint)
+    peer.endpoint
+        .map(|ep| proxy_endpoints.contains(&ep))
+        .unwrap_or_default()
 }
 
 fn peer_state(
     peer: Option<&telio_wg::uapi::Peer>,
     time_since_last_rx: Option<&Duration>,
     time_since_last_endpoint_change: Option<&Duration>,
-    proxy_endpoint: Option<&SocketAddr>,
+    proxy_endpoints: &[SocketAddr],
     requested_state: &RequestedState,
 ) -> PeerState {
     // Define some useful constants
@@ -939,7 +950,10 @@ fn peer_state(
     };
 
     let has_contact = time_since_last_rx < &peer_connectivity_timeout;
-    let is_proxying = peer.endpoint.as_ref() == proxy_endpoint;
+    let is_proxying = peer
+        .endpoint
+        .map(|ep| proxy_endpoints.contains(&ep))
+        .unwrap_or_default();
     let is_in_upgrade_window = time_since_last_endpoint_change < &peer_upgrade_window;
 
     match (has_contact, is_proxying, is_in_upgrade_window) {
@@ -1412,7 +1426,7 @@ mod tests {
                 .map(|i| {
                     (
                         i.0,
-                        SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, i.1)),
+                        vec![SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, i.1))],
                     )
                 })
                 .collect();


### PR DESCRIPTION
### Problem
There was recently a commit that introduced synchronization for the endpoint maps of StateIngress and StateEgress, which fixed an issue where StateEgress would update it's endpoint map on socket error, but StateIngress would be used as the source of truth, leading to an incorrect endpoint map being used. 

### Solution
This commit improves that work in a few ways. It:
- Adds a test to check that the scenario works
- Makes wg_controller know about both the old endpoint and the new endpoint
- Resends the data to make libtelio adapt to endpoint changes quicker


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
