### PR TITLE
LLT-5145 Restore missing init_cert_store method

### DIFF
--- a/.unreleased/LLT-5145
+++ b/.unreleased/LLT-5145
@@ -1,0 +1,1 @@
+Add init_cert_store method to FFI layer (only relevant for integrating on android)


### PR DESCRIPTION
### Problem
This function was accidentally removed without a replacement previously, but it's necessary to make libtelio work on android.

### Solution
Re-add the method, but updated to conform to uniffi and how the FFI code looks now.

Additionally, `TelioError::UnknownError` now has a `String` instead of `anyhow::Error`. This change is not strictly necessary for this PR, but it does make things easier, and the change would have been made anyways when migrating natlab to uniffi, so it was done here.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
