### PR TITLE
Use format string when it is expected to do variable expansion

### DIFF
--- a/nat-lab/bin/kill_process_by_natlab_id
+++ b/nat-lab/bin/kill_process_by_natlab_id
@@ -9,7 +9,8 @@ NATLAB_ID=$1
 
 for pid in $(ps -e -o pid=); do
     if grep --null-data --text KILL_ID=${NATLAB_ID} /proc/${pid}/environ; then
-        echo "Killing ${pid}"
+        cmd=$(cat /proc/${pid}/cmdline || echo "N/A")
+        echo "$(date) Killing ${pid} ${cmd}"
         kill "${pid}"
         exit 0
     fi

--- a/nat-lab/tests/mesh_api.py
+++ b/nat-lab/tests/mesh_api.py
@@ -358,7 +358,7 @@ class API:
                 priv_key = server_config["private_key"]
                 commands = [
                     f"echo {priv_key} > /etc/nordlynx/private.key",
-                    "nlx set nordlynx0 private-key /etc/nordlynx/private.key && nlx set nordlynx0 listen-port {server_config['port']}",
+                    f"nlx set nordlynx0 private-key /etc/nordlynx/private.key && nlx set nordlynx0 listen-port {server_config['port']}",
                 ]
 
                 for cmd in commands:


### PR DESCRIPTION
### Problem
Literal `{server_config['port']}` was being passed to some of the `nlx` configuration commands when starting up servers testing VPN servers. This PR fixes formatting of such commands.



### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
