### PR TITLE
LLT-5319: Create salsa test

### DIFF
--- a/crates/telio-crypto/src/encryption.rs
+++ b/crates/telio-crypto/src/encryption.rs
@@ -181,28 +181,7 @@ mod tests {
     use super::*;
     use bstr::ByteSlice;
     use rand::rngs::mock::StepRng;
-
-    struct CryptoStepRng(StepRng);
-
-    impl RngCore for CryptoStepRng {
-        fn next_u32(&mut self) -> u32 {
-            self.0.next_u32()
-        }
-
-        fn next_u64(&mut self) -> u64 {
-            self.0.next_u64()
-        }
-
-        fn fill_bytes(&mut self, dest: &mut [u8]) {
-            self.0.fill_bytes(dest)
-        }
-
-        fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand::Error> {
-            self.0.try_fill_bytes(dest)
-        }
-    }
-
-    impl CryptoRng for CryptoStepRng {}
+    use telio_utils::test::CryptoStepRng;
 
     const MSG: &[u8] = b"test message";
 

--- a/crates/telio-utils/src/lib.rs
+++ b/crates/telio-utils/src/lib.rs
@@ -46,3 +46,6 @@ pub use interval::*;
 /// Basic ICMP Pinger
 pub mod pinger;
 pub use pinger::*;
+
+/// Testing tools
+pub mod test;

--- a/crates/telio-utils/src/test.rs
+++ b/crates/telio-utils/src/test.rs
@@ -1,0 +1,24 @@
+use rand::{rngs::mock::StepRng, CryptoRng, RngCore};
+
+/// Mocked random number generator for creating not-random results
+pub struct CryptoStepRng(pub StepRng);
+
+impl RngCore for CryptoStepRng {
+    fn next_u32(&mut self) -> u32 {
+        self.0.next_u32()
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        self.0.next_u64()
+    }
+
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        self.0.fill_bytes(dest)
+    }
+
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand::Error> {
+        self.0.try_fill_bytes(dest)
+    }
+}
+
+impl CryptoRng for CryptoStepRng {}


### PR DESCRIPTION
### Problem
We don't have any test for the XSalsa20Poly1305 usage in telio-relay, so if the underlying implementation will change, our unit tests won't fail

### Solution
Create some test for the Salsa use in the telio-relay, similar to the one used for ChaCha in telio-crypto


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
