### PR TITLE
LLT-5291: Make event body non-optional

### DIFF
--- a/.unreleased/LLT-5291
+++ b/.unreleased/LLT-5291
@@ -1,0 +1,1 @@
+Make the body of events non-optional

--- a/clis/tcli/src/bin/tcli.rs
+++ b/clis/tcli/src/bin/tcli.rs
@@ -95,10 +95,9 @@ fn main() -> Result<()> {
             match resp {
                 Info(i) => println!("- {}", i),
                 Event { ts, event } => match *event {
-                    DevEvent::Node { body: Some(b) } => print_event(ts, "node", &b)?,
-                    DevEvent::Relay { body: Some(b) } => print_event(ts, "relay", &b)?,
-                    DevEvent::Error { body: Some(b) } => print_event(ts, "error", &b)?,
-                    _ => (),
+                    DevEvent::Node { body: b } => print_event(ts, "node", &b)?,
+                    DevEvent::Relay { body: b } => print_event(ts, "relay", &b)?,
+                    DevEvent::Error { body: b } => print_event(ts, "error", &b)?,
                 },
                 Error(e) => {
                     println!("error: {e:#?}")

--- a/clis/tcli/src/cli.rs
+++ b/clis/tcli/src/cli.rs
@@ -367,10 +367,12 @@ impl Cli {
                     let ts = SystemTime::now();
 
                     if let DevEvent::Relay { body } = &*event {
-                        *derp_server_lambda.lock() = body
-                            .as_ref()
-                            .filter(|s| s.conn_state != RelayState::Disconnected)
-                            .cloned();
+                        *derp_server_lambda.lock() = if body.conn_state != RelayState::Disconnected
+                        {
+                            Some(body.clone())
+                        } else {
+                            None
+                        }
                     }
                     sender.send(Resp::Event { ts, event }).unwrap()
                 }

--- a/crates/telio-nurse/src/heartbeat.rs
+++ b/crates/telio-nurse/src/heartbeat.rs
@@ -483,7 +483,7 @@ impl Analytics {
     }
 
     async fn handle_wg_event(&mut self, event: Event) {
-        if let Event::Node { body: Some(node) } = event {
+        if let Event::Node { body: node } = event {
             if node.state == PeerState::Disconnected {
                 let _ = self.local_nodes.remove(&node.public_key);
             } else {
@@ -1362,13 +1362,13 @@ mod tests {
 
         analytics
             .handle_wg_event(Event::Node {
-                body: Some(Node {
+                body: Node {
                     public_key: vpn_pk,
                     is_vpn: true,
                     state: NodeState::Connected,
                     endpoint: Some(([1, 2, 3, 4], 5678).into()),
                     ..Default::default()
-                }),
+                },
             })
             .await;
 
@@ -1404,13 +1404,13 @@ mod tests {
 
         analytics
             .handle_wg_event(Event::Node {
-                body: Some(Node {
+                body: Node {
                     public_key: vpn_pk,
                     is_vpn: true,
                     state: NodeState::Connected,
                     endpoint: Some(([1, 2, 3, 4], 5678).into()),
                     ..Default::default()
-                }),
+                },
             })
             .await;
 

--- a/crates/telio-wg/src/wg.rs
+++ b/crates/telio-wg/src/wg.rs
@@ -516,11 +516,14 @@ impl State {
 
         if self.uapi_fail_counter >= MAX_UAPI_FAIL_COUNT && ret.interface.is_none() {
             if let Some(libtelio_event) = &self.libtelio_event {
-                let err_event = LibtelioEvent::new::<LibtelioError>()
+                let err_event = LibtelioEvent::builder::<LibtelioError>()
                     .set(EventMsg::from("Interface gone"))
                     .set(ErrorCode::Unknown)
-                    .set(ErrorLevel::Critical);
-                let _ = libtelio_event.send(Box::new(err_event));
+                    .set(ErrorLevel::Critical)
+                    .build();
+                if let Some(err_event) = err_event {
+                    let _ = libtelio_event.send(Box::new(err_event));
+                }
             }
             return Err(Error::InternalError("Interface gone"));
         }

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -2177,18 +2177,24 @@ impl TaskRuntime for Runtime {
                         ).await;
                     }
                     // Publish WG event to app
+                    let event = Event::builder::<Node>().set(node).build();
+                    if let Some(event) = event {
                     let _ = self.event_publishers.libtelio_event_publisher.send(
-                        Box::new(Event::new::<Node>().set(node))
+                        Box::new(event)
                     );
+                }
                 }
 
                 Ok(())
             },
 
             Ok(derp_event) = self.event_listeners.derp_event_subscriber.recv() => {
+                let event = Event::builder::<DerpServer>().set(*derp_event).build();
+                if let Some(event) = event {
                 let _ = self.event_publishers.libtelio_event_publisher.send(
-                    Box::new(Event::new::<DerpServer>().set(*derp_event))
+                    Box::new(event)
                 );
+            }
                 Ok(())
             },
 

--- a/src/doc/introduction.md
+++ b/src/doc/introduction.md
@@ -59,7 +59,7 @@ let mut device = telio::device::Device::new(
 loop {
     let event = receiver.recv().unwrap();
     match *event {
-        Event::Node { body: Some(b) } => println!(
+        Event::Node { body: b } => println!(
             "event node: {:?}:{};  Path = {:?}",
             b.state,
             b.public_key,

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -238,15 +238,17 @@ impl Telio {
                 error_handling::update_last_error(err);
 
                 // Send this "cry for help" to whoever is on the upper side
-                let e = Box::new(
-                    Event::new::<Error>()
-                        .set(ErrorCode::Unknown)
-                        .set(ErrorLevel::Critical)
-                        .set(format!("{}", info)),
-                );
+                let e = Event::builder::<Error>()
+                    .set(ErrorCode::Unknown)
+                    .set(ErrorLevel::Critical)
+                    .set(format!("{}", info))
+                    .build();
 
-                telio_log_debug!("call_once: {:?}", e);
-                events(e);
+                if let Some(e) = e {
+                    let e = Box::new(e);
+                    telio_log_debug!("call_once: {:?}", e);
+                    events(e);
+                }
             }));
         });
 

--- a/src/libtelio.udl
+++ b/src/libtelio.udl
@@ -690,12 +690,12 @@ dictionary TelioNode {
 [Enum]
 interface Event {
     /// Used to report events related to the Relay
-    Relay(Server? body);
+    Relay(Server body);
     /// Used to report events related to the Node
-    Node(TelioNode? body);
+    Node(TelioNode body);
     /// Initialize an Error type event.
     /// Used to inform errors to the upper layers of libtelio
-    Error(ErrorEvent? body);
+    Error(ErrorEvent body);
 };
 
 /// Error event. Used to inform the upper layer about errors in `libtelio`.


### PR DESCRIPTION
### Problem
So far, the body of the event we send has been an Option, event though it should never be. The reason was to use a sort of builder pattern directly on the events, but this introduces some extra steps for apps where they have to check that the event, that should never be None, is none or not before they proceed. 

### Solution
To make this easier for them, we can make a proper builder pattern implementation for events instead
