### PR TITLE
Resolve LLT-5096: Bump boringtun version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -494,7 +494,7 @@ dependencies = [
 [[package]]
 name = "boringtun"
 version = "0.5.2"
-source = "git+https://github.com/NordSecurity/boringtun.git?tag=v1.1.11#b163cd2681c05877f3d008e38cd7b7409c14c67d"
+source = "git+https://github.com/NordSecurity/boringtun.git?tag=v1.1.12#2dd120dd327f7e1d02644a82184294aaa064eef4"
 dependencies = [
  "aead",
  "base64 0.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,7 +161,7 @@ url = "2.2.2"
 uuid = { version = "1.1.2", features = ["v4"] }
 winapi = { version = "0.3", features = ["netioapi", "ws2def"] }
 
-boringtun = { git = "https://github.com/NordSecurity/boringtun.git", tag = "v1.1.11" }
+boringtun = { git = "https://github.com/NordSecurity/boringtun.git", tag = "v1.1.12" }
 x25519-dalek = { version = "2.0.1", features = ["reusable_secrets", "static_secrets"] }
 
 telio-crypto = { version = "0.1.0", path = "./crates/telio-crypto" }


### PR DESCRIPTION
### Problem
uapi set/get didn't throw an error when device was closed

### Solution
Throw uapi error when adapter is dead and exit
event is generated. Mirror fix, as for wireguard-go at https://github.com/NordSecurity/libtelio/pull/496


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
