### PR TITLE
Tcpdump traces collection from the vpn servers in nat-lab added

### DIFF
--- a/.unreleased/LLT-5119
+++ b/.unreleased/LLT-5119
@@ -1,0 +1,1 @@
+Tcpdump traces collection from the vpn servers in nat-lab added

--- a/nat-lab/tests/helpers.py
+++ b/nat-lab/tests/helpers.py
@@ -3,7 +3,7 @@ import pytest
 from contextlib import AsyncExitStack, asynccontextmanager
 from dataclasses import dataclass, field
 from itertools import product, zip_longest
-from mesh_api import Node, Meshmap, API
+from mesh_api import Node, Meshmap, API, stop_tcpdump_on_vpns
 from telio import Client, AdapterType, State, PathType
 from telio_features import TelioFeatures
 from typing import AsyncIterator, List, Tuple, Optional, Union, Dict, Any
@@ -290,6 +290,7 @@ async def setup_environment(
             if conn_manager.tracker:
                 limits = conn_manager.tracker.get_out_of_limits()
                 assert limits is None, f"conntracker reported out of limits {limits}"
+        stop_tcpdump_on_vpns()
 
 
 async def setup_mesh_nodes(

--- a/nat-lab/tests/telio.py
+++ b/nat-lab/tests/telio.py
@@ -21,6 +21,7 @@ from utils.connection_util import get_libtelio_binary_path
 from utils.output_notifier import OutputNotifier
 from utils.process import Process
 from utils.router import IPStack, Router, new_router
+from utils.testing import test_name_safe_for_file_name
 
 
 # Equivalent of `libtelio/telio-wg/src/uapi.rs`
@@ -1000,11 +1001,7 @@ class Client:
         else:
             container_id = str(self._connection.target_os)
 
-        test_name = os.environ.get("PYTEST_CURRENT_TEST")
-        if test_name is not None:
-            test_name = "".join(
-                [x if x.isalnum() else "_" for x in test_name.split(" ")[0]]
-            )
+        test_name = test_name_safe_for_file_name()
 
         filename = str(test_name) + "_" + container_id + ".log"
         if len(filename.encode("utf-8")) > 256:
@@ -1036,11 +1033,7 @@ class Client:
 
         container_id = str(self._connection.target_os)
 
-        test_name = os.environ.get("PYTEST_CURRENT_TEST")
-        if test_name is not None:
-            test_name = "".join(
-                [x if x.isalnum() else "_" for x in test_name.split(" ")[0]]
-            )
+        test_name = test_name_safe_for_file_name()
 
         filename = str(test_name) + "_" + container_id + "_network_info"
         if len(filename.encode("utf-8")) > 256:

--- a/nat-lab/tests/utils/testing.py
+++ b/nat-lab/tests/utils/testing.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 from asyncio import Future
 from typing import Union, Coroutine, Optional, TypeVar, Any
 
@@ -40,3 +41,10 @@ def unpack_optional(opt: Optional[T]) -> T:
     if opt is None:
         raise ValueError("Optional value is None")
     return opt
+
+
+def test_name_safe_for_file_name():
+    test_name = os.environ.get("PYTEST_CURRENT_TEST")
+    if test_name is not None:
+        return "".join([x if x.isalnum() else "_" for x in test_name.split(" ")[0]])
+    return test_name


### PR DESCRIPTION
### Problem
When debugging issues related to VPN it's sometimes usefull to see the traffic from the point of view of the vpn server.

### Solution
Collect tcpdump traces from all vpn servers and store them in a similar way as the log files.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
