### PR TITLE
print pytest asyncio task stack

### DIFF
--- a/nat-lab/pyproject.toml
+++ b/nat-lab/pyproject.toml
@@ -72,3 +72,6 @@ markers = [
     "ipv6: tests only ipv6 WG connectivity",
     "ipv4v6: tests dual stack WG connectivity",
 ]
+filterwarnings = [
+    "ignore::DeprecationWarning"
+]

--- a/nat-lab/tests/conftest.py
+++ b/nat-lab/tests/conftest.py
@@ -13,6 +13,7 @@ def _cancel_all_tasks(loop: asyncio.AbstractEventLoop):
         return
 
     for task in to_cancel:
+        task.print_stack()
         task.cancel()
 
     loop.run_until_complete(asyncio.tasks.gather(*to_cancel, return_exceptions=True))


### PR DESCRIPTION
### Problem
When `pytest-timeout` cancels test due to timeout, we lose exception traceback, because `pytest-timeout` does `os._exit(1)`

### Solution
Print asyncio running task stack before cancelling them


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
