### PR TITLE
Bump boringtun

### DIFF
--- a/.unreleased/LLT-5208
+++ b/.unreleased/LLT-5208
@@ -1,0 +1,1 @@
+Fix boringtun ignoring preshared key change

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "boringtun"
 version = "0.6.0"
-source = "git+https://github.com/NordSecurity/boringtun.git?tag=v1.2.0#406d7ad1dda34aca831a4bb8db80e9149327fefb"
+source = "git+https://github.com/NordSecurity/boringtun.git?tag=v1.2.1#e79fb28784fa6b3416525c6298364afef0d94b95"
 dependencies = [
  "aead",
  "base64 0.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,7 +159,7 @@ url = "2.2.2"
 uuid = { version = "1.1.2", features = ["v4"] }
 winapi = { version = "0.3", features = ["netioapi", "ws2def"] }
 
-boringtun = { git = "https://github.com/NordSecurity/boringtun.git", tag = "v1.2.0", features = ["device"] }
+boringtun = { git = "https://github.com/NordSecurity/boringtun.git", tag = "v1.2.1", features = ["device"] }
 x25519-dalek = { version = "2.0.1", features = ["reusable_secrets", "static_secrets"] }
 
 telio-crypto = { version = "0.1.0", path = "./crates/telio-crypto" }


### PR DESCRIPTION
### Problem
The old version of boringtun ignores the preshared key changes

### Solution
Update boringtun


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
