### PR TITLE
[LLT-4928] Mask IPs with regex

### DIFF
--- a/.unreleased/LLT-4928
+++ b/.unreleased/LLT-4928
@@ -1,0 +1,1 @@
+Hide IP addresses in release version logs by replacing them with some hashes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,6 +88,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
+name = "arrayref"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+
+[[package]]
 name = "askama"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -418,6 +430,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "blake3"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30cca6d3674597c30ddf2c587bf8d9d65c9a84d2326d941cc79c9842dfe0ef52"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
 ]
 
 [[package]]
@@ -771,6 +796,12 @@ checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
 
 [[package]]
 name = "core-foundation"
@@ -4223,6 +4254,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.13.1",
+ "blake3",
  "cc",
  "cfg-if",
  "crypto_box",
@@ -4243,6 +4275,7 @@ dependencies = [
  "parking_lot",
  "pretty_assertions",
  "rand",
+ "regex",
  "rstest",
  "rustls-platform-verifier",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ crate-type = ["cdylib", "lib"]
 pretend_to_be_macos = ["telio-model/pretend_to_be_macos"]
 
 [dependencies]
+blake3 = "1.5.1"
 cfg-if = "1.0.0"
 ffi_helpers = "0.3.0"
 h2 = "=0.3.26" # RUSTSEC-2024-0332
@@ -28,6 +29,7 @@ libc.workspace = true
 modifier.workspace = true
 num_cpus.workspace = true
 parking_lot.workspace = true
+regex.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 rand.workspace = true
@@ -65,6 +67,7 @@ rustls-platform-verifier = { git = "https://github.com/tomaszklak/rustls-platfor
 
 [target.'cfg(windows)'.dependencies]
 winapi = { workspace = true, features = ["ntdef", "winerror"] }
+
 
 [dev-dependencies]
 maplit.workspace = true
@@ -136,6 +139,7 @@ proptest = "1.2.0"
 proptest-derive = "0.3.0"
 protobuf-codegen-pure = "2"
 rand = "0.8"
+regex = "1.5.5"
 rstest = "0.11.0"
 rupnp = { version = "1.1.0", default-features = false }
 rustc-hash = "1"

--- a/clis/tcli/Cargo.toml
+++ b/clis/tcli/Cargo.toml
@@ -11,7 +11,6 @@ tclid = ["sysinfo", "interprocess", "daemonize"]
 
 [dependencies]
 dirs = "4.0.0"
-regex = "1.5.5"
 reqwest = { version = "0.11.16", default-features = false, features = [
     "json",
     "blocking",
@@ -38,6 +37,7 @@ tracing-subscriber.workspace = true
 tracing-appender.workspace = true
 parking_lot.workspace = true
 rand = { workspace = true, features = ["std", "std_rng"] }
+regex.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true


### PR DESCRIPTION
### Problem
External IP addresses are visible in the logs

### Solution
We replace the IP addresses in the logs with some hashes, so they are not visible anymore

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
