### PR TITLE
Make connection state reporting unaffected by system time changes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -35,6 +35,7 @@
 * LLT-5034: Upgrade rust toolchain to v1.77.2
 * LLT-4924: Enable size reduction compiler flags
 * LLT-5078: Fix telio-proxy panic
+* LLT-5039: Make connection reporting unaffected by system time changes
 
 <br>
 

--- a/nat-lab/tests/test_proxy.py
+++ b/nat-lab/tests/test_proxy.py
@@ -31,7 +31,7 @@ async def test_proxy_endpoint_map_update() -> None:
         )
 
         async with Ping(alpha_connection, beta.ip_addresses[0]).run() as ping:
-            await testing.wait_long(ping.wait_for_next_ping())
+            await testing.wait_lengthy(ping.wait_for_next_ping())
         async with Ping(beta_connection, alpha.ip_addresses[0]).run() as ping:
             await testing.wait_long(ping.wait_for_next_ping())
 

--- a/src/device/wg_controller.rs
+++ b/src/device/wg_controller.rs
@@ -1550,6 +1550,7 @@ mod tests {
                         rx_bytes: None,
                         tx_bytes: None,
                         time_since_last_handshake: None,
+                        time_since_last_rx: None,
                         preshared_key: None,
                     }))
                     .return_once(|_| Ok(()));


### PR DESCRIPTION
### Problem
Changing time by few minutes, caused telio to report disconnect (even if the underlying wireguard connection was fine).

### Solution
Instead of using a system time based 'last handshake time', track the time (using monotonic clock) of the last received bytes. This way changes to the system time (by the user or ntp like service) will not affect our perception of how long ago did we last seen a packet from the other side.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
