### PR TITLE
LLT-5002: Preshared key comparison detect's non exsistant state change

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,7 @@
 * LLT-4980: Introduce synchronization for the endpoint map in telio-proxy
 * LLT-4970: PQ VPN is enabled by calling `telio_connect_to_exit_node_postquantum()`
 * LLT-4981: Add upgrade decision message
+* LLT-5002: Fix preshared key parsing logic
 
 <br>
 

--- a/crates/telio-wg/src/uapi.rs
+++ b/crates/telio-wg/src/uapi.rs
@@ -561,9 +561,13 @@ fn parse_peer<R: Read>(
                     }
                 }
                 "preshared_key" => {
-                    peer.preshared_key = Some(val.parse().map_err(|e: KeyDecodeError| {
+                    let preshared: PresharedKey = val.parse().map_err(|e: KeyDecodeError| {
                         Error::ParsingError("preshared_key", e.to_string())
-                    })?);
+                    })?;
+
+                    if preshared.0 != [0; 32] {
+                        peer.preshared_key = Some(preshared);
+                    }
                 }
                 "public_key" => {
                     break (


### PR DESCRIPTION
### Problem
The zero-valued preshared key is reported for certain interfaces

### Solution
Validate the key


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
