### PR TITLE
[LLT-4996] nurse: Stop adding virtual peers to qos

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -24,6 +24,7 @@
 * LLT-4509: Enable windows arm64 build.
 * LLT-5007: Bump moose tracker to v3.0.0-libtelioApp
 * LLT-4873: Remove old SWIG FFI bindings
+* LLT-4996: nurse: Stop adding virtual peers to qos
 
 <br>
 

--- a/src/device/wg_controller.rs
+++ b/src/device/wg_controller.rs
@@ -518,7 +518,13 @@ async fn build_requested_peers_list<
         } else {
             resolver.get_default_dns_allowed_ips()
         };
-        let dns_peer = resolver.get_peer(dns_allowed_ips);
+        let mut dns_peer = resolver.get_peer(dns_allowed_ips);
+        dns_peer.ip_addresses = dns_peer
+            .allowed_ips
+            .iter()
+            .copied()
+            .map(|ip| ip.ip())
+            .collect();
         let dns_peer_public_key = dns_peer.public_key;
         let requested_peer = RequestedPeer {
             peer: dns_peer,


### PR DESCRIPTION
### Problem
Virtual peers (DNS, Stun, etc.) are being added to QoS which is neither expected nor useful, wasting resources.

### Solution
Stop adding these peers to QoS.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
