### PR TITLE
Add pcap collection for docker based telio peer nodes

### DIFF
--- a/.unreleased/LLT-5119
+++ b/.unreleased/LLT-5119
@@ -1,1 +1,1 @@
-Tcpdump traces collection from the vpn servers in nat-lab added
+Tcpdump traces collection from the vpn servers and telio peers in nat-lab added

--- a/nat-lab/tests/helpers.py
+++ b/nat-lab/tests/helpers.py
@@ -1,9 +1,10 @@
 import asyncio
 import pytest
+from config import WG_SERVERS
 from contextlib import AsyncExitStack, asynccontextmanager
 from dataclasses import dataclass, field
 from itertools import product, zip_longest
-from mesh_api import Node, Meshmap, API, stop_tcpdump_on_vpns
+from mesh_api import Node, Meshmap, API, stop_tcpdump
 from telio import Client, AdapterType, State, PathType
 from telio_features import TelioFeatures
 from typing import AsyncIterator, List, Tuple, Optional, Union, Dict, Any
@@ -290,7 +291,7 @@ async def setup_environment(
             if conn_manager.tracker:
                 limits = conn_manager.tracker.get_out_of_limits()
                 assert limits is None, f"conntracker reported out of limits {limits}"
-        stop_tcpdump_on_vpns()
+        stop_tcpdump([server["container"] for server in WG_SERVERS])
 
 
 async def setup_mesh_nodes(

--- a/nat-lab/tests/utils/connection/docker_connection.py
+++ b/nat-lab/tests/utils/connection/docker_connection.py
@@ -7,6 +7,10 @@ from utils.process import Process, DockerProcess
 
 class DockerConnection(Connection):
     _container: DockerContainer
+    _name: str
+
+    def container_name(self) -> str:
+        return self._name
 
     def __init__(self, container: DockerContainer, container_name: str):
         super().__init__(TargetOS.Linux)


### PR DESCRIPTION
### Problem
Tcpdumps are collected only on vpn server docker containers. We would like to also collect them on the containers that run libtelio/tcli.

### Solution
Start tcpdump on docker containers where we have libtelio/tcli clients running.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
