### PR TITLE
LLT-5325 Add OpenWRT linker

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -42,5 +42,11 @@ linker = "linkers/d-x86_64-linux-android21-clang"
 [target.i686-linux-android]
 linker = "linkers/d-i686-linux-android21-clang"
 
+[target.x86_64-openwrt-linux-musl]
+linker = "linkers/d-x86_64-openwrt-linux-musl"
+
+[target.aarch64-openwrt-linux-musl]
+linker = "linkers/d-aarch64-openwrt-linux-musl"
+
 [target.'cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "tvos-sim"))']
 rustflags = ["-C", "link-arg=-s"]

--- a/.unreleased/LLT-5325
+++ b/.unreleased/LLT-5325
@@ -1,0 +1,1 @@
+Add openwrt musl aarch64 and amd64 x86_64 linkers

--- a/linkers/d-aarch64-openwrt-linux-musl
+++ b/linkers/d-aarch64-openwrt-linux-musl
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+# This forces export of needed binding for Java
+LINKER=$(basename $0)
+LINKER=${LINKER#"d-"}
+ARGS=$@
+
+while (( "$#" )); do
+	if [[ $1 == *"-Wl,--version-script="* && ! $ARGS =~ -o.*librustls_platform_verifier.* ]]; then
+		VERSION=${1#"-Wl,--version-script="}
+		SED_ARGS='s/global:/global:\n    Java*;\n    JNI_OnLoad*;\n    _wrap*;\n/'
+		if [ "$(uname)" != "Darwin" ]; then
+			sed -i "$SED_ARGS" "$VERSION"
+		else
+			sed -i '' "$SED_ARGS" "$VERSION"
+		fi
+		break
+	fi
+
+	shift
+done
+
+ARGS="${ARGS//-lgo_wrap/-Wl,--whole-archive -lgo_wrap -Wl,--no-whole-archive}"
+
+exec $LINKER $ARGS

--- a/linkers/d-x86_64-openwrt-linux-musl
+++ b/linkers/d-x86_64-openwrt-linux-musl
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+# This forces export of needed binding for Java
+LINKER=$(basename $0)
+LINKER=${LINKER#"d-"}
+ARGS=$@
+
+while (( "$#" )); do
+	if [[ $1 == *"-Wl,--version-script="* && ! $ARGS =~ -o.*librustls_platform_verifier.* ]]; then
+		VERSION=${1#"-Wl,--version-script="}
+		SED_ARGS='s/global:/global:\n    Java*;\n    JNI_OnLoad*;\n    _wrap*;\n/'
+		if [ "$(uname)" != "Darwin" ]; then
+			sed -i "$SED_ARGS" "$VERSION"
+		else
+			sed -i '' "$SED_ARGS" "$VERSION"
+		fi
+		break
+	fi
+
+	shift
+done
+
+ARGS="${ARGS//-lgo_wrap/-Wl,--whole-archive -lgo_wrap -Wl,--no-whole-archive}"
+
+exec $LINKER $ARGS

--- a/linkers/generate.sh
+++ b/linkers/generate.sh
@@ -6,6 +6,8 @@ LINKERS=(
 	"armv7a-linux-androideabi21-clang"
 	"x86_64-linux-android21-clang"
 	"i686-linux-android21-clang"
+	"x86_64-openwrt-linux-musl"
+	"aarch64-openwrt-linux-musl"
 )
 
 for i in ${LINKERS[@]}; do


### PR DESCRIPTION
### Problem
Libtelio does not have openwrt targeted linkers defined in linkers config

### Solution
Add those linkers


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
