### PR TITLE
LLT-5220: Use UniFFI interface for TelioError

### DIFF
--- a/.unreleased/LLT-5220
+++ b/.unreleased/LLT-5220
@@ -1,0 +1,1 @@
+Use UniFFI interface instead of enum for TelioError

--- a/src/ffi/types.rs
+++ b/src/ffi/types.rs
@@ -3,7 +3,7 @@ use telio_model::event::Event;
 use telio_utils::map_enum;
 use tracing::Level;
 
-use std::panic::RefUnwindSafe;
+use std::{panic::RefUnwindSafe, sync::Arc};
 
 use crate::device::{AdapterType, Error as DevError};
 
@@ -19,12 +19,12 @@ pub trait TelioProtectCb: Send + Sync + RefUnwindSafe + std::fmt::Debug {
     fn protect(&self, socket_id: i32) -> FFIResult<()>;
 }
 
-pub type FFIResult<T> = Result<T, TelioError>;
+pub type FFIResult<T> = Result<T, Arc<TelioError>>;
 
 #[derive(Debug, thiserror::Error)]
 pub enum TelioError {
-    #[error("UnknownError: {inner}")]
-    UnknownError { inner: String },
+    #[error("UnknownError: {0}")]
+    UnknownError(anyhow::Error),
     #[error("InvalidKey")]
     InvalidKey,
     #[error("BadConfig")]
@@ -37,6 +37,27 @@ pub enum TelioError {
     AlreadyStarted,
     #[error("NotStarted")]
     NotStarted,
+}
+
+impl TelioError {
+    pub fn kind(&self) -> String {
+        match self {
+            TelioError::UnknownError(_) => "UnknownError".to_owned(),
+            TelioError::InvalidKey => "InvalidKey".to_owned(),
+            TelioError::BadConfig => "BadConfig".to_owned(),
+            TelioError::LockError => "LockError".to_owned(),
+            TelioError::InvalidString => "InvalidString".to_owned(),
+            TelioError::AlreadyStarted => "AlreadyStarted".to_owned(),
+            TelioError::NotStarted => "NotStarted".to_owned(),
+        }
+    }
+
+    pub fn message(&self) -> String {
+        match self {
+            TelioError::UnknownError(inner) => format!("{}: {}", self.kind(), inner),
+            _ => format!("{}: ", self.kind()),
+        }
+    }
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -93,9 +114,7 @@ impl From<DevError> for TelioError {
         match err {
             DevError::AlreadyStarted => Self::AlreadyStarted,
             DevError::BadPublicKey => Self::InvalidKey,
-            _ => Self::UnknownError {
-                inner: format!("{err:?}"),
-            },
+            _ => Self::UnknownError(anyhow::anyhow!(err)),
         }
     }
 }
@@ -106,9 +125,7 @@ impl From<&DevError> for TelioError {
         match err {
             DevError::AlreadyStarted => Self::AlreadyStarted,
             DevError::BadPublicKey => Self::InvalidKey,
-            _ => Self::UnknownError {
-                inner: format!("{err:?}"),
-            },
+            _ => Self::UnknownError(anyhow::anyhow!(err.to_string())),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,7 @@ pub use uniffi_libtelio::*;
 mod uniffi_libtelio {
     use std::convert::TryInto;
     use std::net::IpAddr;
+    use std::sync::Arc;
 
     use super::crypto::{PublicKey, SecretKey};
     use super::*;
@@ -74,17 +75,16 @@ mod uniffi_libtelio {
     use telio_model::features::*;
     use telio_model::mesh::*;
     use telio_utils::{Hidden, HiddenString};
+    use uniffi::ConvertError;
 
     type ErrorEvent = telio_model::event::Error;
     type TelioNode = telio_model::mesh::Node;
 
-    impl From<uniffi::UnexpectedUniFFICallbackError> for TelioError {
-        fn from(err: uniffi::UnexpectedUniFFICallbackError) -> Self {
-            let err_string = err.to_string();
-            let err_reason = err.reason;
-            Self::UnknownError {
-                inner: format!("{err_string} - {err_reason}"),
-            }
+    impl ConvertError<uniffi_libtelio::UniFfiTag> for Arc<TelioError> {
+        fn try_convert_unexpected_callback_error(
+            e: uniffi::UnexpectedUniFFICallbackError,
+        ) -> anyhow::Result<Self> {
+            Err(anyhow::Error::new(e))
         }
     }
 
@@ -120,8 +120,8 @@ mod uniffi_libtelio {
         type Builtin = String;
 
         fn into_custom(val: Self::Builtin) -> uniffi::Result<Self> {
-            Ok(val.parse().map_err(|_| TelioError::UnknownError {
-                inner: "Invalid IP address".to_owned(),
+            Ok(val.parse().map_err(|_| {
+                TelioError::UnknownError(anyhow::anyhow!("Invalid IP address".to_owned()))
             })?)
         }
 
@@ -134,8 +134,8 @@ mod uniffi_libtelio {
         type Builtin = String;
 
         fn into_custom(val: Self::Builtin) -> uniffi::Result<Self> {
-            Ok(val.parse().map_err(|_| TelioError::UnknownError {
-                inner: "Invalid IP address".to_owned(),
+            Ok(val.parse().map_err(|_| {
+                TelioError::UnknownError(anyhow::anyhow!("Invalid IP address".to_owned()))
             })?)
         }
 
@@ -161,8 +161,8 @@ mod uniffi_libtelio {
         type Builtin = String;
 
         fn into_custom(val: Self::Builtin) -> uniffi::Result<Self> {
-            Ok(val.parse().map_err(|_| TelioError::UnknownError {
-                inner: "Invalid IP address".to_owned(),
+            Ok(val.parse().map_err(|_| {
+                TelioError::UnknownError(anyhow::anyhow!("Invalid IP address".to_owned()))
             })?)
         }
 

--- a/src/libtelio.udl
+++ b/src/libtelio.udl
@@ -22,15 +22,10 @@ enum RttType {
     "Ping",
 };
 
-[Error]
+[Traits=(Debug)]
 interface TelioError {
-    UnknownError(string inner);
-    InvalidKey();
-    BadConfig();
-    LockError();
-    InvalidString();
-    AlreadyStarted();
-    NotStarted();
+    string kind();
+    string message();
 };
 
 /// Possible adapters.


### PR DESCRIPTION
### Problem
We want to be able to evolve our error definition without having to bump the major version of the lib

### Solution
Use UniFFI interface instead of enum for TelioError, and make necessary changes.

This change also allows us to use anyhow as the inner error of `TelioError::UnknownError`, which was previously blocked by UniFFI not being able to handle anyhow


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
