### PR TITLE
LLT-5198 Skip maven job on nightly

### DIFF
--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -31,4 +31,4 @@ jobs:
           project-id: ${{ secrets.PROJECT_ID }}
           schedule: ${{ github.event_name == 'schedule' }}
           cancel-outdated-pipelines: ${{ github.ref_name != 'main' }}
-          triggered-ref: v1.1.9
+          triggered-ref: v1.1.10

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,4 +15,4 @@ libtelio-build-pipeline:
 
   trigger:
     project: $LIBTELIO_BUILD_PROJECT_PATH
-    branch: v1.1.9
+    branch: v1.1.10


### PR DESCRIPTION
Bumping `libtelio-build` to v1.1.10, that skips maven job on nightly pipelines.