### PR TITLE
LLT-5078 proxy panics when being killed

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,10 @@
+### v4.3.2
+### **Bravas**
+---
+* LLT-5078: Fix telio-proxy panic 
+
+<br>
+
 ### v4.3.1
 ### **Bravas**
 ---


### PR DESCRIPTION
### Problem
`tokio::select!` can panic, if branches are disabled. This was observed when killing `proxy` task. 

### Solution
Update all (exception - tests) `tokio::select!` invokations with `else`, to avoid panics.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
