### PR TITLE
LLT-5286: Update build-info-extractor-gradle to 5.1.14

### DIFF
--- a/android/templates/build.gradle
+++ b/android/templates/build.gradle
@@ -11,7 +11,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:8.0.1'
-        classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.21.0"
+        classpath "org.jfrog.buildinfo:build-info-extractor-gradle:5.1.14"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.23"
     }
 }
@@ -102,15 +102,6 @@ artifactory {
         defaults {
             publications('aar')
             publishArtifacts = true
-        }
-    }
-
-    resolve {
-        repository {
-            repoKey = 'libs-release'
-            username = repoUsername
-            password = repoPassword
-            maven = true
         }
     }
 }


### PR DESCRIPTION
### Problem
It's transient dependecy xstream, used in older version had a known vulnerability.

### Solution
Bump build-info-extractor-gradle version to 5.1.14


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
