### PR TITLE
[LLT-5312] Update wireguard-go reference in libtelio

### DIFF
--- a/wireguard-go-rust-wrapper/wireguard-go/go.mod
+++ b/wireguard-go-rust-wrapper/wireguard-go/go.mod
@@ -3,7 +3,7 @@ module wireguard-go
 go 1.20
 
 require (
-	github.com/NordSecurity/wireguard-go v0.0.2
+	github.com/NordSecurity/wireguard-go v0.0.3
 	github.com/google/uuid v1.5.0
 	golang.org/x/sys v0.16.0
 	golang.zx2c4.com/wireguard/windows v0.5.3

--- a/wireguard-go-rust-wrapper/wireguard-go/go.sum
+++ b/wireguard-go-rust-wrapper/wireguard-go/go.sum
@@ -1,5 +1,5 @@
-github.com/NordSecurity/wireguard-go v0.0.2 h1:BKZnLBZY85ntfj8n8azFVdr1r2ljzHp7MI6ZB8Aa/m0=
-github.com/NordSecurity/wireguard-go v0.0.2/go.mod h1:241ujnEG6CF5gDxsy48HaGoSG1uOgbKHstnvIz8Zj2I=
+github.com/NordSecurity/wireguard-go v0.0.3 h1:717RF0NN9rrlGtNThNL1ujl0bwqmSda5vI8fJZsYwCI=
+github.com/NordSecurity/wireguard-go v0.0.3/go.mod h1:241ujnEG6CF5gDxsy48HaGoSG1uOgbKHstnvIz8Zj2I=
 github.com/google/btree v1.0.1 h1:gK4Kx5IaGY9CD5sPJ36FHiBJ6ZXl0kilRiiCj+jdYp4=
 github.com/google/uuid v1.5.0 h1:1p67kYwdtXjb0gL0BPiP1Av9wiZPo5A8z2cWkTZ+eyU=
 github.com/google/uuid v1.5.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/wireguard-go-rust-wrapper/wireguard-go/interfacewatcher_windows.go
+++ b/wireguard-go-rust-wrapper/wireguard-go/interfacewatcher_windows.go
@@ -38,6 +38,7 @@ func (iw *interfaceWatcher) setup(family winipcfg.AddressFamily, mtu uint32) {
 		changeCallbacks = &iw.changeCallbacks6
 		ipversion = "v6"
 	} else {
+		log.Printf("Encountered invalid Address Family %v", family)
 		return
 	}
 	if len(*changeCallbacks) != 0 {


### PR DESCRIPTION
### Problem
It is hard to understand why wireguard-go sometimes fails to start the adapter. For example in the job 13830453. NordSecurity/Wireguard-go fork has been updated to add more verbose logging. This PR updates libtelio reference.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
