### PR TITLE
Add additional logs to testing framework when copying files into VMs

### DIFF
--- a/nat-lab/tests/utils/vm/windows_vm_util.py
+++ b/nat-lab/tests/utils/vm/windows_vm_util.py
@@ -7,6 +7,7 @@ from config import (
     WINDOWS_1_VM_IP,
 )
 from contextlib import asynccontextmanager
+from datetime import datetime
 from typing import AsyncIterator
 from utils.connection import Connection, SshConnection, TargetOS
 from utils.process import ProcessExecError
@@ -90,14 +91,28 @@ async def _copy_binaries(
         (f"{DIST_DIR}wireguard.dll", VM_UNIFFI_DIR, False),
         (f"{DIST_DIR}wintun.dll", VM_SYSTEM32, False),
     ]
+
     for src, dst, allow_missing in files_to_copy:
         try:
+            print(datetime.now(), f"Copying files into VM: {src} to {dst}")
             await asyncssh.scp(
                 get_root_path(src),
                 (ssh_connection, dst),
             )
+            print(datetime.now(), "Copy succeded")
         except FileNotFoundError as exception:
             if not allow_missing or str(exception).find(src) < 0:
+                print(datetime.now(), "Copy failed", str(exception))
                 raise exception
+
+            print(
+                datetime.now(),
+                "Copy failed",
+                str(exception),
+                "but it is allowed to fail",
+            )
+        except Exception as e:
+            print(datetime.now(), "Copy failed", str(e))
+            raise e
 
     FILES_COPIED = True


### PR DESCRIPTION
### Problem
For some reason sometimes tests times out when copying files to windows VM. What is more, it seems like this happens for the whole test-suite instead of just a few tests. In order to figure out root cause easier -> add some additional logs during copying of files in testing VMs.



### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
