### PR TITLE
Fix cargo doc on mac and add a test for it

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -94,3 +94,19 @@ jobs:
         with:
           name: libtelio-build-${{ matrix.target_os }}-${{ matrix.arch }}-with-replaced-version
           path: dist/
+
+  build-docs-on-mac:
+    runs-on: macos-13
+    env:
+        RUSTDOCFLAGS: "-Zunstable-options --enable-index-page -Aunknown_lints --html-in-header ./rustdoc/header.html --html-after-content ./rustdoc/multi-code.html --html-after-content ./rustdoc/footer.html"
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Build Rust Docs
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly-2024-04-17
+        components: rust-docs
+
+    - run: cargo +nightly-2024-04-17 doc --no-deps --workspace --document-private-items

--- a/.unreleased/LLT-5075
+++ b/.unreleased/LLT-5075
@@ -1,0 +1,1 @@
+Fix cargo doc on mac and add a test for it

--- a/crates/telio-wg/src/adapter/mod.rs
+++ b/crates/telio-wg/src/adapter/mod.rs
@@ -3,7 +3,7 @@
 #[cfg_attr(docsrs, doc(cfg(not(windows))))]
 mod boring;
 
-#[cfg(any(target_os = "linux", doc))]
+#[cfg(target_os = "linux")]
 #[cfg_attr(docsrs, doc(cfg(target_os = "linux")))]
 mod linux_native_wg;
 
@@ -82,7 +82,7 @@ pub enum Error {
     BoringTun(#[from] boringtun::device::Error),
 
     /// Error types from Linux Native implementation
-    #[cfg(any(target_os = "linux", doc))]
+    #[cfg(target_os = "linux")]
     #[cfg_attr(docsrs, doc(cfg(target_os = "linux")))]
     #[error("LinuxNativeWg adapter error {0}")]
     LinuxNativeWg(#[from] linux_native_wg::Error),


### PR DESCRIPTION
### Problem
Cargo doc was not working previously on a macos host.

### Solution
Don't use linux only code on macos. Also automated job is added to not break it in future by accident.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
