### PR TITLE
Remove link_state flaky configurations

### DIFF
--- a/nat-lab/tests/test_events_link_state.py
+++ b/nat-lab/tests/test_events_link_state.py
@@ -35,12 +35,14 @@ def _generate_setup_paramete_pair(
 
 
 FEATURE_ENABLED_PARAMS = [
-    pytest.param(
-        _generate_setup_paramete_pair([
-            (ConnectionTag.DOCKER_CONE_CLIENT_1, AdapterType.LinuxNativeWg),
-            (ConnectionTag.DOCKER_CONE_CLIENT_2, AdapterType.LinuxNativeWg),
-        ])
-    ),
+    # This scenario has been removed because it was causing flakyness due to LLT-5014.
+    # Add it back when the issue is fixed.
+    # pytest.param(
+    #     _generate_setup_paramete_pair([
+    #         (ConnectionTag.DOCKER_CONE_CLIENT_1, AdapterType.LinuxNativeWg),
+    #         (ConnectionTag.DOCKER_CONE_CLIENT_2, AdapterType.LinuxNativeWg),
+    #     ])
+    # ),
     pytest.param(
         _generate_setup_paramete_pair([
             (ConnectionTag.DOCKER_CONE_CLIENT_1, AdapterType.LinuxNativeWg),
@@ -59,11 +61,11 @@ FEATURE_DISABLED_PARAMS = [
     pytest.param([
         SetupParameters(
             connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-            adapter_type=AdapterType.LinuxNativeWg,
+            adapter_type=AdapterType.BoringTun,
         ),
         SetupParameters(
             connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2,
-            adapter_type=AdapterType.LinuxNativeWg,
+            adapter_type=AdapterType.BoringTun,
         ),
     ])
 ]


### PR DESCRIPTION
The link_state tests sometimes fails with timeout error due to a race condition in LinuxNative Wireguard implementation (described in LLT-5014).

This commit removes the flaky configs. We have to add them back when the issue is fixed.



### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
