### PR TITLE
Launch dod automatically after every push

### DIFF
--- a/.github/workflows/dod.yml
+++ b/.github/workflows/dod.yml
@@ -1,7 +1,7 @@
 name: Definition of Done
 on:
   pull_request:
-    types: [opened, edited]
+    types: [opened, edited, synchronize]
 permissions: {}
 
 jobs:


### PR DESCRIPTION
### Problem
DoD must be un-checked and checked once again on every other push to PR.

### Solution
Restart DoD job on every push.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
