### PR TITLE
Add in-repo documentation system skeleton

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -31,6 +31,7 @@
 * LLT-4954: Handle system sleep/wakeup in nat/derp monitoring
 * LLT-5068: Bump Moose 4.0.1
 * LLT-4858: NAT state analytics reporting
+* LLT-5038: Add doc rs as in-repo documentation system skeleton
 
 <br>
 

--- a/src/doc/integrating_telio.md
+++ b/src/doc/integrating_telio.md
@@ -1,0 +1,3 @@
+# Documentation For Integrating Telio Into Other Languages
+
+<!-- TODO: This page is a placeholder and will be populated by upcoming PR's when the actual specification will be more clear -->

--- a/src/doc/introduction.md
+++ b/src/doc/introduction.md
@@ -1,0 +1,221 @@
+# Introduction
+
+Libtelio (pronounced 'lɪbtælɪɔ') is a client-side library for creating encrypted networks (called Meshnet) on the user's nodes.
+It supports a number of features, including:
+
+- adapting different Wireguard implementations to secure the connections,
+- exit nodes which might be either VPN servers or some nodes in the Meshnet,
+- "DNS" which allows name resolution in Meshnets for devices which does not support lookup tables,
+- adjustable firewall.
+
+## Quick Links
+
+- Telio integration [documentation][_telio_integration_documentation]
+- Telio Events [documentation][_telio_events_documentation]
+
+## Using the libtelio API
+
+See [this documentation module][_telio_integration_documentation] for notes on how to integrate Libtelio into an application using one of the different supported languages.
+
+### Initializing the telio device
+
+The main component of the Libtelio library is the `telio::Device` structure and its methods.
+Let's go through the most important ones.
+
+The first of them is the expected function `::new`.
+It takes three arguments, let's describe them briefly:
+ - [`features`](telio_model::features::Features) - tells Libtelio which of the additional features should be enabled - the
+ description of them is out of the scope of this README
+ - `event_cb` - event handler, takes a [`Box<Event>`][telio_model::event::Event], which will be called by Libtelio to handle
+ events of three types:
+   - `Error` - an error occurs, especially urgent are Critical error events, which means
+   that the library is unable to continue running and it requires a call to `hard_reset` method
+   - `Relay` - when the relay (i.e. Derp) server configuration is changed, contains
+   a JSON with a new one
+   - `Node` - appears when the Meshnet node's configuration is changed, it contains
+   a JSON with a new one
+ - `protect` - callback for excluding connections from VPN tunnel (currently used only for android).
+
+`telio::Device` implements `Drop` trait, so we don't need to worry
+about deinitialization in the end.
+Let's look at an example initialization of `telio::Device` with no additional
+features, handling only `Node` events and not using `protect` callback:
+
+```rust no_run
+use telio_model::features::Features;
+use telio_model::event::Event;
+
+let (sender, receiver) = std::sync::mpsc::channel::<Box<Event>>();
+
+let mut device = telio::device::Device::new(
+    Features::default(),
+    move |e| {
+        sender.send(e).unwrap();
+    },
+    None,
+).unwrap();
+
+// ...
+
+loop {
+    let event = receiver.recv().unwrap();
+    match *event {
+        Event::Node { body: Some(b) } => println!(
+            "event node: {:?}:{};  Path = {:?}",
+            b.state,
+            b.public_key,
+            b.path
+        ),
+        _ => {}
+    };
+}
+```
+
+### Starting the Telio device
+
+Once the device is initialized we can start it, so it will create a new network
+interface in your OS. This might be done using `start` method.
+We need to provide an instance of the `DeviceConfig` structure:
+
+```rust no_run
+use telio_wg::AdapterType;
+use telio_crypto::SecretKey;
+use telio_wg::Tun;
+
+pub struct DeviceConfig {
+    pub private_key: SecretKey,
+    pub adapter: AdapterType,
+    pub name: Option<String>,
+    pub tun: Option<Tun>,
+}
+```
+
+Let's discuss its fields shortly:
+ - `private_key` a `telio::crypto::SecretKey` instance containing a 256-bit key,
+ - `adapter` indicating which Wireguard implementation we want to use,
+ - `name` is the name of the network interface, when omitted, Telio uses the default one,
+ - `tun` a file descriptor of the already opened tunnel, if it's not provided Telio will open a new one.
+
+The API provides a default config which is almost sufficient for simple cases,
+the only need that needs to be done is the generation of a private key:
+
+```rust no_run
+use telio_model::{features::Features, event::Event};
+
+let (sender, receiver) = std::sync::mpsc::channel::<Box<Event>>();
+
+let mut device = telio::device::Device::new(
+    Features::default(),
+    move |e| {
+        sender.send(e).unwrap();
+    },
+    None,
+).unwrap();
+
+let config = telio::device::DeviceConfig {
+    private_key: telio_crypto::SecretKey::gen(),
+    ..Default::default()
+};
+
+device.start(&config).unwrap();
+```
+
+To stop the device we can simply call the argumentless `Device::stop` method.
+
+### Creating a Meshnet
+
+To turn on the Meshnet feature, you need to call the `Device::set_config` method
+with the proper config. After logging in and registering to the desired
+Derp server, the JSON with config may be downloaded from it.
+
+In the case of using the Derp server provided by Nord, you can use a token (like the one
+used in the tcli setup) passing it with a user HTTP header (in a form `token:<TOKEN>`),
+to receive the necessary credentials from
+`https://api.nord.com/v1/users/services/credentials`
+which will return you another token, with which you may register to
+`https://api.nord.com/v1/meshnet/machines`
+passing the token in the authorization data: `Bearer token:<TOKEN>`.
+You will be given an `ID` with which you can download the config from
+`https://api.nord.com/v1/meshnet/<ID>/`
+using the same bearer token.
+
+After the device is started and the JSON config downloaded, we can
+deserialize it and finally call `set_config`:
+
+```rust no_run
+use telio_model::{config::Config, features::Features, event::Event};
+# // Leaving this hidden, since there's no point in pasting the whole config here.
+# let serialized_config: &str = "";
+
+let config = telio::device::DeviceConfig {
+    private_key: telio_crypto::SecretKey::gen(),
+    ..Default::default()
+};
+
+let (sender, receiver) = std::sync::mpsc::channel::<Box<Event>>();
+
+let mut device = telio::device::Device::new(
+    Features::default(),
+    move |e| {
+        sender.send(e).unwrap();
+    },
+    None,
+).unwrap();
+
+let config: Config = serde_json::from_str(&serialized_config).unwrap();
+
+device.set_config(&Some(config)).unwrap();
+```
+
+To turn the Meshnet off, we need to just call `Device::set_config` with `None`.
+
+### Selecting an exit node
+
+The other thing you may do with the started device is to set up an exit node.
+It might be either one of the nodes in your internal network, or
+some VPN server compatible with Wireguard. To connect to them, we need
+their public key and endpoint.
+
+If we want to use the NordVPN server, we can obtain them from the JSON
+downloaded from
+`https://api.nordvpn.com/v1/servers/recommendations`.
+The received JSON is rather big, so to get the needed fields
+you can extract the `telio::tcli::nord::find_server` method and simplify
+it a bit to just return a pair of `public_key` and `endpoint`.
+When you have it, setting up the VPN connection is fairly simple:
+
+```rust no_run
+use telio_model::{event::Event, mesh::{IpNetwork, ExitNode}};
+use std::net::{SocketAddr, IpAddr, Ipv4Addr};
+use telio::crypto::PublicKey;
+
+// A very simplified function which returns example values for the public key, IP and port of the VPN server.
+fn find_server() -> (PublicKey, SocketAddr)
+{
+    (PublicKey::default(), SocketAddr::new(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)), 51820))
+};
+
+let (sender, receiver) = std::sync::mpsc::channel::<Box<Event>>();
+
+let mut device = telio::device::Device::new(
+    telio_model::features::Features::default(),
+    move |e| {
+        sender.send(e).unwrap();
+    },
+    None,
+).unwrap();
+
+let (public_key, endpoint) = find_server();
+let exit_node = ExitNode {
+    identifier: "fa5bbe9b-338b-4bd2-8c97-166ceee65790".to_owned(),
+    public_key,
+    allowed_ips: Some(vec![IpNetwork::new(
+        IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
+        0,
+    )
+    .unwrap()]),
+    endpoint: Some(endpoint),
+};
+device.connect_exit_node(&exit_node);
+```
+

--- a/src/doc/telio_events.md
+++ b/src/doc/telio_events.md
@@ -1,0 +1,146 @@
+# Documentation For Describing Telio Events
+
+This module documents the events reported by the Telio library.
+
+## Telio Error Event
+
+[Error][telio_model::event::Error] events are reported in the following format:
+
+```json
+{
+  "type": "error",
+  "body": {
+    "level": "<critical|severe|warning|notice>",
+    "code": "<noerror|unknown>",
+    "msg": string?
+  }
+}
+```
+
+Fields:
+
+- level - error severity:
+
+    - critical - telio panicked
+    - severe - telio can continue operating, but parts of it can malfunction
+    - warning - warning that things can get wrong
+    - notice - not a critical error
+
+- code - common error code:
+
+    - noerror - default value, not an error.
+    - unknown - unknown error
+
+- msg - custom error string, can be empty
+
+
+### When error event is reported?
+
+[Error][telio_model::event::Error] events are reported when a panic occurs on telio side after registering for Telio events by calling `telio_new`.
+
+### Handling error events
+
+- level:
+
+    - critical -  telio panicked, so it must be restarted calling telio_destroy_hard() and starting init procedure from scratch (invoking telio_new() or similar path). Note, that destroying and re-creating telio should not be pe3rformed while handling incoming event (not on telio thread’s context).
+
+## Telio Node Event
+
+[Node][telio_model::mesh::Node] events are reported in the following format:
+
+```json
+{
+  "type": "node",
+  "body": {
+    "identifier": "<Node UUID>",
+    "public_key": "<base64 key>",
+    "state": "<disconnected|connecting|connected>",
+    "link_state": "<null|down|up>"
+    "is_exit": bool,
+    "is_vpn": bool,
+    "ip_addresses": [ "meshnet ip" ] // VPN nodes have reserved addresses: ["10.5.0.1", "100.64.0.1"]
+    "allowed_ips": [ "<CIDR>" ],
+    "endpoint":"<ip:port>",
+    "hostname":"<Node hostname>",
+    "path": "<direct|relay>",
+  }
+}
+```
+
+Fields:
+
+- identifier - A node identifier passed via meshmap, when event is concerning meshnet nodes, and identifier passed via connect_to_exit_node_with_id(...) when connecting to VPN node or null otherwise.
+
+- public_key - Node public key in base64 form. Can be used as identifier.
+
+- state - Connection state of node:
+
+    - disconnected -  Node is not connected and there will be no attempt to connect to it
+    - connecting - Node is not connected, but libtelio is actively trying to connect to it
+    - connected - Node is connected
+
+- link_state - Link state hint (For additional info check RFC-LLT-0045)
+
+    - null - If it’s null or missing it means that the no-link detection mechanism is disabled
+    - down - Link state is down reported as down if the state is different from connected or if there the no-link detection mechanism has detected that the link might be down
+    - up - Reported only if the node is connected and there are no clear indications that the link may be down
+
+- is_exit - It is expected that all traffic will be redirected to this node (true if exit node or VPN node)
+
+- is_vpn - Node represents VPN server (true if VPN node only)
+
+- ip_addresses - Address(es) assigned to a node.
+
+- allowed_ips - Indicates subnets being routed to this node.
+
+- hostname - DNS name of a node.
+
+- path - Indicates whether the connection is direct or relay’ed.
+
+- endpoint - The IP address which is used for underlying communication with the node. May be localhost, which indicates relayed connection.
+
+### When node event is reported?
+
+Node events are reported by any change to any property of the node (be it a VPN node or a mesh node) after registering for Telio events by calling `telio_new`.
+
+### Common scenarios:
+
+- VPN flow (node is not in meshnet config, identified by `public_key`):
+
+    - Connection to VPN server is `requestconnect_to_exit_node(...)` called→ `{ "state": "connecting", "is_vpn": true, "is_exit": true, ... }`
+    - Connection to VPN server is established → `{ "state": "connected", ... }`
+    - Connection to VPN server is lost → `{ "state": "connecting", ... }`
+    - Disconnection requested by calling `disconnect_from_exit_node[s](...)` → `{ "state": "disconnected", ... }`
+
+- MESH flow (node is in meshnet config):
+
+    - Enable meshnet by calling `set_meshnet(...)` -> `{ "state": "connecting", "is_vpn": false, "is_exit": false, ...}`
+    - Meshnet node connection established → `{ "state": "connected", ... }`
+    - Meshnet node connection lost → `{ "state": "connecting", ... }`
+    - Node is promoted to be an exit node by calling `connect_to_exit_node(...)` → `{ "is_exit": true, ... }`
+    - Node is demoted to be meshnet node by calling `disconnect_from_exit_node[s](...)` → `{ "is_exit": false, ... }`
+    - Meshnet disabled by calling `set_meshnet_off(...)` → `{ "state": "disconnected", ... }`
+
+## Telio Relay Event
+
+[Relay][telio_model::config::Server] events contain the Derp Server configuration in JSON and are reported in the following format:
+
+```json
+{
+  "region_code": string,
+  "name": string,
+  "hostname": string,
+  "ipv4": string,
+  "relay_port": int,
+  "stun_port": int,
+  "stun_plaintext_port": int,
+  "public_key": string,
+  "weight": int,
+  "use_plain_text": bool,
+  "conn_state": "<disconnected|connecting|connected>"
+}
+```
+
+### When node event is reported?
+
+A [Relay][telio_model::config::Server] event is reported every time the relay configuration changes or we start connecting to a different relay server.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,13 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
+// Telio doc rs documentation pages:
+#![doc = include_str!["./doc/introduction.md"]]
+
+pub mod _telio_integration_documentation {
+    #![doc = include_str!["./doc/integrating_telio.md"]]
+}
+pub mod _telio_events_documentation {
+    #![doc = include_str!["./doc/telio_events.md"]]
+}
 
 mod ffi;
 use crate::ffi::*;


### PR DESCRIPTION
### Problem
A need arose to have an in-repo documentation system for Libtelio

### Solution
Added mdbook documentation system skeleton to libtelio repo so that it can be populated by further PR's, but after discussions in this PR we've decided that it'd be simpler to use doc rs according to how [the Clap crate](https://docs.rs/clap/latest/clap/index.html) used it to document their tutorials instead.

The current documentation can be viewed by using `cargo doc --open` in the libtelio level of the repo. Proper generation by CI will be added with later PRs

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
