### PR TITLE
Enforce conntrack limits only to succesfull tests

### DIFF
--- a/nat-lab/tests/helpers.py
+++ b/nat-lab/tests/helpers.py
@@ -3,6 +3,7 @@ import pytest
 from config import WG_SERVERS
 from contextlib import AsyncExitStack, asynccontextmanager
 from dataclasses import dataclass, field
+from datetime import datetime
 from itertools import product, zip_longest
 from mesh_api import Node, Meshmap, API, stop_tcpdump
 from telio import Client, AdapterType, State, PathType
@@ -286,11 +287,13 @@ async def setup_environment(
 
     try:
         yield Environment(api, nodes, connection_managers, clients)
-    finally:
+
+        print(datetime.now(), "Checking connection limits")
         for conn_manager in connection_managers:
             if conn_manager.tracker:
                 limits = conn_manager.tracker.get_out_of_limits()
                 assert limits is None, f"conntracker reported out of limits {limits}"
+    finally:
         stop_tcpdump([server["container"] for server in WG_SERVERS])
 
 


### PR DESCRIPTION
### Problem
Conntrack limits may be enforced for tests which has failed, which, in-fact is likely to go out of limits. This PR attempts to enforce the conntrack limits only for succesfull tests.



### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
