### PR TITLE
build: Set libtelio as cdylib crate type

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -36,3 +36,6 @@ linker = "linkers/d-x86_64-linux-android21-clang"
 
 [target.i686-linux-android]
 linker = "linkers/d-i686-linux-android21-clang"
+
+[target.'cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "tvos-sim"))']
+rustflags = ["-C", "link-arg=-s"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/NordSecurity/libtelio"
 normal = ["wasm-bindgen"]
 
 [lib]
-crate-type = ["staticlib", "cdylib", "lib"]
+crate-type = ["cdylib", "lib"]
 
 [features]
 pretend_to_be_macos = ["telio-model/pretend_to_be_macos"]

--- a/ci/build_libtelio.py
+++ b/ci/build_libtelio.py
@@ -179,23 +179,23 @@ LIBTELIO_CONFIG = {
             "tcli": {"tcli": "tcli"},
             "derpcli": {"derpcli": "derpcli"},
             "interderpcli": {"interderpcli": "interderpcli"},
-            NAME: {f"lib{NAME}": f"lib{NAME}.a"},
+            NAME: {f"lib{NAME}": f"lib{NAME}.so"},
         },
     },
     "macos": {
         "packages": {
             "tcli": {"tcli": "tcli"},
-            NAME: {f"lib{NAME}": f"lib{NAME}.a"},
+            NAME: {f"lib{NAME}": f"lib{NAME}.dylib"},
         }
     },
     "ios": {
         "packages": {
-            NAME: {f"lib{NAME}": f"lib{NAME}.a"},
+            NAME: {f"lib{NAME}": f"lib{NAME}.dylib"},
         },
     },
     "tvos": {
         "packages": {
-            NAME: {f"lib{NAME}": f"lib{NAME}.a"},
+            NAME: {f"lib{NAME}": f"lib{NAME}.dylib"},
         },
     },
 }


### PR DESCRIPTION
### Problem
This PR is part of the set of tasks to reduce the application binary sizes. For that, dynamic libraries are necessary to achieve isolation and the ability to use size optimization features that otherwise would be locked, due to possible c symbol collisions.

### Solution
It replaces static for dynamic libs (*.so, *.dylib) on linux and apple builds. Android, Windows builds are already compiling dynamic libraries.

It also removes bitcode from apple binaries and add linker flag `-s` for apple builds as this flag is now removed from `rust_build_utils` repo in order to allow future customizations.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
