### PR TITLE
Resolve LLT-5095: send critical event to app when adapter dead

### DIFF
--- a/clis/tcli/src/main.rs
+++ b/clis/tcli/src/main.rs
@@ -85,11 +85,8 @@ fn main() -> Result<()> {
                 Info(i) => println!("- {}", i),
                 Event { ts, event } => match *event {
                     DevEvent::Node { body: Some(b) } => print_event(ts, "node", &b)?,
-                    DevEvent::Relay { body } => {
-                        if let Some(b) = body.as_ref() {
-                            print_event(ts, "relay", &b)?;
-                        }
-                    }
+                    DevEvent::Relay { body: Some(b) } => print_event(ts, "relay", &b)?,
+                    DevEvent::Error { body: Some(b) } => print_event(ts, "error", &b)?,
                     _ => (),
                 },
                 Error(e) => {

--- a/crates/telio-wg/src/wg.rs
+++ b/crates/telio-wg/src/wg.rs
@@ -6,7 +6,11 @@ use std::{
     collections::HashMap,
     net::{IpAddr, Ipv4Addr, SocketAddr},
 };
-use telio_model::{features::FeatureLinkDetection, mesh::ExitNode};
+use telio_model::{
+    event::{Error as LibtelioError, ErrorCode, ErrorLevel, Event as LibtelioEvent, EventMsg, Set},
+    features::FeatureLinkDetection,
+    mesh::ExitNode,
+};
 use telio_sockets::{NativeProtector, SocketPool};
 use telio_utils::{
     dual_target::{DualTarget, DualTargetError},
@@ -107,6 +111,8 @@ pub struct Io {
     pub events: Tx<Box<Event>>,
     /// Channel to transmit analytics
     pub analytics_tx: Option<mc_chan::Tx<Box<AnalyticsEvent>>>,
+    /// Channel to transmit event to registered event callback
+    pub libtelio_wide_event_publisher: Option<mc_chan::Tx<Box<LibtelioEvent>>>,
 }
 
 struct State {
@@ -121,14 +127,16 @@ struct State {
 
     // Detecting unexpected driver failures, such as a malicious removal
     // We won't be notified of any errors, but a periodic call to get_config_uapi() will return a Win32 error code != 0.
-    uapi_failed_last_call: bool,
     uapi_fail_counter: i32,
 
     // No link detection mechanism
     no_link_detection: LinkDetection,
+
+    libtelio_event: Option<mc_chan::Tx<Box<LibtelioEvent>>>,
 }
 
 const POLL_MILLIS: u64 = 1000;
+const MAX_UAPI_FAIL_COUNT: i32 = 10;
 
 #[cfg(all(not(any(test, feature = "test-adapter")), windows))]
 const DEFAULT_NAME: &str = "NordLynx";
@@ -199,6 +207,7 @@ impl DynamicWg {
     ///         Io {
     ///             events: chan.tx,
     ///             analytics_tx: None,
+    ///             libtelio_wide_event_publisher: None,
     ///         },
     ///         Config {
     ///             adapter: AdapterType::default(),
@@ -249,9 +258,9 @@ impl DynamicWg {
                 event: io.events,
                 last_endpoint_change: Default::default(),
                 analytics_tx: io.analytics_tx,
-                uapi_failed_last_call: false,
                 uapi_fail_counter: 0,
                 no_link_detection: LinkDetection::new(no_link_detection),
+                libtelio_event: io.libtelio_wide_event_publisher,
             }),
         }
     }
@@ -504,12 +513,20 @@ impl State {
         // such as a malicious removal, we need to count the successive failed calls.
         // If a certain threshold is reached, cleanup the network config and notify the app about connection loss.
         if 0 == ret.errno {
-            self.uapi_failed_last_call = false;
             self.uapi_fail_counter = 0;
         } else {
-            self.uapi_failed_last_call = true;
             self.uapi_fail_counter += 1;
-            // TODO: check failure count threshold, cleanup network config, destroy adapter, notify app
+        }
+
+        if self.uapi_fail_counter >= MAX_UAPI_FAIL_COUNT && ret.interface.is_none() {
+            if let Some(libtelio_event) = &self.libtelio_event {
+                let err_event = LibtelioEvent::new::<LibtelioError>()
+                    .set(EventMsg::from("Interface gone"))
+                    .set(ErrorCode::Unknown)
+                    .set(ErrorLevel::Critical);
+                let _ = libtelio_event.send(Box::new(err_event));
+            }
+            return Err(Error::InternalError("Interface gone"));
         }
 
         Ok(ret)
@@ -1052,6 +1069,7 @@ pub mod tests {
             Io {
                 events: events_ch.tx.clone(),
                 analytics_tx: analytics_ch.clone(),
+                libtelio_wide_event_publisher: None,
             },
             Box::new(adapter.clone()),
             None,

--- a/nat-lab/tests/telio.py
+++ b/nat-lab/tests/telio.py
@@ -148,6 +148,26 @@ class PeerInfo(DataClassJsonMixin):
         )
 
 
+class ErrorLevel(Enum):
+    Critical = "critical"
+    Severe = "severe"
+    Warning = "warning"
+    Notice = "notice"
+
+
+class ErrorCode(Enum):
+    NoError = "noerror"
+    Unknown = "unknown"
+
+
+@dataclass_json
+@dataclass
+class ErrorEvent(DataClassJsonMixin):
+    level: ErrorLevel = ErrorLevel.Critical
+    code: ErrorCode = ErrorCode.NoError
+    msg: str = ""
+
+
 # Equivalent of `libtelio/telio-wg/src/adapter/mod.rs`
 class AdapterType(Enum):
     Default = ""
@@ -161,6 +181,7 @@ class Runtime:
     _output_notifier: OutputNotifier
     _peer_state_events: List[PeerInfo]
     _derp_state_events: List[DerpServer]
+    _error_events: List[ErrorEvent]
     _started_tasks: List[str]
     _stopped_tasks: List[str]
     allowed_pub_keys: Set[str]
@@ -169,6 +190,7 @@ class Runtime:
         self._output_notifier = OutputNotifier()
         self._peer_state_events = []
         self._derp_state_events = []
+        self._error_events = []
         self._started_tasks = []
         self._stopped_tasks = []
         self.allowed_pub_keys = set()
@@ -179,6 +201,7 @@ class Runtime:
             or self._output_notifier.handle_output(line)
             or self._handle_derp_event(line)
             or self._handle_task_information(line)
+            or self._handle_error_event(line)
         )
 
     def _handle_task_information(self, line) -> bool:
@@ -371,6 +394,33 @@ class Runtime:
     def get_stopped_tasks(self) -> List[str]:
         return self._stopped_tasks
 
+    def _handle_error_event(self, line) -> bool:
+        tokens = self._extract_event_tokens(line, "error")
+        if tokens is None:
+            return False
+
+        json_string = tokens[1].strip()
+        result = re.search("{(.*)}", json_string)
+        if result:
+            error_event = ErrorEvent.from_json(
+                "{" + result.group(1).replace("\\", "") + "}"
+            )
+            assert isinstance(error_event, ErrorEvent)
+            self._error_events.append(error_event)
+            return True
+        return False
+
+    async def notify_error_event(self, err: ErrorEvent) -> None:
+        def _get_events() -> List[ErrorEvent]:
+            return [error for error in self._error_events if error == err]
+
+        old_events = _get_events()
+        while True:
+            new_events = _get_events()[len(old_events) :]
+            if new_events:
+                return
+            await asyncio.sleep(0.1)
+
 
 class Events:
     _runtime: Runtime
@@ -434,6 +484,9 @@ class Events:
             self._runtime.notify_derp_event(server_ip, states),
             timeout if timeout else 30,
         )
+
+    async def wait_for_event_error(self, err: ErrorEvent, timeout: float = 30) -> None:
+        await asyncio.wait_for(self._runtime.notify_error_event(err), timeout)
 
 
 class Client:
@@ -639,6 +692,9 @@ class Client:
                     await asyncio.sleep(0.1)
             except asyncio.CancelledError:
                 pass
+
+    async def wait_for_event_error(self, err: ErrorEvent):
+        await self.get_events().wait_for_event_error(err)
 
     async def set_meshmap(self, meshmap: Meshmap) -> None:
         made_changes = await self._configure_interface()

--- a/nat-lab/tests/test_adapter_gone.py
+++ b/nat-lab/tests/test_adapter_gone.py
@@ -1,0 +1,73 @@
+import pytest
+from contextlib import AsyncExitStack
+from helpers import SetupParameters, setup_mesh_nodes
+from telio import AdapterType, ErrorEvent, ErrorCode, ErrorLevel
+from utils.connection import TargetOS
+from utils.connection_util import ConnectionTag
+from utils.process import ProcessExecError
+
+
+@pytest.mark.parametrize(
+    "alpha_setup_params",
+    [
+        pytest.param(
+            SetupParameters(
+                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
+                adapter_type=AdapterType.BoringTun,
+            ),
+        ),
+        pytest.param(
+            SetupParameters(
+                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
+                adapter_type=AdapterType.LinuxNativeWg,
+            ),
+            marks=[pytest.mark.linux_native],
+        ),
+        pytest.param(
+            SetupParameters(
+                connection_tag=ConnectionTag.WINDOWS_VM,
+                adapter_type=AdapterType.WindowsNativeWg,
+            ),
+            marks=[pytest.mark.windows],
+        ),
+        pytest.param(
+            SetupParameters(
+                connection_tag=ConnectionTag.WINDOWS_VM,
+                adapter_type=AdapterType.WireguardGo,
+            ),
+            marks=[pytest.mark.windows],
+        ),
+    ],
+)
+async def test_adapter_gone_event(alpha_setup_params: SetupParameters) -> None:
+    async with AsyncExitStack() as exit_stack:
+        env = await setup_mesh_nodes(exit_stack, [alpha_setup_params])
+        conn, *_ = [conn.connection for conn in env.connections]
+        client, *_ = env.clients
+
+        if conn.target_os == TargetOS.Linux:
+            await conn.create_process([
+                "ip",
+                "link",
+                "delete",
+                client.get_router().get_interface_name(),
+            ]).execute()
+        elif conn.target_os == TargetOS.Windows:
+            try:
+                await conn.create_process([
+                    "netsh",
+                    "interface",
+                    "set",
+                    "interface",
+                    client.get_router().get_interface_name(),
+                    "disable",
+                ]).execute()
+            except ProcessExecError as e:
+                if e.returncode != 1:
+                    raise
+        else:
+            raise RuntimeError("unsupported os")
+
+        await client.wait_for_event_error(
+            ErrorEvent(ErrorLevel.Critical, ErrorCode.Unknown, "Interface gone")
+        )

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -1017,6 +1017,7 @@ impl Runtime {
                     wg::Io {
                         events: wg_events.tx.clone(),
                         analytics_tx: analytics_ch.clone(),
+                        libtelio_wide_event_publisher: Some(libtelio_wide_event_publisher.clone()),
                     },
                     wg::Config {
                         adapter: config.adapter,


### PR DESCRIPTION
### Problem
Whenever interface was gone, we just increased fail counter, but didn't do anything.


### Solution
Send critical event to registered event callback, so library users can act on it.


### Note
Boringtun bump commit will be gone, once this https://github.com/NordSecurity/boringtun/pull/17 and this https://github.com/NordSecurity/libtelio/pull/499 PRs will be merged to main.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests

