### PR TITLE
Rename string_to_* FFI functions

### DIFF
--- a/.unreleased/rename-ffi-deserialize-functions
+++ b/.unreleased/rename-ffi-deserialize-functions
@@ -1,0 +1,1 @@
+Rename string_to_features and string_to_meshnet_config to deserialize_feature_config and deserialize_meshnet_config

--- a/src/doc/integrating_telio.md
+++ b/src/doc/integrating_telio.md
@@ -145,7 +145,7 @@ use telio::{ffi::*, types::*};
 use telio_model::features::FeatureLana;
 
 let json_feature_config = "<feature config fetched from API>".to_owned();
-let mut feature_config = string_to_features(json_feature_config).unwrap();
+let mut feature_config = deserialize_feature_config(json_feature_config).unwrap();
 
 feature_config.lana = Some(FeatureLana {  event_path: "some/path.db".to_owned(), prod: true });
 if let Some(nurse) = &mut feature_config.nurse {
@@ -166,7 +166,7 @@ telio.destroy().unwrap();
 import github.com/nordsecurity/telio
 
 jsonFeatureConfig := "<feature config fetched from API>";
-featureConfig, err := StringToFeatures(jsonFeatureConfig);
+featureConfig, err := DeserializeFeatureConfig(jsonFeatureConfig);
 
 featureConfig.lana = FeatureLana { EventPath: "some/path.db", Prod: true}
 if featureConfig.Nurse != nil {
@@ -184,7 +184,7 @@ _, err = telio.Destroy()
 import libtelio
 
 let jsonFeatureConfig = "<feature config fetched from API>";
-let featureConfig = stringToFeatures(jsonFeatureConfig);
+let featureConfig = deserializeFeatureConfig(jsonFeatureConfig);
 
 featureConfig.lana = FeatureLana("some/path.db", true)
 featureConfig.nurse?.fingerprint = "me"
@@ -197,7 +197,7 @@ telio.destroy()
 using uniffi.libtelio;
 
 String jsonFeatureConfig = "<feature config fetched from API>";
-Features featureConfig = StringToFeatures(jsonFeatureConfig);
+Features featureConfig = DeserializeFeatureConfig(jsonFeatureConfig);
 
 featureConfig.lana = new FeatureLana("some/path.db", true);
 if (featureConfig.nurse != null) {
@@ -212,7 +212,7 @@ telio.Destroy();
 import com.nordsec.libtelio.*
 
 val jsonFeatureConfig = "<feature config fetched from API>"
-val featureConfig = stringToFeatures(jsonFeatureConfig)!!
+val featureConfig = deserializeFeatureConfig(jsonFeatureConfig)!!
 
 featureConfig.lana = FeatureLana("some/path.db", true)
 featureConfig.nurse?.fingerprint = "me"
@@ -222,6 +222,7 @@ telio.destroy()!!
 ```
 
 </multi-code>
+
 
 ### Event Callback
 App passes event callback. Deserializes Telio Event from received JSON string. For details on events, see the [events documentation](../_telio_events_documentation/index.html).
@@ -586,7 +587,7 @@ telio.start(sk, adapter).unwrap();
 let mesh_pk = generate_public_key(sk);
 // Register mesh_pk with api if needed
 let json_config = "<json config recieved from api>".to_owned();
-let config = string_to_meshnet_config(json_config).unwrap();
+let config = deserialize_meshnet_config(json_config).unwrap();
 // Change secret key if needed
 telio.set_secret_key(&sk).unwrap();
 /* Turn on or update meshnet */
@@ -609,7 +610,7 @@ _, err = telio.Start(sk, adapter)
 meshPk := GeneratePublicKey(sk)
 // Register meshPk with api if needed
 jsonConfig := "<json config recieved from api>"
-config, err := StringToMeshnetConfig(jsonConfig)
+config, err := DeserializeMeshnetConfig(jsonConfig)
 // Change secret key if needed
 _, err := telio.SetSecretKey(sk)
 /* Turn on or update meshnet */
@@ -632,7 +633,7 @@ telio.start(sk, adapter)
 let meshPk = generatePublicKey(sk)
 // Register meshPk with api if needed
 let jsonConfig = "<json config recieved from api>"
-let config = stringToMeshnetConfig(jsonConfig)
+let config = deserializeMeshnetConfig(jsonConfig)
 // Change secret key if needed
 telio.setSecretKey(sk)
 /* Turn on or update meshnet */
@@ -655,7 +656,7 @@ telio.Start(sk, adapter);
 var meshPk = GeneratePublicKey(sk);
 // Register meshPk with api if needed
 var jsonConfig = "<json config recieved from api>";
-var config = StringToMeshnetConfig(jsonConfig);
+var config = DeserializeMeshnetConfig(jsonConfig);
 // Change secret key if needed
 telio.SetSecretKey(sk);
 /* Turn on or update meshnet */
@@ -678,7 +679,7 @@ telio.start(sk, adapter)!!
 val meshPk = generatePublicKey(sk)
 // Register meshPk with api if needed
 val jsonConfig = "<json config recieved from api>"
-val config = stringToMeshnetConfig(jsonConfig)!!
+val config = deserializeMeshnetConfig(jsonConfig)!!
 // Change secret key if needed
 telio.setSecretKey(sk)!!
 /* Turn on or update meshnet */

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -113,7 +113,7 @@ pub fn generate_public_key(secret_key: SecretKey) -> PublicKey {
 
 /// Utility function to create a `Features` object from a json-string
 /// Passing an empty string will return the default feature config
-pub fn string_to_features(fstr: String) -> FFIResult<Features> {
+pub fn deserialize_feature_config(fstr: String) -> FFIResult<Features> {
     if fstr.is_empty() {
         Ok(Features::default())
     } else {
@@ -122,7 +122,7 @@ pub fn string_to_features(fstr: String) -> FFIResult<Features> {
 }
 
 /// Utility function to create a `Config` object from a json-string
-pub fn string_to_meshnet_config(cfg_str: String) -> FFIResult<Config> {
+pub fn deserialize_meshnet_config(cfg_str: String) -> FFIResult<Config> {
     match Config::new_from_str(&cfg_str) {
         Ok((cfg, _)) => Ok(cfg),
         Err(e) => match e {
@@ -996,13 +996,13 @@ mod tests {
     fn telio_set_meshnet_rejects_too_long_configs() {
         let cfg = "a".repeat(MAX_CONFIG_LENGTH);
         assert!(matches!(
-            string_to_meshnet_config(cfg),
+            deserialize_meshnet_config(cfg),
             Err(TelioError::BadConfig)
         ));
 
         let cfg = "a".repeat(MAX_CONFIG_LENGTH + 2);
         assert!(matches!(
-            string_to_meshnet_config(cfg),
+            deserialize_meshnet_config(cfg),
             Err(TelioError::InvalidString)
         ));
     }
@@ -1018,7 +1018,8 @@ mod tests {
         }
 
         let features =
-            string_to_features(CORRECT_FEATURES_JSON_WITHOUT_IS_TEST_ENV.to_owned()).unwrap();
+            deserialize_feature_config(CORRECT_FEATURES_JSON_WITHOUT_IS_TEST_ENV.to_owned())
+                .unwrap();
         let res = Telio::new(features, Box::new(Events));
 
         assert!(res.is_ok());
@@ -1038,7 +1039,7 @@ mod tests {
         }
 
         let features =
-            string_to_features(CORRECT_FEATURES_JSON_WITH_IS_TEST_ENV.to_owned()).unwrap();
+            deserialize_feature_config(CORRECT_FEATURES_JSON_WITH_IS_TEST_ENV.to_owned()).unwrap();
         let res = Telio::new(features, Box::new(Events));
 
         assert!(res.is_ok());
@@ -1048,15 +1049,16 @@ mod tests {
     }
 
     #[test]
-    fn test_string_to_features_empty_string() {
-        let actual = string_to_features("".to_owned()).unwrap();
+    fn test_deserialize_feature_config_empty_string() {
+        let actual = deserialize_feature_config("".to_owned()).unwrap();
         let expected = Features::default();
         assert_eq!(actual, expected);
     }
 
     #[test]
-    fn test_string_to_features_valid_string() {
-        let actual = string_to_features(CORRECT_FEATURES_JSON_WITHOUT_IS_TEST_ENV.to_owned());
+    fn test_deserialize_feature_config_valid_string() {
+        let actual =
+            deserialize_feature_config(CORRECT_FEATURES_JSON_WITHOUT_IS_TEST_ENV.to_owned());
         assert!(actual.is_ok());
     }
 }

--- a/src/libtelio.udl
+++ b/src/libtelio.udl
@@ -138,11 +138,11 @@ namespace telio {
     /// Utility function to create a `Features` object from a json-string
     /// Passing an empty string will return the default feature config
     [Throws=TelioError]
-    Features string_to_features(string fstr);
+    Features deserialize_feature_config(string fstr);
 
     /// Utility function to create a `Config` object from a json-string
     [Throws=TelioError]
-    Config string_to_meshnet_config(string cfg_str);
+    Config deserialize_meshnet_config(string cfg_str);
 };
 
 interface Telio {


### PR DESCRIPTION
### Problem
`string_to_features` and `string_to_meshnet_config` could be named better

### Solution
Rename to `deserialize_feature_config` and `deserialize_meshnet_config`


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
