### PR TITLE
Simplify exponential backoff constructor

### DIFF
--- a/crates/telio-utils/src/exponential_backoff.rs
+++ b/crates/telio-utils/src/exponential_backoff.rs
@@ -67,18 +67,20 @@ pub struct ExponentialBackoff {
 
 impl ExponentialBackoff {
     /// Given the bounds for exponential backoff returns an instance of
-    /// ExponentialBackofHelper
+    /// `ExponentialBackoff`
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the initial bound is zero or maximal bound is
+    /// defined and is smaller than the initial one.
     pub fn new(bounds: ExponentialBackoffBounds) -> Result<Self, Error> {
-        if bounds.initial == Duration::ZERO
-            || bounds.maximal.map(|t| t < bounds.initial).unwrap_or(false)
-        {
-            Err(Error::InvalidExponentialBackoffBounds)
-        } else {
-            Ok(Self {
-                bounds,
-                current_backoff: bounds.initial,
-            })
+        if bounds.initial == Duration::ZERO || bounds.maximal.is_some_and(|t| t < bounds.initial) {
+            return Err(Error::InvalidExponentialBackoffBounds);
         }
+        Ok(Self {
+            bounds,
+            current_backoff: bounds.initial,
+        })
     }
 }
 


### PR DESCRIPTION
### Problem
Hi :wave:, nothing big - `ExponentialBackoff::new` can be simplified + `Errors` doc section

### Solution
1. Use `is_some_and` instead of `map(..).unwrap_or(false)`
2. Add `Errors` section to method docs

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests