### PR TITLE
LLT-5078 proxy panics when being killed forwardport

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -34,6 +34,7 @@
 * LLT-5038: Add doc rs as in-repo documentation system skeleton
 * LLT-5034: Upgrade rust toolchain to v1.77.2
 * LLT-4924: Enable size reduction compiler flags
+* LLT-5078: Fix telio-proxy panic
 
 <br>
 


### PR DESCRIPTION
### Problem
`tokio::select!` can panic, if branches are disabled. This was observed when killing `proxy` task. 

### Solution
Update all (exception - tests) `tokio::select!` invokations with `else`, to avoid panics.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
