### PR TITLE
Add rustdoc deployment to gh-pages

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,44 @@
+name: Rust Docs to Github Pages
+run-name: ${{ github.actor }} is building and deploying rustdoc to GitHub Pages from ${{ github.ref }}
+# Because documentation versioning and build promotion are not implemente yet, leaving this to be triggered manually only for now.
+on: [workflow_dispatch]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build-and-deploy-docs:
+    runs-on: ubuntu-22.04
+    # Specifying these flags here as environment variables, because specifying them in the .cargo/config file interferes with the other
+    # workflows, because of the nightly features.
+    env:
+        RUSTDOCFLAGS: "-Zunstable-options --enable-index-page -Aunknown_lints"
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Configure GitHub Pages
+      uses: actions/configure-pages@v5
+
+    - name: Build Rust Docs
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly-2024-04-17
+        components: rust-docs
+    # Nightly is required, because index page generation is a nightly feature. Without it the index.html file will not be at the root of
+    # The doc folder and gh-pages won't be able to find it.
+    # --no-deps is required to prevent rustdoc from adding third party dependencies to our documentation, but that also brakes links to
+    # local pages so that's fixed by adding --workspace.
+    - run: cargo +nightly-2024-04-17 doc --no-deps --workspace --document-private-items
+
+    # Using @v1 of actions/upload-pages-artifact, because the later versions are buggy: https://github.com/actions/deploy-pages/issues/179
+    - name: Upload Github pages artifact
+      uses: actions/upload-pages-artifact@v1
+      with:
+        path: 'target/doc/'
+
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4224,7 +4224,7 @@ dependencies = [
 
 [[package]]
 name = "telio"
-version = "4.2.4"
+version = "5.0.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "telio"
-version = "4.2.4"
+version = "5.0.0"
 authors = ["info@nordvpn.com"]
 edition = "2018"
 license = "GPL-3.0-only"

--- a/README.md
+++ b/README.md
@@ -311,6 +311,10 @@ release.py --changelog --push --tag=v4.0.5
 
 You can check the actual commands executed, by passing the `--dry-run` argument.
 
+## Building Documentation
+
+Documentation for Libtelio is currently built and deployed to GitHub Pages by manually triggering the build-and-deploy-docs job on the pipeline in GitHub Actions. If you need to build the rustdocs locally, reference the gh-pages CI file and don't forget to set the RUSTDOCFLAGS env variable accordingly.
+
 ## Contributions
 
 For information about how to contribute, please see [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/src/doc/integrating_telio.md
+++ b/src/doc/integrating_telio.md
@@ -1,3 +1,5 @@
 # Documentation For Integrating Telio Into Other Languages
 
 <!-- TODO: This page is a placeholder and will be populated by upcoming PR's when the actual specification will be more clear -->
+
+WIP


### PR DESCRIPTION
Rust doc will be build and uploaded to libtelio GitHub Pages website by GitHub Actions when manually triggered.

### Problem
There's no convenient way to transfer libtelio documentation to app teams.

### Solution
Rust Doc are now built and the resulting artifact is uploaded to GitHub pages for the app teams to easily access.

Currently the gh-pages generation is triggered manually from CI, because it is not clear on how to best trigger it, because versioning isn't implemented for the documentation and build promotion is still in progress

>NOTE: The gh-pages workflow cannot be triggered manually before it is merged into the default branch. I've tested the gh-pages generation by adding a temporary CI workflow trigger from pushing to this branch, but have removed it for the final merge.

The documentation is already being hosted here: https://nordsecurity.github.io/libtelio/telio/index.html

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
