### PR TITLE
Rebind sockets when network path changes on Apple

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4307,6 +4307,7 @@ dependencies = [
  "nix 0.26.4",
  "objc",
  "objc-foundation",
+ "once_cell",
  "parking_lot",
  "rstest",
  "socket2 0.5.5",

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 * LLT-5097: Update wireguard wrapper to use wireguard-go fork and fix uapi get to throw error when device dead
 * LLT-5096: Fix uapi get/set to throw error when device dead
 * LLT-5017: Fix interface with static IP may be skipped for socket binding
+* LLT-5148: Rebind sockets when network path changes on Apple
 
 <br>
 

--- a/crates/telio-sockets/Cargo.toml
+++ b/crates/telio-sockets/Cargo.toml
@@ -17,6 +17,7 @@ thiserror.workspace = true
 tokio = { workspace = true, features = ["full"] }
 
 telio-utils.workspace = true
+once_cell.workspace = true
 
 [dev-dependencies]
 mockall.workspace = true


### PR DESCRIPTION
When NWPathMonitor call a callback with a new path, not only store it for future use but also notify all NativeProtector instances that the new path had been identified. This will now trigger rebind of protected sockets, if the new interface has changed.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] changelog.md is updated
- [x] Functionality is covered by unit or integration tests
