### PR TITLE
Backport of LLT-5002 into v4.2

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@
 * LLT-4870: Bring back PQ
 * LLT-4406: Implement error handling for proxy egress
 * LLT-4980: Introduce synchronization for the endpoint map in telio-proxy
+* LLT-5002: Fix preshared key parsing logic
 
 <br>
 

--- a/crates/telio-wg/src/uapi.rs
+++ b/crates/telio-wg/src/uapi.rs
@@ -559,9 +559,13 @@ fn parse_peer<R: Read>(
                     }
                 }
                 "preshared_key" => {
-                    peer.preshared_key = Some(val.parse().map_err(|e: KeyDecodeError| {
+                    let preshared: PresharedKey = val.parse().map_err(|e: KeyDecodeError| {
                         Error::ParsingError("preshared_key", e.to_string())
-                    })?);
+                    })?;
+
+                    if preshared.0 != [0; 32] {
+                        peer.preshared_key = Some(preshared);
+                    }
                 }
                 "public_key" => {
                     break (


### PR DESCRIPTION
Backport of https://github.com/NordSecurity/libtelio/pull/409 into 4.2

### Problem
The zero-valued preshared key is reported for certain interfaces

### Solution
Validate the key


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
