### PR TITLE
LLT-5077: Add multicast flags to meshnet config

### DIFF
--- a/.unreleased/LLT-5077
+++ b/.unreleased/LLT-5077
@@ -1,0 +1,1 @@
+Add multicast flags `allow_multicast` and `peer_allows_multicast` to meshnet config

--- a/crates/telio-model/src/config.rs
+++ b/crates/telio-model/src/config.rs
@@ -44,6 +44,12 @@ pub struct Peer {
     #[serde(default)]
     /// Flag to control whether the peer allows incoming files
     pub allow_peer_send_files: bool,
+    #[serde(default)]
+    /// Flag to control whether we allow multicast messages from the peer
+    pub allow_multicast: bool,
+    #[serde(default)]
+    /// Flag to control whether the peer allows multicast messages from us
+    pub peer_allows_multicast: bool,
 }
 
 /// Representation of DNS configuration
@@ -357,7 +363,9 @@ mod tests {
                   "allow_incoming_connections": true,
                   "allow_peer_send_files": true,
                   "peer_allows_traffic_routing": false,
-                  "allow_peer_traffic_routing": true
+                  "allow_peer_traffic_routing": true,
+                  "allow_multicast": true,
+                  "peer_allows_multicast": true
                 },
                 {},
                 {
@@ -374,7 +382,8 @@ mod tests {
                   "allow_incoming_connections": false,
                   "allow_peer_send_files": false,
                   "peer_allows_traffic_routing": true,
-                  "allow_peer_traffic_routing": false
+                  "allow_peer_traffic_routing": false,
+                  "allow_multicast": true
                 },
                 {
                   "invalid_key": "98e00fa1-2c83-4e85-bf01-45c1d4eefea6",
@@ -463,6 +472,8 @@ mod tests {
                     is_local: true,
                     allow_incoming_connections: true,
                     allow_peer_send_files: true,
+                    allow_multicast: true,
+                    peer_allows_multicast: true,
                 },
                 Peer {
                     base: PeerBase {
@@ -477,6 +488,8 @@ mod tests {
                     is_local: false,
                     allow_incoming_connections: false,
                     allow_peer_send_files: false,
+                    allow_multicast: true,
+                    peer_allows_multicast: false,
                 },
             ]),
             derp_servers: Some(vec![Server {

--- a/crates/telio-model/src/event.rs
+++ b/crates/telio-model/src/event.rs
@@ -252,6 +252,8 @@ mod tests {
             allow_incoming_connections: false,
             allow_peer_send_files: false,
             path: crate::features::PathType::Relay,
+            allow_multicast: false,
+            peer_allows_multicast: false,
         };
 
         let server = Server {
@@ -299,7 +301,9 @@ mod tests {
             r#""endpoint":"127.0.0.1:8080","hostname":"example.com","#,
             r#""allow_incoming_connections":false,"#,
             r#""allow_peer_send_files":false,"#,
-            r#""path":"relay""#,
+            r#""path":"relay","#,
+            r#""allow_multicast":false,"#,
+            r#""peer_allows_multicast":false"#,
             r#"}}"#
         ));
 

--- a/crates/telio-model/src/mesh.rs
+++ b/crates/telio-model/src/mesh.rs
@@ -64,6 +64,10 @@ pub struct Node {
     pub allow_peer_send_files: bool,
     /// Connection type in the network mesh (through Relay or hole punched directly)
     pub path: PathType,
+    /// Flag to control whether we allow multicast messages from the Node
+    pub allow_multicast: bool,
+    /// Flag to control whether the Node allows multicast messages from us
+    pub peer_allows_multicast: bool,
 }
 
 /// Description of the Exit Node

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -2068,6 +2068,8 @@ impl Runtime {
                     allow_incoming_connections: meshnet_peer.allow_incoming_connections,
                     allow_peer_send_files: meshnet_peer.allow_peer_send_files,
                     path: path_type,
+                    allow_multicast: meshnet_peer.allow_multicast,
+                    peer_allows_multicast: meshnet_peer.peer_allows_multicast,
                 })
             }
             (None, Some(exit_node)) => {
@@ -2090,6 +2092,8 @@ impl Runtime {
                     allow_incoming_connections: false,
                     allow_peer_send_files: false,
                     path: path_type,
+                    allow_multicast: false,
+                    peer_allows_multicast: false,
                 })
             }
             _ => None,

--- a/src/libtelio.udl
+++ b/src/libtelio.udl
@@ -622,6 +622,10 @@ dictionary Peer {
     boolean allow_incoming_connections;
     /// Flag to control whether the peer allows incoming files
     boolean allow_peer_send_files;
+    /// Flag to control whether we allow multicast messages from the peer
+    boolean allow_multicast;
+    /// Flag to control whether the peer allows multicast messages from us
+    boolean peer_allows_multicast;
 };
 
 /// Representation of a server, which might be used
@@ -690,6 +694,10 @@ dictionary TelioNode {
     boolean allow_peer_send_files;
     /// Connection type in the network mesh (through Relay or hole punched directly)
     PathType path;
+    /// Flag to control whether we allow multicast messages from the Node
+    boolean allow_multicast;
+    /// Flag to control whether the Node allows multicast messages from us
+    boolean peer_allows_multicast;
 };
 
 /// Main object of `Event`. See `Event::new()` for init options.


### PR DESCRIPTION
### Problem
When multicast starts being used we want to give users the ability to granularly enable or disable multicast for different peers

### Solution
Add flags to enable/disable sending and receiving multicast packets for a specific peer


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
