### PR TITLE
Replace custom tvOS versions of crates, with updated upstream ones

### DIFF
--- a/.cargo/config_apple_tvos
+++ b/.cargo/config_apple_tvos
@@ -1,10 +1,4 @@
 
 [patch.crates-io]
-cc = { git = 'https://github.com/nordsecurity/cc-rs.git', branch = 'add_apple_tvos_support' }
-if-addrs = { git = 'https://github.com/nordsecurity/if-addrs.git', branch = 'add_apple_tvos_support_ifaddrs' }
-socket2 = { git = 'https://github.com/nordsecurity/socket2.git', branch = 'add_apple_tvos_support_0_4_10' }
-ring = { git = 'https://github.com/nordsecurity/ring.git', branch = 'add_apple_tvos_support_0_16_20' }
-parking_lot_core = { git = 'https://github.com/nordsecurity/parking_lot.git', branch = 'add_apple_tvos_support_0.9.8' }
-nix = { git = 'https://github.com/nordsecurity/nix.git', branch = 'add_apple_tvos_support_0_26_4' }
 block = { git = 'https://github.com/nordsecurity/rust-block.git', branch = 'add_apple_tvos_support' }
 objc = { git = 'https://github.com/nordsecurity/rust-objc.git', branch = 'add_apple_tvos_support' }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -129,7 +129,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
 dependencies = [
  "anstyle",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -606,9 +606,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+checksum = "17f6e324229dc011159fcc089755d1e2e216a90d43a7dea6853ca740b84f35e7"
 dependencies = [
  "jobserver",
  "libc",
@@ -625,6 +625,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "chacha20"
@@ -805,7 +811,7 @@ checksum = "2674ec482fbc38012cf31e6c42ba0177b431a0cb6f15fe40efa5aab1bda516f6"
 dependencies = [
  "is-terminal",
  "lazy_static",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1010,7 +1016,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82e95fbd621905b854affdc67943b043a0fbb6ed7385fd5a25650d19a8a6cfdf"
 dependencies = [
  "nix 0.27.1",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1364,7 +1370,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f258a7194e7f7c2a7837a8913aeab7fd8c383457034fa20ce4dd3dcb813e8eb8"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1427,7 +1433,7 @@ checksum = "ef033ed5e9bad94e55838ca0ca906db0e043f517adda0c8b79c7a8c66c93c1b5"
 dependencies = [
  "cfg-if",
  "rustix 0.38.24",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1926,9 +1932,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.27"
+version = "0.14.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468"
+checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1941,7 +1947,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.6",
  "tokio",
  "tower-service",
  "tracing",
@@ -2003,12 +2009,12 @@ dependencies = [
 
 [[package]]
 name = "if-addrs"
-version = "0.7.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc0fa01ffc752e9dbc72818cdb072cd028b86be5e09dd04c5a643704fe101a9"
+checksum = "bb2a33e9c38988ecbda730c85b0fd9ddcdf83c0305ac7fd21c8bb9f57f2f0cc8"
 dependencies = [
  "libc",
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2099,7 +2105,7 @@ checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
  "hermit-abi 0.3.3",
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2130,9 +2136,9 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
 dependencies = [
- "socket2 0.5.5",
+ "socket2 0.5.6",
  "widestring 1.0.2",
- "windows-sys",
+ "windows-sys 0.48.0",
  "winreg",
 ]
 
@@ -2159,7 +2165,7 @@ checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi 0.3.3",
  "rustix 0.38.24",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2232,9 +2238,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.150"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libloading"
@@ -2385,15 +2391,6 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "memoffset"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
@@ -2440,7 +2437,7 @@ checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2543,8 +2540,6 @@ dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
- "memoffset 0.7.1",
- "pin-utils",
 ]
 
 [[package]]
@@ -2556,6 +2551,19 @@ dependencies = [
  "bitflags 2.4.1",
  "cfg-if",
  "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.4.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset 0.9.0",
 ]
 
 [[package]]
@@ -2953,7 +2961,7 @@ dependencies = [
  "libc",
  "log",
  "pin-project-lite",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3378,7 +3386,7 @@ dependencies = [
  "libc",
  "spin",
  "untrusted",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3450,7 +3458,7 @@ dependencies = [
  "io-lifetimes",
  "libc",
  "linux-raw-sys 0.3.8",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3463,7 +3471,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.11",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3599,7 +3607,7 @@ version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3973,12 +3981,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
+checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4083,7 +4091,7 @@ dependencies = [
  "parking_lot",
  "pnet_packet",
  "rand",
- "socket2 0.5.5",
+ "socket2 0.5.6",
  "thiserror",
  "tokio",
  "tracing",
@@ -4400,7 +4408,7 @@ dependencies = [
  "serde",
  "serde_json",
  "slog",
- "socket2 0.5.5",
+ "socket2 0.5.6",
  "surge-ping",
  "telio-crypto",
  "telio-lana",
@@ -4425,7 +4433,7 @@ dependencies = [
  "libc",
  "pnet_packet",
  "rand",
- "socket2 0.5.5",
+ "socket2 0.5.6",
  "telio-lana",
  "telio-sockets",
  "telio-utils",
@@ -4545,12 +4553,12 @@ dependencies = [
  "futures",
  "libc",
  "mockall",
- "nix 0.26.4",
+ "nix 0.28.0",
  "objc",
  "objc-foundation",
  "parking_lot",
  "rstest",
- "socket2 0.5.5",
+ "socket2 0.5.6",
  "system-configuration 0.5.1 (git+https://github.com/NordSecurity/system-configuration-rs.git)",
  "telio-utils",
  "thiserror",
@@ -4603,7 +4611,7 @@ dependencies = [
  "rstest",
  "rupnp",
  "sm",
- "socket2 0.5.5",
+ "socket2 0.5.6",
  "strum",
  "stun_codec",
  "surge-ping",
@@ -4691,7 +4699,7 @@ dependencies = [
  "fastrand 2.0.1",
  "redox_syscall",
  "rustix 0.38.24",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4829,9 +4837,9 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.5",
+ "socket2 0.5.6",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -5502,6 +5510,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.4",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5661,7 +5678,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/changelog.md
+++ b/changelog.md
@@ -38,6 +38,7 @@
 * LLT-5039: Make connection reporting unaffected by system time changes
 * LLT-4168: Fix telio-dns assert panics in debug mode
 * LLT-4856: Enable aggregator timed events
+* LLT-4993: Remove most of the forks of dependencies for tvos and replace with latest upstream versions
 
 <br>
 

--- a/crates/telio-sockets/Cargo.toml
+++ b/crates/telio-sockets/Cargo.toml
@@ -29,7 +29,7 @@ version-compare = "0.1"
 
 [target.'cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))'.dependencies]
 debug_panic = "0.2.1"
-nix = "0.26.2"
+nix = { version = "0.28", features=["socket"] }
 system-configuration = { git = 'https://github.com/NordSecurity/system-configuration-rs.git' }
 
 [target.'cfg(windows)'.dependencies]

--- a/crates/telio-traversal/Cargo.toml
+++ b/crates/telio-traversal/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 bytecodec = "0.4.15"
 enum-map = "2.5.0"
 http = "0.2.8"
-if-addrs = "0.7.0"
+if-addrs = "0.12.0"
 igd = { version = "0.12.1", features = ["aio"] }
 sm = "0.9.0"
 stun_codec = "0.1.13"

--- a/crates/telio-traversal/src/endpoint_providers/local.rs
+++ b/crates/telio-traversal/src/endpoint_providers/local.rs
@@ -434,6 +434,9 @@ mod tests {
                         netmask: Ipv4Addr::new(255, 0, 0, 0),
                         broadcast: None,
                     }),
+                    index: None,
+                    #[cfg(windows)]
+                    adapter_name: "{78f73923-a518-4936-ba87-2a30427b1f63}".to_string(),
                 },
                 if_addrs::Interface {
                     name: "correct".to_owned(),
@@ -442,6 +445,9 @@ mod tests {
                         netmask: Ipv4Addr::new(255, 255, 255, 0),
                         broadcast: None,
                     }),
+                    index: None,
+                    #[cfg(windows)]
+                    adapter_name: "{78f73923-a518-4936-ba87-2a30427b1f63}".to_string(),
                 },
                 if_addrs::Interface {
                     name: "internal".to_owned(),
@@ -450,6 +456,9 @@ mod tests {
                         netmask: Ipv4Addr::new(255, 192, 0, 0),
                         broadcast: None,
                     }),
+                    index: None,
+                    #[cfg(windows)]
+                    adapter_name: "{78f73923-a518-4936-ba87-2a30427b1f63}".to_string(),
                 },
                 if_addrs::Interface {
                     name: "ipv6".to_owned(),
@@ -458,6 +467,9 @@ mod tests {
                         netmask: Ipv6Addr::new(255, 255, 255, 255, 0, 0, 0, 0),
                         broadcast: None,
                     }),
+                    index: None,
+                    #[cfg(windows)]
+                    adapter_name: "{78f73923-a518-4936-ba87-2a30427b1f63}".to_string(),
                 },
             ])
         });
@@ -477,6 +489,9 @@ mod tests {
                 netmask: Ipv4Addr::new(255, 255, 255, 0),
                 broadcast: None,
             }),
+            index: None,
+            #[cfg(windows)]
+            adapter_name: "{78f73923-a518-4936-ba87-2a30427b1f63}".to_string(),
         }])
     }
 


### PR DESCRIPTION
### Problem
We are using forked versions of some crates that already contain tvOS support in latest upstream versions.

### Solution
Where possible removed the in house forks of the crates with added tvOS support and replaced with latest upstream versions that already contain tvOS support. Crates replaced with upstream versions:
 - cc
 - if-addrs
 - socket2
 - ring
 - parking_lot_core
 - nix

After this, there are still 2 crates not updated upstream:
 - block
 - objc


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
