### PR TITLE
Add downgrade logic using link detection

### DIFF
--- a/.unreleased/LLT-5222
+++ b/.unreleased/LLT-5222
@@ -1,0 +1,1 @@
+Add downgrade logic using link detection

--- a/crates/telio-model/src/features.rs
+++ b/crates/telio-model/src/features.rs
@@ -447,9 +447,13 @@ pub struct FeatureLinkDetection {
     #[serde(default = "FeatureLinkDetection::default_configurable_rtt")]
     pub rtt_seconds: u64,
 
-    /// Check the link state before reporting it as down.
+    /// Check the link state before reporting it as down
     #[serde(default = "FeatureLinkDetection::default_no_of_pings")]
     pub no_of_pings: u32,
+
+    /// Use link detection for downgrade logic
+    #[serde(default = "FeatureLinkDetection::default_use_for_downgrade")]
+    pub use_for_downgrade: bool,
 }
 
 impl FeatureLinkDetection {
@@ -459,6 +463,10 @@ impl FeatureLinkDetection {
 
     const fn default_no_of_pings() -> u32 {
         0
+    }
+
+    const fn default_use_for_downgrade() -> bool {
+        false
     }
 }
 

--- a/crates/telio-traversal/src/endpoint_providers/stun.rs
+++ b/crates/telio-traversal/src/endpoint_providers/stun.rs
@@ -1042,7 +1042,7 @@ mod tests {
         encryption::{decrypt_request, decrypt_response, encrypt_request, encrypt_response},
         PublicKey, SecretKey,
     };
-    use telio_model::mesh::IpNetwork;
+    use telio_model::mesh::{IpNetwork, LinkState};
     use telio_proto::{CodecError, PacketRelayed, PartialPongerMsg, PingerMsg};
     use telio_sockets::NativeProtector;
     use telio_sockets::SocketPool;
@@ -1948,6 +1948,7 @@ mod tests {
             async fn wait_for_listen_port(&self, d: Duration) -> Result<u16, Error>;
             async fn wait_for_proxy_listen_port(&self, d: Duration) -> Result<u16, Error>;
             async fn get_wg_socket(&self, ipv6: bool) -> Result<Option<i32>, Error>;
+            async fn get_link_state(&self, key: PublicKey) -> Result<Option<LinkState>, Error>;
             async fn set_secret_key(&self, key: SecretKey) -> Result<(), Error>;
             async fn set_fwmark(&self, fwmark: u32) -> Result<(), Error>;
             async fn add_peer(&self, peer: Peer) -> Result<(), Error>;
@@ -2087,6 +2088,8 @@ mod tests {
                 ..Default::default()
             })
         });
+
+        wg.expect_get_link_state().returning(|_| Ok(None));
 
         prepare_test_env_with_server_weights_and_mockwg(
             backoff_array,

--- a/crates/telio-traversal/src/endpoint_providers/upnp.rs
+++ b/crates/telio-traversal/src/endpoint_providers/upnp.rs
@@ -704,6 +704,7 @@ mod tests {
     use std::time::Duration;
     use telio_crypto::PublicKey;
     use telio_crypto::SecretKey;
+    use telio_model::mesh::LinkState;
     use telio_sockets::{NativeProtector, SocketPool};
     use telio_utils::exponential_backoff::MockBackoff;
     use telio_wg::uapi::{Interface, Peer};
@@ -723,6 +724,7 @@ mod tests {
             async fn wait_for_listen_port(&self, d: Duration) -> Result1<u16>;
             async fn wait_for_proxy_listen_port(&self, d: Duration) -> Result1<u16>;
             async fn get_wg_socket(&self, ipv6: bool) -> Result1<Option<i32>>;
+            async fn get_link_state(&self, key: PublicKey) -> Result1<Option<LinkState>>;
             async fn set_secret_key(&self, key: SecretKey) -> Result1<()>;
             async fn set_fwmark(&self, fwmark: u32) -> Result1<()>;
             async fn add_peer(&self, peer: Peer) -> Result1<()>;
@@ -816,7 +818,7 @@ mod tests {
         });
         wg.expect_wait_for_listen_port()
             .returning(move |_| Ok(wg_port));
-
+        wg.expect_get_link_state().returning(|_| Ok(None));
         let mut mock = MockUpnpEpCommands::new();
         mock.expect_add_any_endpoint_routes()
             .returning(move |_, wg_port, proxy_port| add_any_endpoint(wg_port, proxy_port));

--- a/nat-lab/tests/telio_features.py
+++ b/nat-lab/tests/telio_features.py
@@ -81,6 +81,7 @@ class Nurse(DataClassJsonMixin):
 class LinkDetection(DataClassJsonMixin):
     rtt_seconds: Optional[int] = None
     no_of_pings: Optional[int] = 0
+    use_for_downgrade: Optional[bool] = False
 
 
 @dataclass_json(undefined=Undefined.EXCLUDE)

--- a/nat-lab/tests/test_downgrade.py
+++ b/nat-lab/tests/test_downgrade.py
@@ -1,0 +1,194 @@
+import asyncio
+import pytest
+from contextlib import AsyncExitStack
+from helpers import setup_mesh_nodes, SetupParameters
+from telio import PathType, State, AdapterType
+from telio_features import (
+    TelioFeatures,
+    Direct,
+    Wireguard,
+    LinkDetection,
+    PersistentKeepalive,
+)
+from typing import List, Tuple
+from utils.connection_util import ConnectionTag
+from utils.ping import Ping
+
+
+def long_persistent_keepalive_periods() -> Wireguard:
+    return Wireguard(
+        persistent_keepalive=PersistentKeepalive(
+            proxying=3600, direct=3600, vpn=3600, stun=3600
+        )
+    )
+
+
+def _generate_setup_parameter_pair(
+    cfg: List[Tuple[ConnectionTag, AdapterType]],
+) -> List[SetupParameters]:
+    return [
+        SetupParameters(
+            connection_tag=tag,
+            adapter_type=adapter,
+            features=TelioFeatures(
+                link_detection=LinkDetection(
+                    rtt_seconds=1, no_of_pings=1, use_for_downgrade=True
+                ),
+                direct=Direct(providers=["stun", "local"]),
+                wireguard=long_persistent_keepalive_periods(),
+            ),
+        )
+        for tag, adapter in cfg
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "setup_params",
+    [
+        pytest.param(
+            _generate_setup_parameter_pair([
+                (ConnectionTag.DOCKER_CONE_CLIENT_1, AdapterType.BoringTun),
+                (ConnectionTag.DOCKER_CONE_CLIENT_2, AdapterType.BoringTun),
+            ])
+        )
+    ],
+)
+async def test_downgrade_using_link_detection(
+    setup_params: List[SetupParameters],
+) -> None:
+    async with AsyncExitStack() as exit_stack:
+        env = await setup_mesh_nodes(exit_stack, setup_params)
+        alpha, beta = env.nodes
+        alpha_client, beta_client = env.clients
+        alpha_connection, beta_connection = [
+            conn.connection for conn in env.connections
+        ]
+
+        # We have established a direct connection between the peers
+
+        # Generate some traffic
+        async with Ping(alpha_connection, beta.ip_addresses[0]).run() as ping:
+            await ping.wait_for_next_ping(15)
+        async with Ping(beta_connection, alpha.ip_addresses[0]).run() as ping:
+            await ping.wait_for_next_ping(15)
+
+        # Break the direct connection
+        await exit_stack.enter_async_context(
+            alpha_client.get_router().disable_path(
+                alpha_client.get_endpoint_address(beta.public_key)
+            )
+        )
+        await exit_stack.enter_async_context(
+            beta_client.get_router().disable_path(
+                beta_client.get_endpoint_address(alpha.public_key)
+            )
+        )
+
+        # Generate some traffic to trigger link detection
+        with pytest.raises(asyncio.TimeoutError):
+            async with Ping(alpha_connection, beta.ip_addresses[0]).run() as ping:
+                await ping.wait_for_next_ping(5)
+        with pytest.raises(asyncio.TimeoutError):
+            async with Ping(beta_connection, alpha.ip_addresses[0]).run() as ping:
+                await ping.wait_for_next_ping(5)
+
+        # Expect downgrade to relay
+        await asyncio.gather(
+            alpha_client.wait_for_state_peer(
+                beta.public_key, [State.Connected], [PathType.Relay], timeout=35
+            ),
+            beta_client.wait_for_state_peer(
+                alpha.public_key, [State.Connected], [PathType.Relay], timeout=35
+            ),
+        )
+
+        # Check the relayed connection
+        async with Ping(alpha_connection, beta.ip_addresses[0]).run() as ping:
+            await ping.wait_for_next_ping(15)
+        async with Ping(beta_connection, alpha.ip_addresses[0]).run() as ping:
+            await ping.wait_for_next_ping(15)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "setup_params",
+    [
+        pytest.param(
+            _generate_setup_parameter_pair([
+                (ConnectionTag.DOCKER_CONE_CLIENT_1, AdapterType.BoringTun),
+                (ConnectionTag.DOCKER_CONE_CLIENT_2, AdapterType.BoringTun),
+            ])  # Disable enhanced detection via pinging to reduce the test duration
+        )
+    ],
+)
+async def test_downgrade_using_link_detection_with_silent_connection(
+    setup_params: List[SetupParameters],
+) -> None:
+    async with AsyncExitStack() as exit_stack:
+        env = await setup_mesh_nodes(exit_stack, setup_params)
+        alpha, beta = env.nodes
+        alpha_client, beta_client = env.clients
+        alpha_connection, beta_connection = [
+            conn.connection for conn in env.connections
+        ]
+
+        # We have established a direct connection between the peers
+
+        # Generate some traffic
+        async with Ping(alpha_connection, beta.ip_addresses[0]).run() as ping:
+            await ping.wait_for_next_ping(15)
+        async with Ping(beta_connection, alpha.ip_addresses[0]).run() as ping:
+            await ping.wait_for_next_ping(15)
+
+        # Wait for connection to stabilize
+        # Leave time for the passive keepalives to be send
+        await asyncio.sleep(15)
+
+        # Break the direct connection
+        await exit_stack.enter_async_context(
+            alpha_client.get_router().disable_path(
+                alpha_client.get_endpoint_address(beta.public_key)
+            )
+        )
+        await exit_stack.enter_async_context(
+            beta_client.get_router().disable_path(
+                beta_client.get_endpoint_address(alpha.public_key)
+            )
+        )
+
+        # Link detection should be in the state it sees this as a silent healthy connection
+        # So expect no downgrade
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.gather(
+                alpha_client.wait_for_state_peer(
+                    beta.public_key, [State.Connected], [PathType.Relay], timeout=15
+                ),
+                beta_client.wait_for_state_peer(
+                    alpha.public_key, [State.Connected], [PathType.Relay], timeout=15
+                ),
+            )
+
+        # Generate some traffic to trigger link detection
+        with pytest.raises(asyncio.TimeoutError):
+            async with Ping(alpha_connection, beta.ip_addresses[0]).run() as ping:
+                await ping.wait_for_next_ping(5)
+        with pytest.raises(asyncio.TimeoutError):
+            async with Ping(beta_connection, alpha.ip_addresses[0]).run() as ping:
+                await ping.wait_for_next_ping(5)
+
+        # Expect downgrade to relay
+        await asyncio.gather(
+            alpha_client.wait_for_state_peer(
+                beta.public_key, [State.Connected], [PathType.Relay], timeout=35
+            ),
+            beta_client.wait_for_state_peer(
+                alpha.public_key, [State.Connected], [PathType.Relay], timeout=35
+            ),
+        )
+
+        # Check the relayed connection
+        async with Ping(alpha_connection, beta.ip_addresses[0]).run() as ping:
+            await ping.wait_for_next_ping(15)
+        async with Ping(beta_connection, alpha.ip_addresses[0]).run() as ping:
+            await ping.wait_for_next_ping(15)

--- a/nat-lab/tests/test_telio_features.py
+++ b/nat-lab/tests/test_telio_features.py
@@ -3,6 +3,7 @@ from telio_features import (
     TelioFeatures,
     Direct,
     Lana,
+    LinkDetection,
     Nurse,
     Qos,
     ExitDns,
@@ -73,9 +74,12 @@ def test_telio_features():
             exit_dns=ExitDns(auto_switch_dns_ips=True),
             ttl_value=60,
         ),
+        link_detection=LinkDetection(
+            rtt_seconds=10, no_of_pings=1, use_for_downgrade=True
+        ),
     )
     expected_full = TelioFeatures.from_json(
-        """{"is_test_env": false, "exit_dns": {"auto_switch_dns_ips": true}, "direct": {"providers": ["stun", "local"]}, "lana": {"prod": false, "event_path": "/"}, "nurse": {"fingerprint": "alpha", "qos": {"rtt_interval": 5, "rtt_tries": 3, "rtt_types": ["Ping"], "buckets": 5}, "heartbeat_interval": 3600, "initial_heartbeat_interval": 10, "enable_nat_type_collection": true, "enable_relay_conn_data": true}}"""
+        """{"is_test_env": false, "exit_dns": {"auto_switch_dns_ips": true}, "direct": {"providers": ["stun", "local"]}, "lana": {"prod": false, "event_path": "/"}, "nurse": {"fingerprint": "alpha", "qos": {"rtt_interval": 5, "rtt_tries": 3, "rtt_types": ["Ping"], "buckets": 5}, "heartbeat_interval": 3600, "initial_heartbeat_interval": 10, "enable_nat_type_collection": true, "enable_relay_conn_data": true}, "link_detection": {"rtt_seconds": 10, "no_of_pings": 1, "use_for_downgrade": true}}"""
     )
     assert full_features == expected_full
     assert full_features.to_json() == expected_full.to_json()
@@ -93,3 +97,14 @@ def test_telio_features():
     )
     assert firewall_features == expected_firewall
     assert firewall_features.to_json() == expected_firewall.to_json()
+
+    link_detection_features = TelioFeatures(
+        link_detection=LinkDetection(
+            rtt_seconds=10, no_of_pings=1, use_for_downgrade=False
+        )
+    )
+    expected_link_detection = TelioFeatures.from_json(
+        """{"is_test_env": true, "exit_dns": {"auto_switch_dns_ips": true}, "link_detection": {"rtt_seconds": 10, "no_of_pings": 1, "use_for_downgrade": false}}"""
+    )
+    assert link_detection_features == expected_link_detection
+    assert link_detection_features.to_json() == expected_link_detection.to_json()

--- a/src/libtelio.udl
+++ b/src/libtelio.udl
@@ -564,6 +564,8 @@ dictionary FeatureLinkDetection {
     u64 rtt_seconds;
     /// Check the link state before reporting it as down
     u32 no_of_pings;
+    /// Use link detection for downgrade logic
+    boolean use_for_downgrade;
 };
 
 /// Feature configuration for DNS


### PR DESCRIPTION
The old downgrade logic was triggered if we did not receive anything for three direct keepalive period.

For battery improvement purpouses we want to increase these keepalive periods from 5 seconds to somewhere around 120 +- 5 seconds, therefore the old mechanism for downgrade won't work anymore.

The new solution uses the link detection's reports to trigger the downgrades. If the link_state of a peer changes to Down and the peer has a direct connection, we will trigger the downgrade.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
