### PR TITLE
Make link state feature disabled test to not expect an exact number of events

### DIFF
--- a/nat-lab/tests/test_events_link_state.py
+++ b/nat-lab/tests/test_events_link_state.py
@@ -211,7 +211,7 @@ async def test_event_link_state_feature_disabled(
         alpha_events = client_beta.get_link_state_events(alpha.public_key)
         beta_events = client_alpha.get_link_state_events(beta.public_key)
 
-        # There should be 2 node events Connecting and Connected
-        # Both of them should have link_state field empty
-        assert alpha_events == [None, None]
-        assert beta_events == [None, None]
+        assert len(alpha_events) > 1
+        assert len(beta_events) > 1
+        assert all(e is None for e in alpha_events)
+        assert all(e is None for e in beta_events)


### PR DESCRIPTION
Sometimes telio-proxy changes the relying port thus generating more than the 2 events the test expected previously.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
