### PR TITLE
Convert dns failures with NoError to ServFail

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -36,6 +36,7 @@
 * LLT-4924: Enable size reduction compiler flags
 * LLT-5078: Fix telio-proxy panic
 * LLT-5039: Make connection reporting unaffected by system time changes
+* LLT-4168: Fix telio-dns assert panics in debug mode
 
 <br>
 

--- a/nat-lab/bin/dns-server
+++ b/nat-lab/bin/dns-server
@@ -5,10 +5,12 @@ from twisted.names import dns, server
 
 KNOWN = {
     dns.AAAA: {
-        b"google.com": dns.Record_AAAA(address="2a00:1450:400e:80c::200e")
+        b"google.com": dns.Record_AAAA(address="2a00:1450:400e:80c::200e"),
+        b"error-with-noerror-return-code.com": None,
     },
     dns.A: {
-        b"google.com": dns.Record_A(address="142.250.179.206")
+        b"google.com": dns.Record_A(address="142.250.179.206"),
+        b"error-with-noerror-return-code.com": None,
     },
     dns.CNAME: {
         b"www.microsoft.com": dns.Record_CNAME(name="www.microsoft.com-c-3.edgekey.net.")
@@ -19,6 +21,8 @@ KNOWN = {
 class DNSResolver:
     def _reply(self, name, type, record):
         print(f"Resolving name: {name} => {record}")
+        if record is None:
+            return [], [], []
         answer = dns.RRHeader(name=name, type=type, payload=record)
         return [answer], [], []
 


### PR DESCRIPTION
### Problem
In debug mode, trust-dns asserts that `NoError` error type is never converted. But in practice seems that we sometimes receive such cases.

### Solution
Convert such errors to `ServFail` to avoid panic.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
