### PR TITLE
Llt 5124 multicast as virtual peer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4602,6 +4602,7 @@ name = "telio-starcast"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "base64 0.13.1",
  "boringtun",
  "futures",
  "ipnetwork",
@@ -4611,12 +4612,16 @@ dependencies = [
  "sn_fake_clock",
  "telio-crypto",
  "telio-model",
+ "telio-proto",
  "telio-sockets",
  "telio-task",
+ "telio-test",
  "telio-utils",
+ "telio-wg",
  "thiserror",
  "tokio",
  "tracing",
+ "x25519-dalek 2.0.1",
 ]
 
 [[package]]

--- a/crates/telio-starcast/Cargo.toml
+++ b/crates/telio-starcast/Cargo.toml
@@ -13,6 +13,7 @@ test-util = []
 
 [dependencies]
 async-trait.workspace = true
+base64.workspace = true
 boringtun.workspace = true
 futures.workspace = true
 ipnetwork.workspace = true
@@ -20,16 +21,20 @@ pnet_packet.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["rt", "net", "sync", "macros"] }
 tracing.workspace = true
+x25519-dalek.workspace = true
 
 telio-crypto.workspace = true
 telio-model.workspace = true
+telio-proto.workspace = true
 telio-sockets.workspace = true
 telio-task.workspace = true
 telio-utils.workspace = true
+telio-wg.workspace = true
 
 [dev-dependencies]
 rand.workspace = true
 rstest.workspace = true
 sn_fake_clock.workspace = true
 
+telio-test.workspace = true
 telio-utils = { workspace = true, features = ["sn_fake_clock"] }

--- a/crates/telio-starcast/src/lib.rs
+++ b/crates/telio-starcast/src/lib.rs
@@ -1,10 +1,11 @@
 //! telio-starcast crate implements multicast support for the meshnet
 //!
 //! There are three main components to allow this:
-//! 1. Multicast peer responsible for intercepting multicast traffic and injecting it on the receiver side.
-//! 2. Multicaster responsible for multicasting intercepted traffic to the meshnet peers and handling response messages.
-//! 3. Nat is multicaster's utility used to SNAT the packets comming from multiple peers into one multicast peer address.
+//! 1. Starcast peer responsible for intercepting multicast traffic and injecting it on the receiver side.
+//! 2. Starcast transport component responsible for multicasting intercepted traffic to the meshnet peers and handling response messages.
+//! 3. Nat is transport's utility used to SNAT the packets comming from multiple peers into one multicast peer address.
 
 pub mod nat;
+pub mod starcast_peer;
 pub mod transport;
 pub(crate) mod utils;

--- a/crates/telio-starcast/src/starcast_peer.rs
+++ b/crates/telio-starcast/src/starcast_peer.rs
@@ -1,0 +1,356 @@
+//! File containing code for the starcast peer.
+
+use async_trait::async_trait;
+use boringtun::noise::{Tunn, TunnResult};
+use ipnetwork::IpNetwork;
+use std::{net::SocketAddr, time::Duration};
+use telio_crypto::{PublicKey, SecretKey};
+use telio_proto::DataMsg;
+use telio_task::{
+    io::{wait_for_tx, Chan},
+    task_exec, Runtime, RuntimeExt, Task, WaitResponse,
+};
+use telio_utils::interval;
+use telio_utils::{telio_log_error, telio_log_warn};
+use telio_wg::uapi::Peer;
+use tokio::{net::UdpSocket, sync::mpsc::error::SendTimeoutError, time::Interval};
+use x25519_dalek::{PublicKey as PublicKeyDalek, StaticSecret};
+
+/// Constant for maximum packet size.
+const MAX_PACKET: usize = 2048;
+
+#[derive(Debug, thiserror::Error)]
+/// Custom `UdpProxy` error
+pub enum Error {
+    /// `StarcastPeer` Not Configured Error
+    #[error("Starcast peer is not configured")]
+    NotConfigured,
+    /// `StarcastPeer` `IoError`
+    #[error("Starcast peer IoError")]
+    IoError(#[from] std::io::Error),
+    /// Task execution failed
+    #[error(transparent)]
+    Task(#[from] telio_task::ExecError),
+    /// IP network failed
+    #[error("Failed to parse IP network")]
+    IpNetworkError(#[from] ipnetwork::IpNetworkError),
+    /// Send failed
+    #[error(transparent)]
+    Send(#[from] SendTimeoutError<(PublicKey, DataMsg)>),
+    /// Tunnel creation failed
+    #[error("Tunnel creation failed {0}")]
+    TunnNewFail(&'static str),
+}
+
+/// The actual starcast peer containing the task which runs the wait loop for this whole component.
+pub struct StarcastPeer {
+    /// starcast virtual peer task for Telio runtime.
+    task: Task<State>,
+}
+
+/// Starcast virtual peer configuration.
+pub struct Config {
+    /// Public key of the peer with which the starcast virtual peer shall communicate.
+    public_key: PublicKey,
+    /// Port number through which the virtual starcast peer shall communicate with WireGuard.
+    wg_port: u16,
+}
+
+impl StarcastPeer {
+    /// Create and start a new unconfigured starcast virtual peer. Note that it must first be configured to be functional.
+    /// A port is assigned dynamically for it's socket and also a public key which may be obtained by the application
+    /// by using the `get_peer()` method.
+    ///
+    /// # Arguments
+    ///
+    /// * `channel` - Channel for communicating decapsulated packets to and from the multicaster.
+    ///
+    /// # Returns
+    ///
+    /// A new starcast virtual peer.
+    pub async fn start(channel: Chan<Vec<u8>>, allowed_ips: Vec<IpNetwork>) -> Result<Self, Error> {
+        // Port 0 means the OS will dynamically allocate port.
+        const TIMER_UPDATE_PERIOD: Duration = Duration::from_millis(250);
+        let socket = UdpSocket::bind(SocketAddr::from(([127, 0, 0, 1], 0))).await?;
+        let wg_timer_tick_interval = interval(TIMER_UPDATE_PERIOD);
+        let secret_key = SecretKey::gen();
+
+        Ok(StarcastPeer {
+            task: Task::start(State {
+                secret_key,
+                channel,
+                socket,
+                tunnel: None,
+                wg_sock_addr: None,
+                wg_timer_tick_interval,
+                packets_present_in_tunnel: false,
+                sending_buffer: Box::new([0u8; MAX_PACKET]),
+                receiving_buffer: Box::new([0u8; MAX_PACKET]),
+                allowed_ips,
+            }),
+        })
+    }
+
+    // TODO (LLT-5385) figure out the implications and possible side effects of reconfiguring the starcast peer mid operation.
+    /// Configure (or reconfigure) the starcast peer.
+    ///
+    /// # Arguments
+    ///
+    /// * `config` - A struct holding the configuration of the starcast peer.
+    ///
+    /// # Returns
+    ///
+    /// A result indicating wether the configuration was successful.
+    pub async fn configure(&self, config: Config) -> Result<(), Error> {
+        task_exec!(&self.task, async move |state| {
+            Ok(state.configure(config).await)
+        })
+        .await??;
+
+        Ok(())
+    }
+
+    /// Get the starcast virtual peer which can be treated as a regular peer by telio.
+    ///
+    /// # Returns
+    ///
+    /// A starcast peer.
+    pub async fn get_peer(&self) -> Result<Peer, Error> {
+        task_exec!(&self.task, async move |state| Ok(state.get_peer())).await?
+    }
+
+    /// Stop the starcast virtual peer.
+    pub async fn stop(self) {
+        let _ = self.task.stop().await.resume_unwind();
+    }
+}
+
+/// State for the starcast peer runtime where all the "working" members are stored and operated on.
+struct State {
+    /// Secret key of the starcast virtual peer.
+    secret_key: SecretKey,
+    /// Allowed IPs of the starcast virtual peer.
+    allowed_ips: Vec<IpNetwork>,
+    /// Interval at which the tunnel timers will be updated.
+    wg_timer_tick_interval: Interval,
+    /// Channel for sending decapsulated packets to the multicaster and receiving packets for encapsulation from it.
+    channel: Chan<Vec<u8>>,
+    /// Local socket for sending and receiving packets from WireGuard.
+    socket: UdpSocket,
+    /// WireGuard socket address to communicate encapsulated packets to and from Libtelio.
+    wg_sock_addr: Option<SocketAddr>,
+    /// WireGuard encryption tunnel for encapsulation/decapsulation of packets.
+    tunnel: Option<Tunn>,
+    /// Flag indicating that there are packets in the encryption tunnel internal buffer that need to be processed
+    /// before new packets can be received from the socket and decapsulated.
+    packets_present_in_tunnel: bool,
+    /// Buffer for outbound packets.
+    sending_buffer: Box<[u8; MAX_PACKET]>,
+    /// Buffer for inbound packets.
+    receiving_buffer: Box<[u8; MAX_PACKET]>,
+}
+
+impl State {
+    async fn configure(&mut self, config: Config) -> Result<(), Error> {
+        // Because this is a virtual peer, all communication happens on loopback.
+        self.wg_sock_addr = Some(SocketAddr::from(([127, 0, 0, 1], config.wg_port)));
+        // No point in handling old handshakes if the public key and addr have changed.
+        self.packets_present_in_tunnel = false;
+
+        self.tunnel = Some(
+            Tunn::new(
+                StaticSecret::from(self.secret_key.into_bytes()),
+                PublicKeyDalek::from(config.public_key.0),
+                None,
+                None,
+                0,
+                None,
+            )
+            .map_err(Error::TunnNewFail)?,
+        );
+
+        Ok(())
+    }
+
+    fn get_peer(&self) -> Result<Peer, Error> {
+        let static_secret = &StaticSecret::from(self.secret_key.into_bytes());
+
+        Ok(Peer {
+            public_key: PublicKey(PublicKeyDalek::from(static_secret).to_bytes()),
+            endpoint: Some(self.socket.local_addr()?),
+            allowed_ips: self.allowed_ips.to_owned(),
+            ..Default::default()
+        })
+    }
+}
+
+#[async_trait]
+impl Runtime for State {
+    /// Task's name.
+    const NAME: &'static str = "Starcast";
+
+    /// Error that may occur in [Task]
+    type Err = ();
+
+    /// Wait loop for asynchronously handling events for the component.
+    ///
+    /// # Returns
+    ///
+    /// A response for the runtime indicating when to run again.
+    async fn wait(&mut self) -> WaitResponse<'_, Self::Err> {
+        match self {
+            State {
+                channel: Chan { rx, tx },
+                tunnel: Some(peer),
+                wg_sock_addr: Some(ref wg_sock_addr),
+                socket,
+                ..
+            } => {
+                tokio::select! {
+                    // Periodic timer updates for managing handshakes.
+                    _ = self.wg_timer_tick_interval.tick() => {
+                        match peer.update_timers(&mut *self.sending_buffer) {
+                            TunnResult::Done => (),
+                            TunnResult::WriteToNetwork(packet) => {
+                                if let Err(e) = socket.send_to(packet, wg_sock_addr).await {
+                                    telio_log_error!("[Starcast] Update Tunn timers failed to send to socket: {:?}", e);
+                                }
+                            },
+                            TunnResult::Err(e) => {
+                                telio_log_error!("[Starcast] Failed to update Tunn timers: {:?}", e);
+                            }
+                            unexpected_result => telio_log_warn!("[Starcast] Update Tunn timers returned unexpected result: {:?}", unexpected_result),
+                        }
+                    },
+                    // Outbound packets
+                    Some(ip_packet) = rx.recv() => {
+                        match peer.encapsulate(&ip_packet, &mut *self.sending_buffer) {
+                            TunnResult::Done => (),
+                            TunnResult::Err(e) => {
+                                telio_log_error!("[Starcast] Failed to send encapsulate packet: {:?}", e);
+                            },
+                            TunnResult::WriteToNetwork(packet) => {
+                                if let Err(e) = socket.send_to(packet, wg_sock_addr).await {
+                                    telio_log_error!("[Starcast] Failed to send encapsulated packet to socket: {:?}", e);
+                                }
+                            },
+                            unexpected_result => {
+                                telio_log_warn!("[Starcast] Encapsulate packet returned unexpected result: {:?}", unexpected_result);
+                            },
+                        }
+                    },
+                    // Here we're handling the deferred decapsulation of handshake packets to avoid deadlocking.
+                    _ = socket.writable(), if self.packets_present_in_tunnel => {
+                        match peer.decapsulate(None, &[], &mut *self.sending_buffer) {
+                            // Note that the handshake packet here is a slice pointing to the sending buffer.
+                            TunnResult::WriteToNetwork(handshake_packet) => {
+                                if let Err(e) = socket.send_to(handshake_packet, wg_sock_addr).await {
+                                    telio_log_error!("[Starcast] Failed to send handshake packet : {:?}", e);
+                                };
+                            },
+                            TunnResult::Done => {
+                                self.packets_present_in_tunnel = false;
+                            },
+                            TunnResult::Err(e) => {
+                                telio_log_error!("[Starcast] Failed to decapsulate handshake packet: {:?}", e);
+                                self.packets_present_in_tunnel = false;
+                            },
+                            unexpected_state => {
+                                telio_log_warn!("[Starcast] Unexpected state while sending handshake packets {:?}", unexpected_state);
+                                self.packets_present_in_tunnel = false;
+                            },
+                        }
+                    },
+                    // Inbound packets, if there are no handshake packets in the buffer to process.
+                    Some((permit, recv_res)) =
+                    wait_for_tx(tx, socket.recv(&mut *self.receiving_buffer)), if !self.packets_present_in_tunnel => {
+                        match recv_res {
+                            Ok(bytes_read) => {
+                                match peer.decapsulate(
+                                    None,
+                                    self.receiving_buffer.get(..bytes_read).unwrap_or(&[]),
+                                    &mut *self.sending_buffer,
+                                ) {
+                                    // Handshake packets. See the comment above Tunn::decapsulate() for this case.
+                                    TunnResult::WriteToNetwork(packet) => {
+                                        if let Err(e) = socket.send_to(packet, wg_sock_addr).await {
+                                            telio_log_error!("[Starcast] Failed to send handshake packet: {:?}", e);
+                                        }
+                                        // To prevent deadlock while decapsulating handshake packets, deferring to later iteration
+                                        // so that other vital actions (like timer update) could be handled in between.
+                                        self.packets_present_in_tunnel = true;
+                                    },
+                                    // Starcast packets
+                                    TunnResult::WriteToTunnelV4(packet, _)
+                                    | TunnResult::WriteToTunnelV6(packet, _) => {
+                                        permit.send(packet.to_vec());
+                                    },
+                                    TunnResult::Done => (),
+                                    TunnResult::Err(e) => {
+                                        telio_log_error!("[Starcast] Decapsulate error {:?}", e);
+                                    },
+                                }
+                            },
+                            Err(e) => telio_log_error!("[Starcast] Decapsulate error {:?}", e),
+                        }
+                    },
+                };
+                Self::next()
+            }
+            _ => Self::sleep_forever().await,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::utils::test_utils::make_udp_v4;
+
+    use ipnetwork::Ipv4Network;
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+    // This test connects two virtual peers by their sockets and tests if a packet
+    // can make it through between them.
+    #[tokio::test]
+    async fn test_two_virtual_peers_intercommunication() {
+        let (chan_a, chan_a_internal) = Chan::pipe();
+        let (mut chan_b, chan_b_internal) = Chan::pipe();
+        let starcast_allowed_ips = vec![
+            IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(224, 0, 0, 0), 4).unwrap()),
+            IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(100, 64, 0, 5), 32).unwrap()),
+            IpAddr::V6(Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 0, 0xfb)).into(),
+        ];
+        let starcast_vpeer_a = StarcastPeer::start(chan_a_internal, starcast_allowed_ips.clone())
+            .await
+            .unwrap();
+        let starcast_vpeer_b = StarcastPeer::start(chan_b_internal, starcast_allowed_ips)
+            .await
+            .unwrap();
+
+        let a_peer = starcast_vpeer_a.get_peer().await.unwrap();
+        let b_peer = starcast_vpeer_b.get_peer().await.unwrap();
+
+        let peer_a_addr = a_peer.endpoint.unwrap();
+        let peer_b_addr = b_peer.endpoint.unwrap();
+
+        let config_a = Config {
+            public_key: b_peer.public_key,
+            wg_port: peer_b_addr.port(),
+        };
+        let config_b = Config {
+            public_key: a_peer.public_key,
+            wg_port: peer_a_addr.port(),
+        };
+
+        let udp_packet = make_udp_v4(&peer_a_addr.to_string(), &peer_b_addr.to_string());
+
+        starcast_vpeer_a.configure(config_a).await.unwrap();
+        starcast_vpeer_b.configure(config_b).await.unwrap();
+
+        chan_a.tx.send(udp_packet.clone()).await.unwrap();
+        let received_bytes = chan_b.rx.recv().await.unwrap();
+
+        assert_eq!(udp_packet, received_bytes)
+    }
+}

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -51,9 +51,8 @@ use telio_dns::{DnsResolver, LocalDnsResolver, Records};
 use telio_dns::bind_tun;
 use wg::uapi::{self, AnalyticsEvent, PeerState};
 
-use std::collections::HashMap;
 use std::{
-    collections::{hash_map::Entry, HashSet},
+    collections::{hash_map::Entry, HashMap, HashSet},
     future::Future,
     io::{self, Error as IoError, ErrorKind},
     net::{IpAddr, Ipv4Addr, SocketAddr},
@@ -1216,7 +1215,6 @@ impl Runtime {
         let pong_rxed_events = Chan::default();
 
         // Start multiplexer
-        //
         let (multiplexer_derp_chan, derp_multiplexer_chan) = Chan::pipe();
         let multiplexer = Arc::new(Multiplexer::start(multiplexer_derp_chan));
 

--- a/src/device/wg_controller.rs
+++ b/src/device/wg_controller.rs
@@ -1,7 +1,6 @@
 use super::{Entities, RequestedState, Result};
 use ipnetwork::IpNetwork;
-use std::collections::HashMap;
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::iter::FromIterator;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::sync::Arc;
@@ -1206,11 +1205,11 @@ mod tests {
 
         firewall
             .expect_get_peer_whitelist()
-            .return_once(|| Default::default());
+            .return_once(Default::default);
 
         firewall
             .expect_get_port_whitelist()
-            .return_once(|| Default::default());
+            .return_once(Default::default);
 
         expect_add_to_peer_whitelist(&mut firewall, pub_key_1);
         expect_add_to_port_whitelist(&mut firewall, pub_key_1);
@@ -1252,7 +1251,7 @@ mod tests {
 
         firewall
             .expect_get_port_whitelist()
-            .return_once(|| Default::default());
+            .return_once(Default::default);
 
         expect_remove_from_port_whitelist(&mut firewall, pub_key_2);
 


### PR DESCRIPTION
### Problem
We need a virtual peer that would handle multicast according to the telio starcast spec 

### Solution
Add multicast virtual peer for telio starcast implementation

Note that for now unit tests are missing and because this is just part of the whole solution, there wasn't any way to properly test the multicast peer. One solution would be to create two of these multicast peers and get them to communicate over the same socket.

Since this is just part of the whole multicast solution it is not properly integrated into libtelio which is causing unit test failures.

This branch also started off from the multicast PoC, so there is some leftover code present in the wg_controller and device/mod.rs files, because that's where the integration was happening which isn't clear yet.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
