### PR TITLE
Add manual QoS trigger in tcli

### DIFF
--- a/clis/tcli/src/cli.rs
+++ b/clis/tcli/src/cli.rs
@@ -218,6 +218,8 @@ enum DevCmd {
     Stop,
     #[clap(about = "Trigger analytics event")]
     Analytics,
+    #[clap(about = "Trigger qos collection")]
+    Qos,
 }
 
 #[derive(Parser)]
@@ -541,6 +543,10 @@ impl Cli {
             Analytics => {
                 cli_res!(res; (i "Trigger analytics event."));
                 cli_try!(self.telio.trigger_analytics_event());
+            }
+            Qos => {
+                cli_res!(res; (i "Trigger qos collection."));
+                cli_try!(self.telio.trigger_qos_collection());
             }
         }
         res

--- a/crates/telio-nurse/src/heartbeat.rs
+++ b/crates/telio-nurse/src/heartbeat.rs
@@ -102,7 +102,7 @@ pub struct Io {
     /// Channel for sending and receiving analytics data
     pub analytics_channel: chan::Tx<AnalyticsMessage>,
     /// Event channel to manual trigger a collection
-    pub collection_trigger_channel: mc_chan::Rx<Box<()>>,
+    pub collection_trigger_channel: mc_chan::Rx<()>,
 }
 
 enum NodeInfo {

--- a/nat-lab/tests/telio.py
+++ b/nat-lab/tests/telio.py
@@ -836,6 +836,9 @@ class Client:
     async def trigger_event_collection(self) -> None:
         await self._write_command(["dev", "analytics"])
 
+    async def trigger_qos_collection(self) -> None:
+        await self._write_command(["dev", "qos"])
+
     async def _write_command(self, command: List[str]) -> None:
         idx = self._message_idx
         cmd = (


### PR DESCRIPTION
### Problem
The `QoS` collection is not aligned by events to collecting heartbeat events and/or stopping the nodes, but by `rtt_interval`. Therefore it is very prone to race conditions during the tests.

### Solution
Make a manual `QoS` job trigger in `tcli` and use it in `test_lana_with_disconnected_node` test.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
