### PR TITLE
[LLT-5082] Use boringtun v0.6.0

### DIFF
--- a/.unreleased/LLT-5082
+++ b/.unreleased/LLT-5082
@@ -1,0 +1,1 @@
+Update boringtun to version v0.6.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,8 +473,8 @@ dependencies = [
 
 [[package]]
 name = "boringtun"
-version = "0.5.2"
-source = "git+https://github.com/NordSecurity/boringtun.git?tag=v1.1.12#2dd120dd327f7e1d02644a82184294aaa064eef4"
+version = "0.6.0"
+source = "git+https://github.com/NordSecurity/boringtun.git?tag=v1.2.0#406d7ad1dda34aca831a4bb8db80e9149327fefb"
 dependencies = [
  "aead",
  "base64 0.13.1",
@@ -485,10 +485,11 @@ dependencies = [
  "ip_network",
  "ip_network_table",
  "libc",
- "nix 0.24.3",
+ "nix 0.28.0",
  "parking_lot",
  "rand_core 0.6.4",
  "ring",
+ "socket2 0.5.7",
  "thiserror",
  "tracing",
  "untrusted",
@@ -2384,15 +2385,6 @@ checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
 name = "memoffset"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
@@ -2523,18 +2515,6 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.24.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
-dependencies = [
- "bitflags 1.3.2",
- "cfg-if",
- "libc",
- "memoffset 0.6.5",
-]
-
-[[package]]
-name = "nix"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
@@ -2554,7 +2534,7 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
- "memoffset 0.9.1",
+ "memoffset",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,7 +159,7 @@ url = "2.2.2"
 uuid = { version = "1.1.2", features = ["v4"] }
 winapi = { version = "0.3", features = ["netioapi", "ws2def"] }
 
-boringtun = { git = "https://github.com/NordSecurity/boringtun.git", tag = "v1.1.12" }
+boringtun = { git = "https://github.com/NordSecurity/boringtun.git", tag = "v1.2.0", features = ["device"] }
 x25519-dalek = { version = "2.0.1", features = ["reusable_secrets", "static_secrets"] }
 
 telio-crypto = { version = "0.1.0", path = "./crates/telio-crypto" }

--- a/clis/tcli/src/cli.rs
+++ b/clis/tcli/src/cli.rs
@@ -18,9 +18,7 @@ use tokio::{
 };
 use tracing::error;
 use tracing::level_filters::LevelFilter;
-use tracing_appender;
 use tracing_appender::non_blocking::WorkerGuard;
-use tracing_subscriber;
 
 use crate::nord::{Error as NordError, Nord, OAuth};
 

--- a/crates/telio-dns/src/dns.rs
+++ b/crates/telio-dns/src/dns.rs
@@ -7,7 +7,7 @@ use std::{net::SocketAddr, sync::Arc};
 use telio_crypto::{PublicKey, SecretKey};
 use telio_wg::uapi::Peer;
 use tokio::net::UdpSocket;
-use tokio::sync::RwLock;
+use tokio::sync::{Mutex, RwLock};
 use x25519_dalek::{PublicKey as PublicKeyDalek, StaticSecret};
 
 use telio_model::features::{FeatureExitDns, TtlValue};
@@ -48,7 +48,7 @@ pub trait DnsResolver {
 pub struct LocalDnsResolver {
     socket: Arc<UdpSocket>,
     secret_key: SecretKey,
-    peer: Arc<Tunn>,
+    peer: Arc<Mutex<Tunn>>,
     socket_port: u16,
     dst_address: SocketAddr,
     nameserver: Arc<RwLock<LocalNameServer>>,
@@ -102,14 +102,14 @@ impl LocalDnsResolver {
         Ok(LocalDnsResolver {
             socket: Arc::new(socket),
             secret_key: dns_secret_key,
-            peer: Arc::<Tunn>::from(Tunn::new(
+            peer: Arc::new(Mutex::new(Tunn::new(
                 StaticSecret::from(dns_secret_key.into_bytes()),
                 telio_public_key,
                 None,
                 None,
                 0,
                 None,
-            )?),
+            )?)),
             socket_port,
             dst_address,
             nameserver,

--- a/crates/telio-dns/tests/integration_tests.rs
+++ b/crates/telio-dns/tests/integration_tests.rs
@@ -10,7 +10,7 @@ use std::{
 use telio_crypto::{PublicKey, SecretKey};
 use telio_dns::{LocalNameServer, NameServer, Records};
 use telio_model::features::TtlValue;
-use tokio::net::UdpSocket;
+use tokio::{net::UdpSocket, sync::Mutex};
 use x25519_dalek::{PublicKey as PublicDalek, StaticSecret};
 
 /// Config is in INI format.
@@ -137,7 +137,7 @@ async fn dns_over_wireguard() {
         .unwrap();
 
     let dns_socket = Arc::new(UdpSocket::bind("127.0.0.1:51821").await.unwrap());
-    let dns_wireguard = Arc::from(
+    let dns_wireguard = Arc::new(Mutex::new(
         Tunn::new(
             StaticSecret::from(private_key.into_bytes()),
             PublicDalek::from(public_key.0),
@@ -147,7 +147,7 @@ async fn dns_over_wireguard() {
             None,
         )
         .unwrap(),
-    );
+    ));
 
     nameserver
         .start(

--- a/crates/telio-lana/src/event_log_file.rs
+++ b/crates/telio-lana/src/event_log_file.rs
@@ -2,7 +2,6 @@
 //!
 use std::{fs::File, io::Write};
 use telio_utils::telio_log_error;
-use time;
 
 pub use telio_utils::telio_log_warn;
 

--- a/crates/telio-proto/src/packet/relayed/natter.rs
+++ b/crates/telio-proto/src/packet/relayed/natter.rs
@@ -1,4 +1,4 @@
-use std::iter::{FromIterator, IntoIterator};
+use std::iter::FromIterator;
 use std::net::SocketAddr;
 
 use crate::{

--- a/crates/telio-relay/src/derp/mod.rs
+++ b/crates/telio-relay/src/derp/mod.rs
@@ -46,7 +46,6 @@ use crypto_box::{
     ChaChaBox,
 };
 
-use core::result::Result;
 use generic_array::GenericArray;
 use rand::{rngs::StdRng, SeedableRng};
 

--- a/crates/telio-traversal/src/endpoint_providers/mod.rs
+++ b/crates/telio-traversal/src/endpoint_providers/mod.rs
@@ -13,7 +13,6 @@ use thiserror::Error as TError;
 use telio_model::SocketAddr;
 use telio_proto::{PlaintextPongerMsg, Session};
 use telio_task::io::chan;
-use telio_wg;
 
 #[derive(Debug, TError)]
 pub enum Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,9 +67,7 @@ pub use uniffi_libtelio::*;
 #[allow(clippy::panic, clippy::unwrap_used, clippy::expect_used, unwrap_check)]
 mod uniffi_libtelio {
     use std::convert::TryInto;
-    use std::net::{IpAddr, SocketAddr};
-
-    use ipnetwork::IpNetwork;
+    use std::net::IpAddr;
 
     use super::crypto::{PublicKey, SecretKey};
     use super::*;


### PR DESCRIPTION
### Problem
We use boringtun v0.5.2 when v0.6.0 is available

### Solution
Rebase Telio changes to boringtun on v0.6.0 version, use it in libtelio and add some fixes where necessary.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
