### PR TITLE
Use NWPathMonitor to get interfaces in order of preference for socket protector on apple platforms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -742,9 +742,15 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
 dependencies = [
- "core-foundation-sys",
+ "core-foundation-sys 0.8.4",
  "libc",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
 name = "core-foundation-sys"
@@ -1150,6 +1156,11 @@ dependencies = [
  "redox_users",
  "winapi",
 ]
+
+[[package]]
+name = "dispatch"
+version = "0.2.0"
+source = "git+https://github.com/NordSecurity/rust-dispatch.git?rev=13447cd7221a74ebcce1277ae0cfc9a421a28ec5#13447cd7221a74ebcce1277ae0cfc9a421a28ec5"
 
 [[package]]
 name = "dns-parser"
@@ -1824,7 +1835,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
 dependencies = [
  "android_system_properties",
- "core-foundation-sys",
+ "core-foundation-sys 0.8.4",
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
@@ -2314,6 +2325,16 @@ checksum = "8f18857289379de670867542caa2923f46596e04cdeceed178d9cab723dc60e3"
 dependencies = [
  "buffering",
  "byteorder",
+ "libc",
+]
+
+[[package]]
+name = "network-framework-sys"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12a0b02d3ddff8bdf9e3a6f151b20f2b022c394b02a9fccb506ebcbc74db2185"
+dependencies = [
+ "core-foundation-sys 0.7.0",
  "libc",
 ]
 
@@ -3308,7 +3329,7 @@ version = "0.1.0"
 source = "git+https://github.com/tomaszklak/rustls-platform-verifier.git?rev=2db68dd17d76eadb062176b913040341b99ef4f3#2db68dd17d76eadb062176b913040341b99ef4f3"
 dependencies = [
  "core-foundation",
- "core-foundation-sys",
+ "core-foundation-sys 0.8.4",
  "jni",
  "log",
  "once_cell",
@@ -3429,7 +3450,7 @@ checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
- "core-foundation-sys",
+ "core-foundation-sys 0.8.4",
  "libc",
  "security-framework-sys 2.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3441,7 +3462,7 @@ source = "git+https://github.com/kornelski/rust-security-framework.git?rev=67a61
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
- "core-foundation-sys",
+ "core-foundation-sys 0.8.4",
  "libc",
  "num-bigint",
  "security-framework-sys 2.9.1 (git+https://github.com/kornelski/rust-security-framework.git?rev=67a610ec215d207cd158664ab5cf6eca9552ff9f)",
@@ -3453,7 +3474,7 @@ version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
 dependencies = [
- "core-foundation-sys",
+ "core-foundation-sys 0.8.4",
  "libc",
 ]
 
@@ -3462,7 +3483,7 @@ name = "security-framework-sys"
 version = "2.9.1"
 source = "git+https://github.com/kornelski/rust-security-framework.git?rev=67a610ec215d207cd158664ab5cf6eca9552ff9f#67a610ec215d207cd158664ab5cf6eca9552ff9f"
 dependencies = [
- "core-foundation-sys",
+ "core-foundation-sys 0.8.4",
  "libc",
 ]
 
@@ -3911,7 +3932,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
 dependencies = [
- "core-foundation-sys",
+ "core-foundation-sys 0.8.4",
  "libc",
 ]
 
@@ -3920,7 +3941,7 @@ name = "system-configuration-sys"
 version = "0.5.0"
 source = "git+https://github.com/NordSecurity/system-configuration-rs.git#39f80cdfa4785b785f368354d6946111b7774e00"
 dependencies = [
- "core-foundation-sys",
+ "core-foundation-sys 0.8.4",
  "libc",
 ]
 
@@ -4275,11 +4296,14 @@ dependencies = [
 name = "telio-sockets"
 version = "0.1.0"
 dependencies = [
+ "block",
  "boringtun",
  "debug_panic",
+ "dispatch",
  "futures",
  "libc",
  "mockall",
+ "network-framework-sys",
  "nix 0.26.4",
  "objc",
  "objc-foundation",

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 * LLT-5095: Send critical event to app when adapter is dead
 * LLT-5097: Update wireguard wrapper to use wireguard-go fork and fix uapi get to throw error when device dead
 * LLT-5096: Fix uapi get/set to throw error when device dead
+* LLT-5017: Fix interface with static IP may be skipped for socket binding
 
 <br>
 

--- a/crates/telio-sockets/Cargo.toml
+++ b/crates/telio-sockets/Cargo.toml
@@ -31,6 +31,9 @@ version-compare = "0.1"
 debug_panic = "0.2.1"
 nix = "0.26.2"
 system-configuration = { git = 'https://github.com/NordSecurity/system-configuration-rs.git' }
+network-framework-sys = "0.1"
+block = "0.1"
+dispatch = { git = "https://github.com/NordSecurity/rust-dispatch.git", rev = "13447cd7221a74ebcce1277ae0cfc9a421a28ec5" }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { workspace = true, features = [

--- a/crates/telio-sockets/src/protector/apple.rs
+++ b/crates/telio-sockets/src/protector/apple.rs
@@ -1,9 +1,11 @@
 use debug_panic::debug_panic;
-use parking_lot::Mutex;
-use parking_lot::RwLock;
+use parking_lot::{Mutex, RwLock};
 
 use std::{
+    cell::RefCell,
+    ffi::{c_long, c_void, CStr},
     io, os,
+    rc::Rc,
     sync::{Arc, Weak},
 };
 
@@ -22,11 +24,35 @@ use system_configuration::{
 };
 use tokio::{self, sync::Notify, task::JoinHandle};
 
-use crate::native::interface_index_from_name;
-use crate::native::NativeSocket;
+use crate::native::{interface_index_from_name, NativeSocket};
 use crate::Protector;
+use network_framework_sys::{
+    nw_interface_get_name, nw_interface_t, nw_path_monitor_create, nw_path_monitor_set_queue,
+    nw_path_monitor_start, nw_path_monitor_t, nw_path_t,
+};
 use nix::sys::socket::{getsockname, AddressFamily, SockaddrLike, SockaddrStorage};
 use telio_utils::{telio_log_debug, telio_log_error, telio_log_info, telio_log_warn};
+
+extern "C" {
+    // Obj-c signature:
+    // void nw_path_monitor_set_update_handler(nw_path_monitor_t monitor, nw_path_monitor_update_handler_t update_handler);
+    // typedef void (^nw_path_monitor_update_handler_t)(nw_path_t path);
+    pub fn nw_path_monitor_set_update_handler(
+        monitor: nw_path_monitor_t,
+        update_handler: *const c_void,
+    );
+    // Obj-c signature:
+    // void nw_path_enumerate_interfaces(nw_path_t path, nw_path_enumerate_interfaces_block_t enumerate_block);
+    // typedef bool (^nw_path_enumerate_interfaces_block_t)(nw_interface_t interface);
+    pub fn nw_path_enumerate_interfaces(path: nw_path_t, enumerate_block: *const c_void);
+}
+
+pub const DISPATCH_QUEUE_PRIORITY_HIGH: c_long = 2;
+pub const DISPATCH_QUEUE_PRIORITY_DEFAULT: c_long = 0;
+pub const DISPATCH_QUEUE_PRIORITY_LOW: c_long = -2;
+pub const DISPATCH_QUEUE_PRIORITY_BACKGROUND: c_long = -1 << 15;
+
+static INTERFACE_NAMES_IN_OS_PREFERENCE_ORDER: Mutex<Vec<String>> = Mutex::new(Vec::new());
 
 #[cfg(any(target_os = "ios", target_os = "tvos"))]
 use objc::{class, msg_send, runtime::Object, sel, sel_impl};
@@ -325,7 +351,7 @@ fn get_service_order(store: &SCDynamicStore) -> Option<Vec<String>> {
 }
 
 fn get_primary_interface_names() -> Vec<String> {
-    let mut primary_interface_names = Vec::new();
+    let mut primary_ipv4_interface_names = Vec::new();
     let store = dynamic_store::SCDynamicStoreBuilder::new("primary-service-store").build();
 
     if let Some(service_order) = get_service_order(&store) {
@@ -335,26 +361,26 @@ fn get_primary_interface_names() -> Vec<String> {
                 .and_then(CFPropertyList::downcast_into::<CFDictionary>);
 
             if let Some(primary_service_dictionary) = primary_service_dictionary {
-                if primary_service_dictionary
-                    .find(unsafe { schema_definitions::kSCPropNetIPv4Router }.to_void())
-                    .is_some()
-                {
-                    let interface_name = primary_service_dictionary
-                        .find(unsafe { schema_definitions::kSCPropInterfaceName }.to_void())
-                        .map(|ptr| unsafe { CFString::wrap_under_get_rule(*ptr as CFStringRef) });
-                    if let Some(interface_name) = interface_name {
-                        primary_interface_names.push(interface_name.to_string());
-                    }
+                let interface_name = primary_service_dictionary
+                    .find(unsafe { schema_definitions::kSCPropInterfaceName }.to_void())
+                    .map(|ptr| unsafe { CFString::wrap_under_get_rule(*ptr as CFStringRef) });
+                if let Some(interface_name) = interface_name {
+                    primary_ipv4_interface_names.push(interface_name.to_string());
                 }
             }
         }
     }
 
+    let mut interface_names_in_os_preference_order: Vec<String> =
+        INTERFACE_NAMES_IN_OS_PREFERENCE_ORDER.lock().clone();
     telio_log_info!(
-        "Discovered these primary interfaces for use in socket binding: {:?}",
-        primary_interface_names
+        "Discovered these primary IPv4 interfaces for use in socket binding: {:?} (OS pereference order: {interface_names_in_os_preference_order:?})",
+        primary_ipv4_interface_names
     );
-    primary_interface_names
+
+    interface_names_in_os_preference_order
+        .retain(|name| primary_ipv4_interface_names.contains(name));
+    interface_names_in_os_preference_order
 }
 
 fn get_primary_interface(tunnel_interface: u64) -> Option<u64> {
@@ -412,6 +438,58 @@ fn spawn_dynamic_store_loop(sockets: Weak<Mutex<Sockets>>) {
 
         core_foundation::runloop::CFRunLoop::run_current();
     });
+}
+
+pub fn setup_network_path_monitor() {
+    let update_handler = block::ConcreteBlock::new(|path: nw_path_t| {
+        let names = Rc::new(RefCell::new(vec![]));
+        let names_copy = names.clone();
+
+        let enumerate_callback =
+            block::ConcreteBlock::new(move |interface: nw_interface_t| -> bool {
+                let c_name = unsafe { nw_interface_get_name(interface) };
+                if !c_name.is_null() {
+                    let name = unsafe { CStr::from_ptr(c_name) };
+                    if let Ok(name) = name.to_str() {
+                        names_copy.borrow_mut().push(name.to_owned());
+                    }
+                }
+                true
+            })
+            .copy();
+
+        unsafe {
+            nw_path_enumerate_interfaces(
+                path,
+                &*enumerate_callback as *const block::Block<_, _> as *const c_void,
+            )
+        };
+
+        *INTERFACE_NAMES_IN_OS_PREFERENCE_ORDER.lock() = names.borrow().clone();
+
+        telio_log_debug!("Names in os preference order: {:?}", names.borrow());
+    })
+    .copy();
+    unsafe {
+        let monitor = nw_path_monitor_create();
+        if monitor.is_null() {
+            telio_log_warn!("Failed to start network path monitor");
+            return;
+        }
+
+        let queue = dispatch::ffi::dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0);
+        if queue.is_null() {
+            telio_log_warn!("Failed to get global background queue");
+            return;
+        }
+        nw_path_monitor_set_queue(monitor, std::mem::transmute(queue));
+
+        nw_path_monitor_set_update_handler(
+            monitor,
+            &*update_handler as *const block::Block<_, _> as *const c_void,
+        );
+        nw_path_monitor_start(monitor);
+    }
 }
 
 #[cfg(test)]

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -83,6 +83,9 @@ pub use wg::{
     FirewallCb, Tun, WireGuard,
 };
 
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
+static NETWORK_PATH_MONITOR_START: std::sync::Once = std::sync::Once::new();
+
 #[cfg(test)]
 use wg::tests::AdapterExpectation;
 
@@ -387,6 +390,10 @@ impl Device {
         telio_log_info!("Created libtelio instance {}, {}", version_tag, commit_sha);
 
         telio_log_info!("libtelio is starting up with features : {:?}", features);
+
+        #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
+        NETWORK_PATH_MONITOR_START
+            .call_once(telio_sockets::protector::platform::setup_network_path_monitor);
 
         if let Some(lana) = &features.lana {
             if init_lana(lana.event_path.clone(), version_tag.to_string(), lana.prod).is_err() {


### PR DESCRIPTION
Using only interfaces with the router property is incorrect since when using static IPs it's possible to have an interface without router property. Additionally, interfaces returned by the dynamic store are not in any particular order. After this, change, we use the interfaces collected from the NWPathMonitor. Those are ordered in the same way as the OS would prefer them.

I will try to add some sort of tests when merging to main.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
