### PR TITLE
LLT-4935 Do not rotate wg-stun peer when ep paused

### DIFF
--- a/.unreleased/LLT-4935
+++ b/.unreleased/LLT-4935
@@ -1,0 +1,1 @@
+Do not rotate wg-stun peers, when stun ep is paused

--- a/crates/telio-traversal/src/endpoint_providers.rs
+++ b/crates/telio-traversal/src/endpoint_providers.rs
@@ -158,4 +158,9 @@ pub trait EndpointProvider: Sync + Send + 'static {
     /// multiple times in a row even if the endpoint provider is already unpaused. In such a
     /// situation, the function must do nothing.
     async fn unpause(&self) {}
+
+    /// Check if endpoint provider is paused.
+    async fn is_paused(&self) -> bool {
+        false
+    }
 }

--- a/crates/telio-traversal/src/endpoint_providers/stun.rs
+++ b/crates/telio-traversal/src/endpoint_providers/stun.rs
@@ -378,6 +378,14 @@ impl<Wg: WireGuard, E: Backoff + 'static> EndpointProvider for StunEndpointProvi
         })
         .await;
     }
+
+    async fn is_paused(&self) -> bool {
+        task_exec!(&self.task, async move |s| Ok(
+            s.stun_state == StunState::Paused
+        ))
+        .await
+        .unwrap_or(false)
+    }
 }
 
 //                                -------------

--- a/crates/telio-traversal/src/endpoint_providers/upnp.rs
+++ b/crates/telio-traversal/src/endpoint_providers/upnp.rs
@@ -438,6 +438,12 @@ impl<Wg: WireGuard> EndpointProvider for UpnpEndpointProvider<Wg> {
         })
         .await;
     }
+
+    async fn is_paused(&self) -> bool {
+        task_exec!(&self.task, async move |s| Ok(s.is_endpoint_provider_paused))
+            .await
+            .unwrap_or(false)
+    }
 }
 
 struct State<Wg: WireGuard, I: UpnpEpCommands, E: Backoff> {


### PR DESCRIPTION
### Problem
We have an endpoint provider enabled by default, but still managing the `wg-stun` state, on every wg consolidation call, even though, it should be ~left untouched~ removed, when stun provider is paused.

### Solution
Do not _touch_ the `wg-stun` peer, when not using the stun endpoint provider.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
