### PR TITLE
Wrap libtelio_remote runtime into try-except block

### DIFF
--- a/nat-lab/tests/uniffi/libtelio_remote.py
+++ b/nat-lab/tests/uniffi/libtelio_remote.py
@@ -188,12 +188,16 @@ def main():
     container_ip = sys.argv[2]
     port = int(sys.argv[3])
 
-    daemon = Pyro5.server.Daemon(host=container_ip, port=port)
-    wrapper = LibtelioWrapper(daemon)
-    daemon.register(wrapper, objectId=object_name)
+    try:
+        daemon = Pyro5.server.Daemon(host=container_ip, port=port)
+        wrapper = LibtelioWrapper(daemon)
+        daemon.register(wrapper, objectId=object_name)
 
-    daemon.requestLoop()
-    daemon.close()
+        daemon.requestLoop()
+        daemon.close()
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        print(f"libtelio_remote error: {e}")
+        raise e
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Problem
During nightly tests, we're sometimes getting the `FATAL: exception not rethrown` error, when executing `libtelio_remote.py` file.

### Solution
Try to catch and print, what does this not-rethrown exception has in it.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
