### PR TITLE
Llt 4859 fix aggregation for derp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4223,6 +4223,7 @@ dependencies = [
  "telio-crypto",
  "telio-utils",
  "thiserror",
+ "tokio",
  "tracing",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4245,6 +4245,7 @@ dependencies = [
  "futures",
  "histogram",
  "md5",
+ "mockall",
  "nat-detect",
  "protobuf-codegen-pure",
  "rand",

--- a/crates/telio-model/Cargo.toml
+++ b/crates/telio-model/Cargo.toml
@@ -23,6 +23,7 @@ serde_with.workspace = true
 serde_json.workspace = true
 strum.workspace = true
 thiserror.workspace = true
+tokio.workspace = true
 
 telio-crypto.workspace = true
 telio-utils.workspace = true

--- a/crates/telio-model/src/config.rs
+++ b/crates/telio-model/src/config.rs
@@ -52,7 +52,7 @@ pub struct DnsConfig {
 }
 
 /// The currrent state of our connection to derp server
-#[derive(Debug, Default, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum RelayState {
     /// Disconnected from the Derp server
@@ -143,6 +143,26 @@ impl Default for Server {
             conn_state: RelayState::Disconnected,
         }
     }
+}
+
+/// Possible relay server connectivity change reasons
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub enum RelayConnectionChangeReason {
+    // Numbers smaller than 200 for configuration changes
+    /// Generic reason used when everything goes right
+    ConfigurationChange = 101,
+    /// The connection was explicitely closed by user
+    DisabledByUser = 102,
+    /// Some kind of unexpected internal error
+    ClientError = 103,
+
+    // Numbers larger than 200 for network problems
+    /// Derp server connection timed out
+    ConnectionTimeout = 201,
+    /// Server rejected the connection
+    ConnectionTerminatedByServer = 202,
+    /// OS-level network error (e.g. socket failure)
+    NetworkError = 203,
 }
 
 /// [PartialConfig] is similar to [Config] but allows for `peers` to contain invalid entries.

--- a/crates/telio-nurse/Cargo.toml
+++ b/crates/telio-nurse/Cargo.toml
@@ -14,7 +14,7 @@ md5 = "0.7.0"
 async-trait.workspace = true
 crypto_box.workspace = true
 futures.workspace = true
-tracing.workspace = true
+mockall = { workspace = true, optional = true }
 nat-detect.workspace = true
 rand.workspace = true
 serde.workspace = true
@@ -24,6 +24,7 @@ socket2.workspace = true
 surge-ping.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["net", "sync"] }
+tracing.workspace = true
 uuid.workspace = true
 
 telio-crypto.workspace = true

--- a/crates/telio-nurse/src/lib.rs
+++ b/crates/telio-nurse/src/lib.rs
@@ -22,7 +22,7 @@ pub mod error;
 mod nurse;
 
 /// Connectivity data aggregator module
-mod aggregator;
+pub mod aggregator;
 
 mod heartbeat;
 mod qos;

--- a/crates/telio-nurse/src/nurse.rs
+++ b/crates/telio-nurse/src/nurse.rs
@@ -152,11 +152,11 @@ impl State {
         }
     }
 
-    /// Inform Nurse that Derp service started.
+    /// Inform Nurse that Meshnet started or stopped.
     ///
     /// # Arguments
     ///
-    /// * `derp` - The new Derp service pointer to use.
+    /// * `meshnet_entities` - meshnet entities if meshnet started, None if it stopped.
     pub async fn configure_meshnet(&self, meshnet_entities: Option<MeshnetEntities>) {
         let _ = task_exec!(&self.heartbeat, async move |state| {
             state.configure_meshnet(meshnet_entities).await;


### PR DESCRIPTION
### Problem
Current aggregator API for DERP events is a bit hard to use from Derp module

### Solution
Change the aggregator API for Derp events, so it uses `Server` instead of `AnalyticsEvent`

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
