### PR TITLE
Add NAT-Lab test for checking if there are any leftover WireGuard

### DIFF
--- a/nat-lab/tests/test_mesh_off.py
+++ b/nat-lab/tests/test_mesh_off.py
@@ -53,8 +53,8 @@ async def test_mesh_off(
             "tun10",
         ]).execute()
 
-        dig_stdout = process.get_stdout()
+        wg_show_stdout = process.get_stdout()
 
         assert (
-            "peer:" not in dig_stdout.strip().split()
-        ), f"There are leftover WireGuard peers after mesh is set to off: {dig_stdout}"
+            "peer:" not in wg_show_stdout.strip().split()
+        ), f"There are leftover WireGuard peers after mesh is set to off: {wg_show_stdout}"

--- a/nat-lab/tests/test_mesh_off.py
+++ b/nat-lab/tests/test_mesh_off.py
@@ -1,0 +1,60 @@
+import pytest
+import telio
+from contextlib import AsyncExitStack
+from helpers import SetupParameters, setup_mesh_nodes
+from telio_features import TelioFeatures, Direct
+from utils.connection_util import ConnectionTag
+
+
+# Marks in-tunnel stack only, exiting only through IPv4
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "alpha_setup_params",
+    [
+        pytest.param(
+            SetupParameters(
+                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
+                adapter_type=telio.AdapterType.LinuxNativeWg,
+                features=TelioFeatures(direct=Direct(providers=None)),
+            )
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "beta_setup_params",
+    [
+        pytest.param(
+            SetupParameters(
+                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2,
+                adapter_type=telio.AdapterType.LinuxNativeWg,
+                features=TelioFeatures(direct=Direct(providers=None)),
+            ),
+        ),
+    ],
+)
+async def test_mesh_off(
+    alpha_setup_params: SetupParameters, beta_setup_params: SetupParameters
+) -> None:
+    async with AsyncExitStack() as exit_stack:
+        env = await setup_mesh_nodes(
+            exit_stack, [alpha_setup_params, beta_setup_params]
+        )
+
+        client_alpha, _ = env.clients
+        connection_alpha, _ = [conn.connection for conn in env.connections]
+
+        await client_alpha.set_mesh_off()
+
+        # Checking if no peer is left after turning mesh net off
+        # wg show outputs lines that start with the string "peer:" when any peer is present
+        process = await connection_alpha.create_process([
+            "wg",
+            "show",
+            "tun10",
+        ]).execute()
+
+        dig_stdout = process.get_stdout()
+
+        assert (
+            "peer:" not in dig_stdout.strip().split()
+        ), f"There are leftover WireGuard peers after mesh is set to off: {dig_stdout}"


### PR DESCRIPTION
Check for leftover peers after setting mesh to off.

### Problem
In case of a bug, there may be leftover peers after turning mesh off and that can cause issues and even lead to IP leaks.

### Solution
Added a NAT-Lab test which checks if there are any leftover peers after turning mesh off.

Also note since this is an internal test commit, not adding any entry to the changelog as this information is not useful to app teams who are the consumers of the changelog.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
