### PR TITLE
[LLT-4802]Move downgrade handling to mod/device.rs

### DIFF
--- a/crates/telio-wg/src/uapi.rs
+++ b/crates/telio-wg/src/uapi.rs
@@ -251,6 +251,8 @@ pub struct Event {
     pub link_state: Option<LinkState>,
     /// Details regarding the Peer
     pub peer: Peer,
+    /// Previous info about the peer
+    pub old_peer: Option<Peer>,
 }
 
 /// Analytics information to be conveyed

--- a/nat-lab/tests/test_network_switch.py
+++ b/nat-lab/tests/test_network_switch.py
@@ -335,8 +335,5 @@ async def test_mesh_network_switch_direct(
             await relay
             await direct
 
-        # TODO: workaround for LLT-4802, remove after that is fixed
-        await asyncio.sleep(25)
-
         async with Ping(alpha_connection, beta.ip_addresses[0]).run() as ping:
             await testing.wait_long(ping.wait_for_next_ping())


### PR DESCRIPTION
### Problem
Original task was already done in the solution for LLT-4981. We need to additionaly remove timeout from network_switch_direct test which should now be obsolete. But after removing it , so we move downgrade handling to mod/device.rs, to make it more robust.

### Solution
In this PR we remove the mentioned timeout, it also simplifies select_endpoint_for_peer function a bit

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests