### PR TITLE
LLT 5183 list local if ip

### DIFF
--- a/.unreleased/LLT-5183
+++ b/.unreleased/LLT-5183
@@ -1,0 +1,1 @@
+Network monitoring mondule

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2476,6 +2476,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "neli"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1100229e06604150b3becd61a4965d5c70f3be1759544ea7274166f4be41ef43"
+dependencies = [
+ "byteorder",
+ "libc",
+ "log",
+ "neli-proc-macros",
+ "tokio",
+]
+
+[[package]]
+name = "neli-proc-macros"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c168194d373b1e134786274020dae7fc5513d565ea2ebb9bc9ff17ffb69106d4"
+dependencies = [
+ "either",
+ "proc-macro2 1.0.83",
+ "quote 1.0.36",
+ "serde",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "network-framework-sys"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3542,6 +3568,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c947adb109a8afce5fc9c7bf951f87f146e9147b3a6a58413105628fb1d1e66"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3591,6 +3626,12 @@ dependencies = [
  "ring",
  "untrusted",
 ]
+
+[[package]]
+name = "sdd"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a7b59a5d9b0099720b417b6325d91a52cbf5b3dcb5041d864be53eefa58abc"
 
 [[package]]
 name = "security-framework"
@@ -3722,7 +3763,21 @@ dependencies = [
  "lazy_static",
  "log",
  "parking_lot",
- "serial_test_derive",
+ "serial_test_derive 0.8.0",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b4b487fe2acf240a021cf57c6b2b4903b1e78ca0ecd862a71b71d2a51fed77d"
+dependencies = [
+ "futures",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive 3.1.1",
 ]
 
 [[package]]
@@ -3736,6 +3791,17 @@ dependencies = [
  "quote 1.0.36",
  "rustversion",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82fe9db325bcef1fbcde82e078a5cc4efdf787e96b3b9cf45b50b529f2083d67"
+dependencies = [
+ "proc-macro2 1.0.83",
+ "quote 1.0.36",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -4207,6 +4273,7 @@ dependencies = [
  "ffi_helpers",
  "futures",
  "h2",
+ "if-addrs",
  "ipnet",
  "jni",
  "lazy_static",
@@ -4236,6 +4303,7 @@ dependencies = [
  "telio-lana",
  "telio-model",
  "telio-nat-detect",
+ "telio-network-monitors",
  "telio-nurse",
  "telio-pmtu",
  "telio-pq",
@@ -4341,7 +4409,7 @@ dependencies = [
  "cargo-platform",
  "serde",
  "serde_json",
- "serial_test",
+ "serial_test 0.8.0",
  "telio-utils",
  "thiserror",
  "time",
@@ -4376,6 +4444,29 @@ version = "0.1.0"
 dependencies = [
  "nat-detect",
  "tokio",
+]
+
+[[package]]
+name = "telio-network-monitors"
+version = "0.1.0"
+dependencies = [
+ "assert_matches",
+ "block",
+ "dispatch",
+ "if-addrs",
+ "ipnet",
+ "lazy_static",
+ "mockall",
+ "neli 0.6.4",
+ "network-framework-sys",
+ "once_cell",
+ "parking_lot",
+ "serial_test 3.1.1",
+ "telio-utils",
+ "tokio",
+ "tracing",
+ "winapi",
+ "windows 0.34.0",
 ]
 
 [[package]]
@@ -4542,14 +4633,11 @@ dependencies = [
 name = "telio-sockets"
 version = "0.1.0"
 dependencies = [
- "block",
  "boringtun",
  "debug_panic",
- "dispatch",
  "futures",
  "libc",
  "mockall",
- "network-framework-sys",
  "nix 0.28.0",
  "objc",
  "objc-foundation",
@@ -4558,6 +4646,7 @@ dependencies = [
  "rstest",
  "socket2 0.5.7",
  "system-configuration 0.5.1 (git+https://github.com/NordSecurity/system-configuration-rs.git)",
+ "telio-network-monitors",
  "telio-utils",
  "thiserror",
  "tokio",
@@ -4642,6 +4731,7 @@ dependencies = [
  "telio-batcher",
  "telio-crypto",
  "telio-model",
+ "telio-network-monitors",
  "telio-proto",
  "telio-sockets",
  "telio-task",
@@ -5506,6 +5596,19 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45296b64204227616fdbf2614cefa4c236b98ee64dfaaaa435207ed99fe7829f"
+dependencies = [
+ "windows_aarch64_msvc 0.34.0",
+ "windows_i686_gnu 0.34.0",
+ "windows_i686_msvc 0.34.0",
+ "windows_x86_64_gnu 0.34.0",
+ "windows_x86_64_msvc 0.34.0",
+]
+
+[[package]]
+name = "windows"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
@@ -5648,6 +5751,12 @@ checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17cffbe740121affb56fad0fc0e421804adf0ae00891205213b5cecd30db881d"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -5657,6 +5766,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2564fde759adb79129d9b4f54be42b32c89970c18ebf93124ca8870a498688ed"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5678,6 +5793,12 @@ checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cd9d32ba70453522332c14d38814bceeb747d80b3958676007acadd7e166956"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -5687,6 +5808,12 @@ name = "windows_i686_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfce6deae227ee8d356d19effc141a509cc503dfd1f850622ec4b0f84428e1f4"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5711,6 +5838,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d19538ccc21819d01deaf88d6a17eae6596a12e9aafdbb97916fb49896d89de9"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -5776,7 +5909,7 @@ dependencies = [
  "derive_builder",
  "hex",
  "libc",
- "neli",
+ "neli 0.4.3",
  "take-until",
  "thiserror",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ base64.workspace = true
 crypto_box.workspace = true
 futures.workspace = true
 ipnet.workspace = true
+if-addrs.workspace = true
 lazy_static.workspace = true
 libc.workspace = true
 modifier.workspace = true
@@ -42,6 +43,7 @@ uuid.workspace = true
 
 telio-crypto.workspace = true
 telio-dns.workspace = true
+telio-network-monitors.workspace = true
 telio-firewall.workspace = true
 telio-lana.workspace = true
 telio-model.workspace = true
@@ -123,7 +125,9 @@ futures = "0.3"
 hashlink = "0.8.3"
 hex = "0.4.3"
 httparse = "1.8.0"
+if-addrs = "0.12.0"
 ipnet = { version = "2.3", features = ["serde"] }
+ipnetwork = "0.18"
 itertools = "0.10"
 lazy_static = "1.4.0"
 libc = "0.2.112"
@@ -180,6 +184,7 @@ telio-firewall = { version = "0.1.0", path = "./crates/telio-firewall" }
 telio-lana = { version = "0.1.0", path = "./crates/telio-lana" }
 telio-model = { version = "0.1.0", path = "./crates/telio-model" }
 telio-nat-detect = { version = "0.1.0", path = "./crates/telio-nat-detect" }
+telio-network-monitors = { version = "0.1.0", path = "./crates/telio-network-monitors" }
 telio-nurse = { version = "0.1.0", path = "./crates/telio-nurse" }
 telio-proto = { version = "0.1.0", path = "./crates/telio-proto" }
 telio-batcher = { version = "0.1.0", path = "./crates/telio-batcher" }

--- a/crates/telio-network-monitors/Cargo.toml
+++ b/crates/telio-network-monitors/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "telio-network-monitors"
+version = "0.1.0"
+edition = "2018"
+license = "GPL-3.0-only"
+repository = "https://github.com/NordSecurity/libtelio"
+publish = false
+
+[dependencies]
+if-addrs.workspace = true
+ipnet.workspace = true
+telio-utils.workspace = true
+tracing.workspace = true
+parking_lot.workspace = true
+tokio = { workspace = true, features = ["sync", "test-util", "time", "rt", "macros"] }
+once_cell.workspace = true
+mockall.workspace = true
+
+[target.'cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))'.dependencies]
+dispatch = { git = "https://github.com/NordSecurity/rust-dispatch.git", rev = "13447cd7221a74ebcce1277ae0cfc9a421a28ec5" }
+network-framework-sys = "0.1"
+block = "0.1"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+neli = { version = "0.6.4", features = ["async"] }
+
+[target.'cfg(windows)'.dependencies]
+winapi = { workspace = true, features = ["iphlpapi", "netioapi", "winnt", "ws2def"] }
+windows = { version = "0.34.0", features = [
+    "alloc",
+    "Win32_Networking_WinSock",
+    "Win32_NetworkManagement_IpHelper",
+] }
+
+[dev-dependencies]
+assert_matches = "1.5.0"
+lazy_static.workspace = true
+serial_test = "3.1.1"

--- a/crates/telio-network-monitors/src/apple.rs
+++ b/crates/telio-network-monitors/src/apple.rs
@@ -1,0 +1,80 @@
+//! Module to monitor network changes in Apple
+
+use network_framework_sys::{
+    nw_path_monitor_create, nw_path_monitor_set_queue, nw_path_monitor_start, nw_path_monitor_t,
+    nw_path_t,
+};
+use std::ffi::{c_long, c_void};
+use telio_utils::{telio_log_info, telio_log_warn};
+
+use crate::monitor::PATH_CHANGE_BROADCAST;
+
+/// Dispatch queue priority as high priority queue
+pub const DISPATCH_QUEUE_PRIORITY_HIGH: c_long = 2;
+/// Dispatch queue priority as default queue
+pub const DISPATCH_QUEUE_PRIORITY_DEFAULT: c_long = 0;
+/// Dispatch queue priority as low priority queue
+pub const DISPATCH_QUEUE_PRIORITY_LOW: c_long = -2;
+/// Dispatch queue priority as background queue
+pub const DISPATCH_QUEUE_PRIORITY_BACKGROUND: c_long = -1 << 15;
+
+extern "C" {
+    /// Obj-c signature:
+    /// void nw_path_monitor_set_update_handler(nw_path_monitor_t monitor, nw_path_monitor_update_handler_t update_handler);
+    /// typedef void (^nw_path_monitor_update_handler_t)(nw_path_t path);
+    pub fn nw_path_monitor_set_update_handler(
+        monitor: nw_path_monitor_t,
+        update_handler: *const c_void,
+    );
+    /// Obj-c signature:
+    /// void nw_path_enumerate_interfaces(nw_path_t path, nw_path_enumerate_interfaces_block_t enumerate_block);
+    /// typedef bool (^nw_path_enumerate_interfaces_block_t)(nw_interface_t interface);
+    pub fn nw_path_enumerate_interfaces(path: nw_path_t, enumerate_block: *const c_void);
+}
+
+/// This function configuresa a network path monitor using Apple's networking framework that tracks
+/// changes in the network path and updates the local interface cache.
+///
+/// # How it Works
+///
+/// 1. **Objective-C Blocks**: The Apple `Network.framework` uses blocks as callbacks
+///    for handling asynchronous events.
+///
+/// 3. **Global Queue Setup**: The monitor runs on a background queue using Grand Central Dispatch (GCD).
+///    This allows it to handle updates without blocking the main thread.
+///
+/// 4. **Broadcast Notification**: After the interfaces are updated, a notification is sent via a broadcast channel
+///    (`PATH_CHANGE_BROADCAST`) to inform other parts of the system that the path has changed.
+///
+/// For more details on Apple's `Network.framework` see:
+/// - [Apple Network.framework Documentation](https://developer.apple.com/documentation/network)
+pub fn setup_network_monitor() {
+    let update_handler = block::ConcreteBlock::new(|_path: nw_path_t| {
+        if let Err(e) = PATH_CHANGE_BROADCAST.send(()) {
+            telio_log_warn!("Failed to notify about changed path, error: {e}");
+        }
+
+        telio_log_info!("Path change notification sent");
+    })
+    .copy();
+    unsafe {
+        let monitor = nw_path_monitor_create();
+        if monitor.is_null() {
+            telio_log_warn!("Failed to start network path monitor");
+            return;
+        }
+
+        let queue = dispatch::ffi::dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0);
+        if queue.is_null() {
+            telio_log_warn!("Failed to get global background queue");
+            return;
+        }
+        nw_path_monitor_set_queue(monitor, std::mem::transmute(queue));
+
+        nw_path_monitor_set_update_handler(
+            monitor,
+            &*update_handler as *const block::Block<_, _> as *const c_void,
+        );
+        nw_path_monitor_start(monitor);
+    }
+}

--- a/crates/telio-network-monitors/src/lib.rs
+++ b/crates/telio-network-monitors/src/lib.rs
@@ -1,0 +1,19 @@
+#![deny(missing_docs)]
+
+//! Network monitor module
+pub mod monitor;
+
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
+/// Utility to get monitor network on apple
+pub mod apple;
+
+#[cfg(target_os = "linux")]
+/// Utility to get monitor network on linux
+pub mod linux;
+
+#[cfg(target_os = "windows")]
+/// Utility to get monitor network on windows
+pub mod windows;
+
+/// Get local interfaces
+pub mod local_interfaces;

--- a/crates/telio-network-monitors/src/linux.rs
+++ b/crates/telio-network-monitors/src/linux.rs
@@ -1,0 +1,72 @@
+use crate::monitor::PATH_CHANGE_BROADCAST;
+use neli::{
+    consts::socket::NlFamily::Route,
+    socket::{tokio::NlSocket as TokioSocket, NlSocket},
+    FromBytesWithInput,
+};
+use std::io;
+use telio_utils::{telio_log_debug, telio_log_error, telio_log_warn};
+use tokio::task::JoinHandle;
+
+const RTMGRP_LINK: u32 = 0x0001;
+const RTMGRP_IPV4_IFADDR: u32 = 0x0010;
+
+/// Sets up linux network monitoring task
+pub async fn setup_network_monitor() -> Option<JoinHandle<io::Result<()>>> {
+    match open_netlink_socket().await {
+        Ok(sock) => read_event(sock).await,
+        Err(e) => {
+            telio_log_error!("Unable to open network monitor socket: {e:?}");
+            None
+        }
+    }
+}
+
+async fn open_netlink_socket() -> Result<TokioSocket, io::Error> {
+    let s = NlSocket::connect(Route, None, &[RTMGRP_LINK, RTMGRP_IPV4_IFADDR])?;
+    let sock = TokioSocket::new(s)?;
+    telio_log_debug!("Network monitor socket opened");
+    Ok(sock)
+}
+
+async fn read_event(mut sock: TokioSocket) -> Option<JoinHandle<io::Result<()>>> {
+    Some(tokio::spawn({
+        let mut buffer: Vec<u8> = Vec::new();
+
+        // Uninitialized object to satisfy recv constraints.
+        // Since data isn't required from recv, hence initialzing
+        // it properly isn't necessary as well.
+        #[derive(Debug, FromBytesWithInput)]
+        struct Payload;
+
+        async move {
+            loop {
+                let _ = sock
+                    .recv::<neli::consts::rtnl::Rtm, Payload>(&mut buffer)
+                    .await;
+                {
+                    telio_log_debug!("Network path updated");
+                    if let Err(e) = PATH_CHANGE_BROADCAST.send(()) {
+                        telio_log_warn!("Failed to notify about changed path: {e}");
+                    }
+                }
+            }
+        }
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_unregister_callback() {
+        let monitor_handle = setup_network_monitor().await;
+
+        if let Some(handle) = monitor_handle {
+            handle.abort();
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            assert!(handle.is_finished());
+        }
+    }
+}

--- a/crates/telio-network-monitors/src/local_interfaces.rs
+++ b/crates/telio-network-monitors/src/local_interfaces.rs
@@ -1,0 +1,107 @@
+use ipnet::Ipv4Net;
+use mockall::automock;
+use std::net::{IpAddr, Ipv4Addr};
+
+/// A trait that provides an interface for retrieving network interface addresses.
+#[automock]
+pub trait GetIfAddrs: Send + Sync + Default + 'static {
+    /// Fetches the list of network interfaces available on the system.
+    /// Returns a `Result` which is contains a `Vec` of `if_addrs::Interface`
+    /// representing the available network interfaces.
+    fn get(&self) -> std::io::Result<Vec<if_addrs::Interface>>;
+}
+
+/// A concrete implementation of the `GetIfAddrs` trait that retrieves network interface
+/// addresses from the operating system using the `if_addrs` crate.
+#[derive(Default)]
+pub struct SystemGetIfAddrs;
+impl GetIfAddrs for SystemGetIfAddrs {
+    fn get(&self) -> std::io::Result<Vec<if_addrs::Interface>> {
+        if_addrs::get_if_addrs()
+    }
+}
+
+/// Method that returns vector of Interfaces on the system
+/// Filtering out meshnet and loopback IP
+pub fn gather_local_interfaces<G: GetIfAddrs>(
+    get_if_addr: &G,
+) -> std::io::Result<Vec<if_addrs::Interface>> {
+    let shared_range: Ipv4Net = Ipv4Net::new(Ipv4Addr::new(100, 64, 0, 0), 10).unwrap_or_default();
+    Ok((*get_if_addr)
+        .get()?
+        .into_iter()
+        .filter(|x| {
+            !x.addr.is_loopback() && {
+                match x.addr.ip() {
+                    // Filter 100.64/10 libtelio's meshnet network.
+                    IpAddr::V4(v4) => !shared_range.contains(&v4),
+                    // Filter IPv6
+                    _ => false,
+                }
+            }
+        })
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{Ipv4Addr, Ipv6Addr};
+
+    #[tokio::test]
+    async fn gather_local_interfaces_filtering() {
+        let mut get_if_addrs_mock = MockGetIfAddrs::new();
+        get_if_addrs_mock.expect_get().return_once(|| {
+            Ok(vec![
+                if_addrs::Interface {
+                    name: "localhost".to_owned(),
+                    addr: if_addrs::IfAddr::V4(if_addrs::Ifv4Addr {
+                        ip: Ipv4Addr::new(127, 0, 0, 1),
+                        netmask: Ipv4Addr::new(255, 0, 0, 0),
+                        broadcast: None,
+                    }),
+                    index: None,
+                    #[cfg(windows)]
+                    adapter_name: "{78f73923-a518-4936-ba87-2a30427b1f63}".to_string(),
+                },
+                if_addrs::Interface {
+                    name: "correct".to_owned(),
+                    addr: if_addrs::IfAddr::V4(if_addrs::Ifv4Addr {
+                        ip: Ipv4Addr::new(10, 0, 0, 1),
+                        netmask: Ipv4Addr::new(255, 255, 255, 0),
+                        broadcast: None,
+                    }),
+                    index: None,
+                    #[cfg(windows)]
+                    adapter_name: "{78f73923-a518-4936-ba87-2a30427b1f63}".to_string(),
+                },
+                if_addrs::Interface {
+                    name: "internal".to_owned(),
+                    addr: if_addrs::IfAddr::V4(if_addrs::Ifv4Addr {
+                        ip: Ipv4Addr::new(100, 64, 0, 1),
+                        netmask: Ipv4Addr::new(255, 192, 0, 0),
+                        broadcast: None,
+                    }),
+                    index: None,
+                    #[cfg(windows)]
+                    adapter_name: "{78f73923-a518-4936-ba87-2a30427b1f63}".to_string(),
+                },
+                if_addrs::Interface {
+                    name: "ipv6".to_owned(),
+                    addr: if_addrs::IfAddr::V6(if_addrs::Ifv6Addr {
+                        ip: Ipv6Addr::new(0xfd74, 0x656c, 0x696f, 0, 0x12, 0x34, 0x56, 0),
+                        netmask: Ipv6Addr::new(255, 255, 255, 255, 0, 0, 0, 0),
+                        broadcast: None,
+                    }),
+                    index: None,
+                    #[cfg(windows)]
+                    adapter_name: "{78f73923-a518-4936-ba87-2a30427b1f63}".to_string(),
+                },
+            ])
+        });
+
+        let interfaces = gather_local_interfaces(&get_if_addrs_mock).unwrap();
+        assert!(interfaces.len() == 1);
+        assert!(interfaces[0].name == "correct");
+    }
+}

--- a/crates/telio-network-monitors/src/monitor.rs
+++ b/crates/telio-network-monitors/src/monitor.rs
@@ -1,0 +1,185 @@
+//! Module to monitor changes in network.
+//! Get notified when network paths change
+//! and update local IP address cache
+use crate::{local_interfaces::gather_local_interfaces, local_interfaces::GetIfAddrs};
+use once_cell::sync::Lazy;
+use parking_lot::Mutex;
+use std::io;
+use telio_utils::{telio_log_debug, telio_log_warn};
+use tokio::{sync::broadcast::Sender, task::JoinHandle};
+/// Sender to notify if there is a change in OS interface order
+pub static PATH_CHANGE_BROADCAST: Lazy<Sender<()>> = Lazy::new(|| Sender::new(2));
+/// Vector containing all local interfaces
+pub static LOCAL_ADDRS_CACHE: Mutex<Vec<if_addrs::Interface>> = Mutex::new(Vec::new());
+#[cfg(all(
+    not(test),
+    any(target_os = "macos", target_os = "ios", target_os = "tvos")
+))]
+static NW_PATH_MONITOR_START: std::sync::Once = std::sync::Once::new();
+
+#[derive(Debug)]
+/// Struct to monitor network
+pub struct NetworkMonitor {
+    if_cache_updater_handle: Option<JoinHandle<io::Result<()>>>,
+    // Mac and Windows use callbacks, whereas in Linux a socket is registered
+    // with netlink multicast group messages
+    #[cfg(target_os = "linux")]
+    monitor_handle: Option<JoinHandle<io::Result<()>>>,
+    #[cfg(target_os = "windows")]
+    monitor_handle: crate::windows::SafeHandle,
+}
+
+fn save_local_interfaces<G: GetIfAddrs>(get_if_addr: &G) {
+    match gather_local_interfaces(get_if_addr) {
+        Ok(v) => {
+            telio_log_debug!("Updating local addr cache");
+            *(LOCAL_ADDRS_CACHE.lock()) = v;
+        }
+        Err(e) => telio_log_warn!("Unable to get local interfaces {e}"),
+    }
+}
+
+impl NetworkMonitor {
+    /// Sets up and spawns network monitor
+    pub async fn new<G: GetIfAddrs>(get_if_addr: G) -> std::io::Result<NetworkMonitor> {
+        save_local_interfaces(&get_if_addr);
+
+        let if_cache_updater_handle = Some(tokio::spawn({
+            let mut notify = PATH_CHANGE_BROADCAST.subscribe();
+            async move {
+                loop {
+                    match notify.recv().await {
+                        Ok(()) => save_local_interfaces(&get_if_addr),
+                        Err(e) => {
+                            telio_log_warn!("Failed to receive new path for sockets ({e}): ");
+                        }
+                    }
+                }
+            }
+        }));
+
+        // Only add in production, otherwise network triggers from OS can occur
+        // which can make the test (test_path_change_notification) flaky sometimes
+        #[cfg(all(
+            not(test),
+            any(target_os = "macos", target_os = "ios", target_os = "tvos")
+        ))]
+        NW_PATH_MONITOR_START.call_once(crate::apple::setup_network_monitor);
+        #[cfg(target_os = "linux")]
+        let monitor_handle = crate::linux::setup_network_monitor().await;
+
+        #[cfg(target_os = "windows")]
+        let monitor_handle = crate::windows::setup_network_monitor();
+
+        Ok(Self {
+            if_cache_updater_handle,
+            #[cfg(any(target_os = "linux", target_os = "windows"))]
+            monitor_handle,
+        })
+    }
+}
+
+impl Drop for NetworkMonitor {
+    fn drop(&mut self) {
+        if let Some(handle) = &self.if_cache_updater_handle {
+            handle.abort();
+        }
+        #[cfg(target_os = "linux")]
+        if let Some(handle) = &self.monitor_handle {
+            handle.abort();
+        }
+        #[cfg(target_os = "windows")]
+        if !self.monitor_handle.0.is_null() {
+            crate::windows::deregister_network_monitor(self.monitor_handle.clone());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::local_interfaces::MockGetIfAddrs;
+
+    use super::*;
+    use serial_test::serial;
+    use std::{
+        net::Ipv4Addr,
+        sync::atomic::{AtomicU8, Ordering},
+    };
+
+    static CALL_COUNT: AtomicU8 = AtomicU8::new(0);
+
+    async fn setup_network_monitor() -> NetworkMonitor {
+        CALL_COUNT.store(0, Ordering::SeqCst);
+        let mut get_if_addrs_mock = MockGetIfAddrs::new();
+        get_if_addrs_mock.expect_get().returning(|| {
+            CALL_COUNT.fetch_add(1, Ordering::SeqCst);
+            Ok(vec![if_addrs::Interface {
+                name: "correct".to_owned(),
+                addr: if_addrs::IfAddr::V4(if_addrs::Ifv4Addr {
+                    ip: Ipv4Addr::new(10, 0, 0, 1),
+                    netmask: Ipv4Addr::new(255, 255, 255, 0),
+                    broadcast: None,
+                }),
+                index: None,
+                #[cfg(windows)]
+                adapter_name: "{78f73923-a518-4936-ba87-2a30427b1f63}".to_string(),
+            }])
+        });
+        NetworkMonitor::new(get_if_addrs_mock).await.unwrap()
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_path_change_notification() {
+        let _network_monitor = setup_network_monitor().await;
+        if let Err(e) = PATH_CHANGE_BROADCAST.send(()) {
+            panic!("Failed to notify about changed path, error: {}", e);
+        }
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+        assert_eq!(CALL_COUNT.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_multiple_monitor_instances() {
+        let _network_monitor = setup_network_monitor().await;
+        let _network_mon = setup_network_monitor().await;
+
+        CALL_COUNT.store(0, Ordering::SeqCst);
+        if let Err(e) = PATH_CHANGE_BROADCAST.send(()) {
+            panic!("Failed to notify about changed path, error: {}", e);
+        }
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+        assert_eq!(CALL_COUNT.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_monitor_dropping() {
+        let _network_monitor = setup_network_monitor().await;
+        if let Err(e) = PATH_CHANGE_BROADCAST.send(()) {
+            panic!("Failed to notify about changed path, error: {}", e);
+        }
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+        drop(_network_monitor);
+        let _network_monitor = setup_network_monitor().await;
+
+        assert_eq!(CALL_COUNT.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_gather_if_error() {
+        let mut get_if_addrs_mock = MockGetIfAddrs::new();
+        get_if_addrs_mock
+            .expect_get()
+            .returning(|| Err(io::ErrorKind::NotFound.into()));
+
+        if let Err(e) = NetworkMonitor::new(get_if_addrs_mock).await {
+            panic!("Network monitor not started with {}", e);
+        }
+    }
+}

--- a/crates/telio-network-monitors/src/windows.rs
+++ b/crates/telio-network-monitors/src/windows.rs
@@ -1,0 +1,93 @@
+use crate::monitor::PATH_CHANGE_BROADCAST;
+use std::os::raw::c_ulong;
+use std::ptr;
+use telio_utils::{telio_log_error, telio_log_trace, telio_log_warn};
+use winapi::shared::{
+    netioapi::{CancelMibChangeNotify2, NotifyIpInterfaceChange, MIB_IPINTERFACE_ROW},
+    ntdef::{HANDLE, PVOID},
+    winerror::NO_ERROR,
+    ws2def::AF_UNSPEC,
+};
+
+#[derive(Clone, Debug)]
+/// Wrapper around HANDLE to pass between threads
+pub struct SafeHandle(
+    /// Making HANDLE publically accessible in monitor
+    pub HANDLE,
+);
+unsafe impl Send for SafeHandle {}
+unsafe impl Sync for SafeHandle {}
+
+unsafe extern "system" fn callback(
+    _caller_context: PVOID,
+    _row: *mut MIB_IPINTERFACE_ROW,
+    _notification_type: c_ulong,
+) {
+    if let Err(e) = PATH_CHANGE_BROADCAST.send(()) {
+        telio_log_warn!("Failed to notify about changed path {e}");
+    }
+}
+
+/// Method to setup network monitoring for Windows
+pub fn setup_network_monitor() -> SafeHandle {
+    unsafe {
+        let mut handle: HANDLE = ptr::null_mut();
+
+        let result = NotifyIpInterfaceChange(
+            AF_UNSPEC as u16,
+            Some(callback),
+            ptr::null_mut(),
+            0,
+            &mut handle,
+        );
+
+        if result != NO_ERROR {
+            telio_log_error!(
+                "NotifyIpInterfaceChange call failed with error code: {}",
+                result
+            );
+        }
+
+        SafeHandle(handle)
+    }
+}
+
+/// Clean up the network notification
+pub fn deregister_network_monitor(safe_handle: SafeHandle) {
+    // Denotification has to be done in a separate thread
+    // otherwise would lead to deadlock
+    tokio::task::spawn_blocking({
+        move || unsafe {
+            let cancel_result = CancelMibChangeNotify2(safe_handle.0);
+            if cancel_result == NO_ERROR {
+                telio_log_trace!("Notification cancelled successfully.");
+            } else {
+                telio_log_error!(
+                    "Failed to cancel notification with error code: {}",
+                    cancel_result
+                );
+            }
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_unregister_callback() {
+        let handle = setup_network_monitor();
+
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        tokio::spawn({
+            async move {
+                unsafe {
+                    assert!(CancelMibChangeNotify2(handle.0) == NO_ERROR);
+                }
+            }
+        })
+        .await;
+    }
+}

--- a/crates/telio-sockets/Cargo.toml
+++ b/crates/telio-sockets/Cargo.toml
@@ -32,9 +32,7 @@ version-compare = "0.1"
 debug_panic = "0.2.1"
 nix = { version = "0.28", features=["socket"] }
 system-configuration = { git = 'https://github.com/NordSecurity/system-configuration-rs.git' }
-network-framework-sys = "0.1"
-block = "0.1"
-dispatch = { git = "https://github.com/NordSecurity/rust-dispatch.git", rev = "13447cd7221a74ebcce1277ae0cfc9a421a28ec5" }
+telio-network-monitors.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 winapi = { workspace = true, features = [

--- a/crates/telio-sockets/src/protector/apple.rs
+++ b/crates/telio-sockets/src/protector/apple.rs
@@ -1,12 +1,9 @@
 use debug_panic::debug_panic;
-use once_cell::sync::Lazy;
 use parking_lot::{Mutex, RwLock};
+use telio_network_monitors::{monitor::LOCAL_ADDRS_CACHE, monitor::PATH_CHANGE_BROADCAST};
 
 use std::{
-    cell::RefCell,
-    ffi::{c_long, c_void, CStr},
     io, os,
-    rc::Rc,
     sync::{Arc, Weak},
 };
 
@@ -23,42 +20,12 @@ use system_configuration::{
     dynamic_store::{self, SCDynamicStore},
     sys::schema_definitions,
 };
-use tokio::{
-    self,
-    sync::{broadcast::Sender, Notify},
-    task::JoinHandle,
-};
+use tokio::{self, sync::Notify, task::JoinHandle};
 
 use crate::native::{interface_index_from_name, NativeSocket};
 use crate::Protector;
-use network_framework_sys::{
-    nw_interface_get_name, nw_interface_t, nw_path_monitor_create, nw_path_monitor_set_queue,
-    nw_path_monitor_start, nw_path_monitor_t, nw_path_t,
-};
 use nix::sys::socket::{getsockname, AddressFamily, SockaddrLike, SockaddrStorage};
 use telio_utils::{telio_log_debug, telio_log_error, telio_log_info, telio_log_warn};
-
-extern "C" {
-    // Obj-c signature:
-    // void nw_path_monitor_set_update_handler(nw_path_monitor_t monitor, nw_path_monitor_update_handler_t update_handler);
-    // typedef void (^nw_path_monitor_update_handler_t)(nw_path_t path);
-    pub fn nw_path_monitor_set_update_handler(
-        monitor: nw_path_monitor_t,
-        update_handler: *const c_void,
-    );
-    // Obj-c signature:
-    // void nw_path_enumerate_interfaces(nw_path_t path, nw_path_enumerate_interfaces_block_t enumerate_block);
-    // typedef bool (^nw_path_enumerate_interfaces_block_t)(nw_interface_t interface);
-    pub fn nw_path_enumerate_interfaces(path: nw_path_t, enumerate_block: *const c_void);
-}
-
-pub const DISPATCH_QUEUE_PRIORITY_HIGH: c_long = 2;
-pub const DISPATCH_QUEUE_PRIORITY_DEFAULT: c_long = 0;
-pub const DISPATCH_QUEUE_PRIORITY_LOW: c_long = -2;
-pub const DISPATCH_QUEUE_PRIORITY_BACKGROUND: c_long = -1 << 15;
-
-static INTERFACE_NAMES_IN_OS_PREFERENCE_ORDER: Mutex<Vec<String>> = Mutex::new(Vec::new());
-static PATH_CHANGE_BROADCAST: Lazy<Sender<()>> = Lazy::new(|| Sender::new(1));
 
 #[cfg(any(target_os = "ios", target_os = "tvos"))]
 use objc::{class, msg_send, runtime::Object, sel, sel_impl};
@@ -409,8 +376,11 @@ fn get_primary_interface_names() -> Vec<String> {
         }
     }
 
-    let mut interface_names_in_os_preference_order: Vec<String> =
-        INTERFACE_NAMES_IN_OS_PREFERENCE_ORDER.lock().clone();
+    let mut interface_names_in_os_preference_order: Vec<String> = LOCAL_ADDRS_CACHE
+        .lock()
+        .iter()
+        .map(|interface| interface.name.clone())
+        .collect();
     telio_log_info!(
         "Discovered these primary IPv4 interfaces for use in socket binding: {:?} (OS pereference order: {interface_names_in_os_preference_order:?})",
         primary_ipv4_interface_names
@@ -478,82 +448,25 @@ fn spawn_dynamic_store_loop(sockets: Weak<Mutex<Sockets>>) {
     });
 }
 
-pub fn setup_network_path_monitor() {
-    let update_handler = block::ConcreteBlock::new(|path: nw_path_t| {
-        let names = Rc::new(RefCell::new(vec![]));
-        let names_copy = names.clone();
-
-        let enumerate_callback =
-            block::ConcreteBlock::new(move |interface: nw_interface_t| -> bool {
-                let c_name = unsafe { nw_interface_get_name(interface) };
-                if !c_name.is_null() {
-                    let name = unsafe { CStr::from_ptr(c_name) };
-                    if let Ok(name) = name.to_str() {
-                        names_copy.borrow_mut().push(name.to_owned());
-                    }
-                }
-                true
-            })
-            .copy();
-
-        unsafe {
-            nw_path_enumerate_interfaces(
-                path,
-                &*enumerate_callback as *const block::Block<_, _> as *const c_void,
-            )
-        };
-
-        *INTERFACE_NAMES_IN_OS_PREFERENCE_ORDER.lock() = names.borrow().clone();
-        if let Err(e) = PATH_CHANGE_BROADCAST.send(()) {
-            telio_log_warn!(
-                "Failed to notify about changed path, error: {e}, path: {:?}",
-                names.borrow()
-            );
-        }
-
-        telio_log_info!(
-            "Path change notification sent, current network path in os preference order: {:?}",
-            names.borrow()
-        );
-    })
-    .copy();
-    unsafe {
-        let monitor = nw_path_monitor_create();
-        if monitor.is_null() {
-            telio_log_warn!("Failed to start network path monitor");
-            return;
-        }
-
-        let queue = dispatch::ffi::dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0);
-        if queue.is_null() {
-            telio_log_warn!("Failed to get global background queue");
-            return;
-        }
-        nw_path_monitor_set_queue(monitor, std::mem::transmute(queue));
-
-        nw_path_monitor_set_update_handler(
-            monitor,
-            &*update_handler as *const block::Block<_, _> as *const c_void,
-        );
-        nw_path_monitor_start(monitor);
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use socket2::{Domain, Protocol, Socket, Type};
+    use telio_network_monitors::{
+        apple::setup_network_monitor, local_interfaces::SystemGetIfAddrs, monitor::NetworkMonitor,
+    };
 
     use crate::native::AsNativeSocket;
 
     use super::*;
 
-    #[test]
-    fn test_ipv6_sk_bind() {
-        setup_network_path_monitor();
+    #[tokio::test]
+    async fn test_ipv6_sk_bind() {
+        setup_network_monitor();
 
         let socket2_socket = Socket::new(Domain::IPV6, Type::STREAM, Some(Protocol::TCP));
 
         let socket_fd = socket2_socket.as_ref().unwrap().as_native_socket();
+        let _network_monitor = NetworkMonitor::new(SystemGetIfAddrs).await.unwrap();
 
         if let Err(e) = bind(get_primary_interface(0).unwrap() as u32, socket_fd) {
             panic!("Test failed with error : {}", e)

--- a/crates/telio-traversal/Cargo.toml
+++ b/crates/telio-traversal/Cargo.toml
@@ -10,7 +10,6 @@ publish = false
 bytecodec = "0.4.15"
 enum-map = "2.5.0"
 http = "0.2.8"
-if-addrs = "0.12.0"
 igd = { version = "0.12.1", features = ["aio"], default-features = false }
 sm = "0.9.0"
 stun_codec = "0.1.13"
@@ -20,6 +19,7 @@ base64.workspace = true
 boringtun.workspace = true
 futures.workspace = true
 httparse.workspace = true
+if-addrs.workspace = true
 ipnet.workspace = true
 lazy_static.workspace = true
 tracing.workspace = true
@@ -35,6 +35,7 @@ tokio = { workspace = true, features = ["full"] }
 telio-batcher.workspace = true
 telio-crypto.workspace = true
 telio-model.workspace = true
+telio-network-monitors.workspace = true
 telio-proto.workspace = true
 telio-sockets.workspace = true
 telio-task.workspace = true

--- a/nat-lab/tests/telio.py
+++ b/nat-lab/tests/telio.py
@@ -944,6 +944,12 @@ class Client:
 
         return False
 
+    async def restart_interface(self):
+        if self._interface_configured:
+            await self.get_router().deconfigure_interface(self._node.ip_addresses)
+            self._interface_configured = False
+        await self._configure_interface()
+
     async def connect_to_exit_node(
         self,
         public_key: str,

--- a/nat-lab/tests/test_network_monitor.py
+++ b/nat-lab/tests/test_network_monitor.py
@@ -1,0 +1,49 @@
+import asyncio
+import pytest
+from contextlib import AsyncExitStack
+from helpers import setup_mesh_nodes, SetupParameters
+from telio import AdapterType
+from utils.connection_util import ConnectionTag
+
+DEFAULT_WAITING_TIME = 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "alpha_setup_params",
+    [
+        pytest.param(
+            SetupParameters(
+                connection_tag=ConnectionTag.DOCKER_SHARED_CLIENT_1,
+                adapter_type=AdapterType.BoringTun,
+            ),
+        ),
+        pytest.param(
+            SetupParameters(
+                connection_tag=ConnectionTag.WINDOWS_VM_1,
+                adapter_type=AdapterType.WireguardGo,
+            ),
+            marks=[pytest.mark.windows],
+        ),
+        pytest.param(
+            SetupParameters(
+                connection_tag=ConnectionTag.MAC_VM,
+                adapter_type=AdapterType.BoringTun,
+            ),
+            marks=[
+                pytest.mark.mac,
+            ],
+        ),
+    ],
+)
+async def test_network_monitor(
+    alpha_setup_params: SetupParameters,
+) -> None:
+    async with AsyncExitStack() as exit_stack:
+        env = await setup_mesh_nodes(exit_stack, [alpha_setup_params])
+        [client_alpha] = env.clients
+
+        await asyncio.sleep(DEFAULT_WAITING_TIME)
+        await client_alpha.restart_interface()
+
+        await client_alpha.wait_for_log("Updating local addr cache")

--- a/nat-lab/tests/utils/router/linux_router.py
+++ b/nat-lab/tests/utils/router/linux_router.py
@@ -61,6 +61,23 @@ class LinuxRouter(Router):
             ["ip", "link", "set", "up", "dev", self._interface_name]
         ).execute()
 
+    async def deconfigure_interface(self, addresses: List[str]) -> None:
+        for address in addresses:
+            await self._connection.create_process(
+                [
+                    "ip",
+                    ("-4" if self.check_ip_address(address) == IPProto.IPv4 else "-6"),
+                    "addr",
+                    "del",
+                    address,
+                    "dev",
+                    self._interface_name,
+                ],
+            ).execute()
+        await self._connection.create_process(
+            ["ip", "link", "set", "down", "dev", self._interface_name]
+        ).execute()
+
     async def create_meshnet_route(self):
         if self.ip_stack in [IPStack.IPv4, IPStack.IPv4v6]:
             await self._connection.create_process(

--- a/nat-lab/tests/utils/router/mac_router.py
+++ b/nat-lab/tests/utils/router/mac_router.py
@@ -46,6 +46,35 @@ class MacRouter(Router):
                     ],
                 ).execute()
 
+    async def deconfigure_interface(self, addresses: List[str]) -> None:
+        for address in addresses:
+            addr_proto = self.check_ip_address(address)
+
+            if addr_proto == IPProto.IPv4:
+                await self._connection.create_process(
+                    [
+                        "ifconfig",
+                        self._interface_name,
+                        "inet",
+                        "delete",
+                        address,
+                        "255.192.0.0",
+                        address,
+                    ],
+                ).execute()
+            elif addr_proto == IPProto.IPv6:
+                await self._connection.create_process(
+                    [
+                        "ifconfig",
+                        self._interface_name,
+                        "inet6",
+                        "delete",
+                        address,
+                        "prefixlen",
+                        "64",
+                    ],
+                ).execute()
+
     async def create_meshnet_route(self) -> None:
         if self.ip_stack in [IPStack.IPv4, IPStack.IPv4v6]:
             await self._connection.create_process(

--- a/nat-lab/tests/utils/router/router.py
+++ b/nat-lab/tests/utils/router/router.py
@@ -75,6 +75,10 @@ class Router(ABC):
         pass
 
     @abstractmethod
+    async def deconfigure_interface(self, addresses: List[str]) -> None:
+        pass
+
+    @abstractmethod
     async def create_meshnet_route(self) -> None:
         pass
 

--- a/src/device.rs
+++ b/src/device.rs
@@ -5,6 +5,7 @@ use telio_crypto::{PublicKey, SecretKey};
 use telio_firewall::firewall::{Firewall, StatefullFirewall};
 use telio_lana::init_lana;
 use telio_nat_detect::nat_detection::{retrieve_single_nat, NatData};
+use telio_network_monitors::{local_interfaces::SystemGetIfAddrs, monitor::NetworkMonitor};
 use telio_pq::PostQuantum;
 use telio_proto::HeartbeatMessage;
 use telio_proxy::{Config as ProxyConfig, Io as ProxyIo, Proxy, UdpProxy};
@@ -87,13 +88,13 @@ use telio_model::{
     EndpointMap,
 };
 
+#[cfg(target_os = "android")]
+use telio_network_monitors::monitor::PATH_CHANGE_BROADCAST;
+
 pub use wg::{
     uapi::Event as WGEvent, uapi::Interface, AdapterType, DynamicWg, Error as AdapterError,
     FirewallCb, Tun, WireGuard,
 };
-
-#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
-static NETWORK_PATH_MONITOR_START: std::sync::Once = std::sync::Once::new();
 
 #[cfg(test)]
 use wg::tests::AdapterExpectation;
@@ -305,6 +306,8 @@ pub struct Entities {
     postquantum_wg: telio_pq::Entity,
 
     pmtu_detection: Option<telio_pmtu::Entity>,
+
+    network_monitor: NetworkMonitor,
 }
 
 impl Entities {
@@ -464,10 +467,6 @@ impl Device {
         telio_log_info!("Created libtelio instance {}, {}", version_tag, commit_sha);
 
         telio_log_info!("libtelio is starting up with features : {:?}", features);
-
-        #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
-        NETWORK_PATH_MONITOR_START
-            .call_once(telio_sockets::protector::platform::setup_network_path_monitor);
 
         if let Some(lana) = &features.lana {
             if init_lana(lana.event_path.clone(), version_tag.to_string(), lana.prod).is_err() {
@@ -1046,6 +1045,7 @@ impl Runtime {
             None
         };
 
+        let network_monitor = NetworkMonitor::new(SystemGetIfAddrs).await?;
         let socket_pool = Arc::new({
             if let Some(protect) = protect.clone() {
                 SocketPool::new(protect)
@@ -1227,6 +1227,7 @@ impl Runtime {
                 aggregator: aggregator.clone(),
                 postquantum_wg,
                 pmtu_detection,
+                network_monitor,
             },
             event_listeners: EventListeners {
                 wg_endpoint_publish_event_subscriber: wg_endpoint_publish_events.rx,
@@ -1619,6 +1620,9 @@ impl Runtime {
 
             meshnet_entities.derp.reconnect().await;
         }
+
+        #[cfg(target_os = "android")]
+        PATH_CHANGE_BROADCAST.send(());
 
         self.log_nat().await;
         Ok(())
@@ -2461,6 +2465,7 @@ impl TaskRuntime for Runtime {
         }
 
         drop(self.entities.aggregator);
+        drop(self.entities.network_monitor);
 
         stop_arc_entity!(self.entities.wireguard_interface, "WireguardInterface");
 


### PR DESCRIPTION
### Problem
https://github.com/NordSecurity/libtelio/pull/529 introduces filtering in firewall on incoming packets on local IP. Calling if-addr on every packet is an expensive process.

### Solution
Cache local IPs, and update it on notification from the OS.

P..S.
This PR is currently divided into 5 commits. I have tried to separate them as logically as possible. There might be some overlap. Each commit can be looked at separately, but some things (very minor things) might have changed in future commits.

1 - Separates out fetching local interfaces into its own module
2 - Creates a network monitor module and adds network monitoring for Apple. Apple has a callback for network and link changes. As far as I could see, there is no need to deregister or cleanup.
3 - Creates a network monitor for linux and windows. Uses netlink sockets for monitoring in linux, and network callback in windows. The callback in windows has to be deregistered after use, but a caveat that it has to be done on a separate thread to avoid deadlock.
4 - Adds a trigger for Android. Android unfortunately does not support netlink sockets or any other callback, and its trigger would come from App side
5 - Adds an integration test for network monitor. Integration test adds an interface and then removes it to trigger network monitor. Network monitor gets triggered on both occasions though.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
