### PR TITLE
Update README.md: Add gcc check and ca-certificates installation (in Dockerfile)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,17 @@ To go through the short TCLI tutorial you need also [docker](https://docs.docker
 
 You can build the `libtelio` library using standard `cargo build` command.
 
+#### Linux toolchain
+1. Verify that GCC (GNU Compiler Collection) has been installed:
+```shell
+gcc --version
+```
+Otherwise run following command to install it:
+```shell
+sudo apt update
+sudo apt install gcc
+```
+
 #### Windows msvc toolchain
 
 To build `libtelio` on Windows with `x86_64-pc-windows-msvc` toolchain you need to install:
@@ -63,7 +74,7 @@ Make a `docker` directory in `tcli-test` and put there the following simple Dock
 FROM ubuntu
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y iproute2 iputils-ping tcpdump
+    DEBIAN_FRONTEND=noninteractive apt-get install -y iproute2 iputils-ping tcpdump ca-certificates
 ```
 
 Then build it and tag it as `tcli-test`, running the following command from the `docker` directory:


### PR DESCRIPTION
1. Add to README.md check to verify if gcc (required for libtelio build) was installed. 
2. Add ca-certificates package (in order to connect to Derb server) installation for Docker container in README.md

### Problem
1. During build of libetlio on linux VM there was following error:
` error: linking with: /home/{username}/libtelio/linkers/d-x86_64-linux-gnu-gcc failed: exit status: 127`
2. Peer in docker container was not able to connect to DERB:
`2024-05-17T08:55:07.250137Z  WARN telio_relay::derp: 284: (DerpRelay) Failed to connect: I/O Error: invalid peer certificate: UnknownIssuer`

### Solution
1. For linux VM add check to verify if gcc (GNU Compiler Collection) is installed
2. Add `ca-certificates` to Dockerfile


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
