### PR TITLE
Fix wg adapter gone test

### DIFF
--- a/.unreleased/fix-wg-adapter-gone-test
+++ b/.unreleased/fix-wg-adapter-gone-test
@@ -1,0 +1,1 @@
+Fix wg adapter gone test being flaky

--- a/nat-lab/tests/test_wg_adapter.py
+++ b/nat-lab/tests/test_wg_adapter.py
@@ -52,6 +52,12 @@ async def test_wg_adapter_cleanup():
             "DeviceInstanceID",
         ]).execute()
 
+        while (
+            "tcli.exe"
+            in (await conn.create_process(["tasklist"]).execute()).get_stdout()
+        ):
+            await asyncio.sleep(0.1)
+
         # as mentioned before, wintun adapter is not left behind 100%
         # if it is not there, we do nothing
         if "Wintun" not in reg_query.get_stdout():


### PR DESCRIPTION
### Problem
If tcli still exists, it is not possible to create or delete adapter with same GUID, since tcli is still holding a reference to it.

### Solution
Wait for tcli to be gone and then proceed with test


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
