### PR TITLE
LLT-5294: Add FFI function to get default feature config

### DIFF
--- a/.unreleased/LLT-5294
+++ b/.unreleased/LLT-5294
@@ -1,0 +1,1 @@
+Add FFI function to get default feature config

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -111,6 +111,11 @@ pub fn generate_public_key(secret_key: SecretKey) -> PublicKey {
     secret_key.public()
 }
 
+/// Utility function to get the default feature config
+pub fn get_default_feature_config() -> Features {
+    Features::default()
+}
+
 /// Utility function to create a `Features` object from a json-string
 /// Passing an empty string will return the default feature config
 pub fn deserialize_feature_config(fstr: String) -> FFIResult<Features> {

--- a/src/libtelio.udl
+++ b/src/libtelio.udl
@@ -135,6 +135,9 @@ namespace telio {
     /// Get the public key that corresponds to a given private key.
     PublicKey generate_public_key(SecretKey secret_key);
 
+    /// Utility function to get the default feature config
+    Features get_default_feature_config();
+
     /// Utility function to create a `Features` object from a json-string
     /// Passing an empty string will return the default feature config
     [Throws=TelioError]


### PR DESCRIPTION
### Problem
Apps teams want a function to get default config

### Solution
Add the function 


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
