### PR TITLE
Do not reenable management interface

### DIFF
--- a/nat-lab/tests/utils/network_switcher/network_switcher_windows.py
+++ b/nat-lab/tests/utils/network_switcher/network_switcher_windows.py
@@ -97,7 +97,12 @@ class NetworkSwitcherWindows(NetworkSwitcher):
         try:
             yield
         finally:
-            await self._enable_management_interface()
+            # Restoring management interface after a test
+            # Seems to be causing some flakyness. In order to
+            # Test this theory, restoring is being disabled
+            #
+            # await self._enable_management_interface()
+            pass
 
     @asynccontextmanager
     async def switch_to_secondary_network(self) -> AsyncIterator:
@@ -115,7 +120,12 @@ class NetworkSwitcherWindows(NetworkSwitcher):
         try:
             yield
         finally:
-            await self._enable_management_interface()
+            # Restoring management interface after a test
+            # Seems to be causing some flakyness. In order to
+            # Test this theory, restoring is being disabled
+            #
+            # await self._enable_management_interface()
+            pass
 
     async def _delete_existing_route(self) -> None:
         # Deleting routes by interface name instead of network destination (0.0.0.0/0) makes


### PR DESCRIPTION
### Problem
I have a suspicion that we still have some race conditions with DHCP on management interface for windows VMs, which causes non-deterministic test failures. I would like to observe how much and what tests are affected to be able to better decide on next actions, but for that, DHCP on management interface needs to not be reenabled. This PR makes that happen.

**Note:**

When management interface is disabled on windows VM:
```bash
vagrant ssh windows-1
```
will not work anymore, and one will have to use primary or secondary interface to access the VM, for example:
```bash
ssh vagrant@10.55.0.13
```
will be equivalent to the above command.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
