### PR TITLE
Add firewall feature config

### DIFF
--- a/.unreleased/LLT-5278
+++ b/.unreleased/LLT-5278
@@ -1,0 +1,1 @@
+Make separate feature config for firewall

--- a/nat-lab/tests/telio_features.py
+++ b/nat-lab/tests/telio_features.py
@@ -111,6 +111,12 @@ class PostQuantumVPN(DataClassJsonMixin):
 
 @dataclass_json(undefined=Undefined.EXCLUDE)
 @dataclass
+class Firewall(DataClassJsonMixin):
+    boringtun_reset_conns: bool = False
+
+
+@dataclass_json(undefined=Undefined.EXCLUDE)
+@dataclass
 class TelioFeatures(DataClassJsonMixin):
     is_test_env: Optional[bool] = True
     direct: Optional[Direct] = None
@@ -118,7 +124,9 @@ class TelioFeatures(DataClassJsonMixin):
     nurse: Optional[Nurse] = None
     ipv6: bool = False
     nicknames: bool = False
-    boringtun_reset_connections: bool = False
+    firewall: Firewall = field(
+        default_factory=lambda: Firewall(boringtun_reset_conns=False)
+    )
     link_detection: Optional[LinkDetection] = None
     wireguard: Optional[Wireguard] = None
     dns: Dns = field(

--- a/nat-lab/tests/test_telio_features.py
+++ b/nat-lab/tests/test_telio_features.py
@@ -1,4 +1,13 @@
-from telio_features import TelioFeatures, Direct, Lana, Nurse, Qos, ExitDns, Dns
+from telio_features import (
+    Firewall,
+    TelioFeatures,
+    Direct,
+    Lana,
+    Nurse,
+    Qos,
+    ExitDns,
+    Dns,
+)
 
 
 def test_telio_features():
@@ -76,3 +85,10 @@ def test_telio_features():
     )
     assert multicast_features == expected_multicast
     assert multicast_features.to_json() == expected_multicast.to_json()
+
+    firewall_features = TelioFeatures(firewall=Firewall(boringtun_reset_conns=False))
+    expected_firewall = TelioFeatures.from_json(
+        """{"is_test_env": true, "exit_dns": {"auto_switch_dns_ips": true}, "firewall": {"boringtun_reset_conns": false}}"""
+    )
+    assert firewall_features == expected_firewall
+    assert firewall_features.to_json() == expected_firewall.to_json()

--- a/nat-lab/tests/test_vpn.py
+++ b/nat-lab/tests/test_vpn.py
@@ -5,7 +5,7 @@ import pytest
 from contextlib import AsyncExitStack
 from helpers import SetupParameters, setup_environment, setup_connections
 from telio import AdapterType, Client
-from telio_features import TelioFeatures
+from telio_features import TelioFeatures, Firewall
 from typing import Optional
 from utils import testing, stun
 from utils.connection import Connection
@@ -340,7 +340,7 @@ async def test_vpn_reconnect(
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
                 adapter_type=AdapterType.BoringTun,
                 ip_stack=IPStack.IPv4,
-                features=TelioFeatures(boringtun_reset_connections=True),
+                features=TelioFeatures(firewall=Firewall(boringtun_reset_conns=True)),
             )
         ),
         # TODO(msz): IPv6 public server, it doesn't work with the current VPN implementation
@@ -349,7 +349,7 @@ async def test_vpn_reconnect(
         #         connection_tag=ConnectionTag.DOCKER_OPEN_INTERNET_CLIENT_DUAL_STACK,
         #         adapter_type=AdapterType.BoringTun,
         #         ip_stack=IPStack.IPv6,
-        #         telio_features=TelioFeatures(boringtun_reset_connections=True),
+        #         telio_features=TelioFeatures(boringtun_reset_conns=True),
         #     )
         # ),
     ],
@@ -477,7 +477,7 @@ async def test_kill_external_tcp_conn_on_vpn_reconnect(
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
                 adapter_type=AdapterType.BoringTun,
                 ip_stack=IPStack.IPv4,
-                features=TelioFeatures(boringtun_reset_connections=True),
+                features=TelioFeatures(firewall=Firewall(boringtun_reset_conns=True)),
             )
         ),
         # TODO(msz): IPv6 public server, it doesn't work with the current VPN implementation
@@ -486,7 +486,7 @@ async def test_kill_external_tcp_conn_on_vpn_reconnect(
         #         connection_tag=ConnectionTag.DOCKER_OPEN_INTERNET_CLIENT_DUAL_STACK,
         #         adapter_type=AdapterType.BoringTun,
         #         ip_stack=IPStack.IPv6,
-        #         telio_features=TelioFeatures(boringtun_reset_connections=True),
+        #         telio_features=TelioFeatures(boringtun_reset_conns=True),
         #     )
         # ),
     ],

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -976,7 +976,7 @@ impl Runtime {
     ) -> Result<Self> {
         let firewall = Arc::new(StatefullFirewall::new(
             features.ipv6,
-            features.boringtun_reset_connections.0,
+            features.firewall.boringtun_reset_conns,
         ));
 
         let firewall_filter_inbound_packets = {
@@ -987,7 +987,7 @@ impl Runtime {
             let fw = firewall.clone();
             move |peer: &[u8; 32], packet: &[u8]| fw.process_outbound_packet(peer, packet)
         };
-        let firewall_reset_connections = if features.boringtun_reset_connections.0 {
+        let firewall_reset_connections = if features.firewall.boringtun_reset_conns {
             let fw = firewall.clone();
             let cb = move |exit_pubkey: &PublicKey,
                            exit_ipv4: Ipv4Addr,

--- a/src/device/wg_controller.rs
+++ b/src/device/wg_controller.rs
@@ -1379,7 +1379,7 @@ mod tests {
                     validate_keys: Default::default(),
                     ipv6: true,
                     nicknames: false,
-                    boringtun_reset_connections: Default::default(),
+                    firewall: Default::default(),
                     flush_events_on_stop_timeout_seconds: None,
                     post_quantum_vpn: Default::default(),
                     link_detection: None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -219,18 +219,6 @@ mod uniffi_libtelio {
         }
     }
 
-    impl UniffiCustomTypeConverter for FeatureBoringtunResetConns {
-        type Builtin = bool;
-
-        fn into_custom(val: Self::Builtin) -> uniffi::Result<Self> {
-            Ok(FeatureBoringtunResetConns(val))
-        }
-
-        fn from_custom(obj: Self) -> Self::Builtin {
-            obj.0
-        }
-    }
-
     uniffi::include_scaffolding!("libtelio");
 
     #[cfg(test)]
@@ -447,26 +435,6 @@ mod uniffi_libtelio {
         fn test_from_feature_ttl_value(#[case] val: u32) {
             let expected = val;
             let actual = TtlValue::from_custom(TtlValue(val));
-
-            assert_eq!(actual, expected);
-        }
-
-        #[rstest]
-        #[case(true)]
-        #[case(false)]
-        fn test_to_feature_boring_tun_reset_conns(#[case] val: bool) {
-            let expected = FeatureBoringtunResetConns(val);
-            let actual = FeatureBoringtunResetConns::into_custom(val).unwrap();
-
-            assert_eq!(actual, expected);
-        }
-
-        #[rstest]
-        #[case(true)]
-        #[case(false)]
-        fn test_from_feature_boring_tun_reset_conns(#[case] val: bool) {
-            let expected = val;
-            let actual = FeatureBoringtunResetConns::from_custom(FeatureBoringtunResetConns(val));
 
             assert_eq!(actual, expected);
         }

--- a/src/libtelio.udl
+++ b/src/libtelio.udl
@@ -110,9 +110,6 @@ typedef boolean FeatureValidateKeys;
 [Custom]
 typedef u32 TtlValue;
 
-[Custom]
-typedef boolean FeatureBoringtunResetConns;
-
 namespace telio {
     /// Set the global logger.
     /// # Parameters
@@ -424,8 +421,8 @@ dictionary Features {
     boolean ipv6;
     /// Nicknames support
     boolean nicknames;
-    /// Flag to turn on connection reset upon VPN server change for boringtun adapter
-    FeatureBoringtunResetConns boringtun_reset_connections;
+    /// Feature config for firewall
+    FeatureFirewall firewall;
     /// If and for how long to flush events when stopping telio. Setting to Some(0) means waiting until all events have been flushed, regardless of how long it takes
     u64? flush_events_on_stop_timeout_seconds;
     /// No-link detection mechanism
@@ -548,6 +545,12 @@ dictionary FeatureDerp {
     boolean? enable_polling;
     /// Use Mozilla's root certificates instead of OS ones [default false]
     boolean use_built_in_root_certificates;
+};
+
+/// Feature config for firewall
+dictionary FeatureFirewall {
+    /// Turns on connection resets upon VPN server change
+    boolean boringtun_reset_conns;
 };
 
 /// Link detection mechanism


### PR DESCRIPTION
This PR creates a new feature for firewall. This answers the PR review comment https://github.com/NordSecurity/libtelio/pull/529/files#r1626552500

Above mentioned PR is already too large, so creating a separate PR to have `boringtun_reset_connection` as part of `FeatureFirewall` config. 


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
