### PR TITLE
Fix wrong key type error

### DIFF
--- a/nat-lab/tests/telio.py
+++ b/nat-lab/tests/telio.py
@@ -1,7 +1,6 @@
 # pylint: disable=too-many-lines
 
 import asyncio
-import base64
 import datetime
 import json
 import os
@@ -1170,10 +1169,8 @@ class Client:
 
 
 def generate_secret_key() -> str:
-    return base64.b64encode(bytes(libtelio.generate_secret_key())).decode("ascii")
+    return libtelio.generate_secret_key()
 
 
 def generate_public_key(private_key: str) -> str:
-    private_key_bytes = list(base64.b64decode(private_key))
-    public_key_bytes = bytes(libtelio.generate_public_key(private_key_bytes))
-    return base64.b64encode(public_key_bytes).decode("ascii")
+    return libtelio.generate_public_key(private_key)

--- a/nat-lab/tests/uniffi/libtelio_remote.py
+++ b/nat-lab/tests/uniffi/libtelio_remote.py
@@ -165,7 +165,7 @@ class LibtelioWrapper:
 
     @serialize_error
     def set_secret_key(self, secret_key):
-        self._libtelio.set_secret_key(base64.b64decode(secret_key))
+        self._libtelio.set_secret_key(secret_key)
 
     @serialize_error
     def is_running(self) -> bool:


### PR DESCRIPTION
### Problem
A recent set of commits again broke natlab. One commit was changing the underlying type for keys to strings, while another commit added more functions for dealing with keys. There was no code overlap so there were no conflicts, yet the change of underlying type for keys is made the added key handling break, causing type check errors and broke a test

### Solution
Make the new key-handling code use strings directly instead of trying to convert to and from bytes


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
