### PR TITLE
Resolve LLT-5005: add direct connection test for same adapter types

### DIFF
--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -31,4 +31,4 @@ jobs:
           project-id: ${{ secrets.PROJECT_ID }}
           schedule: ${{ github.event_name == 'schedule' }}
           cancel-outdated-pipelines: ${{ github.ref_name != 'main' }}
-          triggered-ref: v1.0.3
+          triggered-ref: v1.1.0

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,4 +15,4 @@ libtelio-build-pipeline:
 
   trigger:
     project: $LIBTELIO_BUILD_PROJECT_PATH
-    branch: v1.0.3
+    branch: v1.1.0

--- a/.unreleased/LLT-5005
+++ b/.unreleased/LLT-5005
@@ -1,0 +1,1 @@
+Add second windows VM to natlab and state flickering test

--- a/nat-lab/tests/config.py
+++ b/nat-lab/tests/config.py
@@ -17,8 +17,9 @@ def get_root_path(path: str) -> str:
 
 # Same as defined in `Vagrantfile`
 LINUX_VM_IP = "10.55.0.10"
-WINDOWS_VM_IP = "10.55.0.11"
 MAC_VM_IP = "10.55.0.12"
+WINDOWS_1_VM_IP = "10.55.0.13"
+WINDOWS_2_VM_IP = "10.55.0.14"
 
 LINUX_VM_PRIMARY_GATEWAY = "10.55.0.10"
 LINUX_VM_SECONDARY_GATEWAY = "10.66.0.10"

--- a/nat-lab/tests/test_adapter_gone.py
+++ b/nat-lab/tests/test_adapter_gone.py
@@ -25,14 +25,14 @@ from utils.process import ProcessExecError
         ),
         pytest.param(
             SetupParameters(
-                connection_tag=ConnectionTag.WINDOWS_VM,
+                connection_tag=ConnectionTag.WINDOWS_VM_1,
                 adapter_type=AdapterType.WindowsNativeWg,
             ),
             marks=[pytest.mark.windows],
         ),
         pytest.param(
             SetupParameters(
-                connection_tag=ConnectionTag.WINDOWS_VM,
+                connection_tag=ConnectionTag.WINDOWS_VM_1,
                 adapter_type=AdapterType.WireguardGo,
             ),
             marks=[pytest.mark.windows],

--- a/nat-lab/tests/test_client_basic_stun.py
+++ b/nat-lab/tests/test_client_basic_stun.py
@@ -10,7 +10,7 @@ from utils.connection_util import ConnectionTag, new_connection_by_tag
     [
         pytest.param(ConnectionTag.DOCKER_CONE_CLIENT_1, "10.0.254.1"),
         pytest.param(
-            ConnectionTag.WINDOWS_VM,
+            ConnectionTag.WINDOWS_VM_1,
             "10.0.254.7",
             marks=pytest.mark.windows,
         ),

--- a/nat-lab/tests/test_connection_states.py
+++ b/nat-lab/tests/test_connection_states.py
@@ -35,10 +35,10 @@ from utils.ping import Ping
         ),
         pytest.param(
             SetupParameters(
-                connection_tag=ConnectionTag.WINDOWS_VM,
+                connection_tag=ConnectionTag.WINDOWS_VM_1,
                 adapter_type=telio.AdapterType.WindowsNativeWg,
                 connection_tracker_config=generate_connection_tracker_config(
-                    ConnectionTag.WINDOWS_VM,
+                    ConnectionTag.WINDOWS_VM_1,
                     derp_1_limits=ConnectionLimits(1, 1),
                 ),
             ),
@@ -46,10 +46,10 @@ from utils.ping import Ping
         ),
         pytest.param(
             SetupParameters(
-                connection_tag=ConnectionTag.WINDOWS_VM,
+                connection_tag=ConnectionTag.WINDOWS_VM_1,
                 adapter_type=telio.AdapterType.WireguardGo,
                 connection_tracker_config=generate_connection_tracker_config(
-                    ConnectionTag.WINDOWS_VM,
+                    ConnectionTag.WINDOWS_VM_1,
                     derp_1_limits=ConnectionLimits(1, 1),
                 ),
             ),

--- a/nat-lab/tests/test_derp_client_message_forward.py
+++ b/nat-lab/tests/test_derp_client_message_forward.py
@@ -15,7 +15,7 @@ TESTING_STRING = "testing"
     "connection_tag",
     [
         ConnectionTag.DOCKER_CONE_CLIENT_1,
-        pytest.param(ConnectionTag.WINDOWS_VM, marks=[pytest.mark.windows]),
+        pytest.param(ConnectionTag.WINDOWS_VM_1, marks=[pytest.mark.windows]),
     ],
 )
 async def test_derp_client_message_forward(connection_tag: ConnectionTag) -> None:

--- a/nat-lab/tests/test_events.py
+++ b/nat-lab/tests/test_events.py
@@ -39,10 +39,10 @@ from utils.router import IPStack
         ),
         pytest.param(
             SetupParameters(
-                connection_tag=ConnectionTag.WINDOWS_VM,
+                connection_tag=ConnectionTag.WINDOWS_VM_1,
                 adapter_type=AdapterType.WindowsNativeWg,
                 connection_tracker_config=generate_connection_tracker_config(
-                    ConnectionTag.WINDOWS_VM,
+                    ConnectionTag.WINDOWS_VM_1,
                     derp_1_limits=ConnectionLimits(1, 1),
                 ),
             ),
@@ -50,10 +50,10 @@ from utils.router import IPStack
         ),
         pytest.param(
             SetupParameters(
-                connection_tag=ConnectionTag.WINDOWS_VM,
+                connection_tag=ConnectionTag.WINDOWS_VM_1,
                 adapter_type=AdapterType.WireguardGo,
                 connection_tracker_config=generate_connection_tracker_config(
-                    ConnectionTag.WINDOWS_VM,
+                    ConnectionTag.WINDOWS_VM_1,
                     derp_1_limits=ConnectionLimits(1, 1),
                 ),
             ),
@@ -199,10 +199,10 @@ async def test_event_content_meshnet(
         ),
         pytest.param(
             SetupParameters(
-                connection_tag=ConnectionTag.WINDOWS_VM,
+                connection_tag=ConnectionTag.WINDOWS_VM_1,
                 adapter_type=AdapterType.WindowsNativeWg,
                 connection_tracker_config=generate_connection_tracker_config(
-                    ConnectionTag.WINDOWS_VM,
+                    ConnectionTag.WINDOWS_VM_1,
                     vpn_1_limits=ConnectionLimits(1, 1),
                     stun_limits=ConnectionLimits(2, 2),
                 ),
@@ -215,10 +215,10 @@ async def test_event_content_meshnet(
         ),
         pytest.param(
             SetupParameters(
-                connection_tag=ConnectionTag.WINDOWS_VM,
+                connection_tag=ConnectionTag.WINDOWS_VM_1,
                 adapter_type=AdapterType.WireguardGo,
                 connection_tracker_config=generate_connection_tracker_config(
-                    ConnectionTag.WINDOWS_VM,
+                    ConnectionTag.WINDOWS_VM_1,
                     vpn_1_limits=ConnectionLimits(1, 1),
                     stun_limits=ConnectionLimits(2, 2),
                 ),
@@ -341,10 +341,10 @@ async def test_event_content_vpn_connection(
         ),
         pytest.param(
             SetupParameters(
-                connection_tag=ConnectionTag.WINDOWS_VM,
+                connection_tag=ConnectionTag.WINDOWS_VM_1,
                 adapter_type=AdapterType.WindowsNativeWg,
                 connection_tracker_config=generate_connection_tracker_config(
-                    ConnectionTag.WINDOWS_VM,
+                    ConnectionTag.WINDOWS_VM_1,
                     derp_1_limits=ConnectionLimits(1, 1),
                 ),
             ),
@@ -352,10 +352,10 @@ async def test_event_content_vpn_connection(
         ),
         pytest.param(
             SetupParameters(
-                connection_tag=ConnectionTag.WINDOWS_VM,
+                connection_tag=ConnectionTag.WINDOWS_VM_1,
                 adapter_type=AdapterType.WireguardGo,
                 connection_tracker_config=generate_connection_tracker_config(
-                    ConnectionTag.WINDOWS_VM,
+                    ConnectionTag.WINDOWS_VM_1,
                     derp_1_limits=ConnectionLimits(1, 1),
                 ),
             ),
@@ -488,10 +488,10 @@ async def test_event_content_exit_through_peer(
         ),
         pytest.param(
             SetupParameters(
-                connection_tag=ConnectionTag.WINDOWS_VM,
+                connection_tag=ConnectionTag.WINDOWS_VM_1,
                 adapter_type=AdapterType.WindowsNativeWg,
                 connection_tracker_config=generate_connection_tracker_config(
-                    ConnectionTag.WINDOWS_VM,
+                    ConnectionTag.WINDOWS_VM_1,
                     derp_1_limits=ConnectionLimits(1, 1),
                 ),
                 features=TelioFeatures(direct=Direct(providers=["stun"])),
@@ -501,10 +501,10 @@ async def test_event_content_exit_through_peer(
         ),
         pytest.param(
             SetupParameters(
-                connection_tag=ConnectionTag.WINDOWS_VM,
+                connection_tag=ConnectionTag.WINDOWS_VM_1,
                 adapter_type=AdapterType.WireguardGo,
                 connection_tracker_config=generate_connection_tracker_config(
-                    ConnectionTag.WINDOWS_VM,
+                    ConnectionTag.WINDOWS_VM_1,
                     derp_1_limits=ConnectionLimits(1, 1),
                 ),
                 features=TelioFeatures(direct=Direct(providers=["stun"])),

--- a/nat-lab/tests/test_mesh_exit_through_peer.py
+++ b/nat-lab/tests/test_mesh_exit_through_peer.py
@@ -60,11 +60,11 @@ from utils.router import IPProto, IPStack
         ),
         pytest.param(
             SetupParameters(
-                connection_tag=ConnectionTag.WINDOWS_VM,
+                connection_tag=ConnectionTag.WINDOWS_VM_1,
                 ip_stack=IPStack.IPv4v6,
                 adapter_type=telio.AdapterType.WindowsNativeWg,
                 connection_tracker_config=generate_connection_tracker_config(
-                    ConnectionTag.WINDOWS_VM,
+                    ConnectionTag.WINDOWS_VM_1,
                     derp_1_limits=ConnectionLimits(1, 1),
                 ),
             ),
@@ -72,11 +72,11 @@ from utils.router import IPProto, IPStack
         ),
         pytest.param(
             SetupParameters(
-                connection_tag=ConnectionTag.WINDOWS_VM,
+                connection_tag=ConnectionTag.WINDOWS_VM_1,
                 ip_stack=IPStack.IPv4v6,
                 adapter_type=telio.AdapterType.WireguardGo,
                 connection_tracker_config=generate_connection_tracker_config(
-                    ConnectionTag.WINDOWS_VM,
+                    ConnectionTag.WINDOWS_VM_1,
                     derp_1_limits=ConnectionLimits(1, 1),
                 ),
             ),
@@ -214,14 +214,14 @@ async def test_mesh_exit_through_peer(
             marks=pytest.mark.linux_native,
         ),
         pytest.param(
-            ConnectionTag.WINDOWS_VM,
+            ConnectionTag.WINDOWS_VM_1,
             telio.AdapterType.WindowsNativeWg,
             marks=[
                 pytest.mark.windows,
             ],
         ),
         pytest.param(
-            ConnectionTag.WINDOWS_VM,
+            ConnectionTag.WINDOWS_VM_1,
             telio.AdapterType.WireguardGo,
             marks=[
                 pytest.mark.windows,

--- a/nat-lab/tests/test_mesh_plus_vpn.py
+++ b/nat-lab/tests/test_mesh_plus_vpn.py
@@ -47,10 +47,10 @@ from utils.ping import Ping
         ),
         pytest.param(
             SetupParameters(
-                connection_tag=ConnectionTag.WINDOWS_VM,
+                connection_tag=ConnectionTag.WINDOWS_VM_1,
                 adapter_type=telio.AdapterType.WindowsNativeWg,
                 connection_tracker_config=generate_connection_tracker_config(
-                    ConnectionTag.WINDOWS_VM,
+                    ConnectionTag.WINDOWS_VM_1,
                     derp_1_limits=ConnectionLimits(1, 1),
                     vpn_1_limits=ConnectionLimits(1, 1),
                 ),
@@ -59,10 +59,10 @@ from utils.ping import Ping
         ),
         pytest.param(
             SetupParameters(
-                connection_tag=ConnectionTag.WINDOWS_VM,
+                connection_tag=ConnectionTag.WINDOWS_VM_1,
                 adapter_type=telio.AdapterType.WireguardGo,
                 connection_tracker_config=generate_connection_tracker_config(
-                    ConnectionTag.WINDOWS_VM,
+                    ConnectionTag.WINDOWS_VM_1,
                     derp_1_limits=ConnectionLimits(1, 1),
                     vpn_1_limits=ConnectionLimits(1, 1),
                 ),
@@ -163,10 +163,10 @@ async def test_mesh_plus_vpn_one_peer(
         ),
         pytest.param(
             SetupParameters(
-                connection_tag=ConnectionTag.WINDOWS_VM,
+                connection_tag=ConnectionTag.WINDOWS_VM_1,
                 adapter_type=telio.AdapterType.WindowsNativeWg,
                 connection_tracker_config=generate_connection_tracker_config(
-                    ConnectionTag.WINDOWS_VM,
+                    ConnectionTag.WINDOWS_VM_1,
                     derp_1_limits=ConnectionLimits(1, 1),
                     vpn_1_limits=ConnectionLimits(1, 1),
                 ),
@@ -175,10 +175,10 @@ async def test_mesh_plus_vpn_one_peer(
         ),
         pytest.param(
             SetupParameters(
-                connection_tag=ConnectionTag.WINDOWS_VM,
+                connection_tag=ConnectionTag.WINDOWS_VM_1,
                 adapter_type=telio.AdapterType.WireguardGo,
                 connection_tracker_config=generate_connection_tracker_config(
-                    ConnectionTag.WINDOWS_VM,
+                    ConnectionTag.WINDOWS_VM_1,
                     derp_1_limits=ConnectionLimits(1, 1),
                     vpn_1_limits=ConnectionLimits(1, 1),
                 ),
@@ -283,13 +283,13 @@ async def test_mesh_plus_vpn_both_peers(
             marks=pytest.mark.linux_native,
         ),
         pytest.param(
-            ConnectionTag.WINDOWS_VM,
+            ConnectionTag.WINDOWS_VM_1,
             AdapterType.WindowsNativeWg,
             "10.0.254.7",
             marks=pytest.mark.windows,
         ),
         pytest.param(
-            ConnectionTag.WINDOWS_VM,
+            ConnectionTag.WINDOWS_VM_1,
             AdapterType.WireguardGo,
             "10.0.254.7",
             marks=pytest.mark.windows,
@@ -415,10 +415,10 @@ async def test_vpn_plus_mesh(
         ),
         pytest.param(
             SetupParameters(
-                connection_tag=ConnectionTag.WINDOWS_VM,
+                connection_tag=ConnectionTag.WINDOWS_VM_1,
                 adapter_type=telio.AdapterType.WindowsNativeWg,
                 connection_tracker_config=generate_connection_tracker_config(
-                    ConnectionTag.WINDOWS_VM,
+                    ConnectionTag.WINDOWS_VM_1,
                     derp_1_limits=ConnectionLimits(1, 1),
                     vpn_1_limits=ConnectionLimits(1, 1),
                 ),
@@ -430,10 +430,10 @@ async def test_vpn_plus_mesh(
         ),
         pytest.param(
             SetupParameters(
-                connection_tag=ConnectionTag.WINDOWS_VM,
+                connection_tag=ConnectionTag.WINDOWS_VM_1,
                 adapter_type=telio.AdapterType.WireguardGo,
                 connection_tracker_config=generate_connection_tracker_config(
-                    ConnectionTag.WINDOWS_VM,
+                    ConnectionTag.WINDOWS_VM_1,
                     derp_1_limits=ConnectionLimits(1, 1),
                     vpn_1_limits=ConnectionLimits(1, 1),
                 ),
@@ -563,10 +563,10 @@ async def test_vpn_plus_mesh_over_direct(
         ),
         pytest.param(
             SetupParameters(
-                connection_tag=ConnectionTag.WINDOWS_VM,
+                connection_tag=ConnectionTag.WINDOWS_VM_1,
                 adapter_type=telio.AdapterType.WindowsNativeWg,
                 connection_tracker_config=generate_connection_tracker_config(
-                    ConnectionTag.WINDOWS_VM,
+                    ConnectionTag.WINDOWS_VM_1,
                     derp_1_limits=ConnectionLimits(1, 1),
                     vpn_1_limits=ConnectionLimits(1, 1),
                 ),
@@ -576,10 +576,10 @@ async def test_vpn_plus_mesh_over_direct(
         ),
         pytest.param(
             SetupParameters(
-                connection_tag=ConnectionTag.WINDOWS_VM,
+                connection_tag=ConnectionTag.WINDOWS_VM_1,
                 adapter_type=telio.AdapterType.WireguardGo,
                 connection_tracker_config=generate_connection_tracker_config(
-                    ConnectionTag.WINDOWS_VM,
+                    ConnectionTag.WINDOWS_VM_1,
                     derp_1_limits=ConnectionLimits(1, 1),
                     vpn_1_limits=ConnectionLimits(1, 1),
                 ),

--- a/nat-lab/tests/test_mesh_remove_node.py
+++ b/nat-lab/tests/test_mesh_remove_node.py
@@ -37,10 +37,10 @@ from utils.ping import Ping
         ),
         pytest.param(
             SetupParameters(
-                connection_tag=ConnectionTag.WINDOWS_VM,
+                connection_tag=ConnectionTag.WINDOWS_VM_1,
                 adapter_type=telio.AdapterType.WindowsNativeWg,
                 connection_tracker_config=generate_connection_tracker_config(
-                    ConnectionTag.WINDOWS_VM,
+                    ConnectionTag.WINDOWS_VM_1,
                     derp_1_limits=ConnectionLimits(1, 1),
                 ),
             ),
@@ -50,10 +50,10 @@ from utils.ping import Ping
         ),
         pytest.param(
             SetupParameters(
-                connection_tag=ConnectionTag.WINDOWS_VM,
+                connection_tag=ConnectionTag.WINDOWS_VM_1,
                 adapter_type=telio.AdapterType.WireguardGo,
                 connection_tracker_config=generate_connection_tracker_config(
-                    ConnectionTag.WINDOWS_VM,
+                    ConnectionTag.WINDOWS_VM_1,
                     derp_1_limits=ConnectionLimits(1, 1),
                 ),
             ),

--- a/nat-lab/tests/test_network_switch.py
+++ b/nat-lab/tests/test_network_switch.py
@@ -28,7 +28,7 @@ from utils.ping import Ping
             "10.0.254.13",
         ),
         pytest.param(
-            ConnectionTag.WINDOWS_VM,
+            ConnectionTag.WINDOWS_VM_1,
             "10.0.254.7",
             "10.0.254.8",
             marks=pytest.mark.windows,
@@ -80,14 +80,14 @@ async def test_network_switcher(
         ),
         pytest.param(
             SetupParameters(
-                connection_tag=ConnectionTag.WINDOWS_VM,
+                connection_tag=ConnectionTag.WINDOWS_VM_1,
                 adapter_type=telio.AdapterType.WindowsNativeWg,
             ),
             marks=pytest.mark.windows,
         ),
         pytest.param(
             SetupParameters(
-                connection_tag=ConnectionTag.WINDOWS_VM,
+                connection_tag=ConnectionTag.WINDOWS_VM_1,
                 adapter_type=telio.AdapterType.WireguardGo,
             ),
             marks=[
@@ -160,7 +160,7 @@ async def test_mesh_network_switch(
         ),
         pytest.param(
             SetupParameters(
-                connection_tag=ConnectionTag.WINDOWS_VM,
+                connection_tag=ConnectionTag.WINDOWS_VM_1,
                 adapter_type=telio.AdapterType.WindowsNativeWg,
                 is_meshnet=False,
             ),
@@ -168,7 +168,7 @@ async def test_mesh_network_switch(
         ),
         pytest.param(
             SetupParameters(
-                connection_tag=ConnectionTag.WINDOWS_VM,
+                connection_tag=ConnectionTag.WINDOWS_VM_1,
                 adapter_type=telio.AdapterType.WireguardGo,
                 is_meshnet=False,
             ),
@@ -249,7 +249,7 @@ async def test_vpn_network_switch(alpha_setup_params: SetupParameters) -> None:
         ),
         pytest.param(
             SetupParameters(
-                connection_tag=ConnectionTag.WINDOWS_VM,
+                connection_tag=ConnectionTag.WINDOWS_VM_1,
                 adapter_type=telio.AdapterType.WindowsNativeWg,
                 features=TelioFeatures(direct=Direct(providers=["stun"])),
             ),
@@ -259,7 +259,7 @@ async def test_vpn_network_switch(alpha_setup_params: SetupParameters) -> None:
         ),
         pytest.param(
             SetupParameters(
-                connection_tag=ConnectionTag.WINDOWS_VM,
+                connection_tag=ConnectionTag.WINDOWS_VM_1,
                 adapter_type=telio.AdapterType.WireguardGo,
                 features=TelioFeatures(direct=Direct(providers=["stun"])),
             ),

--- a/nat-lab/tests/test_node_state_flickering.py
+++ b/nat-lab/tests/test_node_state_flickering.py
@@ -1,8 +1,12 @@
 import asyncio
+import itertools
 import pytest
 import telio
 from contextlib import AsyncExitStack
 from helpers import SetupParameters, setup_mesh_nodes
+from telio_features import TelioFeatures, Direct
+from typing import Tuple
+from utils.connection import TargetOS
 from utils.connection_tracker import ConnectionLimits
 from utils.connection_util import generate_connection_tracker_config, ConnectionTag
 
@@ -36,10 +40,10 @@ from utils.connection_util import generate_connection_tracker_config, Connection
         ),
         pytest.param(
             SetupParameters(
-                connection_tag=ConnectionTag.WINDOWS_VM,
+                connection_tag=ConnectionTag.WINDOWS_VM_1,
                 adapter_type=telio.AdapterType.WindowsNativeWg,
                 connection_tracker_config=generate_connection_tracker_config(
-                    ConnectionTag.WINDOWS_VM,
+                    ConnectionTag.WINDOWS_VM_1,
                     derp_1_limits=ConnectionLimits(1, 1),
                 ),
             ),
@@ -47,10 +51,10 @@ from utils.connection_util import generate_connection_tracker_config, Connection
         ),
         pytest.param(
             SetupParameters(
-                connection_tag=ConnectionTag.WINDOWS_VM,
+                connection_tag=ConnectionTag.WINDOWS_VM_1,
                 adapter_type=telio.AdapterType.WireguardGo,
                 connection_tracker_config=generate_connection_tracker_config(
-                    ConnectionTag.WINDOWS_VM,
+                    ConnectionTag.WINDOWS_VM_1,
                     derp_1_limits=ConnectionLimits(1, 1),
                 ),
             ),
@@ -83,7 +87,7 @@ from utils.connection_util import generate_connection_tracker_config, Connection
         )
     ],
 )
-async def test_node_state_flickering(
+async def test_node_state_flickering_relay(
     alpha_setup_params: SetupParameters, beta_setup_params: SetupParameters
 ) -> None:
     async with AsyncExitStack() as exit_stack:
@@ -100,6 +104,78 @@ async def test_node_state_flickering(
                 ),
                 client_beta.wait_for_event_peer(
                     alpha.public_key, list(telio.State), timeout=120
+                ),
+                client_alpha.wait_for_event_on_any_derp(list(telio.State), timeout=120),
+                client_beta.wait_for_event_on_any_derp(list(telio.State), timeout=120),
+            )
+
+
+CFG = [
+    (TargetOS.Windows, telio.AdapterType.WindowsNativeWg),
+    (TargetOS.Windows, telio.AdapterType.WireguardGo),
+    (TargetOS.Linux, telio.AdapterType.BoringTun),
+    (TargetOS.Linux, telio.AdapterType.LinuxNativeWg),
+]
+
+
+@pytest.mark.long
+@pytest.mark.timeout(180)
+@pytest.mark.parametrize(
+    "alpha_cfg, beta_cfg", itertools.combinations_with_replacement(CFG, 2)
+)
+async def test_node_state_flickering_direct(
+    alpha_cfg: Tuple[TargetOS, telio.AdapterType],
+    beta_cfg: Tuple[TargetOS, telio.AdapterType],
+) -> None:
+    async with AsyncExitStack() as exit_stack:
+        (alpha_target_os, alpha_adapter_type) = alpha_cfg
+        (beta_target_os, beta_adapter_type) = beta_cfg
+        alpha_conn_tag = (
+            ConnectionTag.WINDOWS_VM_1
+            if alpha_target_os == TargetOS.Windows
+            else ConnectionTag.DOCKER_CONE_CLIENT_1
+        )
+        beta_conn_tag = (
+            ConnectionTag.WINDOWS_VM_2
+            if beta_target_os == TargetOS.Windows
+            else ConnectionTag.DOCKER_CONE_CLIENT_2
+        )
+
+        env = await setup_mesh_nodes(
+            exit_stack,
+            [
+                SetupParameters(
+                    connection_tag=alpha_conn_tag,
+                    adapter_type=alpha_adapter_type,
+                    features=TelioFeatures(
+                        direct=Direct(providers=["stun", "local", "upnp"])
+                    ),
+                ),
+                SetupParameters(
+                    connection_tag=beta_conn_tag,
+                    adapter_type=beta_adapter_type,
+                    features=TelioFeatures(
+                        direct=Direct(providers=["stun", "local", "upnp"])
+                    ),
+                ),
+            ],
+        )
+        alpha, beta = env.nodes
+        client_alpha, client_beta = env.clients
+
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.gather(
+                client_alpha.wait_for_event_peer(
+                    beta.public_key,
+                    list(telio.State),
+                    list(telio.PathType),
+                    timeout=120,
+                ),
+                client_beta.wait_for_event_peer(
+                    alpha.public_key,
+                    list(telio.State),
+                    list(telio.PathType),
+                    timeout=120,
                 ),
                 client_alpha.wait_for_event_on_any_derp(list(telio.State), timeout=120),
                 client_beta.wait_for_event_on_any_derp(list(telio.State), timeout=120),

--- a/nat-lab/tests/test_pq.py
+++ b/nat-lab/tests/test_pq.py
@@ -65,10 +65,10 @@ async def _connect_vpn_pq(
         ),
         pytest.param(
             SetupParameters(
-                connection_tag=ConnectionTag.WINDOWS_VM,
+                connection_tag=ConnectionTag.WINDOWS_VM_1,
                 adapter_type=AdapterType.WindowsNativeWg,
                 connection_tracker_config=generate_connection_tracker_config(
-                    ConnectionTag.WINDOWS_VM,
+                    ConnectionTag.WINDOWS_VM_1,
                     stun_limits=ConnectionLimits(1, 1),
                     nlx_1_limits=ConnectionLimits(2, 2),
                 ),
@@ -81,10 +81,10 @@ async def _connect_vpn_pq(
         ),
         pytest.param(
             SetupParameters(
-                connection_tag=ConnectionTag.WINDOWS_VM,
+                connection_tag=ConnectionTag.WINDOWS_VM_1,
                 adapter_type=AdapterType.WireguardGo,
                 connection_tracker_config=generate_connection_tracker_config(
-                    ConnectionTag.WINDOWS_VM,
+                    ConnectionTag.WINDOWS_VM_1,
                     stun_limits=ConnectionLimits(1, 1),
                     nlx_1_limits=ConnectionLimits(2, 2),
                 ),

--- a/nat-lab/tests/test_process.py
+++ b/nat-lab/tests/test_process.py
@@ -18,7 +18,7 @@ async def _get_running_process_list(connection: Connection) -> str:
     "connection_tag,command",
     [
         pytest.param(ConnectionTag.DOCKER_CONE_CLIENT_1, "/usr/bin/ls"),
-        pytest.param(ConnectionTag.WINDOWS_VM, "dir", marks=pytest.mark.windows),
+        pytest.param(ConnectionTag.WINDOWS_VM_1, "dir", marks=pytest.mark.windows),
         pytest.param(ConnectionTag.MAC_VM, "/bin/ls", marks=pytest.mark.mac),
     ],
 )
@@ -35,7 +35,7 @@ async def test_process_execute_success(connection_tag: ConnectionTag, command: s
     "connection_tag",
     [
         pytest.param(ConnectionTag.DOCKER_CONE_CLIENT_1),
-        pytest.param(ConnectionTag.WINDOWS_VM, marks=pytest.mark.windows),
+        pytest.param(ConnectionTag.WINDOWS_VM_1, marks=pytest.mark.windows),
         pytest.param(ConnectionTag.MAC_VM, marks=pytest.mark.mac),
     ],
 )
@@ -59,7 +59,7 @@ async def test_process_execute_fail(connection_tag: ConnectionTag):
             ["ping", config.PHOTO_ALBUM_IP],
         ),
         pytest.param(
-            ConnectionTag.WINDOWS_VM,
+            ConnectionTag.WINDOWS_VM_1,
             ["ping", "-t", config.PHOTO_ALBUM_IP],
             marks=pytest.mark.windows,
         ),
@@ -96,7 +96,7 @@ async def test_process_run_success(
             ["bash", "-c", "exit 77"],
         ),
         pytest.param(
-            ConnectionTag.WINDOWS_VM,
+            ConnectionTag.WINDOWS_VM_1,
             ["cmd.exe", "/c", "exit 77"],
             marks=pytest.mark.windows,
         ),
@@ -127,7 +127,7 @@ async def test_process_run_fail(connection_tag: ConnectionTag, command: list[str
             ConnectionTag.DOCKER_CONE_CLIENT_1,
         ),
         pytest.param(
-            ConnectionTag.WINDOWS_VM,
+            ConnectionTag.WINDOWS_VM_1,
             marks=pytest.mark.windows,
         ),
         pytest.param(
@@ -157,7 +157,7 @@ async def test_process_run_not_found(connection_tag: ConnectionTag):
             ["ping", config.PHOTO_ALBUM_IP],
         ),
         pytest.param(
-            ConnectionTag.WINDOWS_VM,
+            ConnectionTag.WINDOWS_VM_1,
             ["ping", "-t", config.PHOTO_ALBUM_IP],
             marks=pytest.mark.windows,
         ),
@@ -198,7 +198,7 @@ async def test_process_run_cancel(
             ["ping", config.PHOTO_ALBUM_IP],
         ),
         pytest.param(
-            ConnectionTag.WINDOWS_VM,
+            ConnectionTag.WINDOWS_VM_1,
             ["ping", "-t", config.PHOTO_ALBUM_IP],
             marks=pytest.mark.windows,
         ),

--- a/nat-lab/tests/test_reconnections.py
+++ b/nat-lab/tests/test_reconnections.py
@@ -36,10 +36,10 @@ from utils.ping import Ping
         ),
         pytest.param(
             SetupParameters(
-                connection_tag=ConnectionTag.WINDOWS_VM,
+                connection_tag=ConnectionTag.WINDOWS_VM_1,
                 adapter_type=telio.AdapterType.WindowsNativeWg,
                 connection_tracker_config=generate_connection_tracker_config(
-                    ConnectionTag.WINDOWS_VM,
+                    ConnectionTag.WINDOWS_VM_1,
                     derp_1_limits=ConnectionLimits(2, 2),
                 ),
             ),
@@ -49,10 +49,10 @@ from utils.ping import Ping
         ),
         pytest.param(
             SetupParameters(
-                connection_tag=ConnectionTag.WINDOWS_VM,
+                connection_tag=ConnectionTag.WINDOWS_VM_1,
                 adapter_type=telio.AdapterType.WireguardGo,
                 connection_tracker_config=generate_connection_tracker_config(
-                    ConnectionTag.WINDOWS_VM,
+                    ConnectionTag.WINDOWS_VM_1,
                     derp_1_limits=ConnectionLimits(2, 2),
                 ),
             ),

--- a/nat-lab/tests/test_upnp_connection.py
+++ b/nat-lab/tests/test_upnp_connection.py
@@ -106,7 +106,7 @@ async def test_upnp_route_removed(
         ),
         pytest.param(
             SetupParameters(
-                connection_tag=ConnectionTag.WINDOWS_VM,
+                connection_tag=ConnectionTag.WINDOWS_VM_1,
                 adapter_type=AdapterType.WindowsNativeWg,
                 features=TelioFeatures(direct=Direct(providers=["upnp"])),
             ),
@@ -114,7 +114,7 @@ async def test_upnp_route_removed(
         ),
         pytest.param(
             SetupParameters(
-                connection_tag=ConnectionTag.WINDOWS_VM,
+                connection_tag=ConnectionTag.WINDOWS_VM_1,
                 adapter_type=AdapterType.WireguardGo,
                 features=TelioFeatures(direct=Direct(providers=["upnp"])),
             ),

--- a/nat-lab/tests/test_vpn.py
+++ b/nat-lab/tests/test_vpn.py
@@ -84,10 +84,10 @@ class VpnConfig:
         ),
         pytest.param(
             SetupParameters(
-                connection_tag=ConnectionTag.WINDOWS_VM,
+                connection_tag=ConnectionTag.WINDOWS_VM_1,
                 adapter_type=AdapterType.WindowsNativeWg,
                 connection_tracker_config=generate_connection_tracker_config(
-                    ConnectionTag.WINDOWS_VM,
+                    ConnectionTag.WINDOWS_VM_1,
                     stun_limits=ConnectionLimits(1, 1),
                 ),
                 is_meshnet=False,
@@ -99,10 +99,10 @@ class VpnConfig:
         ),
         pytest.param(
             SetupParameters(
-                connection_tag=ConnectionTag.WINDOWS_VM,
+                connection_tag=ConnectionTag.WINDOWS_VM_1,
                 adapter_type=AdapterType.WireguardGo,
                 connection_tracker_config=generate_connection_tracker_config(
-                    ConnectionTag.WINDOWS_VM,
+                    ConnectionTag.WINDOWS_VM_1,
                     stun_limits=ConnectionLimits(1, 1),
                 ),
                 is_meshnet=False,
@@ -237,10 +237,10 @@ async def test_vpn_connection(
         ),
         pytest.param(
             SetupParameters(
-                connection_tag=ConnectionTag.WINDOWS_VM,
+                connection_tag=ConnectionTag.WINDOWS_VM_1,
                 adapter_type=AdapterType.WindowsNativeWg,
                 connection_tracker_config=generate_connection_tracker_config(
-                    ConnectionTag.WINDOWS_VM,
+                    ConnectionTag.WINDOWS_VM_1,
                     vpn_1_limits=ConnectionLimits(1, 1),
                     vpn_2_limits=ConnectionLimits(1, 1),
                     stun_limits=ConnectionLimits(2, 2),
@@ -254,10 +254,10 @@ async def test_vpn_connection(
         ),
         pytest.param(
             SetupParameters(
-                connection_tag=ConnectionTag.WINDOWS_VM,
+                connection_tag=ConnectionTag.WINDOWS_VM_1,
                 adapter_type=AdapterType.WireguardGo,
                 connection_tracker_config=generate_connection_tracker_config(
-                    ConnectionTag.WINDOWS_VM,
+                    ConnectionTag.WINDOWS_VM_1,
                     vpn_1_limits=ConnectionLimits(1, 1),
                     vpn_2_limits=ConnectionLimits(1, 1),
                     stun_limits=ConnectionLimits(2, 2),

--- a/nat-lab/tests/test_wg_adapter.py
+++ b/nat-lab/tests/test_wg_adapter.py
@@ -23,7 +23,7 @@ async def test_wg_adapter_cleanup():
 
     private, _ = Key.key_pair()
 
-    async with new_connection_raw(ConnectionTag.WINDOWS_VM) as conn:
+    async with new_connection_raw(ConnectionTag.WINDOWS_VM_1) as conn:
         cli_started = asyncio.Event()
         output_notifier.notify_output("telio dev cli", cli_started)
 

--- a/nat-lab/tests/utils/connection_util.py
+++ b/nat-lab/tests/utils/connection_util.py
@@ -36,7 +36,8 @@ class ConnectionTag(Enum):
     DOCKER_UDP_BLOCK_CLIENT_1 = auto()
     DOCKER_UDP_BLOCK_CLIENT_2 = auto()
     DOCKER_INTERNAL_SYMMETRIC_CLIENT = auto()
-    WINDOWS_VM = auto()
+    WINDOWS_VM_1 = auto()
+    WINDOWS_VM_2 = auto()
     MAC_VM = auto()
     DOCKER_CONE_GW_1 = auto()
     DOCKER_CONE_GW_2 = auto()
@@ -105,7 +106,8 @@ DOCKER_GW_MAP: Dict[ConnectionTag, ConnectionTag] = {
     ConnectionTag.DOCKER_SHARED_CLIENT_1: ConnectionTag.DOCKER_CONE_GW_1,
     ConnectionTag.DOCKER_UDP_BLOCK_CLIENT_1: ConnectionTag.DOCKER_UDP_BLOCK_GW_1,
     ConnectionTag.DOCKER_UDP_BLOCK_CLIENT_2: ConnectionTag.DOCKER_UDP_BLOCK_GW_2,
-    ConnectionTag.WINDOWS_VM: ConnectionTag.DOCKER_CONE_GW_3,
+    ConnectionTag.WINDOWS_VM_1: ConnectionTag.DOCKER_CONE_GW_3,
+    ConnectionTag.WINDOWS_VM_2: ConnectionTag.DOCKER_CONE_GW_3,
     ConnectionTag.MAC_VM: ConnectionTag.DOCKER_CONE_GW_3,
     ConnectionTag.DOCKER_OPEN_INTERNET_CLIENT_1: (
         ConnectionTag.DOCKER_OPEN_INTERNET_CLIENT_1
@@ -137,7 +139,8 @@ LAN_ADDR_MAP: Dict[ConnectionTag, str] = {
     ConnectionTag.DOCKER_UDP_BLOCK_CLIENT_1: "192.168.110.100",
     ConnectionTag.DOCKER_UDP_BLOCK_CLIENT_2: "192.168.111.100",
     ConnectionTag.DOCKER_INTERNAL_SYMMETRIC_CLIENT: "192.168.114.88",
-    ConnectionTag.WINDOWS_VM: "10.55.0.11",
+    ConnectionTag.WINDOWS_VM_1: "10.55.0.13",
+    ConnectionTag.WINDOWS_VM_2: "10.55.0.14",
     ConnectionTag.MAC_VM: "10.55.0.12",
     ConnectionTag.DOCKER_CONE_GW_1: "192.168.101.254",
     ConnectionTag.DOCKER_CONE_GW_2: "192.168.102.254",
@@ -192,8 +195,8 @@ async def new_connection_raw(tag: ConnectionTag) -> AsyncIterator[Connection]:
             async with container_util.get(docker, container_id(tag)) as connection:
                 yield connection
 
-    elif tag == ConnectionTag.WINDOWS_VM:
-        async with windows_vm_util.new_connection() as connection:
+    elif tag in [ConnectionTag.WINDOWS_VM_1, ConnectionTag.WINDOWS_VM_2]:
+        async with windows_vm_util.new_connection(LAN_ADDR_MAP[tag]) as connection:
             yield connection
 
     elif tag == ConnectionTag.MAC_VM:
@@ -210,7 +213,7 @@ async def create_network_switcher(
     if tag in DOCKER_SERVICE_IDS:
         return NetworkSwitcherDocker(connection)
 
-    if tag == ConnectionTag.WINDOWS_VM:
+    if tag in [ConnectionTag.WINDOWS_VM_1, ConnectionTag.WINDOWS_VM_2]:
         return await NetworkSwitcherWindows.create(connection)
 
     if tag == ConnectionTag.MAC_VM:

--- a/nat-lab/tests/utils/vm/mac_vm_util.py
+++ b/nat-lab/tests/utils/vm/mac_vm_util.py
@@ -12,7 +12,7 @@ FILES_COPIED = False
 
 
 @asynccontextmanager
-async def new_connection() -> AsyncIterator[Connection]:
+async def new_connection(ip: str = config.MAC_VM_IP) -> AsyncIterator[Connection]:
     subprocess.check_call(["sudo", "bash", "vm_nat.sh", "disable"])
     subprocess.check_call(["sudo", "bash", "vm_nat.sh", "enable"])
 
@@ -28,7 +28,7 @@ async def new_connection() -> AsyncIterator[Connection]:
     )
 
     async with asyncssh.connect(
-        config.MAC_VM_IP,
+        ip,
         username="root",
         password="vagrant",  # NOTE: this is hardcoded password for transient vm existing only during the tests
         known_hosts=None,

--- a/nat-lab/tests/utils/vm/windows_vm_util.py
+++ b/nat-lab/tests/utils/vm/windows_vm_util.py
@@ -1,7 +1,6 @@
 import asyncssh
-import config
 import subprocess
-from config import get_root_path, LIBTELIO_BINARY_PATH_WINDOWS_VM
+from config import get_root_path, LIBTELIO_BINARY_PATH_WINDOWS_VM, WINDOWS_1_VM_IP
 from contextlib import asynccontextmanager
 from typing import AsyncIterator
 from utils.connection import Connection, SshConnection, TargetOS
@@ -12,7 +11,7 @@ FILES_COPIED = False
 
 
 @asynccontextmanager
-async def new_connection() -> AsyncIterator[Connection]:
+async def new_connection(ip: str = WINDOWS_1_VM_IP) -> AsyncIterator[Connection]:
     subprocess.check_call(["sudo", "bash", "vm_nat.sh", "disable"])
     subprocess.check_call(["sudo", "bash", "vm_nat.sh", "enable"])
 
@@ -28,7 +27,7 @@ async def new_connection() -> AsyncIterator[Connection]:
     )
 
     async with asyncssh.connect(
-        config.WINDOWS_VM_IP,
+        ip,
         username="vagrant",
         password="vagrant",  # NOTE: this is hardcoded password for transient vm existing only during the tests
         known_hosts=None,


### PR DESCRIPTION
### Problem
Missing state flickering test for direct connection.

### Solution
- Update libtelio-build ref (add second windows vm)
- Add state flickering test for direct connection


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
