### PR TITLE
LLT_4954 handle sleeping state

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -28,6 +28,7 @@
 * LLT-4687: Add PQ VPN nat-lab tests
 * LLT-5009: Enable QoS feature by default
 * LLT-4980: Add exponential backoff for socket updates on error
+* LLT-4954: Handle system sleep/wakeup in nat/derp monitoring
 
 <br>
 

--- a/crates/telio-nurse/src/heartbeat.rs
+++ b/crates/telio-nurse/src/heartbeat.rs
@@ -1211,7 +1211,7 @@ mod tests {
                 },
         } = analytics_channel.recv().await.expect("message");
 
-        assert_eq!(false, meshnet_enabled);
+        assert!(!meshnet_enabled);
         assert_eq!("vpn:7600617f9f9db5691a8c2768bd9d8110:2", external_links);
     }
 
@@ -1253,7 +1253,7 @@ mod tests {
                 },
         } = analytics_channel.recv().await.expect("message");
 
-        assert_eq!(true, meshnet_enabled);
+        assert!(meshnet_enabled);
         assert_eq!("vpn:7600617f9f9db5691a8c2768bd9d8110:2", external_links);
     }
 
@@ -1278,20 +1278,14 @@ mod tests {
         let rt = Task::start(analytics);
 
         // Should succeed to get one analytic meesage
-        assert_eq!(
-            true,
-            timeout(Duration::from_secs(1), analytics_channel.recv())
-                .await
-                .is_ok()
-        );
+        assert!(timeout(Duration::from_secs(1), analytics_channel.recv())
+            .await
+            .is_ok());
 
         // Should timeout trying to get second analytic message
-        assert_eq!(
-            false,
-            timeout(Duration::from_secs(1), analytics_channel.recv())
-                .await
-                .is_ok()
-        );
+        assert!(timeout(Duration::from_secs(1), analytics_channel.recv())
+            .await
+            .is_err());
 
         rt.stop().await;
     }

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -606,6 +606,18 @@ impl Device {
         })
     }
 
+    pub fn notify_sleep(&self) -> Result {
+        self.art()?.block_on(async {
+            task_exec!(self.rt()?, async move |rt| Ok(rt.notify_sleep().await)).await?
+        })
+    }
+
+    pub fn notify_wakeup(&self) -> Result {
+        self.art()?.block_on(async {
+            task_exec!(self.rt()?, async move |rt| Ok(rt.notify_wakeup().await)).await?
+        })
+    }
+
     /// Connect to exit node
     ///
     /// Exit node in this case may be the VPN server or another meshnet node. In the former case,
@@ -1453,6 +1465,19 @@ impl Runtime {
         }
 
         self.log_nat().await;
+        Ok(())
+    }
+
+    async fn notify_sleep(&mut self) -> Result {
+        self.entities
+            .aggregator
+            .force_save_unacknowledged_segments()
+            .await;
+        Ok(())
+    }
+
+    async fn notify_wakeup(&mut self) -> Result {
+        self.entities.aggregator.clear_ongoinging_segments().await;
         Ok(())
     }
 

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -496,6 +496,26 @@ impl Telio {
         })
     }
 
+    /// Notify telio system is going to sleep.
+    pub fn notify_sleep(&self) -> FFIResult<()> {
+        telio_log_info!("telio_notify_sleep entry with instance id: {}.", self.id);
+        catch_ffi_panic(|| {
+            self.device_op(true, |dev| {
+                dev.notify_sleep().log_result("Telio::notify_sleep")
+            })
+        })
+    }
+
+    /// Notify telio system has woken up.
+    pub fn notify_wakeup(&self) -> FFIResult<()> {
+        telio_log_info!("telio_notify_wakeup entry with instance id: {}.", self.id);
+        catch_ffi_panic(|| {
+            self.device_op(true, |dev| {
+                dev.notify_wakeup().log_result("Telio::notify_wakeup")
+            })
+        })
+    }
+
     /// Wrapper for `Telio::connect_to_exit_node_with_id` that doesn't take an identifier
     pub fn connect_to_exit_node(
         &self,

--- a/src/libtelio.udl
+++ b/src/libtelio.udl
@@ -229,7 +229,15 @@ interface Telio {
     [Throws=TelioError]
     void notify_network_change(string network_info);
 
-    /// Wrapper for `connect_to_exit_node_with_id` that doesn't take an identifier
+    /// Notify telio when system goes to sleep.
+    [Throws=TelioError]
+    void notify_sleep();
+
+    /// Notify telio when system wakes up.
+    [Throws=TelioError]
+    void notify_wakeup();
+
+    /// Wrapper for `telio_connect_to_exit_node_with_id` that doesn't take an identifier
     [Throws=TelioError]
     void connect_to_exit_node(PublicKey public_key, sequence<IpNetwork>? allowed_ips, SocketAddr? endpoint);
 


### PR DESCRIPTION
### Problem
NAT and DERP data aggregator needs to be notified when the system is going to sleep, and when it wakes up in order to not take those timings into consideration.

 - a small bug in the aggregator was also found and fixed.

### Solution
When the system goes to sleep, simply gather all the unacknowledged segments and clear the rest.
At wakeup, do an additional clearing of current segments to handle the race condition where a new segment might begin after clearing the segments when system goes to sleep. The beginning of new segment would be handled by wg notifications.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
