### PR TITLE
[LLT-4979] Add test for set_secret_key

### DIFF
--- a/nat-lab/bin/update_wg_peer_key
+++ b/nat-lab/bin/update_wg_peer_key
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Hardcoded variables
+INTERFACE="wg0"
+
+# Arguments
+CURRENT_PUBLIC_KEY=$1
+NEW_PUBLIC_KEY=$2
+
+# Check if both arguments are provided
+if [ -z "$CURRENT_PUBLIC_KEY" ] || [ -z "$NEW_PUBLIC_KEY" ]; then
+    echo "Usage: $0 <current_public_key> <new_public_key>"
+    exit 1
+fi
+
+# Check if wg command is available
+if ! command -v wg &> /dev/null
+then
+    echo "wg command could not be found. Please install WireGuard tools."
+    exit 1
+fi
+
+# Get the IP of the current peer
+PEER_IP=$(wg show $INTERFACE allowed-ips | grep $CURRENT_PUBLIC_KEY | awk '{print $2}')
+if [ -z "$PEER_IP" ]; then
+    echo "No peer found with the given public key: $CURRENT_PUBLIC_KEY"
+    exit 1
+fi
+
+# Remove the current peer
+wg set $INTERFACE peer $CURRENT_PUBLIC_KEY remove
+if [ $? -ne 0 ]; then
+    echo "Failed to remove peer with public key: $CURRENT_PUBLIC_KEY"
+    exit 1
+fi
+
+# Add the new peer with the same IP
+wg set $INTERFACE peer $NEW_PUBLIC_KEY allowed-ips $PEER_IP
+if [ $? -ne 0 ]; then
+    echo "Failed to add new peer with public key: $NEW_PUBLIC_KEY"
+    exit 1
+fi

--- a/nat-lab/tests/telio.py
+++ b/nat-lab/tests/telio.py
@@ -1,6 +1,7 @@
 # pylint: disable=too-many-lines
 
 import asyncio
+import base64
 import datetime
 import json
 import os
@@ -824,6 +825,9 @@ class Client:
                 )
             await event
 
+    async def set_secret_key(self, secret_key: str):
+        self.get_proxy().set_secret_key(secret_key)
+
     async def disconnect_from_vpn(
         self,
         public_key: str,
@@ -1163,3 +1167,13 @@ class Client:
         ev = self.wait_for_output(f"PMTU -> {host}: {expected}")
         await self._write_command(["pmtu", host])
         await ev.wait()
+
+
+def generate_secret_key() -> str:
+    return base64.b64encode(bytes(libtelio.generate_secret_key())).decode("ascii")
+
+
+def generate_public_key(private_key: str) -> str:
+    private_key_bytes = list(base64.b64decode(private_key))
+    public_key_bytes = bytes(libtelio.generate_public_key(private_key_bytes))
+    return base64.b64encode(public_key_bytes).decode("ascii")

--- a/nat-lab/tests/uniffi/libtelio_proxy.py
+++ b/nat-lab/tests/uniffi/libtelio_proxy.py
@@ -110,6 +110,9 @@ class LibtelioProxy:
     def set_meshnet_off(self):
         self.handle_remote_error(lambda r: r.set_meshnet_off())
 
+    def set_secret_key(self, secret_key):
+        self.handle_remote_error(lambda r: r.set_secret_key(secret_key))
+
     def is_running(self) -> bool:
         return self.handle_remote_error(lambda r: r.is_running())
 

--- a/nat-lab/tests/uniffi/libtelio_remote.py
+++ b/nat-lab/tests/uniffi/libtelio_remote.py
@@ -167,6 +167,10 @@ class LibtelioWrapper:
         self._libtelio.set_meshnet_off()
 
     @serialize_error
+    def set_secret_key(self, secret_key):
+        self._libtelio.set_secret_key(base64.b64decode(secret_key))
+
+    @serialize_error
     def is_running(self) -> bool:
         return self._libtelio.is_running()
 


### PR DESCRIPTION
### Problem
Before rebase on Boringtun v0.6.0 calling `set_secret_key` while using Boringtun adapter caused panic. We need to make sure that setting private key will work in the future.

### Solution
Add a test for `set_secret_key` Telio method


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
