### PR TITLE
Synchronize racey configure_route.sh

### DIFF
--- a/nat-lab/bin/configure_route.sh
+++ b/nat-lab/bin/configure_route.sh
@@ -6,9 +6,42 @@ print_help() {
     exit 1
 }
 
+# There are a bunch of nightly failures on new Vagrant runners #13, #14, #15, and #16, e.g.
+#
+# [2024-03-19 12:47:09] |EXECUTE| docker compose logs internal-symmetric-gw-01
+# [2024-03-19 12:47:10] internal-symmetric-gw-01-1  | + case "${1:-}" in
+# [2024-03-19 12:47:10] internal-symmetric-gw-01-1  | + ip route delete 10.0.0.0/16
+# [2024-03-19 12:47:10] internal-symmetric-gw-01-1  | RTNETLINK answers: No such process
+# [2024-03-19 12:47:10] internal-symmetric-gw-01-1  | + true
+# [2024-03-19 12:47:10] internal-symmetric-gw-01-1  | + ip route add 10.0.0.0/16 via 192.168.103.254 dev eth1
+# [2024-03-19 12:47:10] internal-symmetric-gw-01-1  | Cannot find device "eth1"
+#
+# Its probably because the new runners have much more powerfull CPUs, and this causes some type
+# of race condition somewhere in Docker/Compose. Seems like entrypoint is somehow executed first
+# before interfaces have been fully configured. To try and workaround this, allow a little bit of
+# time for interfaces to be fully initialized.
+wait_for_interface() {
+    interface=$1
+
+    for i in {0..10}; do
+        if ip a show "$interface" up | grep -q inet; then
+            echo "Network interface $interface is up."
+            return
+        else
+            echo "Waiting for network interface $interface to be up..."
+            sleep 0.2
+        fi
+    done
+
+    echo "Timeout reached. Network interface $interface is not up."
+    exit 1
+}
+
 case "${1:-}" in
     primary)
         if [[ $CLIENT_GATEWAY_PRIMARY != "none" ]]; then
+            wait_for_interface eth0
+
             ip route delete 10.0.0.0/16 || true
             ip route add 10.0.0.0/16 via $CLIENT_GATEWAY_PRIMARY dev eth0
 
@@ -19,6 +52,8 @@ case "${1:-}" in
         fi
         ;;
     secondary)
+        wait_for_interface eth1
+
         ip route delete 10.0.0.0/16 || true
         ip route add 10.0.0.0/16 via $CLIENT_GATEWAY_SECONDARY dev eth1
         ;;


### PR DESCRIPTION
### Problem
`configure_route.sh` fails on new Vagrant runners. My theory is that the new runners have much faster CPUs, and that causes a racey condition to happen. Container entrypoint executes faster than interfaces are initialized.

### Solution
Allow a little bit of time for interfaces to be initialized before using the interfaces.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
