### PR TITLE
[LLT-4928] Mask IP addresses in logs

### DIFF
--- a/clis/tcli/src/derp.rs
+++ b/clis/tcli/src/derp.rs
@@ -9,7 +9,7 @@ use telio_proto::{Codec, PacketRelayed};
 use telio_relay::{DerpRelay, SortedServers};
 use telio_sockets::{NativeProtector, SocketPool};
 use telio_task::io::{chan::Tx, Chan, McChan};
-use telio_utils::{telio_log_debug, telio_log_warn};
+use telio_utils::{telio_log_debug, telio_log_generic, telio_log_warn};
 use tokio::{runtime::Runtime, task::JoinHandle};
 
 use crate::{cli::Resp, cli_res, cli_try};

--- a/crates/telio-dns/src/bind_tun.rs
+++ b/crates/telio-dns/src/bind_tun.rs
@@ -21,7 +21,7 @@ mod darwin {
     use lazy_static::lazy_static;
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::{io, os::unix::prelude::AsRawFd, sync::Mutex};
-    use telio_utils::{telio_log_debug, telio_log_trace, telio_log_warn};
+    use telio_utils::{telio_log_debug, telio_log_generic, telio_log_trace, telio_log_warn};
 
     static SHOULD_BIND: AtomicBool = AtomicBool::new(false);
 
@@ -110,7 +110,7 @@ mod darwin {
 mod any {
     use std::io;
 
-    use telio_utils::telio_log_trace;
+    use telio_utils::{telio_log_generic, telio_log_trace};
 
     #[inline]
     pub(crate) fn set_tun<T>(_: T) -> io::Result<()> {

--- a/crates/telio-dns/src/dns.rs
+++ b/crates/telio-dns/src/dns.rs
@@ -13,7 +13,7 @@ use x25519_dalek::{PublicKey as PublicKeyDalek, StaticSecret};
 use telio_model::features::{FeatureExitDns, TtlValue};
 
 //debug tools
-use telio_utils::{telio_log_debug, telio_log_error};
+use telio_utils::{telio_log_debug, telio_log_error, telio_log_generic};
 
 /// A trait for managing dns resolver server instance.
 #[cfg_attr(any(test, feature = "mockall"), mockall::automock)]

--- a/crates/telio-dns/src/forward.rs
+++ b/crates/telio-dns/src/forward.rs
@@ -25,7 +25,9 @@ use hickory_server::{
     server::RequestInfo,
     store::forwarder::ForwardConfig,
 };
-use telio_utils::{telio_log_debug, telio_log_info, telio_log_trace, telio_log_warn};
+use telio_utils::{
+    telio_log_debug, telio_log_generic, telio_log_info, telio_log_trace, telio_log_warn,
+};
 use tokio::net::UdpSocket;
 
 use crate::bind_tun;

--- a/crates/telio-dns/src/nameserver.rs
+++ b/crates/telio-dns/src/nameserver.rs
@@ -25,7 +25,9 @@ use tokio::sync::{RwLock, RwLockMappedWriteGuard, RwLockWriteGuard, Semaphore};
 use tokio::task::JoinHandle;
 use tokio::{net::UdpSocket, sync::Mutex};
 
-use telio_utils::{telio_log_debug, telio_log_error, telio_log_trace, telio_log_warn};
+use telio_utils::{
+    telio_log_debug, telio_log_error, telio_log_generic, telio_log_trace, telio_log_warn,
+};
 
 const IPV4_HEADER: usize = 20; // bytes
 const IPV6_HEADER: usize = 40; // bytes

--- a/crates/telio-dns/src/zone.rs
+++ b/crates/telio-dns/src/zone.rs
@@ -17,7 +17,7 @@ use std::{
     str::FromStr,
 };
 use telio_model::features::TtlValue;
-use telio_utils::telio_log_warn;
+use telio_utils::{telio_log_generic, telio_log_warn};
 
 use crate::forward::ForwardAuthority;
 

--- a/crates/telio-firewall/src/firewall.rs
+++ b/crates/telio-firewall/src/firewall.rs
@@ -28,7 +28,7 @@ use telio_utils::{
 use tracing::error;
 
 use telio_crypto::PublicKey;
-use telio_utils::{telio_log_debug, telio_log_trace, telio_log_warn};
+use telio_utils::{telio_log_debug, telio_log_generic, telio_log_trace, telio_log_warn};
 
 /// HashSet type used internally by firewall and returned by get_peer_whitelist
 pub type HashSet<V> = rustc_hash::FxHashSet<V>;
@@ -650,7 +650,7 @@ impl StatefullFirewall {
                     return false;
                 }
 
-                telio_log_trace!("Updating UDP conntrack entry {:?} {:?}", key, peer,);
+                telio_log_trace!("Updating UDP conntrack entry {:?} {:?}", key, peer);
                 vacc.insert(UdpConnectionInfo {
                     is_remote_initiated: true,
                     last_out_pkg_chunk: None,
@@ -759,7 +759,7 @@ impl StatefullFirewall {
                 let mut icmp_cache = unwrap_lock_or_return!(self.icmp.lock(), false);
                 let is_in_cache = icmp_cache.get(&key).is_some();
                 if is_in_cache {
-                    telio_log_trace!("Matched ICMP conntrack entry {:?}", key,);
+                    telio_log_trace!("Matched ICMP conntrack entry {:?}", key);
                     telio_log_trace!("Removing ICMP conntrack entry {:?}", key);
                     icmp_cache.remove(&key);
                     telio_log_trace!("Accepting ICMP packet {:?} {:?}", ip, peer);
@@ -970,7 +970,7 @@ impl StatefullFirewall {
                 if is_in_cache {
                     telio_log_trace!(
                         "Nested packet in ICMP error packet matched ICMP conntrack entry {:?}",
-                        icmp_key,
+                        icmp_key
                     );
                     telio_log_trace!("Removing ICMP conntrack entry {:?}", icmp_key);
                     icmp_cache.remove(&icmp_key);
@@ -986,7 +986,7 @@ impl StatefullFirewall {
                 if is_in_cache {
                     telio_log_trace!(
                         "Nested packet in ICMP error packet matched TCP conntrack entry {:?}",
-                        tcp_key,
+                        tcp_key
                     );
                     telio_log_trace!("Removing TCP conntrack entry {:?}", tcp_key);
                     tcp_cache.remove(&tcp_key);
@@ -1001,7 +1001,7 @@ impl StatefullFirewall {
                 if is_in_cache {
                     telio_log_trace!(
                         "Nested packet in ICMP error packet matched UDP conntrack entry {:?}",
-                        udp_key,
+                        udp_key
                     );
                     telio_log_trace!("Removing UDP conntrack entry {:?}", udp_key);
                     udp_cache.remove(&udp_key);

--- a/crates/telio-lana/src/event_log_file.rs
+++ b/crates/telio-lana/src/event_log_file.rs
@@ -1,7 +1,7 @@
 //! This module is a mock for libmoose API, it logs moose function calls to file.
 //!
 use std::{fs::File, io::Write};
-use telio_utils::telio_log_error;
+use telio_utils::{telio_log_error, telio_log_generic};
 
 pub use telio_utils::telio_log_warn;
 

--- a/crates/telio-lana/src/lib.rs
+++ b/crates/telio-lana/src/lib.rs
@@ -9,7 +9,7 @@ use std::{
     time::Duration,
 };
 
-pub use telio_utils::{telio_log_error, telio_log_warn};
+pub use telio_utils::{telio_log_error, telio_log_generic, telio_log_warn};
 
 #[cfg_attr(all(feature = "moose", not(docrs)), path = "event_log_moose.rs")]
 #[cfg_attr(any(not(feature = "moose"), docsrs), path = "event_log_file.rs")]

--- a/crates/telio-lana/src/moose_callbacks.rs
+++ b/crates/telio-lana/src/moose_callbacks.rs
@@ -3,7 +3,7 @@ pub use crate::event_log::moose::{
 };
 
 use std::sync::mpsc::SyncSender;
-pub use telio_utils::{telio_log_error, telio_log_info, telio_log_warn};
+pub use telio_utils::{telio_log_error, telio_log_generic, telio_log_info, telio_log_warn};
 
 /// Struct for moose::InitCallback
 pub struct MooseInitCallback {

--- a/crates/telio-model/src/config.rs
+++ b/crates/telio-model/src/config.rs
@@ -3,7 +3,7 @@
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use serde_json::{from_value, Error, Value};
-use telio_utils::{telio_log_error, telio_log_warn, Hidden};
+use telio_utils::{telio_log_error, telio_log_generic, telio_log_warn, Hidden};
 use tokio::time::Instant;
 
 use std::{

--- a/crates/telio-model/src/features.rs
+++ b/crates/telio-model/src/features.rs
@@ -6,7 +6,7 @@ use std::{collections::HashSet, fmt};
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 use serde::{de::IntoDeserializer, Deserialize, Deserializer, Serialize};
 use strum_macros::EnumCount;
-use telio_utils::telio_log_warn;
+use telio_utils::{telio_log_generic, telio_log_warn};
 
 /// Default keepalive period used for proxying peers,
 /// STUN servers and VPN servers

--- a/crates/telio-model/src/validation.rs
+++ b/crates/telio-model/src/validation.rs
@@ -1,6 +1,6 @@
 //! Config validation checks
 
-use telio_utils::telio_log_debug;
+use telio_utils::{telio_log_debug, telio_log_generic};
 
 /// Nickname validation checks (RFC #009)
 pub fn validate_nickname(name: &str) -> bool {

--- a/crates/telio-nurse/src/aggregator.rs
+++ b/crates/telio-nurse/src/aggregator.rs
@@ -11,7 +11,7 @@ use telio_model::{
     features::EndpointProvider,
     HashMap,
 };
-use telio_utils::{telio_log_debug, telio_log_warn};
+use telio_utils::{telio_log_debug, telio_log_generic, telio_log_warn};
 use telio_wg::{
     uapi::{AnalyticsEvent, PeerState},
     WireGuard,
@@ -297,7 +297,7 @@ impl ConnectivityDataAggregator {
                 event.public_key,
                 event.peer_state,
                 endpoints.local_ep,
-                endpoints.remote_ep,
+                endpoints.remote_ep
             );
         }
 

--- a/crates/telio-nurse/src/heartbeat.rs
+++ b/crates/telio-nurse/src/heartbeat.rs
@@ -28,7 +28,8 @@ use telio_task::{
     Runtime, RuntimeExt, WaitResponse,
 };
 use telio_utils::{
-    interval_at, map_enum, telio_log_debug, telio_log_error, telio_log_trace, telio_log_warn,
+    interval_at, map_enum, telio_log_debug, telio_log_error, telio_log_generic, telio_log_trace,
+    telio_log_warn,
 };
 use telio_wg::uapi::PeerState;
 use tokio::time::{sleep, Duration, Instant, Interval, Sleep};

--- a/crates/telio-nurse/src/nurse.rs
+++ b/crates/telio-nurse/src/nurse.rs
@@ -250,7 +250,7 @@ impl State {
                 "disconnect"
             } else {
                 "heartbeat"
-            },
+            }
         );
 
         let qos_data = QoSData::merge(internal_qos_data, external_qos_data);

--- a/crates/telio-nurse/src/qos.rs
+++ b/crates/telio-nurse/src/qos.rs
@@ -14,7 +14,7 @@ use telio_model::features::RttType;
 use telio_task::{io::mc_chan, Runtime, RuntimeExt, WaitResponse};
 use telio_wg::uapi::{AnalyticsEvent, PeerState};
 
-use telio_utils::{interval, telio_log_debug, telio_log_trace, DualTarget};
+use telio_utils::{interval, telio_log_debug, telio_log_generic, telio_log_trace, DualTarget};
 
 use crate::config::QoSConfig;
 

--- a/crates/telio-nurse/src/rtt/ping.rs
+++ b/crates/telio-nurse/src/rtt/ping.rs
@@ -1,14 +1,14 @@
 use socket2::Type;
-use std::net::{Ipv4Addr, Ipv6Addr};
+use std::convert::TryInto;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::sync::Arc;
 use std::time::Duration;
-use std::{convert::TryInto, net::IpAddr};
 use surge_ping::{
     Client, Config as PingerConfig, ConfigBuilder, PingIdentifier, PingSequence, ICMP,
 };
 
 use telio_crypto::PublicKey;
-use telio_utils::{telio_log_debug, telio_log_error, DualTarget};
+use telio_utils::{telio_log_debug, telio_log_error, telio_log_generic, DualTarget};
 
 /// Information needed to check the reachability of endpoints.
 ///

--- a/crates/telio-pmtu/src/lib.rs
+++ b/crates/telio-pmtu/src/lib.rs
@@ -6,6 +6,8 @@ use std::{net::IpAddr, ops::Range, sync::Arc, time::Duration};
 
 use tokio::task::JoinHandle;
 
+use telio_utils::telio_log_generic;
+
 #[cfg(any(target_os = "linux", target_os = "android"))]
 pub use platform::PMTUSocket;
 

--- a/crates/telio-pmtu/src/linux.rs
+++ b/crates/telio-pmtu/src/linux.rs
@@ -18,7 +18,7 @@
 use std::{ffi::c_int, io, net::IpAddr, os::fd::AsRawFd, time::Duration};
 
 use pnet_packet::{icmp, icmpv6, Packet};
-use telio_utils::{telio_log_debug, telio_log_warn};
+use telio_utils::{telio_log_debug, telio_log_generic, telio_log_warn};
 use tokio::net::UdpSocket;
 
 pub struct PMTUSocket {
@@ -473,7 +473,7 @@ fn read_error_pmtu(sock: &impl AsRawFd, is_ipv6: bool) -> io::Result<u32> {
                             err.ee_code,
                             err.ee_pad,
                             err.ee_info,
-                            err.ee_data,
+                            err.ee_data
                         );
 
                         if err.ee_errno == libc::EMSGSIZE as u32 {

--- a/crates/telio-pq/src/conn.rs
+++ b/crates/telio-pq/src/conn.rs
@@ -4,7 +4,7 @@ use tokio::task::JoinHandle;
 
 use telio_model::features::FeaturePostQuantumVPN;
 use telio_task::io::chan;
-use telio_utils::{interval, telio_log_debug, telio_log_warn};
+use telio_utils::{interval, telio_log_debug, telio_log_generic, telio_log_warn};
 
 use crate::proto;
 

--- a/crates/telio-pq/src/entity.rs
+++ b/crates/telio-pq/src/entity.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use telio_model::features::FeaturePostQuantumVPN;
 use telio_task::io::chan;
-use telio_utils::telio_log_debug;
+use telio_utils::{telio_log_debug, telio_log_generic};
 
 struct Peer {
     addr: SocketAddr,

--- a/crates/telio-pq/src/proto.rs
+++ b/crates/telio-pq/src/proto.rs
@@ -17,7 +17,7 @@ use pnet_packet::{
 use pqcrypto_kyber::kyber768;
 use pqcrypto_traits::kem::{Ciphertext, PublicKey, SharedSecret};
 use rand::{prelude::Distribution, SeedableRng};
-use telio_utils::telio_log_debug;
+use telio_utils::{telio_log_debug, telio_log_generic};
 use tokio::net::{ToSocketAddrs, UdpSocket};
 
 const SERVICE_PORT: u16 = 6480;

--- a/crates/telio-proto/src/packet/relayed/data.rs
+++ b/crates/telio-proto/src/packet/relayed/data.rs
@@ -1,6 +1,6 @@
 use bytes::BufMut;
 use std::convert::TryFrom;
-use telio_utils::telio_log_error;
+use telio_utils::{telio_log_error, telio_log_generic};
 
 use crate::{
     Codec, CodecError, CodecResult, DowncastPacket, Generation, PacketRelayed, PacketTypeRelayed,

--- a/crates/telio-proto/src/packet/relayed/natter.rs
+++ b/crates/telio-proto/src/packet/relayed/natter.rs
@@ -1,3 +1,4 @@
+use std::fmt::Debug;
 use std::iter::FromIterator;
 use std::net::SocketAddr;
 
@@ -23,8 +24,27 @@ use telio_utils::Hidden;
 ///
 /// assert_eq!(bytes, data.encode().unwrap().as_slice());
 /// ```
-#[derive(Debug, PartialEq, Clone)]
+#[derive(PartialEq, Clone)]
 pub struct CallMeMaybeMsg(CallMeMaybe);
+
+impl Debug for CallMeMaybeMsg {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("CallMeMaybe")
+            .field(&self.0.get_i_am())
+            .field(
+                &self
+                    .0
+                    .my_addresses
+                    .clone()
+                    .into_iter()
+                    .map(Hidden)
+                    .collect::<Vec<Hidden<String>>>(),
+            )
+            .field(&self.0.get_session())
+            .field(&self)
+            .finish()
+    }
+}
 
 impl CallMeMaybeMsg {
     /// Returns new msg [`CallMeMaybeMsg`].

--- a/crates/telio-proxy/src/proxy.rs
+++ b/crates/telio-proxy/src/proxy.rs
@@ -22,7 +22,8 @@ use tokio::{net::UdpSocket, sync::mpsc::error::SendTimeoutError};
 
 use telio_utils::{
     exponential_backoff::{Backoff, ExponentialBackoff, ExponentialBackoffBounds},
-    telio_log_debug, telio_log_error, telio_log_info, telio_log_warn, PinnedSleep,
+    telio_log_debug, telio_log_error, telio_log_generic, telio_log_info, telio_log_warn,
+    PinnedSleep,
 };
 
 type SocketMap = HashMap<PublicKey, Arc<UdpSocket>>;

--- a/crates/telio-relay/src/derp/mod.rs
+++ b/crates/telio-relay/src/derp/mod.rs
@@ -35,8 +35,8 @@ use telio_sockets::SocketPool;
 use telio_task::io::{wait_for_tx, Chan};
 use telio_task::{io::mc_chan::Tx, task_exec, BoxAction, Runtime, Task};
 use telio_utils::{
-    telio_err_with_log, telio_log_debug, telio_log_error, telio_log_info, telio_log_trace,
-    telio_log_warn,
+    telio_err_with_log, telio_log_debug, telio_log_error, telio_log_generic, telio_log_info,
+    telio_log_trace, telio_log_warn,
 };
 use tokio::sync::mpsc::OwnedPermit;
 use tokio::{task::JoinHandle, time::sleep};

--- a/crates/telio-relay/src/derp/proto.rs
+++ b/crates/telio-relay/src/derp/proto.rs
@@ -21,7 +21,7 @@ use std::{
 };
 use telio_crypto::{PublicKey, SecretKey, KEY_SIZE};
 use telio_model::config::RelayConnectionChangeReason;
-use telio_utils::{telio_log_debug, telio_log_trace};
+use telio_utils::{telio_log_debug, telio_log_generic, telio_log_trace};
 use thiserror::Error as TError;
 use tracing::{enabled, Level};
 
@@ -224,7 +224,7 @@ pub async fn start_read<R: AsyncRead + Unpin>(
                         frame_type,
                         data.len(),
                         public_key,
-                        chan,
+                        chan
                     );
                 }
                 sender_relayed.send((public_key, data)).await?
@@ -236,7 +236,7 @@ pub async fn start_read<R: AsyncRead + Unpin>(
                     addr.remote,
                     addr.local,
                     frame_type,
-                    data.len(),
+                    data.len()
                 );
                 sender_direct.send(data).await?
             }
@@ -272,7 +272,7 @@ pub async fn start_write<W: AsyncWrite + Unpin>(
                             addr.remote,
                             data.len(),
                             public_key,
-                            chan,
+                            chan
                         );
                     }
 

--- a/crates/telio-relay/src/multiplexer/mod.rs
+++ b/crates/telio-relay/src/multiplexer/mod.rs
@@ -13,7 +13,7 @@ use tokio_util::sync::PollSender;
 use telio_crypto::PublicKey;
 use telio_proto::{AnyPacket, PacketRelayed, PacketTypeRelayed};
 use telio_task::{io::Chan, task_exec, BoxAction, Runtime, Task};
-use telio_utils::telio_log_error;
+use telio_utils::{telio_log_error, telio_log_generic};
 
 use self::inout::InOut;
 use self::mc::MultiChannel;

--- a/crates/telio-sockets/src/protector/apple.rs
+++ b/crates/telio-sockets/src/protector/apple.rs
@@ -36,7 +36,9 @@ use network_framework_sys::{
     nw_path_monitor_start, nw_path_monitor_t, nw_path_t,
 };
 use nix::sys::socket::{getsockname, AddressFamily, SockaddrLike, SockaddrStorage};
-use telio_utils::{telio_log_debug, telio_log_error, telio_log_info, telio_log_warn};
+use telio_utils::{
+    telio_log_debug, telio_log_error, telio_log_generic, telio_log_info, telio_log_warn,
+};
 
 extern "C" {
     // Obj-c signature:
@@ -115,7 +117,7 @@ pub(crate) fn bind(interface_index: u32, socket: i32) -> io::Result<()> {
             }
         }
     } else {
-        telio_log_warn!("Failed to find sock addr for socket : {}", socket);
+        telio_log_warn!("Failed to find sock addr for socket : {}", Hidden(socket));
     }
 
     Ok(())
@@ -280,7 +282,7 @@ impl Sockets {
     }
 
     fn rebind(&mut self, sock: i32, force: bool) {
-        telio_log_debug!("Rebinding socket {}, force: {}", sock, force);
+        telio_log_debug!("Rebinding socket {}, force: {}", Hidden(sock), force);
 
         if !self.set_new_default_interface(force) {
             return;

--- a/crates/telio-sockets/src/protector/windows.rs
+++ b/crates/telio-sockets/src/protector/windows.rs
@@ -4,7 +4,7 @@ use std::io::{self, Result};
 use std::net::Ipv4Addr;
 use std::os::windows::io::RawSocket;
 use std::sync::Arc;
-use telio_utils::{telio_log_debug, telio_log_error, telio_log_warn};
+use telio_utils::{telio_log_debug, telio_log_error, telio_log_generic, telio_log_warn};
 use tokio::sync::mpsc::{self, Sender};
 use tokio::sync::Notify;
 use tokio::task::JoinHandle;

--- a/crates/telio-sockets/src/socket_params.rs
+++ b/crates/telio-sockets/src/socket_params.rs
@@ -1,6 +1,6 @@
 use std::{io::Error, time::Duration};
 
-use telio_utils::{telio_log_trace, telio_log_warn};
+use telio_utils::{telio_log_generic, telio_log_trace, telio_log_warn};
 
 use socket2::Socket;
 
@@ -124,7 +124,7 @@ impl TcpParams {
                     "Cannot set TCP_NODELAY={} for {:?} socket: {}",
                     nodelay_enable,
                     addr,
-                    Error::last_os_error().to_string(),
+                    Error::last_os_error().to_string()
                 );
             }
         }
@@ -135,7 +135,7 @@ impl TcpParams {
                 "Cannot set TCP user timeout: {:?} for {:?} socket: {}",
                 self.user_timeout,
                 socket.local_addr(),
-                Error::last_os_error().to_string(),
+                Error::last_os_error().to_string()
             );
         }
 
@@ -157,7 +157,7 @@ impl TcpParams {
                     "Cannot set TCP keepalive options {:?} for {:?} socket: {}",
                     keepalive,
                     addr,
-                    Error::last_os_error().to_string(),
+                    Error::last_os_error().to_string()
                 );
             }
 
@@ -167,7 +167,7 @@ impl TcpParams {
             telio_log_warn!(
                 "Cannot disable TCP keepalive for {:?} socket: {}",
                 addr,
-                Error::last_os_error().to_string(),
+                Error::last_os_error().to_string()
             );
         }
 

--- a/crates/telio-sockets/src/socket_pool.rs
+++ b/crates/telio-sockets/src/socket_pool.rs
@@ -16,7 +16,7 @@ use tokio::{
 
 #[cfg(unix)]
 use boringtun::device::MakeExternalBoringtun;
-use telio_utils::{telio_log_debug, telio_log_warn};
+use telio_utils::{telio_log_debug, telio_log_generic, telio_log_warn};
 
 use crate::{
     native::{AsNativeSocket, NativeSocket},

--- a/crates/telio-task/src/task.rs
+++ b/crates/telio-task/src/task.rs
@@ -10,7 +10,7 @@ use tokio::{
     task::JoinHandle,
 };
 
-use telio_utils::telio_log_warn;
+use telio_utils::{telio_log_generic, telio_log_warn};
 
 use crate::io::{
     chan::{Rx, Tx},

--- a/crates/telio-traversal/src/connectivity_check/cross_ping_check.rs
+++ b/crates/telio-traversal/src/connectivity_check/cross_ping_check.rs
@@ -24,7 +24,8 @@ use telio_proto::{CallMeMaybeMsg, CallMeMaybeType, Session};
 use telio_task::{io::chan, io::Chan, task_exec, BoxAction, Runtime, Task};
 use telio_utils::{
     exponential_backoff::{Backoff, ExponentialBackoff, ExponentialBackoffBounds},
-    interval, telio_log_debug, telio_log_info, telio_log_trace, telio_log_warn, LruCache,
+    interval, telio_log_debug, telio_log_generic, telio_log_info, telio_log_trace, telio_log_warn,
+    LruCache,
 };
 use tokio::sync::Mutex;
 use tokio::time::{Instant, Interval};
@@ -882,13 +883,13 @@ impl<E: Backoff> EndpointConnectivityCheckState<E> {
                         telio_log_debug!(
                             "Received a pong for session {:?} for a different candidate {:?} on stun socket, ignoring.",
                             event.msg.get_session(),
-                            event.msg.get_ping_source_address(),
+                            event.msg.get_ping_source_address()
                         );
                     }
                 } else {
                     telio_log_warn!(
                         "Received a pong for session {:?} without ping_source_address. Ignoring",
-                        event.msg.get_session(),
+                        event.msg.get_session()
                     );
                 }
             }
@@ -981,7 +982,7 @@ impl<E: Backoff> EndpointConnectivityCheckState<E> {
                     reason => {
                         telio_log_debug!(
                             "Skipping sending CMM to peer {} ({reason:?})",
-                            self.public_key,
+                            self.public_key
                         );
                     }
                 }

--- a/crates/telio-traversal/src/endpoint_providers/local.rs
+++ b/crates/telio-traversal/src/endpoint_providers/local.rs
@@ -14,7 +14,7 @@ use telio_crypto::PublicKey;
 use telio_proto::{Session, WGPort};
 use telio_sockets::External;
 use telio_task::{io::chan, task_exec, BoxAction, Runtime, Task};
-use telio_utils::{interval, telio_log_debug, telio_log_info, telio_log_warn};
+use telio_utils::{interval, telio_log_debug, telio_log_generic, telio_log_info, telio_log_warn};
 use telio_wg::{DynamicWg, WireGuard};
 use tokio::net::UdpSocket;
 use tokio::sync::Mutex;

--- a/crates/telio-traversal/src/endpoint_providers/stun.rs
+++ b/crates/telio-traversal/src/endpoint_providers/stun.rs
@@ -14,7 +14,8 @@ use telio_sockets::{native::AsNativeSocket, External};
 use telio_task::{io::chan, task_exec, BoxAction, Runtime, Task};
 use telio_utils::{
     exponential_backoff::{Backoff, ExponentialBackoff, ExponentialBackoffBounds},
-    telio_log_debug, telio_log_error, telio_log_info, telio_log_warn, PinnedSleep,
+    telio_log_debug, telio_log_error, telio_log_generic, telio_log_info, telio_log_warn,
+    PinnedSleep,
 };
 use telio_wg::{DynamicWg, WireGuard};
 use tokio::{net::UdpSocket, pin, sync::Mutex};
@@ -890,7 +891,7 @@ impl StunSession {
         telio_log_debug!(
             "Sending wg-stun: {} for ses: {:?}",
             &wg,
-            wg_stun.0.as_bytes(),
+            wg_stun.0.as_bytes()
         );
 
         if let Err(err) = socket_via_wg.send_to(&wg_stun.1, wg).await {
@@ -949,7 +950,7 @@ impl StunRequest {
                     "Got stun response from {} for session {:?} -> {}",
                     src_addr,
                     tid.as_bytes(),
-                    &sa,
+                    &sa
                 );
 
                 sa

--- a/crates/telio-traversal/src/endpoint_providers/upnp/mod.rs
+++ b/crates/telio-traversal/src/endpoint_providers/upnp/mod.rs
@@ -24,7 +24,7 @@ use telio_sockets::External;
 use telio_task::{io::chan::Tx, task_exec, BoxAction, Runtime, Task};
 use telio_utils::{
     exponential_backoff::{Backoff, ExponentialBackoff, ExponentialBackoffBounds},
-    telio_log_debug, telio_log_info, PinnedSleep,
+    telio_log_debug, telio_log_generic, telio_log_info, PinnedSleep,
 };
 use telio_wg::{DynamicWg, WireGuard};
 use tokio::{net::UdpSocket, pin, sync::Mutex};

--- a/crates/telio-traversal/src/ping_pong_handler.rs
+++ b/crates/telio-traversal/src/ping_pong_handler.rs
@@ -14,7 +14,7 @@ use telio_proto::{
     CodecError, PacketRelayed, PacketTypeRelayed, PingerMsg, Session, Timestamp, WGPort,
 };
 use telio_task::io::chan;
-use telio_utils::{telio_log_debug, telio_log_warn};
+use telio_utils::{telio_log_debug, telio_log_generic, telio_log_warn};
 use tokio::{net::UdpSocket, sync::Mutex};
 
 use crate::endpoint_providers::PongEvent;

--- a/crates/telio-traversal/src/session_keeper.rs
+++ b/crates/telio-traversal/src/session_keeper.rs
@@ -12,8 +12,8 @@ use telio_crypto::PublicKey;
 use telio_sockets::SocketPool;
 use telio_task::{task_exec, BoxAction, Runtime, Task};
 use telio_utils::{
-    dual_target, repeated_actions, telio_log_debug, telio_log_trace, telio_log_warn, DualTarget,
-    RepeatedActions,
+    dual_target, repeated_actions, telio_log_debug, telio_log_generic, telio_log_trace,
+    telio_log_warn, DualTarget, RepeatedActions,
 };
 
 const PING_PAYLOAD_SIZE: usize = 56;

--- a/crates/telio-traversal/src/upgrade_sync.rs
+++ b/crates/telio-traversal/src/upgrade_sync.rs
@@ -10,7 +10,9 @@ use telio_model::features::EndpointProvider;
 use telio_nurse::aggregator::ConnectivityDataAggregator;
 use telio_proto::{Decision, Session, UpgradeDecisionMsg, UpgradeMsg};
 use telio_task::{io::chan, io::Chan, task_exec, BoxAction, Runtime, Task};
-use telio_utils::{interval, telio_log_debug, telio_log_info, telio_log_warn, LruCache};
+use telio_utils::{
+    interval, telio_log_debug, telio_log_generic, telio_log_info, telio_log_warn, LruCache,
+};
 use telio_wg::uapi::{AnalyticsEvent, PeerState};
 use telio_wg::WireGuard;
 use tokio::{
@@ -204,7 +206,7 @@ impl State {
             public_key,
             remote_endpoint,
             local_direct_endpoint,
-            session,
+            session
         );
 
         if let Some(upgrade_request) = self.upgrade_requests.get(&Direction::Received(*public_key))
@@ -266,7 +268,7 @@ impl State {
             upgrade_msg.endpoint,
             upgrade_msg.endpoint_type,
             upgrade_msg.receiver_endpoint_type,
-            upgrade_msg.session,
+            upgrade_msg.session
         );
 
         match self

--- a/crates/telio-utils/src/tokio.rs
+++ b/crates/telio-utils/src/tokio.rs
@@ -1,3 +1,4 @@
+use crate::telio_log_generic;
 use crate::telio_log_warn;
 use rustc_hash::FxHashMap;
 use std::{

--- a/crates/telio-utils/src/utils.rs
+++ b/crates/telio-utils/src/utils.rs
@@ -1,39 +1,61 @@
 /// Utilities
 ///
 
+#[macro_export]
+macro_rules! telio_log_generic {
+    ( $log_func: ident, $msg: expr) => {tracing::$log_func!($msg)};
+    ( $log_func: ident, $format: expr, $($arg:expr),+) => {{
+        use std::net::{IpAddr, SocketAddr};
+
+        #[allow(dead_code)]
+        trait HideSensitiveInfo {
+            fn hide_me_maybe(&self) -> &'static str {
+                "******"
+            }
+        }
+        impl HideSensitiveInfo for IpAddr {}
+        impl HideSensitiveInfo for SocketAddr {}
+
+        #[allow(dead_code)]
+        trait NotHideAtAll {
+            fn hide_me_maybe(&self) -> &Self {
+                self
+            }
+        }
+        impl<T> NotHideAtAll for &T {}
+
+        tracing::$log_func!($format,  $((&$arg).hide_me_maybe()),+)
+    }};
+}
+
 /// wrapping tracing::trace and adding more information
 #[macro_export]
 macro_rules! telio_log_trace {
-       ( $msg: expr) => {tracing::trace!($msg)};
-       ( $format: expr, $($arg:tt)+) => {tracing::trace!($format,  $($arg)+)};
+       ( $($arg:expr),*) => { telio_log_generic!(trace, $($arg),*) };
 }
 
 /// wrapping tracing::debug and adding more information
 #[macro_export]
 macro_rules! telio_log_debug {
-       ( $msg: expr) => {tracing::debug!($msg)};
-       ( $format: expr, $($arg:tt)+) => { tracing::debug!( $format,  $($arg)+) };
+       ( $($arg:expr),*) => { telio_log_generic!(debug, $($arg),*) };
 }
 
 /// wrapping tracing::info and adding more information
 #[macro_export]
 macro_rules! telio_log_info {
-       ( $msg: expr) => {tracing::info!($msg)};
-       ( $format: expr, $($arg:tt)+) => { tracing::info!( $format,  $($arg)+) };
+       ( $($arg:expr),*) => { telio_log_generic!(info, $($arg),*) };
 }
 
 /// wrapping tracing::warn and adding more information
 #[macro_export]
 macro_rules! telio_log_warn {
-       ( $msg: expr) => {tracing::warn!($msg)};
-       ( $format: expr, $($arg:tt)+) => { tracing::warn!( $format,  $($arg)+) };
+       ( $($arg:expr),*) => { telio_log_generic!(warn, $($arg),*) };
 }
 
 /// wrapping tracing::error and adding more information
 #[macro_export]
 macro_rules! telio_log_error {
-       ( $msg: expr) => {tracing::error!($msg)};
-       ( $format: expr, $($arg:tt)+) => { tracing::error!( $format,  $($arg)+) };
+       ( $($arg:expr),*) => { telio_log_generic!(error, $($arg),*) };
 }
 
 /// Error with log is used to log something

--- a/crates/telio-wg/src/adapter/boring.rs
+++ b/crates/telio-wg/src/adapter/boring.rs
@@ -7,7 +7,7 @@ use std::net::{IpAddr, Ipv4Addr};
 use std::sync::Arc;
 use std::{io, ops::Deref};
 use telio_crypto::PublicKey;
-use telio_utils::telio_log_debug;
+use telio_utils::{telio_log_debug, telio_log_generic};
 use tokio::sync::RwLock;
 
 use super::{Adapter, Error as AdapterError, Tun as NativeTun};

--- a/crates/telio-wg/src/adapter/linux_native_wg.rs
+++ b/crates/telio-wg/src/adapter/linux_native_wg.rs
@@ -10,7 +10,7 @@ use ipnetwork::{IpNetwork, IpNetworkError};
 use std::collections::BTreeMap;
 use std::net::IpAddr;
 use telio_crypto::{PublicKey, SecretKey};
-use telio_utils::{telio_log_error, telio_log_info};
+use telio_utils::{telio_log_error, telio_log_generic, telio_log_info};
 use tokio::sync::Mutex;
 use wireguard_uapi::{
     err, get, linux::set::WgDeviceF, set, xplatform, DeviceInterface, RouteSocket, WgSocket,

--- a/crates/telio-wg/src/adapter/windows_native_wg.rs
+++ b/crates/telio-wg/src/adapter/windows_native_wg.rs
@@ -9,7 +9,8 @@ use std::slice::Windows;
 use std::sync::{Arc, Mutex, MutexGuard};
 use std::{mem, option, result};
 use telio_utils::{
-    telio_log_debug, telio_log_error, telio_log_info, telio_log_trace, telio_log_warn,
+    telio_log_debug, telio_log_error, telio_log_generic, telio_log_info, telio_log_trace,
+    telio_log_warn,
 };
 #[cfg(windows)]
 use wireguard_nt::{self, set_logger, SetInterface, SetPeer};

--- a/crates/telio-wg/src/uapi.rs
+++ b/crates/telio-wg/src/uapi.rs
@@ -4,7 +4,7 @@ use ipnetwork::{IpNetwork, IpNetworkError};
 use serde::{Deserialize, Serialize};
 use telio_crypto::{KeyDecodeError, PresharedKey, PublicKey, SecretKey};
 use telio_model::mesh::{LinkState, Node, NodeState};
-use telio_utils::{telio_log_warn, DualTarget, DualTargetError};
+use telio_utils::{telio_log_generic, telio_log_warn, DualTarget, DualTargetError};
 use wireguard_uapi::{get, xplatform::set};
 
 use std::{

--- a/crates/telio-wg/src/wg.rs
+++ b/crates/telio-wg/src/wg.rs
@@ -14,7 +14,8 @@ use telio_model::{
 use telio_sockets::{NativeProtector, SocketPool};
 use telio_utils::{
     dual_target::{DualTarget, DualTargetError},
-    interval, telio_err_with_log, telio_log_debug, telio_log_trace, telio_log_warn,
+    interval, telio_err_with_log, telio_log_debug, telio_log_generic, telio_log_trace,
+    telio_log_warn,
 };
 use thiserror::Error as TError;
 use tokio::time::{self, sleep, Instant, Interval, MissedTickBehavior};

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -67,7 +67,7 @@ use futures::FutureExt;
 use telio_utils::{
     commit_sha,
     exponential_backoff::ExponentialBackoffBounds,
-    interval, telio_log_debug, telio_log_error, telio_log_info, telio_log_warn,
+    interval, telio_log_debug, telio_log_error, telio_log_generic, telio_log_info, telio_log_warn,
     tokio::{Monitor, ThreadTracker},
     version_tag,
 };

--- a/src/device/wg_controller.rs
+++ b/src/device/wg_controller.rs
@@ -23,7 +23,7 @@ use telio_traversal::{
     },
     SessionKeeperTrait, UpgradeSyncTrait, WireGuardEndpointCandidateChangeEvent,
 };
-use telio_utils::{telio_log_debug, telio_log_info, telio_log_warn};
+use telio_utils::{telio_log_debug, telio_log_generic, telio_log_info, telio_log_warn};
 use telio_wg::{uapi::Peer, WireGuard};
 use thiserror::Error as TError;
 use tokio::sync::Mutex;
@@ -830,7 +830,7 @@ async fn select_endpoint_for_peer<'a>(
             telio_log_debug!(
                 "Connections seems to be dead, forcing proxied EP: {:?} {:?}",
                 public_key,
-                time_since_last_rx,
+                time_since_last_rx
             );
             Ok((proxy_endpoint.first().copied(), None))
         }
@@ -840,7 +840,7 @@ async fn select_endpoint_for_peer<'a>(
             telio_log_debug!(
                 "Keeping proxied EP: {:?} {:?}",
                 public_key,
-                time_since_last_rx,
+                time_since_last_rx
             );
             Ok((proxy_endpoint.first().copied(), None))
         }
@@ -850,7 +850,7 @@ async fn select_endpoint_for_peer<'a>(
             telio_log_debug!(
                 "Selecting checked EP: {:?} {:?}",
                 public_key,
-                time_since_last_rx,
+                time_since_last_rx
             );
             Ok((
                 Some(checked_endpoint.remote_endpoint.0),
@@ -868,7 +868,7 @@ async fn select_endpoint_for_peer<'a>(
             telio_log_debug!(
                 "Selecting current Direct EP: {:?} {:?}",
                 public_key,
-                time_since_last_rx,
+                time_since_last_rx
             );
             Ok((actual_endpoint, None))
         }
@@ -878,7 +878,7 @@ async fn select_endpoint_for_peer<'a>(
             telio_log_debug!(
                 "Selecting current Direct EP: {:?} {:?}",
                 public_key,
-                time_since_last_rx,
+                time_since_last_rx
             );
             Ok((actual_endpoint, None))
         }

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -31,7 +31,8 @@ use telio_model::{
 
 // debug tools
 use telio_utils::{
-    commit_sha, telio_log_debug, telio_log_error, telio_log_info, telio_log_warn, version_tag,
+    commit_sha, telio_log_debug, telio_log_error, telio_log_generic, telio_log_info,
+    telio_log_warn, version_tag,
 };
 
 const DEFAULT_PANIC_MSG: &str = "libtelio panicked";
@@ -383,7 +384,7 @@ impl Telio {
             self.id,
             private_key.public(),
             &adapter,
-            &name,
+            &name
         );
         catch_ffi_panic(|| {
             self.device_op(true, |dev| {
@@ -443,7 +444,7 @@ impl Telio {
 
     /// Stop telio device.
     pub fn stop(&self) -> FFIResult<()> {
-        telio_log_info!("Telio::stop entry with instance id: {}.", self.id,);
+        telio_log_info!("Telio::stop entry with instance id: {}.", self.id);
         catch_ffi_panic(|| {
             self.device_op(false, |dev| {
                 dev.stop();
@@ -564,7 +565,7 @@ impl Telio {
             self.id,
             public_key,
             allowed_ips,
-            endpoint,
+            endpoint
         );
         self.connect_to_exit_node_with_id(None, public_key, allowed_ips, endpoint)
     }
@@ -592,7 +593,7 @@ impl Telio {
             identifier,
             public_key,
             allowed_ips,
-            endpoint,
+            endpoint
         );
         let identifier = identifier.unwrap_or_else(|| Uuid::new_v4().to_string());
         let node = ExitNode {
@@ -632,7 +633,7 @@ impl Telio {
             identifier,
             public_key,
             allowed_ips,
-            endpoint,
+            endpoint
         );
         let identifier = identifier.unwrap_or_else(|| Uuid::new_v4().to_string());
         let node = ExitNode {


### PR DESCRIPTION
Adds a filter to telio_log_* macros, which masks the IP addresses passed to it.

### Problem
We print unmasked IP addresses in logs

### Solution
This is not a solution to the whole problem - we still need to remember to use `Hidden` with IPs which are stored in structures.

This should work for the IPs and Endpoints which are directly passed to logs. It might be good to reduce a bit a possibility of the human error - it introduces some additional complexity to log macros, so I'm not sure if it's worth it in the end.


### :ballot_box_with_check: Definition of Done checklist
- [ ] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [ ] README.md is updated
- [ ] Functionality is covered by unit or integration tests
