### PR TITLE
Verify that all non management interfaces in nat-lab have no 'Router' property

### DIFF
--- a/.unreleased/LLT-5196
+++ b/.unreleased/LLT-5196
@@ -1,0 +1,1 @@
+Verify that all non management interfaces in nat-lab have no 'Router' property

--- a/nat-lab/bin/mac/list_interfaces_with_router_property.py
+++ b/nat-lab/bin/mac/list_interfaces_with_router_property.py
@@ -1,0 +1,46 @@
+# mypy: ignore-errors
+# autoflake: skip_file
+# pylint: skip-file
+
+from sys import exit
+from SystemConfiguration import SCDynamicStoreCreate, SCDynamicStoreCopyValue
+
+
+def main():
+    interfaces_with_router_prop = 0
+    store = SCDynamicStoreCreate(None, "demo.controller", None, None)
+    service_ids = SCDynamicStoreCopyValue(store, "Setup:/Network/Global/IPv4")
+
+    for id in service_ids["ServiceOrder"]:
+        dict = SCDynamicStoreCopyValue(store, f"State:/Network/Service/{id}/IPv4")
+        if dict:
+            if "Router" in dict:
+                interfaces_with_router_prop += 1
+                if "SubnetMasks" in dict:
+                    print(
+                        id,
+                        "name:",
+                        dict["InterfaceName"],
+                        "addr:",
+                        dict["Addresses"][0],
+                        "mask:",
+                        dict["SubnetMasks"][0],
+                        "router:",
+                        dict["Router"],
+                    )
+                else:
+                    print(
+                        id,
+                        "name:",
+                        dict["InterfaceName"],
+                        "addr:",
+                        dict["Addresses"][0],
+                        "router:",
+                        dict["Router"],
+                    )
+            else:
+                pass
+
+
+if __name__ == "__main__":
+    main()

--- a/nat-lab/tests/utils/vm/mac_vm_util.py
+++ b/nat-lab/tests/utils/vm/mac_vm_util.py
@@ -89,4 +89,9 @@ async def _copy_binaries(
         if set_exec:
             await connection.create_process(["chmod", "+x", dst]).execute()
 
+    await asyncssh.scp(
+        get_root_path("nat-lab/bin/mac/list_interfaces_with_router_property.py"),
+        (ssh_connection, f"{VM_TCLI_DIR}"),
+    )
+
     FILES_COPIED = True


### PR DESCRIPTION
### Problem
No test was added to #548

### Solution
Turns out that we already have very recently set all non management interfaces to be static and unknowingly removed the 'Router' property. To keep it that way, I've added a check to make sure that only the vagrant management interface can have the 'Router' property.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
