### PR TITLE
Fix clippy warning which got accidentally pushed to main

### DIFF
--- a/crates/telio-utils/src/repeated_actions.rs
+++ b/crates/telio-utils/src/repeated_actions.rs
@@ -111,13 +111,7 @@ where
 
         // Transform futures to `Output = (key, action)`
         let mut b: FuturesUnordered<_> = a
-            .map(|(key, interval, action)| {
-                interval
-                    .map(move |instant| {
-                        (key, action)
-                    })
-                    .boxed()
-            })
+            .map(|(key, interval, action)| interval.map(move |_| (key, action)).boxed())
             .collect();
 
         b.next()


### PR DESCRIPTION
Reverts NordSecurity/libtelio#566 As it broke some clippy checks

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
