### PR TITLE
Use hash_one to simplify hashing in LruCache::entry

### DIFF
--- a/crates/telio-utils/src/lru_cache.rs
+++ b/crates/telio-utils/src/lru_cache.rs
@@ -1,7 +1,7 @@
 use hashlink::lru_cache::RawOccupiedEntryMut;
 use hashlink::{linked_hash_map::RawEntryMut, LinkedHashMap};
 use rustc_hash::FxHasher;
-use std::hash::{BuildHasher, Hasher};
+use std::hash::BuildHasher;
 use std::{
     borrow::Borrow,
     hash::{BuildHasherDefault, Hash},
@@ -185,9 +185,7 @@ impl<Key: Clone + Eq + Hash, Value> LruCache<Key, Value> {
     /// Gets the given key’s corresponding entry in the map for in-place manipulation.
     #[inline(always)]
     pub fn entry(&mut self, key: Key) -> Entry<'_, Key, Value> {
-        let mut state = self.map.hasher().build_hasher();
-        key.hash(&mut state);
-        let hash = state.finish();
+        let hash = self.map.hasher().hash_one(&key);
         match self.map.raw_entry_mut().from_key_hashed_nocheck(hash, &key) {
             RawEntryMut::Occupied(mut e) => {
                 let now = Instant::now();


### PR DESCRIPTION
### Problem
Hi :wave:, just small change - there is no need to create hasher to hash only one value

### Solution
1. Use `hasher().hash_one(..)` which does the same thing as previous code

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests