### PR TITLE
LLT-5246 Add netsh checks on config changes in win VM

### DIFF
--- a/nat-lab/tests/utils/command_grepper.py
+++ b/nat-lab/tests/utils/command_grepper.py
@@ -1,0 +1,116 @@
+import asyncio
+from typing import List, Optional
+from utils.connection import Connection
+from utils.process import ProcessExecError
+
+
+class CommandGrepper:
+    _connection: Connection
+    _check_cmd: List[str]
+    _timeout: Optional[float]
+
+    def __init__(
+        self,
+        connection: Connection,
+        check_cmd: List[str],
+        timeout: Optional[float] = None,
+    ):
+        """
+        A class that runs a command and checks if the expected strings are present or not present in the output.
+
+        Args:
+            connection: Connection object to container to run the command on.
+            check_cmd: Command to run.
+            timeout: Timeout for the check. If the check does not have expected results within the timeout, it will return False.
+        """
+        self._connection = connection
+        self._check_cmd = check_cmd
+        self._timeout = timeout
+
+    async def check_exists(
+        self, exp_primary: str, exp_secondary: Optional[List[str]] = None
+    ) -> bool:
+        """
+        Checks if the expected strings are present in the output of the command.
+        If only the primary string is provided, check for its presence in whole stdout.
+        If secondary strings are also provided, checks, if primary and all secondaries are in one line
+        """
+        try:
+            return await asyncio.wait_for(
+                self._run_check(exp_primary, exp_secondary, True),
+                self._timeout,
+            )
+        except ProcessExecError:
+            return False
+
+    async def check_not_exists(
+        self, exp_primary: str, exp_secondary: Optional[List[str]] = None
+    ) -> bool:
+        """
+        Check if the expected strings are not present in the output of the command.
+        If only the primary string is provided, check for its absence in whole stdout.
+        If secondary strings are also provided, checks, if primary and secondary are NOT in one line.
+        """
+        try:
+            return await asyncio.wait_for(
+                self._run_check(exp_primary, exp_secondary, exists=False),
+                self._timeout,
+            )
+        except ProcessExecError:
+            return False
+
+    async def _run_check(
+        self, exp_primary: str, exp_secondary: Optional[List[str]], exists: bool
+    ) -> bool:
+        while True:
+            process = await self._connection.create_process(self._check_cmd).execute()
+
+            if exists:
+                if self._check_if_exists(
+                    process.get_stdout(), exp_primary, exp_secondary
+                ):
+                    return True
+            else:
+                if self._check_if_not_exists(
+                    process.get_stdout(), exp_primary, exp_secondary
+                ):
+                    return True
+
+            await asyncio.sleep(1.0)
+
+    def _check_if_exists(
+        self, stdout: str, exp_primary: str, exp_secondary: Optional[List[str]]
+    ) -> bool:
+        # Both primary and secondary strings are expected to be in one line
+        for line in stdout.split("\n"):
+            if exp_primary in line:
+                if exp_secondary is not None:
+                    missing = False
+                    for expected_str in exp_secondary:
+                        if expected_str not in line:
+                            missing = True
+                            break
+                    if not missing:
+                        return True
+                else:
+                    return True
+        return False
+
+    def _check_if_not_exists(
+        self, stdout: str, exp_primary: str, exp_secondary: Optional[List[str]]
+    ) -> bool:
+        if exp_secondary is not None:
+            for line in stdout.split("\n"):
+                missing = True
+                if exp_primary in line:
+                    for expected_str in exp_secondary:
+                        if expected_str in line:
+                            missing = False
+                            break
+                    if not missing:
+                        return False
+            return True
+        if exp_primary not in stdout:
+            return True
+
+        return False


### PR DESCRIPTION
### Problem
Some commands in VM do not generate results instantly. This was observed primarily on Windows, when setting IP addresses on interface using `netsh` command.

### Solution
After command execution, launch a "check-and-grep-like" commands for some predetermined amount of time, to search for a command execution result.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
