### PR TITLE
When meshnet is off, use the last known state to determine path type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1293,9 +1293,9 @@ checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
 
 [[package]]
 name = "either"
-version = "1.9.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
 
 [[package]]
 name = "encoding_rs"

--- a/changelog.md
+++ b/changelog.md
@@ -16,6 +16,7 @@
 * LLT-4168: Fix telio-dns assert panics in debug mode
 * LLT-4856: Enable aggregator timed events
 * LLT-4993: Remove most of the forks of dependencies for tvos and replace with latest upstream versions
+* LLT-4351: Fix when shutting down meshnet, in the disconnect event, path is sometimes incorrectly reported as direct
 
 <br>
 

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -214,7 +214,7 @@ pub struct RequestedState {
     pub(crate) keepalive_periods: FeaturePersistentKeepalive,
 }
 
-pub struct MeshnetEntites {
+pub struct MeshnetEntities {
     // Relay Multiplexer
     multiplexer: Arc<Multiplexer>,
 
@@ -234,12 +234,12 @@ pub struct MeshnetEntitiesLastState {
 }
 
 pub enum MeshnetState {
-    Entities(MeshnetEntites),
+    Entities(MeshnetEntities),
     LastState(MeshnetEntitiesLastState),
 }
 
 impl MeshnetState {
-    fn left(&self) -> Option<&MeshnetEntites> {
+    fn left(&self) -> Option<&MeshnetEntities> {
         if let Self::Entities(entities) = self {
             Some(entities)
         } else {
@@ -249,7 +249,7 @@ impl MeshnetState {
 
     #[cfg(test)]
     #[track_caller]
-    fn expect_left(&self, msg: &str) -> &MeshnetEntites {
+    fn expect_left(&self, msg: &str) -> &MeshnetEntities {
         self.left().expect(msg)
     }
 
@@ -894,7 +894,7 @@ impl RequestedState {
     }
 }
 
-impl MeshnetEntites {
+impl MeshnetEntities {
     async fn stop(mut self) -> MeshnetEntitiesLastState {
         macro_rules! stop_entity {
             ($entity: expr, $name: expr) => {{
@@ -1188,7 +1188,7 @@ impl Runtime {
         })
     }
 
-    async fn start_meshnet_entities(&mut self) -> Result<MeshnetEntites> {
+    async fn start_meshnet_entities(&mut self) -> Result<MeshnetEntities> {
         let endpoint_publish_events = Chan::default();
         let pong_rxed_events = Chan::default();
 
@@ -1390,7 +1390,7 @@ impl Runtime {
             None
         };
 
-        Ok(MeshnetEntites {
+        Ok(MeshnetEntities {
             multiplexer,
             derp,
             proxy,
@@ -1648,7 +1648,7 @@ impl Runtime {
                 .wait_for_proxy_listen_port(Duration::from_secs(1))
                 .await?;
 
-            let meshnet_entities: MeshnetEntites = if let MeshnetState::Entities(entities) =
+            let meshnet_entities: MeshnetEntities = if let MeshnetState::Entities(entities) =
                 std::mem::replace(
                     &mut self.entities.meshnet,
                     MeshnetState::LastState(Default::default()),

--- a/src/device/wg_controller.rs
+++ b/src/device/wg_controller.rs
@@ -65,7 +65,7 @@ pub async fn consolidate_wg_state(
     entities: &Entities,
     features: &Features,
 ) -> Result {
-    let remote_peer_states = if let Some(meshnet_entities) = entities.meshnet.as_ref() {
+    let remote_peer_states = if let Some(meshnet_entities) = entities.meshnet.left() {
         meshnet_entities.derp.get_remote_peer_states().await
     } else {
         Default::default()
@@ -81,18 +81,18 @@ pub async fn consolidate_wg_state(
     consolidate_wg_peers(
         requested_state,
         &*entities.wireguard_interface,
-        entities.meshnet.as_ref().map(|m| &*m.proxy),
+        entities.meshnet.left().map(|m| &*m.proxy),
         entities.cross_ping_check(),
         entities.upgrade_sync(),
         entities.session_keeper(),
         &*entities.dns,
         remote_peer_states,
-        entities.meshnet.as_ref().and_then(|m| {
+        entities.meshnet.left().and_then(|m| {
             m.direct
                 .as_ref()
                 .and_then(|direct| direct.stun_endpoint_provider.as_ref())
         }),
-        entities.meshnet.as_ref().and_then(|m| {
+        entities.meshnet.left().and_then(|m| {
             m.direct
                 .as_ref()
                 .and_then(|direct| direct.upnp_endpoint_provider.as_ref())


### PR DESCRIPTION
When meshnet is being turned off, save all the needed state so that it's possible to compute the correct (as it was just before turning off) path type of each peer.

### Problem
When reporting events for peers after turning off the meshnet, we always reported path type 'relayed', regardless of what was the actual path type just before turning off the meshnet.

### Solution
When meshnet is being turned off, save all the needed state so that it's possible to compute the correct (as it was just before turning off) path type of each peer.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
