### PR TITLE
LLT-5040 Fix nat-lab issues around dockers

### DIFF
--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -31,4 +31,4 @@ jobs:
           project-id: ${{ secrets.PROJECT_ID }}
           schedule: ${{ github.event_name == 'schedule' }}
           cancel-outdated-pipelines: ${{ github.ref_name != 'main' }}
-          triggered-ref: v1.0.1
+          triggered-ref: v1.0.2

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,4 +15,4 @@ libtelio-build-pipeline:
 
   trigger:
     project: $LIBTELIO_BUILD_PROJECT_PATH
-    branch: v1.0.1
+    branch: v1.0.2

--- a/nat-lab/bin/configure_route.sh
+++ b/nat-lab/bin/configure_route.sh
@@ -6,42 +6,9 @@ print_help() {
     exit 1
 }
 
-# There are a bunch of nightly failures on new Vagrant runners #13, #14, #15, and #16, e.g.
-#
-# [2024-03-19 12:47:09] |EXECUTE| docker compose logs internal-symmetric-gw-01
-# [2024-03-19 12:47:10] internal-symmetric-gw-01-1  | + case "${1:-}" in
-# [2024-03-19 12:47:10] internal-symmetric-gw-01-1  | + ip route delete 10.0.0.0/16
-# [2024-03-19 12:47:10] internal-symmetric-gw-01-1  | RTNETLINK answers: No such process
-# [2024-03-19 12:47:10] internal-symmetric-gw-01-1  | + true
-# [2024-03-19 12:47:10] internal-symmetric-gw-01-1  | + ip route add 10.0.0.0/16 via 192.168.103.254 dev eth1
-# [2024-03-19 12:47:10] internal-symmetric-gw-01-1  | Cannot find device "eth1"
-#
-# Its probably because the new runners have much more powerfull CPUs, and this causes some type
-# of race condition somewhere in Docker/Compose. Seems like entrypoint is somehow executed first
-# before interfaces have been fully configured. To try and workaround this, allow a little bit of
-# time for interfaces to be fully initialized.
-wait_for_interface() {
-    interface=$1
-
-    for i in {0..10}; do
-        if ip a show "$interface" up | grep -q inet; then
-            echo "Network interface $interface is up."
-            return
-        else
-            echo "Waiting for network interface $interface to be up..."
-            sleep 0.2
-        fi
-    done
-
-    echo "Timeout reached. Network interface $interface is not up."
-    exit 1
-}
-
 case "${1:-}" in
     primary)
         if [[ $CLIENT_GATEWAY_PRIMARY != "none" ]]; then
-            wait_for_interface eth0
-
             ip route delete 10.0.0.0/16 || true
             ip route add 10.0.0.0/16 via $CLIENT_GATEWAY_PRIMARY dev eth0
 
@@ -52,8 +19,6 @@ case "${1:-}" in
         fi
         ;;
     secondary)
-        wait_for_interface eth1
-
         ip route delete 10.0.0.0/16 || true
         ip route add 10.0.0.0/16 via $CLIENT_GATEWAY_SECONDARY dev eth1
         ;;

--- a/nat-lab/docker-compose.yml
+++ b/nat-lab/docker-compose.yml
@@ -32,11 +32,11 @@ services:
         ipv4_address: 10.0.100.51
         priority: 1000
     environment:
-      CLIENT_GATEWAY_PRIMARY: none    
+      CLIENT_GATEWAY_PRIMARY: none
     volumes:
       - ./:/sync
       - ../:/libtelio
-  
+
   ###########################################################
   #                         CLIENTS                         #
   ###########################################################
@@ -61,7 +61,7 @@ services:
       # net.ipv4.conf.all.rp_filter.src_valid_mark=1 is supposed to fix this, but it doesn't
       # seem to work. So for now disable return path filter outright.
       - net.ipv4.conf.all.rp_filter=0
-      - net.ipv4.conf.eth0.rp_filter=0
+      - net.ipv4.conf.default.rp_filter=0
       # Enable IPv6, by default, docker has this set to '1'
       - net.ipv6.conf.all.disable_ipv6=0
       - net.ipv6.conf.default.disable_ipv6=0


### PR DESCRIPTION
Bug no. 1: Bug in docker compose: https://github.com/docker/compose/issues/11510
This bug randomly causes missing network interfaces in started containers. We just updated docker compose version to the version which is not affected.

Bug no. 2: Bug in docker daemon: https://github.com/moby/moby/issues/47619
Because of this bug eth0 is not created before sysctls are being set so it is not possible to set any sysctls related to the specific interfaces.
We can create a workaround by not setting eth0. Instead we can set default so eth0 will have this value assigned later when created.



### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
