### PR TITLE
LLT-5072: Move linux binaries strip to rust_build_utils

### DIFF
--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -31,4 +31,4 @@ jobs:
           project-id: ${{ secrets.PROJECT_ID }}
           schedule: ${{ github.event_name == 'schedule' }}
           cancel-outdated-pipelines: ${{ github.ref_name != 'main' }}
-          triggered-ref: v1.2.12 # REMEMBER to also update in .gitlab-ci.yml
+          triggered-ref: v2.0.0 # REMEMBER to also update in .gitlab-ci.yml

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,4 +15,4 @@ libtelio-build-pipeline:
 
   trigger:
     project: $LIBTELIO_BUILD_PROJECT_PATH
-    branch: v1.2.12 # REMEMBER to also update in .github/workflows/gitlab.yml
+    branch: v2.0.0 # REMEMBER to also update in .github/workflows/gitlab.yml

--- a/.unreleased/LLT-5072
+++ b/.unreleased/LLT-5072
@@ -1,0 +1,1 @@
+Implement binary full stripping

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -193,6 +193,7 @@ telio-pmtu = { version = "0.1.0", path = "./crates/telio-pmtu" }
 opt-level = "s"
 lto = true
 codegen-units = 1
+debug = "full"
 
 #TODO: remove this when anyone starts using telio-starcast
 [workspace.metadata.cargo-udeps.ignore]

--- a/ci/build_libtelio.py
+++ b/ci/build_libtelio.py
@@ -449,22 +449,22 @@ def call_build(config, args):
             post(config, args)
 
 
-def darwin_build_all(debug: bool) -> None:
+def darwin_build_all(args) -> None:
     for target_os in rutils.LIPO_TARGET_OSES:
         for arch in GLOBAL_CONFIG[target_os]["archs"].keys():
             if target_os in LIBTELIO_CONFIG:
                 config = rutils.CargoConfig(
                     target_os,
                     arch,
-                    debug,
+                    args.debug,
                 )
 
-                call_build(config)
+                call_build(config, args)
 
 
 def exec_lipo(args):
     if args.build:
-        darwin_build_all(args.debug)
+        darwin_build_all(args)
 
     for target_os in rutils.LIPO_TARGET_OSES:
         dbu.lipo(

--- a/ci/build_libtelio.py
+++ b/ci/build_libtelio.py
@@ -154,12 +154,6 @@ LIBTELIO_CONFIG = {
                 }
             },
         },
-        "env": {
-            "RUSTFLAGS": (
-                [f" -C debuginfo=2"],
-                "set",
-            )
-        },
         "packages": {
             NAME: {f"lib{NAME}": f"lib{NAME}.so"},
         },
@@ -167,7 +161,6 @@ LIBTELIO_CONFIG = {
     "linux": {
         "archs": {
             "x86_64": {
-                "strip_path": "/usr/bin/strip",
                 "env": {
                     "RUSTFLAGS": (
                         f" -L {PROJECT_ROOT}/3rd-party/libmoose/{LIBTELIO_ENV_MOOSE_RELEASE_TAG}/bin/common/linux/{MOOSE_MAP['x86_64']}",
@@ -176,16 +169,6 @@ LIBTELIO_CONFIG = {
                 },
             },
             "aarch64": {
-                "strip_path": "/usr/aarch64-linux-gnu/bin/strip",
-                "env": {
-                    "RUSTFLAGS": (
-                        f" -L {PROJECT_ROOT}/3rd-party/libmoose/{LIBTELIO_ENV_MOOSE_RELEASE_TAG}/bin/common/linux/{MOOSE_MAP['aarch64']}",
-                        "set",
-                    )
-                },
-            },
-            "arm64": {
-                "strip_path": "/usr/aarch64-linux-gnu/bin/strip",
                 "env": {
                     "RUSTFLAGS": (
                         f" -L {PROJECT_ROOT}/3rd-party/libmoose/{LIBTELIO_ENV_MOOSE_RELEASE_TAG}/bin/common/linux/{MOOSE_MAP['aarch64']}",
@@ -194,7 +177,6 @@ LIBTELIO_CONFIG = {
                 },
             },
             "i686": {
-                "strip_path": "/usr/i686-linux-gnu/bin/strip",
                 "env": {
                     "RUSTFLAGS": (
                         f" -L {PROJECT_ROOT}/3rd-party/libmoose/{LIBTELIO_ENV_MOOSE_RELEASE_TAG}/bin/common/linux/{MOOSE_MAP['i686']}",
@@ -203,7 +185,6 @@ LIBTELIO_CONFIG = {
                 },
             },
             "armv7hf": {
-                "strip_path": "/usr/arm-linux-gnueabihf/bin/strip",
                 "env": {
                     "RUSTFLAGS": (
                         f" -L {PROJECT_ROOT}/3rd-party/libmoose/{LIBTELIO_ENV_MOOSE_RELEASE_TAG}/bin/common/linux/{MOOSE_MAP['armv7hf']}",
@@ -212,7 +193,6 @@ LIBTELIO_CONFIG = {
                 },
             },
             "armv5": {
-                "strip_path": "/usr/arm-linux-gnueabi/bin/strip",
                 "env": {
                     "RUSTFLAGS": (
                         f" -L {PROJECT_ROOT}/3rd-party/libmoose/{LIBTELIO_ENV_MOOSE_RELEASE_TAG}/bin/common/linux/{MOOSE_MAP['armv5']}",
@@ -222,9 +202,6 @@ LIBTELIO_CONFIG = {
             },
         },
         "post_build": [post_copy_libsqlite3_binary_to_dist],
-        "env": {
-            "RUSTFLAGS": ([" -C debuginfo=2 "], "set"),
-        },
         "packages": {
             "tcli": {"tcli": "tcli"},
             "derpcli": {"derpcli": "derpcli"},
@@ -457,85 +434,6 @@ def exec_build(args):
     call_build(config, args)
 
 
-def create_debug_symbols(config):
-    if config.debug:
-        return
-
-    if config.target_os != "android" and config.target_os != "linux":
-        return
-
-    dist_dir = PROJECT_CONFIG.get_distribution_path(
-        config.target_os, config.arch, "", config.debug
-    )
-
-    def _create_debug_symbol(path: str, strip_bin: str):
-        if not os.path.isfile(strip_bin):
-            # fallback to default strip
-            strip_bin = "strip"
-        create_debug_file = [
-            f"{strip_bin}",
-            "--only-keep-debug",
-            f"{path}",
-            "-o",
-            f"{path}.debug",
-        ]
-        remove_debug_from_original = [
-            f"{strip_bin}",
-            "--strip-debug",
-            f"{path}",
-            "-o",
-            f"{path}",
-        ]
-        set_read_only = ["chmod", "0444", f"{path}.debug"]
-        subprocess.check_call(create_debug_file, stderr=subprocess.DEVNULL)
-        subprocess.check_call(remove_debug_from_original)
-        subprocess.check_call(set_read_only)
-
-    lib_name = LIBTELIO_CONFIG[config.target_os]["packages"][NAME][
-        f"lib{NAME}" if config.target_os != "windows" else NAME
-    ]
-
-    if config.target_os == "linux":
-        strip = LIBTELIO_CONFIG["linux"]["archs"][config.arch]["strip_path"]
-        _create_debug_symbol(f"{dist_dir}/{lib_name}", strip_bin=strip)
-    elif config.target_os == "android":
-        strip = f"{abu.TOOLCHAIN}/bin/llvm-strip"
-        renamed_arch = GLOBAL_CONFIG[config.target_os]["archs"][config.arch]["dist"]
-        dist_dir = PROJECT_CONFIG.get_distribution_path(
-            config.target_os, config.arch, "../unstripped", config.debug
-        )
-        _create_debug_symbol(f"{dist_dir}/{renamed_arch}/{lib_name}", strip_bin=strip)
-
-
-def strip_binaries(config):
-    if config.debug or config.target_os != "linux":
-        return
-
-    dist_dir = PROJECT_CONFIG.get_distribution_path(
-        config.target_os, config.arch, "", config.debug
-    )
-
-    def _strip_debug_symbols(path: str, strip_bin: str):
-        if not os.path.isfile(strip_bin):
-            # fallback to default strip
-            strip_bin = "strip"
-        strip_debug_symbols = [
-            f"{strip_bin}",
-            "--strip-debug",
-            f"{path}",
-            "-o",
-            f"{path}",
-        ]
-        subprocess.check_call(strip_debug_symbols)
-
-    strip = LIBTELIO_CONFIG["linux"]["archs"][config.arch]["strip_path"]
-    binaries = [
-        bin for bin in LIBTELIO_CONFIG["linux"]["packages"].keys() if bin != NAME
-    ]
-    for binary in binaries:
-        _strip_debug_symbols(f"{dist_dir}/{binary}", strip_bin=strip)
-
-
 def call_build(config, args):
     rutils.config_local_env_vars(config, LIBTELIO_CONFIG)
 
@@ -546,8 +444,6 @@ def call_build(config, args):
         LIBTELIO_CONFIG[config.target_os].get("build_args", None),
     )
 
-    create_debug_symbols(config)
-    strip_binaries(config)
     if "post_build" in LIBTELIO_CONFIG[config.target_os]:
         for post in LIBTELIO_CONFIG[config.target_os]["post_build"]:
             post(config, args)

--- a/ci/insert_libtelio_version.py
+++ b/ci/insert_libtelio_version.py
@@ -33,7 +33,10 @@ def insert_version_to_libtelio_binaries_in_dir(new_version: str, path: str):
                     os.system(f"codesign --remove-signature {path}")
                     os.system(f"codesign --sign - {path}")
         else:
-            for dirname, _, filenames in os.walk(path):
+            for dirname, subdirnames, filenames in os.walk(path):
+                if "dSYM" in dirname:
+                    subdirnames[:] = []
+                    continue
                 for filename in filenames:
                     full_path = os.path.join(dirname, filename)
                     if target_os in full_path and filename in packages:


### PR DESCRIPTION
### Problem
- With the merge of https://github.com/NordSecurity/rust_build_utils/pull/23 binary stripping will be moved to `rust-build-utils` scripts.
- Windows and macOS debug symbols were not being released.

### Solution
This PR removes binary stripping from `build_libtelio.py` and adds post-build stages to copy the debug-symbols to the distributable directory `/dist`.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
