### PR TITLE
Make failed SessionKeeper startup non-fatal for the meshnet

### DIFF
--- a/.unreleased/LLT-4641
+++ b/.unreleased/LLT-4641
@@ -1,0 +1,1 @@
+Make SessionKeeper startup failures non-fatal

--- a/crates/telio-nurse/src/heartbeat.rs
+++ b/crates/telio-nurse/src/heartbeat.rs
@@ -1117,17 +1117,14 @@ mod tests {
             Ok(())
         }
 
-        #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
         fn make_internal(&self, _socket: NativeSocket) -> std::io::Result<()> {
             Ok(())
         }
 
         fn clean(&self, _: NativeSocket) {}
 
-        #[cfg(target_os = "linux")]
         fn set_fwmark(&self, _fwmark: u32) {}
 
-        #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos", windows))]
         fn set_tunnel_interface(&self, _interface: u64) {}
     }
 

--- a/crates/telio-sockets/src/protector/apple.rs
+++ b/crates/telio-sockets/src/protector/apple.rs
@@ -245,6 +245,9 @@ impl Protector for NativeProtector {
             socks.notify.notify_waiters();
         }
     }
+
+    /// This is a no-op on apple platforms.
+    fn set_fwmark(&self, _fwmark: u32) {}
 }
 
 #[derive(Debug)]

--- a/crates/telio-sockets/src/protector/linux.rs
+++ b/crates/telio-sockets/src/protector/linux.rs
@@ -32,6 +32,11 @@ impl Protector for NativeProtector {
         Ok(())
     }
 
+    /// This is a no-op on linux.
+    fn make_internal(&self, _socket: NativeSocket) -> io::Result<()> {
+        Ok(())
+    }
+
     fn clean(&self, _socket: NativeSocket) {
         // Skip, socket will be removed
     }
@@ -41,6 +46,9 @@ impl Protector for NativeProtector {
             *my_fwmark = fwmark;
         }
     }
+
+    /// This is a no-op on linux.
+    fn set_tunnel_interface(&self, _interface: u64) {}
 }
 
 fn set_fwmark(fd: i32, fwmark: u32) -> io::Result<()> {

--- a/crates/telio-sockets/src/protector/mod.rs
+++ b/crates/telio-sockets/src/protector/mod.rs
@@ -25,34 +25,54 @@ pub type Protect = Arc<dyn Fn(NativeSocket) + Send + Sync + RefUnwindSafe + 'sta
 pub trait Protector: Send + Sync {
     fn make_external(&self, socket: NativeSocket) -> io::Result<()>;
 
-    #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
     fn make_internal(&self, socket: NativeSocket) -> io::Result<()>;
 
     fn clean(&self, socket: NativeSocket);
 
-    #[cfg(target_os = "linux")]
     fn set_fwmark(&self, fwmark: u32);
 
-    #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos", windows))]
     fn set_tunnel_interface(&self, interface: u64);
 }
 
-impl Protector for Protect {
+impl<T: Protector + ?Sized> Protector for Arc<T> {
     fn make_external(&self, socket: NativeSocket) -> io::Result<()> {
-        (self)(socket);
-        Ok(())
+        self.as_ref().make_external(socket)
     }
 
-    #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
-    fn make_internal(&self, _socket: NativeSocket) -> io::Result<()> {
-        Ok(())
+    fn make_internal(&self, socket: NativeSocket) -> io::Result<()> {
+        self.as_ref().make_internal(socket)
     }
 
-    fn clean(&self, _socket: NativeSocket) {}
+    fn clean(&self, socket: NativeSocket) {
+        self.as_ref().clean(socket)
+    }
 
-    #[cfg(target_os = "linux")]
-    fn set_fwmark(&self, _fwmark: u32) {}
+    fn set_fwmark(&self, fwmark: u32) {
+        self.as_ref().set_fwmark(fwmark);
+    }
 
-    #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos", windows))]
-    fn set_tunnel_interface(&self, _: u64) {}
+    fn set_tunnel_interface(&self, interface: u64) {
+        self.as_ref().set_tunnel_interface(interface)
+    }
+}
+
+pub fn make_external_protector(protect: Protect) -> Arc<(dyn Protector + 'static)> {
+    struct ProtectorMakeExternalCb(Protect);
+    impl Protector for ProtectorMakeExternalCb {
+        fn make_external(&self, socket: NativeSocket) -> std::io::Result<()> {
+            (self.0)(socket);
+            Ok(())
+        }
+
+        fn make_internal(&self, _socket: NativeSocket) -> std::io::Result<()> {
+            Ok(())
+        }
+
+        fn clean(&self, _socket: NativeSocket) {}
+
+        fn set_fwmark(&self, _fwmark: u32) {}
+
+        fn set_tunnel_interface(&self, _interface: u64) {}
+    }
+    Arc::new(ProtectorMakeExternalCb(protect))
 }

--- a/crates/telio-sockets/src/protector/unsupported.rs
+++ b/crates/telio-sockets/src/protector/unsupported.rs
@@ -17,7 +17,15 @@ impl Protector for NativeProtector {
         Ok(())
     }
 
+    fn make_internal(&self, socket: NativeSocket) -> io::Result<()> {
+        Ok(())
+    }
+
     fn clean(&self, _socket: NativeSocket) {
         // Skip, socket will be removed
     }
+
+    fn set_fwmark(&self, fwmark: u32) {}
+
+    fn set_tunnel_interface(&self, interface: u64) {}
 }

--- a/crates/telio-sockets/src/protector/windows.rs
+++ b/crates/telio-sockets/src/protector/windows.rs
@@ -52,11 +52,19 @@ impl Protector for NativeProtector {
         Ok(())
     }
 
+    /// This is a no-op on Windows.
+    fn make_internal(&self, _socket: NativeSocket) -> io::Result<()> {
+        Ok(())
+    }
+
     fn clean(&self, socket: NativeSocket) {
         let mut socks = self.sockets.lock();
         socks.sockets.retain(|s| s != &socket);
         socks.notify.notify_waiters();
     }
+
+    /// This is a no-op on Windows.
+    fn set_fwmark(&self, _fwmark: u32) {}
 
     fn set_tunnel_interface(&self, interface: u64) {
         let mut socks = self.sockets.lock();

--- a/crates/telio-wg/src/wg.rs
+++ b/crates/telio-wg/src/wg.rs
@@ -182,12 +182,9 @@ impl DynamicWg {
     ///         Protector {}
     ///         impl Protector for Protector {
     ///         fn make_external(&self, socket: NativeSocket) -> io::Result<()>;
-    ///         #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
     ///         fn make_internal(&self, interface: i32) -> Result<(), std::io::Error>;
     ///         fn clean(&self, socket: NativeSocket);
-    ///         #[cfg(target_os = "linux")]
     ///         fn set_fwmark(&self, fwmark: u32);
-    ///         #[cfg(any(target_os = "macos", windows))]
     ///         fn set_tunnel_interface(&self, interface: u64);
     ///         }
     ///     }


### PR DESCRIPTION
### Problem
Failed `SessionKeeper` startup is "fatal" - whole meshnet startup fails. Yet it only prevents the direct part of the meshnet from working.

### Solution
When the SessionKeeper fails to start (for whatever reason), make it as if the config didn't have the 'direct' section and continue the startup. This will result in meshnet still working, but only in the relayed mode.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
