### PR TITLE
Change the interval missed tick behaviour to Delay in RepeatedActions::add_action

### DIFF
--- a/.unreleased/LLT-5139
+++ b/.unreleased/LLT-5139
@@ -1,0 +1,1 @@
+Change the interval missed tick behaviour to Delay in RepeatedActions::add_action

--- a/crates/telio-nurse/src/heartbeat.rs
+++ b/crates/telio-nurse/src/heartbeat.rs
@@ -27,9 +27,11 @@ use telio_task::{
     io::{chan, mc_chan, Chan},
     Runtime, RuntimeExt, WaitResponse,
 };
-use telio_utils::{map_enum, telio_log_debug, telio_log_error, telio_log_trace, telio_log_warn};
+use telio_utils::{
+    interval_at, map_enum, telio_log_debug, telio_log_error, telio_log_trace, telio_log_warn,
+};
 use telio_wg::uapi::PeerState;
-use tokio::time::{interval_at, sleep, Duration, Instant, Interval, MissedTickBehavior, Sleep};
+use tokio::time::{sleep, Duration, Instant, Interval, Sleep};
 use uuid::Uuid;
 
 #[mockall_double::double]
@@ -397,8 +399,7 @@ impl Analytics {
     ) -> Self {
         let start_time = Instant::now() + config.initial_collect_interval;
 
-        let mut interval: Interval = interval_at(start_time, config.collect_interval);
-        interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+        let interval: Interval = interval_at(start_time, config.collect_interval);
 
         let mut config_nodes = HashMap::new();
         // Add self in config_nodes hashset

--- a/crates/telio-nurse/src/qos.rs
+++ b/crates/telio-nurse/src/qos.rs
@@ -7,14 +7,14 @@ use std::time::Instant;
 use telio_model::constants::{VPN_INTERNAL_IPV4, VPN_INTERNAL_IPV6};
 
 use tokio::sync::mpsc;
-use tokio::time::{interval_at, Duration, Interval, MissedTickBehavior};
+use tokio::time::{Duration, Interval};
 
 use telio_crypto::PublicKey;
 use telio_model::features::RttType;
 use telio_task::{io::mc_chan, Runtime, RuntimeExt, WaitResponse};
 use telio_wg::uapi::{AnalyticsEvent, PeerState};
 
-use telio_utils::{telio_log_debug, telio_log_trace, DualTarget};
+use telio_utils::{interval_at, telio_log_debug, telio_log_trace, DualTarget};
 
 use crate::config::QoSConfig;
 
@@ -233,8 +233,7 @@ impl Analytics {
         } else {
             Arc::new(None)
         };
-        let mut rtt_interval = interval_at(tokio::time::Instant::now(), config.rtt_interval);
-        rtt_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+        let rtt_interval = interval_at(tokio::time::Instant::now(), config.rtt_interval);
 
         Self {
             rtt_interval,

--- a/crates/telio-nurse/src/qos.rs
+++ b/crates/telio-nurse/src/qos.rs
@@ -14,7 +14,7 @@ use telio_model::features::RttType;
 use telio_task::{io::mc_chan, Runtime, RuntimeExt, WaitResponse};
 use telio_wg::uapi::{AnalyticsEvent, PeerState};
 
-use telio_utils::{interval_at, telio_log_debug, telio_log_trace, DualTarget};
+use telio_utils::{interval, telio_log_debug, telio_log_trace, DualTarget};
 
 use crate::config::QoSConfig;
 
@@ -233,7 +233,7 @@ impl Analytics {
         } else {
             Arc::new(None)
         };
-        let rtt_interval = interval_at(tokio::time::Instant::now(), config.rtt_interval);
+        let rtt_interval = interval(config.rtt_interval);
 
         Self {
             rtt_interval,

--- a/crates/telio-relay/src/derp/http.rs
+++ b/crates/telio-relay/src/derp/http.rs
@@ -14,12 +14,13 @@ use std::{
 };
 use telio_sockets::{SocketBufSizes, SocketPool, TcpParams};
 use telio_task::io::Chan;
+use telio_utils::interval_at;
 use webpki_roots::TLS_SERVER_ROOTS;
 
 use crate::{Config, DerpKeepaliveConfig};
 
 use telio_crypto::{PublicKey, SecretKey};
-use tokio::time::{interval_at, Interval, MissedTickBehavior};
+use tokio::time::Interval;
 use tokio::{
     io::{split, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt},
     task::JoinHandle,
@@ -200,9 +201,7 @@ async fn connect_and_start<RW: AsyncRead + AsyncWrite + Send + 'static>(
         }),
         poll_timer: {
             let poll_interval = Duration::from_secs(server_keepalives.derp_keepalive as u64);
-            let mut timer = interval_at(tokio::time::Instant::now() + poll_interval, poll_interval);
-            timer.set_missed_tick_behavior(MissedTickBehavior::Delay);
-            timer
+            interval_at(tokio::time::Instant::now() + poll_interval, poll_interval)
         },
     })
 }

--- a/crates/telio-traversal/src/connectivity_check/cross_ping_check.rs
+++ b/crates/telio-traversal/src/connectivity_check/cross_ping_check.rs
@@ -24,7 +24,7 @@ use telio_proto::{CallMeMaybeMsg, CallMeMaybeType, Session};
 use telio_task::{io::chan, io::Chan, task_exec, BoxAction, Runtime, Task};
 use telio_utils::{
     exponential_backoff::{Backoff, ExponentialBackoff, ExponentialBackoffBounds},
-    interval_at, telio_log_debug, telio_log_info, telio_log_trace, telio_log_warn, LruCache,
+    interval, telio_log_debug, telio_log_info, telio_log_trace, telio_log_warn, LruCache,
 };
 use tokio::sync::Mutex;
 use tokio::time::{Instant, Interval};
@@ -221,7 +221,7 @@ impl<E: Backoff> CrossPingCheck<E> {
         ping_pong_handler: Arc<Mutex<PingPongHandler>>,
         exponential_backoff_helper_provider: ExponentialBackoffProvider<E>,
     ) -> Self {
-        let poll_timer = interval_at(tokio::time::Instant::now(), poll_period);
+        let poll_timer = interval(poll_period);
         Self {
             task: Task::start(State {
                 io,

--- a/crates/telio-traversal/src/connectivity_check/cross_ping_check.rs
+++ b/crates/telio-traversal/src/connectivity_check/cross_ping_check.rs
@@ -24,10 +24,10 @@ use telio_proto::{CallMeMaybeMsg, CallMeMaybeType, Session};
 use telio_task::{io::chan, io::Chan, task_exec, BoxAction, Runtime, Task};
 use telio_utils::{
     exponential_backoff::{Backoff, ExponentialBackoff, ExponentialBackoffBounds},
-    telio_log_debug, telio_log_info, telio_log_trace, telio_log_warn, LruCache,
+    interval_at, telio_log_debug, telio_log_info, telio_log_trace, telio_log_warn, LruCache,
 };
-use tokio::time::{interval_at, Instant, Interval};
-use tokio::{sync::Mutex, time::MissedTickBehavior};
+use tokio::sync::Mutex;
+use tokio::time::{Instant, Interval};
 
 const CPC_TIMEOUT: Duration = Duration::from_secs(10);
 const UPGRADE_TIMEOUT: Duration = Duration::from_secs(60);
@@ -221,8 +221,7 @@ impl<E: Backoff> CrossPingCheck<E> {
         ping_pong_handler: Arc<Mutex<PingPongHandler>>,
         exponential_backoff_helper_provider: ExponentialBackoffProvider<E>,
     ) -> Self {
-        let mut poll_timer = interval_at(tokio::time::Instant::now(), poll_period);
-        poll_timer.set_missed_tick_behavior(MissedTickBehavior::Delay);
+        let poll_timer = interval_at(tokio::time::Instant::now(), poll_period);
         Self {
             task: Task::start(State {
                 io,

--- a/crates/telio-traversal/src/endpoint_providers/local.rs
+++ b/crates/telio-traversal/src/endpoint_providers/local.rs
@@ -14,7 +14,7 @@ use telio_crypto::PublicKey;
 use telio_proto::{Session, WGPort};
 use telio_sockets::External;
 use telio_task::{io::chan, task_exec, BoxAction, Runtime, Task};
-use telio_utils::{interval_at, telio_log_debug, telio_log_info, telio_log_warn};
+use telio_utils::{interval, telio_log_debug, telio_log_info, telio_log_warn};
 use telio_wg::{DynamicWg, WireGuard};
 use tokio::net::UdpSocket;
 use tokio::sync::Mutex;
@@ -137,7 +137,7 @@ impl<T: WireGuard, G: GetIfAddrs> LocalInterfacesEndpointProvider<T, G> {
         get_if_addr: G,
     ) -> Self {
         telio_log_info!("Starting local interfaces endpoint provider");
-        let poll_timer = interval_at(tokio::time::Instant::now(), poll_interval);
+        let poll_timer = interval(poll_interval);
         Self {
             task: Task::start(State {
                 endpoint_candidates_change_publisher: None,
@@ -335,7 +335,7 @@ mod tests {
                 endpoint_candidates_change_publisher: None,
                 pong_publisher: None,
                 last_endpoint_candidates_event: vec![],
-                poll_timer: interval_at(tokio::time::Instant::now(), Duration::from_secs(10)),
+                poll_timer: interval(Duration::from_secs(10)),
                 wireguard_interface: Arc::new(wg_mock),
                 udp_socket: SocketPool::new(
                     NativeProtector::new(

--- a/crates/telio-traversal/src/endpoint_providers/local.rs
+++ b/crates/telio-traversal/src/endpoint_providers/local.rs
@@ -14,11 +14,11 @@ use telio_crypto::PublicKey;
 use telio_proto::{Session, WGPort};
 use telio_sockets::External;
 use telio_task::{io::chan, task_exec, BoxAction, Runtime, Task};
-use telio_utils::{telio_log_debug, telio_log_info, telio_log_warn};
+use telio_utils::{interval_at, telio_log_debug, telio_log_info, telio_log_warn};
 use telio_wg::{DynamicWg, WireGuard};
 use tokio::net::UdpSocket;
 use tokio::sync::Mutex;
-use tokio::time::{interval_at, Interval, MissedTickBehavior};
+use tokio::time::Interval;
 
 #[cfg(test)]
 use mockall::automock;
@@ -137,8 +137,7 @@ impl<T: WireGuard, G: GetIfAddrs> LocalInterfacesEndpointProvider<T, G> {
         get_if_addr: G,
     ) -> Self {
         telio_log_info!("Starting local interfaces endpoint provider");
-        let mut poll_timer = interval_at(tokio::time::Instant::now(), poll_interval);
-        poll_timer.set_missed_tick_behavior(MissedTickBehavior::Delay);
+        let poll_timer = interval_at(tokio::time::Instant::now(), poll_interval);
         Self {
             task: Task::start(State {
                 endpoint_candidates_change_publisher: None,

--- a/crates/telio-traversal/src/upgrade_sync.rs
+++ b/crates/telio-traversal/src/upgrade_sync.rs
@@ -10,12 +10,12 @@ use telio_model::features::EndpointProvider;
 use telio_nurse::aggregator::ConnectivityDataAggregator;
 use telio_proto::{Decision, Session, UpgradeDecisionMsg, UpgradeMsg};
 use telio_task::{io::chan, io::Chan, task_exec, BoxAction, Runtime, Task};
-use telio_utils::{telio_log_debug, telio_log_info, telio_log_warn, LruCache};
+use telio_utils::{interval_at, telio_log_debug, telio_log_info, telio_log_warn, LruCache};
 use telio_wg::uapi::{AnalyticsEvent, PeerState};
 use telio_wg::WireGuard;
 use tokio::{
     sync::mpsc::error::SendError,
-    time::{interval_at, Instant, Interval, MissedTickBehavior},
+    time::{Instant, Interval},
 };
 
 use crate::cross_ping_check::UpgradeController;
@@ -120,8 +120,7 @@ impl UpgradeSync {
         wireguard: Arc<dyn WireGuard>,
     ) -> Result<Self> {
         telio_log_info!("Starting Upgrade sync module");
-        let mut poll_timer = interval_at(Instant::now(), expiration_period / 2);
-        poll_timer.set_missed_tick_behavior(MissedTickBehavior::Delay);
+        let poll_timer = interval_at(Instant::now(), expiration_period / 2);
         Ok(Self {
             task: Task::start(State {
                 upgrade_request_publisher,

--- a/crates/telio-traversal/src/upgrade_sync.rs
+++ b/crates/telio-traversal/src/upgrade_sync.rs
@@ -10,7 +10,7 @@ use telio_model::features::EndpointProvider;
 use telio_nurse::aggregator::ConnectivityDataAggregator;
 use telio_proto::{Decision, Session, UpgradeDecisionMsg, UpgradeMsg};
 use telio_task::{io::chan, io::Chan, task_exec, BoxAction, Runtime, Task};
-use telio_utils::{interval_at, telio_log_debug, telio_log_info, telio_log_warn, LruCache};
+use telio_utils::{interval, telio_log_debug, telio_log_info, telio_log_warn, LruCache};
 use telio_wg::uapi::{AnalyticsEvent, PeerState};
 use telio_wg::WireGuard;
 use tokio::{
@@ -120,7 +120,7 @@ impl UpgradeSync {
         wireguard: Arc<dyn WireGuard>,
     ) -> Result<Self> {
         telio_log_info!("Starting Upgrade sync module");
-        let poll_timer = interval_at(Instant::now(), expiration_period / 2);
+        let poll_timer = interval(expiration_period / 2);
         Ok(Self {
             task: Task::start(State {
                 upgrade_request_publisher,

--- a/crates/telio-utils/src/interval.rs
+++ b/crates/telio-utils/src/interval.rs
@@ -1,0 +1,15 @@
+use tokio::time::{self, Duration, Instant, Interval, MissedTickBehavior};
+
+/// Just like `tokio::time::interval` but the missed tick behaviour
+/// is set to `Delay`.
+pub fn interval(period: Duration) -> Interval {
+    interval_at(Instant::now(), period)
+}
+
+/// Just like `tokio::time::interval_at` but the missed tick behaviour
+/// is set to `Delay`.
+pub fn interval_at(start: Instant, period: Duration) -> Interval {
+    let mut interval = time::interval_at(start, period);
+    interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    interval
+}

--- a/crates/telio-utils/src/lib.rs
+++ b/crates/telio-utils/src/lib.rs
@@ -38,3 +38,7 @@ pub use ::tokio::*;
 /// Least Recently Used cache implementation
 pub mod lru_cache;
 pub use lru_cache::*;
+
+/// Tokio interval creation wrappers
+pub mod interval;
+pub use interval::*;

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -67,7 +67,7 @@ use futures::FutureExt;
 use telio_utils::{
     commit_sha,
     exponential_backoff::ExponentialBackoffBounds,
-    interval_at, telio_log_debug, telio_log_error, telio_log_info, telio_log_warn,
+    interval, telio_log_debug, telio_log_error, telio_log_info, telio_log_warn,
     tokio::{Monitor, ThreadTracker},
     version_tag,
 };
@@ -1152,7 +1152,7 @@ impl Runtime {
             post_quantum.tx,
         );
 
-        let polling_interval = interval_at(tokio::time::Instant::now(), Duration::from_secs(5));
+        let polling_interval = interval(Duration::from_secs(5));
 
         let pmtu_detection = features.pmtu_discovery.map(|cfg| {
             telio_pmtu::Entity::new(

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -43,7 +43,7 @@ use thiserror::Error as TError;
 use tokio::{
     runtime::{Builder, Runtime as AsyncRuntime},
     sync::Mutex,
-    time::{interval_at, Interval, MissedTickBehavior},
+    time::Interval,
 };
 
 use telio_dns::{DnsResolver, LocalDnsResolver, Records};
@@ -67,7 +67,7 @@ use futures::FutureExt;
 use telio_utils::{
     commit_sha,
     exponential_backoff::ExponentialBackoffBounds,
-    telio_log_debug, telio_log_error, telio_log_info, telio_log_warn,
+    interval_at, telio_log_debug, telio_log_error, telio_log_info, telio_log_warn,
     tokio::{Monitor, ThreadTracker},
     version_tag,
 };
@@ -1152,8 +1152,7 @@ impl Runtime {
             post_quantum.tx,
         );
 
-        let mut polling_interval = interval_at(tokio::time::Instant::now(), Duration::from_secs(5));
-        polling_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+        let polling_interval = interval_at(tokio::time::Instant::now(), Duration::from_secs(5));
 
         let pmtu_detection = features.pmtu_discovery.map(|cfg| {
             telio_pmtu::Entity::new(


### PR DESCRIPTION
### Problem
`RepeatedActions::add_action` used intervals with default missed tick behaviour. This caused many 'activations' after a long sleep, one for each missed tick. This is not desired - we want to ignore all the missed ticks.

### Solution
`add_action` is modified to use a missed tick behaviour that will skip all the missed ticks. Additionally, to make it a little bit less likely that this kind of a mistake will be once again made all the places where the intervals are created had been converted to use our internal wrapper that returns `Interval` with already correct missed tick behaviour.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
