### PR TITLE
Fix derp disconnect

### DIFF
--- a/crates/telio-relay/src/derp/mod.rs
+++ b/crates/telio-relay/src/derp/mod.rs
@@ -201,6 +201,7 @@ impl State {
         // Stop attempts to connect
         if let Some(c) = self.connecting.take() {
             c.abort();
+            let _ = c.await;
         }
         // Stop current connection
         if let Some(c) = self.conn.take() {

--- a/nat-lab/tests/telio.py
+++ b/nat-lab/tests/telio.py
@@ -777,9 +777,12 @@ class Client:
     async def stop_device(self, timeout: float = 5) -> None:
         await asyncio.wait_for(self._write_command(["dev", "stop"]), timeout)
         self._interface_configured = False
-        assert Counter(self.get_runtime().get_started_tasks()) == Counter(
-            self.get_runtime().get_stopped_tasks()
-        ), "started tasks and stopped tasks differ!"
+        started_tasks = self.get_runtime().get_started_tasks()
+        stopped_tasks = self.get_runtime().get_stopped_tasks()
+        diff = Counter(started_tasks) - Counter(stopped_tasks)
+        assert (
+            diff == Counter()
+        ), f"started tasks and stopped tasks differ! diff: {diff} | started tasks: {started_tasks} | stopped tasks: {stopped_tasks}"
 
     def get_node_state(self, public_key: str) -> Optional[PeerInfo]:
         return self.get_runtime().get_peer_info(public_key)


### PR DESCRIPTION
Wait for derp connection join handle to finish when aborting. Not waiting sometimes prevents some other tasks from stopping. It is because of strong pointer being still held.

### Problem
Derp holds strong pointer to aggregator, which hold strong pointer to wireguard. When stopping Derp, strong pointer of aggregator not released on time, therefore wireguard pointer from aggregator is not released also, preventing wireguard task from stopping.

### Solution
Wait for derp connection join handle to finish when aborting.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
