### PR TITLE
LLT-5292: Make string the underlying UniFFI type of keys

### DIFF
--- a/.unreleased/LLT-5292
+++ b/.unreleased/LLT-5292
@@ -1,0 +1,1 @@
+Change underlying FFI type for keys to be string

--- a/nat-lab/tests/uniffi/libtelio_remote.py
+++ b/nat-lab/tests/uniffi/libtelio_remote.py
@@ -1,4 +1,3 @@
-import base64
 import datetime
 import json
 import os
@@ -44,14 +43,12 @@ def serialize_event(event: libtelio.Event) -> str:
     if event.is_relay():
         event_dict["type"] = "relay"
         body["conn_state"] = extract_value(body["conn_state"])
-        body["public_key"] = base64.b64encode(bytes(body["public_key"])).decode("utf-8")
     elif event.is_node():
         event_dict["type"] = "node"
         body["state"] = extract_value(body["state"])
         if body["link_state"] is not None:
             body["link_state"] = extract_value(body["link_state"])
         body["path"] = extract_value(body["path"])
-        body["public_key"] = base64.b64encode(bytes(body["public_key"])).decode("utf-8")
     elif event.is_error():
         event_dict["type"] = "error"
         body["level"] = extract_value(body["level"])
@@ -122,7 +119,7 @@ class LibtelioWrapper:
     @serialize_error
     def start_named(self, private_key, adapter, name: str):
         self._libtelio.start_named(
-            base64.b64decode(private_key), libtelio.TelioAdapterType(adapter), name
+            private_key, libtelio.TelioAdapterType(adapter), name
         )
 
     @serialize_error
@@ -136,13 +133,13 @@ class LibtelioWrapper:
     @serialize_error
     def connect_to_exit_node(self, public_key, allowed_ips: str, endpoint: str):
         self._libtelio.connect_to_exit_node_with_id(
-            "natlab", base64.b64decode(public_key), allowed_ips, endpoint
+            "natlab", public_key, allowed_ips, endpoint
         )
 
     @serialize_error
     def connect_to_exit_node_pq(self, public_key, allowed_ips: str, endpoint: str):
         self._libtelio.connect_to_exit_node_postquantum(
-            "natlabpq", base64.b64decode(public_key), allowed_ips, endpoint
+            "natlabpq", public_key, allowed_ips, endpoint
         )
 
     @serialize_error

--- a/src/libtelio.udl
+++ b/src/libtelio.udl
@@ -81,10 +81,10 @@ enum RelayState {
 };
 
 [Custom]
-typedef sequence<u8> PublicKey;
+typedef string PublicKey;
 
 [Custom]
-typedef sequence<u8> SecretKey;
+typedef string SecretKey;
 
 [Custom]
 typedef string IpAddr;


### PR DESCRIPTION
### Problem
All official apps use strings to represent keys internally. Using byte arrays for keys in the ffi layer meant that they had to do the conversion on their side before interacting with libtelio. By using string as the underlying type in UniFFI, the conversion happens transparently

### Solution
Use string as the underlying type for keys in UniFFI


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
