### PR TITLE
Backport no-link enhanced detection mod to v4.2.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -129,7 +129,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
 dependencies = [
  "anstyle",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -714,7 +714,7 @@ checksum = "2674ec482fbc38012cf31e6c42ba0177b431a0cb6f15fe40efa5aab1bda516f6"
 dependencies = [
  "is-terminal",
  "lazy_static",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -904,7 +904,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82e95fbd621905b854affdc67943b043a0fbb6ed7385fd5a25650d19a8a6cfdf"
 dependencies = [
  "nix 0.27.1",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1263,7 +1263,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f258a7194e7f7c2a7837a8913aeab7fd8c383457034fa20ce4dd3dcb813e8eb8"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1326,7 +1326,7 @@ checksum = "ef033ed5e9bad94e55838ca0ca906db0e043f517adda0c8b79c7a8c66c93c1b5"
 dependencies = [
  "cfg-if",
  "rustix 0.38.24",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1965,7 +1965,7 @@ checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
  "hermit-abi 0.3.3",
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1996,9 +1996,9 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
 dependencies = [
- "socket2 0.5.5",
+ "socket2 0.5.7",
  "widestring 1.0.2",
- "windows-sys",
+ "windows-sys 0.48.0",
  "winreg",
 ]
 
@@ -2025,7 +2025,7 @@ checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi 0.3.3",
  "rustix 0.38.24",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2267,7 +2267,7 @@ checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2786,7 +2786,7 @@ dependencies = [
  "libc",
  "log",
  "pin-project-lite",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3202,7 +3202,7 @@ dependencies = [
  "libc",
  "spin",
  "untrusted",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3274,7 +3274,7 @@ dependencies = [
  "io-lifetimes",
  "libc",
  "linux-raw-sys 0.3.8",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3287,7 +3287,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.11",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3423,7 +3423,7 @@ version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3756,12 +3756,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.5"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
+checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3866,7 +3866,7 @@ dependencies = [
  "parking_lot",
  "pnet_packet 0.33.0",
  "rand",
- "socket2 0.5.5",
+ "socket2 0.5.7",
  "thiserror",
  "tokio",
  "tracing",
@@ -4175,7 +4175,7 @@ dependencies = [
  "serde",
  "serde_json",
  "slog",
- "socket2 0.5.5",
+ "socket2 0.5.7",
  "surge-ping",
  "telio-crypto",
  "telio-lana",
@@ -4310,7 +4310,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "rstest",
- "socket2 0.5.5",
+ "socket2 0.5.7",
  "system-configuration 0.5.1 (git+https://github.com/NordSecurity/system-configuration-rs.git)",
  "telio-utils",
  "thiserror",
@@ -4363,7 +4363,7 @@ dependencies = [
  "rstest",
  "rupnp",
  "sm",
- "socket2 0.5.5",
+ "socket2 0.5.7",
  "strum",
  "stun_codec",
  "surge-ping",
@@ -4424,6 +4424,8 @@ dependencies = [
  "sha2",
  "slog",
  "slog-stdlog",
+ "socket2 0.5.7",
+ "surge-ping",
  "telio-crypto",
  "telio-firewall",
  "telio-model",
@@ -4450,7 +4452,7 @@ dependencies = [
  "fastrand 2.0.1",
  "redox_syscall",
  "rustix 0.38.24",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4583,9 +4585,9 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.5",
+ "socket2 0.5.7",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -5100,6 +5102,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.4",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5259,7 +5270,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 * LLT-5096: Fix uapi get/set to throw error when device dead
 * LLT-5017: Fix interface with static IP may be skipped for socket binding
 * LLT-5148: Rebind sockets when network path changes on Apple
+* LLT-5023: Add no-link enhanced detection mod
 
 <br>
 

--- a/crates/telio-model/src/features.rs
+++ b/crates/telio-model/src/features.rs
@@ -411,11 +411,19 @@ pub struct FeatureLinkDetection {
     /// Configurable rtt in seconds
     #[serde(default = "FeatureLinkDetection::default_configurable_rtt")]
     pub rtt_seconds: u64,
+
+    /// Check the link state before reporting it as down.
+    #[serde(default = "FeatureLinkDetection::default_enhanced_detection")]
+    pub enhanced_detection: bool,
 }
 
 impl FeatureLinkDetection {
     const fn default_configurable_rtt() -> u64 {
         15
+    }
+
+    const fn default_enhanced_detection() -> bool {
+        false
     }
 }
 

--- a/crates/telio-wg/Cargo.toml
+++ b/crates/telio-wg/Cargo.toml
@@ -26,6 +26,8 @@ rand.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 slog.workspace = true
+socket2.workspace = true
+surge-ping.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["full"] }
 

--- a/crates/telio-wg/src/link_detection/mod.rs
+++ b/crates/telio-wg/src/link_detection/mod.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, time::Duration};
+use std::{collections::HashMap, default, net::IpAddr, time::Duration};
 use tokio::time::Instant;
 
 use telio_crypto::PublicKey;
@@ -6,6 +6,10 @@ use telio_model::{
     features::FeatureLinkDetection,
     mesh::{LinkState, NodeState},
 };
+use telio_task::io::{chan, Chan};
+use telio_utils::{telio_err_with_log, telio_log_debug, telio_log_trace, telio_log_warn};
+
+mod pinger;
 
 /// Default wireguard keepalive duration
 const WG_KEEPALIVE: Duration = Duration::from_secs(10);
@@ -23,6 +27,7 @@ impl LinkDetection {
             None => LinkDetection::Disabled(LinkDetectionDisabled::default()),
             Some(features) => LinkDetection::Enabled(LinkDetectionEnabled::new(
                 Duration::from_secs(features.rtt_seconds),
+                features.enhanced_detection,
             )),
         }
     }
@@ -47,17 +52,28 @@ impl LinkDetection {
         }
     }
 
-    pub fn update(
+    pub async fn update(
         &mut self,
         public_key: &PublicKey,
         rx_bytes: Option<u64>,
         tx_bytes: Option<u64>,
         node_state: NodeState,
+        node_address: Option<IpAddr>,
         push: bool,
     ) -> LinkDetectionUpdateResult {
         match self {
-            LinkDetection::Enabled(l) => l.update(public_key, rx_bytes, tx_bytes, node_state, push),
-            LinkDetection::Disabled(l) => l.update(public_key, rx_bytes, push),
+            LinkDetection::Enabled(l) => {
+                l.update(
+                    public_key,
+                    rx_bytes,
+                    tx_bytes,
+                    node_state,
+                    node_address,
+                    push,
+                )
+                .await
+            }
+            LinkDetection::Disabled(l) => l.update(public_key, rx_bytes, push).await,
         }
     }
 
@@ -71,17 +87,37 @@ impl LinkDetection {
     pub fn is_disabled(&self) -> bool {
         matches!(self, LinkDetection::Disabled(_))
     }
+
+    pub async fn stop(self) {
+        match self {
+            LinkDetection::Enabled(l) => l.stop().await,
+            LinkDetection::Disabled(_) => (),
+        }
+    }
 }
 
 pub struct LinkDetectionEnabled {
     rtt: Duration,
+    enhanced_detection: bool,
+    pinger: Option<pinger::Pinger>,
+    ping_channel: chan::Tx<IpAddr>,
     peers: HashMap<PublicKey, State>,
 }
 
 impl LinkDetectionEnabled {
-    fn new(rtt: Duration) -> Self {
+    fn new(rtt: Duration, enhanced_detection: bool) -> Self {
+        let ping_channel = Chan::default();
+        let pinger = if enhanced_detection {
+            pinger::Pinger::start_with(ping_channel.rx).ok()
+        } else {
+            None
+        };
+
         LinkDetectionEnabled {
             rtt,
+            enhanced_detection,
+            pinger,
+            ping_channel: ping_channel.tx,
             peers: HashMap::default(),
         }
     }
@@ -97,12 +133,13 @@ impl LinkDetectionEnabled {
             .insert(*public_key, State::new(rx_bytes, tx_bytes, node_state));
     }
 
-    fn update(
+    async fn update(
         &mut self,
         public_key: &PublicKey,
         rx_bytes: Option<u64>,
         tx_bytes: Option<u64>,
         node_state: NodeState,
+        node_address: Option<IpAddr>,
         push: bool,
     ) -> LinkDetectionUpdateResult {
         // We want to update info only on pull
@@ -111,7 +148,17 @@ impl LinkDetectionEnabled {
         }
 
         if let Some(state) = self.peers.get_mut(public_key) {
-            state.update(rx_bytes, tx_bytes, node_state, self.rtt)
+            let result = state.update(rx_bytes, tx_bytes, node_state, self.rtt);
+
+            if self.enhanced_detection && result.should_ping {
+                if let Some(target) = node_address {
+                    if let Err(e) = self.ping_channel.send(target).await {
+                        telio_log_warn!("Failed to trigger ping to {:?} {:?}", node_address, e);
+                    }
+                }
+            }
+
+            result.link_detection_update_result
         } else {
             // Somehow we missed the node when it was new. We should recover from it.
             // To be less intrusive and to not disturb direct connections insert it.
@@ -139,6 +186,12 @@ impl LinkDetectionEnabled {
         self.peers
             .get(public_key)
             .and_then(|p| p.time_since_last_rx())
+    }
+
+    async fn stop(self) {
+        if let Some(pinger) = self.pinger {
+            pinger.stop().await;
+        }
     }
 
     fn push_update(
@@ -182,7 +235,7 @@ impl LinkDetectionDisabled {
         }
     }
 
-    fn update(
+    async fn update(
         &mut self,
         public_key: &PublicKey,
         rx_bytes: Option<u64>,
@@ -241,6 +294,28 @@ enum StateVariant {
     PossibleDown { deadline: Instant },
     Up,
 }
+
+struct StateUpdateResult {
+    should_ping: bool,
+    link_detection_update_result: LinkDetectionUpdateResult,
+}
+
+enum StateDecision {
+    NoAction,
+    Notify,
+    Ping,
+}
+
+impl StateDecision {
+    fn should_notify(&self) -> bool {
+        matches!(self, StateDecision::Notify)
+    }
+
+    fn should_ping(&self) -> bool {
+        matches!(self, StateDecision::Ping)
+    }
+}
+
 struct State {
     stats: BytesAndTimestamps,
     variant: StateVariant,
@@ -270,15 +345,12 @@ impl State {
         tx_bytes: Option<u64>,
         node_state: NodeState,
         rtt: Duration,
-    ) -> LinkDetectionUpdateResult {
+    ) -> StateUpdateResult {
         // Guard if node_state is not connected
         // self -> new with down and return
         if !matches!(node_state, NodeState::Connected) {
             *self = State::new(rx_bytes, tx_bytes, node_state);
-            return LinkDetectionUpdateResult {
-                should_notify: false,
-                link_state: Some(LinkState::Down),
-            };
+            return Self::build_result(StateDecision::NoAction, LinkState::Down);
         }
 
         let new_rx = rx_bytes.unwrap_or_default();
@@ -286,6 +358,7 @@ impl State {
         self.stats.update(new_rx, new_tx);
 
         let is_link_up = self.stats.is_link_up(rtt);
+        let is_silent_connection = self.stats.is_silent_connection(rtt);
 
         match &mut self.variant {
             StateVariant::Down => {
@@ -293,11 +366,11 @@ impl State {
                     // Transition to Up
                     // Report link state Up
                     self.variant = StateVariant::Up;
-                    Self::build_result(true, LinkState::Up)
+                    Self::build_result(StateDecision::Notify, LinkState::Up)
                 } else {
                     // Stay in Down
                     // No notify
-                    Self::build_result(false, LinkState::Down)
+                    Self::build_result(StateDecision::NoAction, LinkState::Down)
                 }
             }
 
@@ -306,14 +379,14 @@ impl State {
                     // Transition to Up
                     // No notify
                     self.variant = StateVariant::Up;
-                    Self::build_result(false, LinkState::Up)
+                    Self::build_result(StateDecision::NoAction, LinkState::Up)
                 } else if Instant::now() >= *deadline {
                     // Transition to Down
                     // Report link state Down
                     self.variant = StateVariant::Down;
-                    Self::build_result(true, LinkState::Down)
+                    Self::build_result(StateDecision::Notify, LinkState::Down)
                 } else {
-                    Self::build_result(false, LinkState::Up)
+                    Self::build_result(StateDecision::NoAction, LinkState::Up)
                 }
             }
 
@@ -321,15 +394,21 @@ impl State {
                 if !is_link_up {
                     // Transition to PossibleDown
                     // No notify for now
+                    // But if the enhanced detection is enabled
+                    // Check the connection
                     self.variant = StateVariant::PossibleDown {
                         deadline: Instant::now()
                             .checked_add(Self::POSSIBLE_DOWN_DELAY)
                             .unwrap_or_else(Instant::now),
                     };
+                    Self::build_result(StateDecision::Ping, LinkState::Up)
+                } else if is_silent_connection {
+                    // The connection is silent. Might be down so let's ping.
+                    Self::build_result(StateDecision::Ping, LinkState::Up)
+                } else {
+                    // Current link_state is Up
+                    Self::build_result(StateDecision::NoAction, LinkState::Up)
                 }
-
-                // Current link_state is Up
-                Self::build_result(false, LinkState::Up)
             }
         }
     }
@@ -349,10 +428,13 @@ impl State {
         }
     }
 
-    fn build_result(should_notify: bool, link_state: LinkState) -> LinkDetectionUpdateResult {
-        LinkDetectionUpdateResult {
-            should_notify,
-            link_state: Some(link_state),
+    fn build_result(state_decision: StateDecision, link_state: LinkState) -> StateUpdateResult {
+        StateUpdateResult {
+            should_ping: state_decision.should_ping(),
+            link_detection_update_result: LinkDetectionUpdateResult {
+                should_notify: state_decision.should_notify(),
+                link_state: Some(link_state),
+            },
         }
     }
 }
@@ -401,6 +483,10 @@ impl BytesAndTimestamps {
     fn is_link_up(&self, rtt: Duration) -> bool {
         self.tx_ts <= self.rx_ts || self.rx_ts.elapsed() < WG_KEEPALIVE + rtt
     }
+
+    fn is_silent_connection(&self, rtt: Duration) -> bool {
+        self.tx_ts <= self.rx_ts && self.rx_ts.elapsed() >= WG_KEEPALIVE + rtt
+    }
 }
 
 #[cfg(test)]
@@ -419,7 +505,10 @@ mod tests {
         assert_eq!(no_link_detection.is_disabled(), true);
 
         // Enabled
-        let features = FeatureLinkDetection { rtt_seconds: 1 };
+        let features = FeatureLinkDetection {
+            rtt_seconds: 1,
+            enhanced_detection: false,
+        };
         let no_link_detection = LinkDetection::new(Some(features));
         assert_eq!(no_link_detection.is_disabled(), false);
     }
@@ -446,19 +535,19 @@ mod tests {
         time::advance(Duration::from_secs(1)).await;
 
         // Update with no change in rx_bytes, so there will be no timestamp update
-        ld.update(&key, Some(5), false);
+        ld.update(&key, Some(5), false).await;
         assert_eq!(ld.time_since_last_rx(&key), Some(last_change.elapsed()));
 
         time::advance(Duration::from_secs(1)).await;
 
         // Update with different rx_bytes
-        ld.update(&key, Some(10), false);
+        ld.update(&key, Some(10), false).await;
         assert_eq!(ld.time_since_last_rx(&key), Some(Instant::now().elapsed()));
     }
 
     #[tokio::test(start_paused = true)]
     async fn test_time_since_last_rx_with_enabled_link_detection() {
-        let mut ld = LinkDetectionEnabled::new(Duration::from_secs(15));
+        let mut ld = LinkDetectionEnabled::new(Duration::from_secs(15), false);
         let key = PublicKey::default();
 
         assert_eq!(ld.time_since_last_rx(&key), None);
@@ -478,13 +567,15 @@ mod tests {
         time::advance(Duration::from_secs(1)).await;
 
         // Update with no change in rx_bytes, so there will be no timestamp update
-        ld.update(&key, Some(5), None, NodeState::Connected, false);
+        ld.update(&key, Some(5), None, NodeState::Connected, None, false)
+            .await;
         assert_eq!(ld.time_since_last_rx(&key), Some(last_change.elapsed()));
 
         time::advance(Duration::from_secs(1)).await;
 
         // Update with different rx_bytes
-        ld.update(&key, Some(10), None, NodeState::Connected, false);
+        ld.update(&key, Some(10), None, NodeState::Connected, None, false)
+            .await;
         assert_eq!(ld.time_since_last_rx(&key), Some(Instant::now().elapsed()));
     }
 

--- a/crates/telio-wg/src/link_detection/pinger.rs
+++ b/crates/telio-wg/src/link_detection/pinger.rs
@@ -1,0 +1,121 @@
+use async_trait::async_trait;
+use socket2::Type;
+use std::net::{Ipv4Addr, Ipv6Addr};
+use std::sync::Arc;
+use std::time::Duration;
+use std::{convert::TryInto, net::IpAddr};
+use surge_ping::{
+    Client, Config as PingerConfig, ConfigBuilder, PingIdentifier, PingSequence, ICMP,
+};
+
+use telio_crypto::PublicKey;
+use telio_task::{
+    io::{chan, mc_chan, Chan, McChan},
+    task_exec, ExecError, Runtime, RuntimeExt, Task, WaitResponse,
+};
+use telio_utils::{telio_log_debug, telio_log_error, DualTarget};
+
+/// Component used to check the link state when we think it's down.
+/// We can check it before we announce it as down.
+///
+/// Can be used with both IPv4 and IPv6 addresses.
+pub struct Pinger {
+    task: Task<State>,
+}
+
+impl Pinger {
+    pub fn start_with(ping_channel: chan::Rx<IpAddr>) -> std::io::Result<Self> {
+        Ok(Self {
+            task: Task::start(State::new(ping_channel)?),
+        })
+    }
+
+    pub async fn stop(self) {
+        let _ = self.task.stop().await.resume_unwind();
+    }
+}
+
+pub struct State {
+    pub ping_channel: chan::Rx<IpAddr>,
+    client_v4: Arc<Client>,
+    client_v6: Arc<Client>,
+}
+
+impl State {
+    const PING_TIMEOUT: Duration = Duration::from_secs(3);
+
+    pub fn new(ping_channel: chan::Rx<IpAddr>) -> std::io::Result<Self> {
+        Ok(State {
+            ping_channel,
+            client_v4: Arc::new(Self::build_client(ICMP::V4)?),
+            client_v6: Arc::new(Self::build_client(ICMP::V6)?),
+        })
+    }
+
+    pub async fn ping(&self, target: IpAddr) {
+        telio_log_debug!("Trying to ping {:?} host", target);
+
+        let mut pinger = match target {
+            IpAddr::V4(_) => {
+                self.client_v4
+                    .clone()
+                    .pinger(target, PingIdentifier(rand::random()))
+                    .await
+            }
+            IpAddr::V6(_) => {
+                self.client_v6
+                    .clone()
+                    .pinger(target, PingIdentifier(rand::random()))
+                    .await
+            }
+        };
+
+        pinger.timeout(Self::PING_TIMEOUT);
+
+        match pinger.ping(PingSequence(0), &[0; 56]).await {
+            Ok(_) => telio_log_debug!("Ping to {} succeeded", target),
+            Err(e) => telio_log_debug!("Ping to {} failed: {}", target, e.to_string()),
+        }
+    }
+
+    fn build_client(proto: ICMP) -> std::io::Result<Client> {
+        let mut config_builder = PingerConfig::builder().kind(proto);
+        if cfg!(any(
+            target_os = "ios",
+            target_os = "macos",
+            target_os = "tvos",
+        )) {
+            config_builder = config_builder.sock_type_hint(Type::RAW);
+        }
+        if cfg!(not(target_os = "android")) {
+            match proto {
+                ICMP::V4 => {
+                    config_builder = config_builder.bind((Ipv4Addr::UNSPECIFIED, 0).into());
+                }
+                ICMP::V6 => {
+                    config_builder = config_builder.bind((Ipv6Addr::UNSPECIFIED, 0).into());
+                }
+            }
+        }
+
+        Client::new(&config_builder.build())
+    }
+}
+
+#[async_trait]
+impl Runtime for State {
+    const NAME: &'static str = "Link detection pinger";
+
+    type Err = ();
+
+    async fn wait(&mut self) -> WaitResponse<'_, Self::Err> {
+        if let Some(target) = self.ping_channel.recv().await {
+            Self::guard(async move {
+                self.ping(target).await;
+                Ok(())
+            })
+        } else {
+            Self::next()
+        }
+    }
+}

--- a/crates/telio-wg/src/wg.rs
+++ b/crates/telio-wg/src/wg.rs
@@ -639,10 +639,19 @@ impl State {
             if let (Some(old), Some(new)) = (from.peers.get(key), to.peers.get(key)) {
                 let old_state = old.state();
                 let new_state = new.state();
+                let node_address = new.ip_addresses.first().cloned();
 
-                let no_link_detection_update_result =
-                    self.no_link_detection
-                        .update(key, new.rx_bytes, new.tx_bytes, new_state, push);
+                let no_link_detection_update_result = self
+                    .no_link_detection
+                    .update(
+                        key,
+                        new.rx_bytes,
+                        new.tx_bytes,
+                        new_state,
+                        node_address,
+                        push,
+                    )
+                    .await;
 
                 if !old.is_same_event(new)
                     || old_state != new_state
@@ -864,6 +873,7 @@ impl Runtime for State {
 
     async fn stop(self) {
         self.adapter.stop().await;
+        self.no_link_detection.stop().await;
         #[cfg(unix)]
         self.cfg
             .tun

--- a/nat-lab/tests/telio_features.py
+++ b/nat-lab/tests/telio_features.py
@@ -62,6 +62,7 @@ class Nurse(DataClassJsonMixin):
 @dataclass
 class LinkDetection(DataClassJsonMixin):
     rtt_seconds: Optional[int] = None
+    enhanced_detection: Optional[bool] = False
 
 
 @dataclass_json(undefined=Undefined.EXCLUDE)

--- a/nat-lab/tests/test_events_link_state.py
+++ b/nat-lab/tests/test_events_link_state.py
@@ -20,13 +20,16 @@ def long_persistent_keepalive_periods() -> Wireguard:
 
 def _generate_setup_paramete_pair(
     cfg: List[Tuple[ConnectionTag, AdapterType]],
+    enhaced_detection: bool,
 ) -> List[SetupParameters]:
     return [
         SetupParameters(
             connection_tag=tag,
             adapter_type=adapter,
             features=TelioFeatures(
-                link_detection=LinkDetection(rtt_seconds=1),
+                link_detection=LinkDetection(
+                    rtt_seconds=1, enhanced_detection=enhaced_detection
+                ),
                 wireguard=long_persistent_keepalive_periods(),
             ),
         )
@@ -48,7 +51,17 @@ FEATURE_ENABLED_PARAMS = [
             [
                 (ConnectionTag.DOCKER_CONE_CLIENT_1, AdapterType.LinuxNativeWg),
                 (ConnectionTag.DOCKER_CONE_CLIENT_2, AdapterType.BoringTun),
-            ]
+            ],
+            False,
+        )
+    ),
+    pytest.param(
+        _generate_setup_paramete_pair(
+            [
+                (ConnectionTag.DOCKER_CONE_CLIENT_1, AdapterType.LinuxNativeWg),
+                (ConnectionTag.DOCKER_CONE_CLIENT_2, AdapterType.BoringTun),
+            ],
+            True,
         )
     ),
     pytest.param(
@@ -56,8 +69,38 @@ FEATURE_ENABLED_PARAMS = [
             [
                 (ConnectionTag.DOCKER_CONE_CLIENT_1, AdapterType.BoringTun),
                 (ConnectionTag.DOCKER_CONE_CLIENT_2, AdapterType.BoringTun),
-            ]
+            ],
+            False,
         )
+    ),
+    pytest.param(
+        _generate_setup_paramete_pair(
+            [
+                (ConnectionTag.DOCKER_CONE_CLIENT_1, AdapterType.BoringTun),
+                (ConnectionTag.DOCKER_CONE_CLIENT_2, AdapterType.BoringTun),
+            ],
+            True,
+        )
+    ),
+    pytest.param(
+        _generate_setup_paramete_pair(
+            [
+                (ConnectionTag.WINDOWS_VM, AdapterType.WindowsNativeWg),
+                (ConnectionTag.DOCKER_CONE_CLIENT_1, AdapterType.BoringTun),
+            ],
+            False,
+        ),
+        marks=pytest.mark.windows,
+    ),
+    pytest.param(
+        _generate_setup_paramete_pair(
+            [
+                (ConnectionTag.WINDOWS_VM, AdapterType.WindowsNativeWg),
+                (ConnectionTag.DOCKER_CONE_CLIENT_1, AdapterType.BoringTun),
+            ],
+            True,
+        ),
+        marks=pytest.mark.windows,
     ),
 ]
 


### PR DESCRIPTION
Improve no-link detection by sending a ping when we have clues that the connection might be down or when the connection is silent for too long.




### :ballot_box_with_check: Definition of Done checklist
- [ ] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [ ] README.md is updated
- [ ] changelog.md is updated
- [ ] Functionality is covered by unit or integration tests
