### PR TITLE
Update mio to 0.8.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2283,9 +2283,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.8"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "wasi",


### PR DESCRIPTION
This fixes https://rustsec.org/advisories/RUSTSEC-2024-0019
