### PR TITLE
build: Enable size reduction compiler flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,3 +182,8 @@ telio-utils = { version = "0.1.0", path = "./crates/telio-utils" }
 telio-wg = { version = "0.1.0", path = "./crates/telio-wg" }
 telio-pq = { version = "0.1.0", path = "./crates/telio-pq" }
 telio-pmtu = { version = "0.1.0", path = "./crates/telio-pmtu" }
+
+[profile.release]
+opt-level = "s"
+lto = true
+codegen-units = 1

--- a/changelog.md
+++ b/changelog.md
@@ -33,6 +33,7 @@
 * LLT-4858: NAT state analytics reporting
 * LLT-5038: Add doc rs as in-repo documentation system skeleton
 * LLT-5034: Upgrade rust toolchain to v1.77.2
+* LLT-4924: Enable size reduction compiler flags
 
 <br>
 


### PR DESCRIPTION
# Problem
After switching to dynamic linked libraries, we're able to reduce the size of the binaries even further by enabling optimization flags on the compiler.

## Optimization experiments
For convenience, builds were made locally on a linux x86_64 machine, comparing with CI there's an error tolerance of +/- 1%.
Also, by default debug symbols are split into a separate file (329 MB) and stripped from the final binary (ie. `strip = "debug"`).

| linux-x86_64 optimizations | size (MB) | reduction gain (%) | Description                                                                                                      |
| -------------------------- | --------- | ------------------ | ---------------------------------------------------------------------------------------------------------------- |
| opt-level = 3 (default)    | 22.8      | -                  | Optimize for speed and remove debug symbols. |
| strip = "symbols"          | 17        | 25.4               | Remove all symbols.                                               |
| strip = "none"             | 345       | -1413              | Don’t remove any symbols.|
| opt-level = "z"            | 22.1      | 3.1                | Optimize for binary size, but also turn off loop vectorization.|
| opt-level = "s"            | 20.5      | 10                 | Optimize for binary size.                              |
| lto + codegen-units = 1    | 17.2      | 24.5               | Control’s LLVM link time optimizations (LTO). Produces better optimized code at the cost of longer linking time. |
| panic = "abort"            | 16.5      | 27.6               | Terminate the process upon panic. Disables unwinding/backtrace|

Combining the best results from the table above:

| linux-x86_64 optimizations                                                      | size (MB) | reduction gain (%) |
| ------------------------------------------------------------------------------- | --------- | ------------------ |
| opt-level = "s" + lto + codegen-units = 1                                       | 16.4      | 28                 |
| opt-level = "s" + lto + codegen-units = 1 + panic = "abort"                     | 13.3      | 41.6               |
| opt-level = "s" + lto + codegen-units = 1 + panic = "abort" + strip = "symbols" | 9.3       | 59                 |


## Benchmarks
### Nat-lab tests execution time

To benchmark the closest scenario with the real usage of the library, 3 different tests were chosen where direct connection, reconnections, network switches and moose database dumps are performed. These tests were repeated 20 times and the Mean, Median and Standard Deviation of the execution times were computed.

**test_direct_working_paths_are_reestablished**

| Configuration | Mean  (s)  | Median (s)  | Standard Deviation (s) |
|---------------|---------|---------|--------------------|
| opt-level = 3 (default) | 59.75  | 59.83  | 0.24               |
| opt-level = "s"         | 59.79  | 59.80  | 0.30             |
| opt-level = "s" + lto = true + codegen-units = 1 + panic = "abort" + strip = "symbols" | 59.67  | 59.64  | 0.23 |

**test_mesh_network_switch_direct**

| Configuration | Mean (s)   | Median (s) | Standard Deviation (s) |
|---------------|--------|--------|--------------------|
| opt-level = 3 (default) | 35.35 | 35.27 | 0.55 |
| opt-level = "s"         | 35.39 | 35.14 | 0.60 |
| opt-level = "s" + lto = true + codegen-units = 1 + panic = "abort" + strip = "symbols" | 35.30 | 35.17 | 0.61 |

**test_lana_with_disconnected_node**

| Configuration | Mean (s)   | Median (s)  | Standard Deviation (s) |
|---------------|---------|---------|--------------------|
| opt-level = 3 (default) | 42.03  | 41.98  | 0.61               |
| opt-level = "s"         | 41.40  | 41.37  | 0.36               |
| opt-level = "s" + lto = true + codegen-units = 1 + panic = "abort" + strip = "symbols" | 41.81  | 41.95  | 0.55 |


### Throughput
With two peers on a meshnet with a direct connection and using Boringtun adapter, Iperf3 tool was used to perform throughput tests for 60 seconds, using unlimited bandwitdh on UDP protocol:

| Configuration | Avg. Bitrate (Mb/s)   | Avg. Jitter (ms)  | Avg. Loss (%) |
|---------------|---------|---------|--------------------|
| opt-level = 3 (default) | 727 | 0.021  | 17               |
| opt-level = "s"         | 725  | 0.031  | 17               |
| opt-level = "s" + lto = true + codegen-units = 1 + panic = "abort" + strip = "symbols" | 733 | 0.022  | 17 |


## Conclusion
Tests reveal that not always the more extreme optimizations yield the best results, with rust versions this can change, however with the current rust version it’s shown that `opt-level = "s"` is outperforming `opt-level = "z"`.

The combination of best optimizations is `opt-level = "s" + lto + codegen-units = 1 + panic = "abort" + strip = "symbols"` and we see no relevant differences in terms of both throughput and performance metrics.

By default the debug symbols were already being stripped and split into a separate file. The optimization gains from removing all other symbols are not that significant against the information that would be lost, the team decided to keep as is and having only the debug symbols stripped.

`panic = "abort"` will also be kept out, as not only the stack unwinding is valuable in case of errors, the process is immediately terminated and it may results in desctructors not being called.

Therefore, the optimizations that best represent the chosen trade-offs are `opt-level = "s" + lto + codegen-units = 1`, while keeping the debug symbols on a separate file. This represents a reduction of 27% (22.3 MB → 16.4 MB) on the dynamic libraries.

# Solution
Given the above conclusion, this PR adds the following flags to `release` builds:
```
opt-level = "s"
lto = true
codegen-units = 1
```


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
