### PR TITLE
build: Update h2 dependency to patch RUSTSEC-2024-0332

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1687,9 +1687,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.24"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
 dependencies = [
  "bytes",
  "fnv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ cfg-if = "1.0.0"
 ffi_helpers = "0.3.0"
 num_cpus = "1.15.0"
 wasm-bindgen = "=0.2.83" # Only for compatability with moose wasm version
-h2 = "=0.3.24" # RUSTSEC-2024-0003
+h2 = "=0.3.26" # RUSTSEC-2024-0332
 
 anyhow.workspace = true
 async-trait.workspace = true


### PR DESCRIPTION
### Problem
`cargo-deny` job started to fail due to RUSTSEC-2024-0332 found in the `h2` crate.

### Solution
Upgrade crate: `h2 v0.3.24` -> `h2 v0.3.26`


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
