### PR TITLE
Exclude Dependabot from changelog entry file check

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -9,6 +9,8 @@ permissions: {}
 jobs:
   changelog:
     runs-on: ubuntu-latest
+    # Excluding Dependabot PRs from this check.
+    if: github.actor != 'dependabot[bot]'
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/dod.yml
+++ b/.github/workflows/dod.yml
@@ -9,6 +9,8 @@ jobs:
     permissions:
       pull-requests: write
     runs-on: ubuntu-20.04
+    # Excluding Dependabot PRs from this check.
+    if: github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       - name: Check DoD


### PR DESCRIPTION
### Problem
Dependabot PRs fail changelog entry file check, because it does not create changelog files at all and we require at least empty changelog files to be present in a PR. 

### Solution
Exclude Dependabot from this check entirely


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
