### PR TITLE
Llt 5319 move to our chachabox wrapper

### DIFF
--- a/.unreleased/LLT-5319
+++ b/.unreleased/LLT-5319
@@ -1,0 +1,1 @@
+Bump crypto_box and thus curve25519-dalek to get rid of RUSTSEC-2024-0344

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -972,15 +972,14 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.2"
+version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a677b8922c94e01bdbb12126b0bc852f00447528dee1782229af9c720c3f348"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
  "fiat-crypto",
- "platforms",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -2842,12 +2841,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
-name = "platforms"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db23d408679286588f4d4644f965003d056e3dd5abcaaa938116871d7ce2fee7"
-
-[[package]]
 name = "plotters"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4298,9 +4291,13 @@ dependencies = [
 name = "telio-crypto"
 version = "0.1.0"
 dependencies = [
+ "aead",
  "base64 0.13.1",
  "bstr",
+ "chacha20",
+ "chacha20poly1305",
  "crypto_box",
+ "curve25519-dalek",
  "hex",
  "rand",
  "serde",
@@ -4308,6 +4305,7 @@ dependencies = [
  "telio-utils",
  "thiserror",
  "tracing",
+ "zeroize",
 ]
 
 [[package]]
@@ -4610,7 +4608,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
- "x25519-dalek 2.0.1",
+ "x25519-dalek",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,7 +417,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -465,13 +465,13 @@ dependencies = [
  "libc",
  "nix 0.28.0",
  "parking_lot",
- "rand_core 0.6.4",
+ "rand_core",
  "ring",
  "socket2 0.5.7",
  "thiserror",
  "tracing",
  "untrusted",
- "x25519-dalek 2.0.1",
+ "x25519-dalek",
 ]
 
 [[package]]
@@ -894,22 +894,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
+ "rand_core",
  "typenum",
 ]
 
 [[package]]
 name = "crypto_box"
-version = "0.8.2"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd26c32de5307fd08aac445a75c43472b14559d5dccdfba8022dbcd075838ebc"
+checksum = "16182b4f39a82ec8a6851155cc4c0cda3065bb1db33651726a29e1951de0f009"
 dependencies = [
  "aead",
  "chacha20",
- "chacha20poly1305",
+ "crypto_secretbox",
+ "curve25519-dalek",
  "salsa20",
- "x25519-dalek 1.1.1",
- "xsalsa20poly1305",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto_secretbox"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d6cf87adf719ddf43a805e92c6870a531aedda35ff640442cbaf8674e141e1"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "generic-array",
+ "poly1305",
+ "salsa20",
+ "subtle",
  "zeroize",
 ]
 
@@ -952,19 +968,6 @@ checksum = "672465ae37dc1bc6380a6547a8883d5dd397b0f1faaad4f265726cc7042a5345"
 dependencies = [
  "nix 0.28.0",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "curve25519-dalek"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
-dependencies = [
- "byteorder",
- "digest 0.9.0",
- "rand_core 0.5.1",
- "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -1151,15 +1154,6 @@ name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
-
-[[package]]
-name = "digest"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
-dependencies = [
- "generic-array",
-]
 
 [[package]]
 name = "digest"
@@ -1616,6 +1610,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -1846,7 +1841,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -3193,7 +3188,7 @@ checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -3203,14 +3198,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
+ "rand_core",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 
 [[package]]
 name = "rand_core"
@@ -3227,7 +3216,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -3803,7 +3792,7 @@ checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -4345,7 +4334,7 @@ dependencies = [
  "telio-wg",
  "tokio",
  "tracing",
- "x25519-dalek 2.0.1",
+ "x25519-dalek",
 ]
 
 [[package]]
@@ -4484,7 +4473,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
- "x25519-dalek 2.0.1",
+ "x25519-dalek",
 ]
 
 [[package]]
@@ -4543,7 +4532,7 @@ dependencies = [
  "ntest",
  "num_enum",
  "rand",
- "rand_core 0.6.4",
+ "rand_core",
  "rstest",
  "rustls-pemfile",
  "rustls-platform-verifier",
@@ -5812,23 +5801,12 @@ dependencies = [
 
 [[package]]
 name = "x25519-dalek"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a0c105152107e3b96f6a00a65e86ce82d9b125230e1c4302940eca58ff71f4f"
-dependencies = [
- "curve25519-dalek 3.2.0",
- "rand_core 0.5.1",
- "zeroize",
-]
-
-[[package]]
-name = "x25519-dalek"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
- "curve25519-dalek 4.1.2",
- "rand_core 0.6.4",
+ "curve25519-dalek",
+ "rand_core",
  "serde",
  "zeroize",
 ]
@@ -5852,19 +5830,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7d8a75eaf6557bb84a65ace8609883db44a29951042ada9b393151532e41fcb"
 dependencies = [
  "xml-rs",
-]
-
-[[package]]
-name = "xsalsa20poly1305"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02a6dad357567f81cd78ee75f7c61f1b30bb2fe4390be8fb7c69e2ac8dffb6c7"
-dependencies = [
- "aead",
- "poly1305",
- "salsa20",
- "subtle",
- "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,7 @@ base64 = "0.13.0"
 bytes = "1"
 cc = "1.0"
 clap = { version = "3.1", features = ["derive"] }
-crypto_box = { version = "0.8.2", features = ["std"] }
+crypto_box = { version = "0.9.1", features = ["std", "chacha20"]}
 env_logger = "0.9.0"
 futures = "0.3"
 hashlink = "0.8.3"

--- a/crates/telio-crypto/Cargo.toml
+++ b/crates/telio-crypto/Cargo.toml
@@ -7,7 +7,12 @@ repository = "https://github.com/NordSecurity/libtelio"
 publish = false
 
 [dependencies]
+aead = { version = "0.5.2", default-features = false }
 serde_with = { features = ["macros"], default-features = false, version = "3.7.0" }
+chacha20poly1305 = { default-features = false, version = "0.10.1" }
+chacha20 = "0.9.1"
+zeroize = { version = "1", default-features = false }
+curve25519-dalek = { default-features = false, version = "4.1.3" }
 
 base64.workspace = true
 crypto_box.workspace = true

--- a/crates/telio-crypto/src/chachabox.rs
+++ b/crates/telio-crypto/src/chachabox.rs
@@ -1,0 +1,63 @@
+//! The module contains a replacement of the crypto_box::ChaChaBox using XChaCha20 which was
+//! removed from the new versions of the library.
+
+use aead::{Aead, AeadCore, KeyInit, Payload};
+use chacha20::{cipher::generic_array::GenericArray, hchacha};
+use chacha20poly1305::consts::U10;
+use chacha20poly1305::XChaCha20Poly1305;
+use curve25519_dalek::{scalar::clamp_integer, MontgomeryPoint, Scalar};
+use rand::{CryptoRng, RngCore};
+use zeroize::Zeroizing;
+
+use crate::{PublicKey, SecretKey};
+
+/// Public-key encryption scheme based on the X25519 Elliptic Curve Diffie-Hellman function and
+/// the [XChaCha20Poly1305] authenticated encryption cipher.
+pub struct ChaChaBox(XChaCha20Poly1305);
+
+type Nonce = GenericArray<u8, <XChaCha20Poly1305 as AeadCore>::NonceSize>;
+
+impl AeadCore for ChaChaBox {
+    type NonceSize = <XChaCha20Poly1305 as AeadCore>::NonceSize;
+
+    type TagSize = <XChaCha20Poly1305 as AeadCore>::TagSize;
+
+    type CiphertextOverhead = <XChaCha20Poly1305 as AeadCore>::CiphertextOverhead;
+}
+
+impl ChaChaBox {
+    /// Create a ChaCha20 crypto box for given remote public key and local private key
+    pub fn new(public_key: &PublicKey, secret_key: &SecretKey) -> Self {
+        let scalar_sk = Scalar::from_bytes_mod_order(clamp_integer(secret_key.0));
+        let shared_secret = Zeroizing::new(scalar_sk * MontgomeryPoint(public_key.0));
+
+        // Use HChaCha20 to create a uniformly random key from the shared secret
+        Self(XChaCha20Poly1305::new(&hchacha::<U10>(
+            GenericArray::from_slice(&shared_secret.0),
+            &GenericArray::default(),
+        )))
+    }
+
+    /// Generate nonce bytes
+    pub fn generate_nonce(rng: impl CryptoRng + RngCore) -> Nonce {
+        XChaCha20Poly1305::generate_nonce(rng)
+    }
+
+    /// Encrypt the data for the given nonce
+    pub fn encrypt<'msg, 'aad>(
+        &self,
+        nonce: &Nonce,
+        plaintext: impl Into<Payload<'msg, 'aad>>,
+    ) -> Result<Vec<u8>, aead::Error> {
+        self.0.encrypt(nonce, plaintext)
+    }
+
+    /// Decrypt the data for the given nonce
+    pub fn decrypt<'msg, 'aad>(
+        &self,
+        nonce: &Nonce,
+        ciphertext: impl Into<Payload<'msg, 'aad>>,
+    ) -> Result<Vec<u8>, aead::Error> {
+        self.0.decrypt(nonce, ciphertext)
+    }
+}

--- a/crates/telio-crypto/src/lib.rs
+++ b/crates/telio-crypto/src/lib.rs
@@ -160,13 +160,13 @@ impl PresharedKey {
 
 impl From<crypto_box::SecretKey> for SecretKey {
     fn from(sk: crypto_box::SecretKey) -> Self {
-        Self(*sk.as_bytes())
+        Self(sk.to_bytes())
     }
 }
 
 impl From<&crypto_box::SecretKey> for SecretKey {
     fn from(sk: &crypto_box::SecretKey) -> Self {
-        Self(*sk.as_bytes())
+        Self(sk.to_bytes())
     }
 }
 

--- a/crates/telio-crypto/src/lib.rs
+++ b/crates/telio-crypto/src/lib.rs
@@ -20,6 +20,7 @@
 //! # }
 //! ```
 
+pub mod chachabox;
 pub mod encryption;
 
 use std::{cmp::Ordering, convert::TryInto, fmt};

--- a/crates/telio-firewall/src/firewall.rs
+++ b/crates/telio-firewall/src/firewall.rs
@@ -419,7 +419,7 @@ impl StatefullFirewall {
         buffer: &'a [u8],
     ) -> bool {
         let ip = unwrap_option_or_return!(P::try_from(buffer), false);
-        let peer: PublicKey = public_key.into();
+        let peer: PublicKey = PublicKey(*public_key);
         let proto = ip.get_next_level_protocol();
 
         // whitelist read-lock scope
@@ -479,7 +479,7 @@ impl StatefullFirewall {
         buffer: &'a [u8],
     ) -> bool {
         let ip = unwrap_option_or_return!(P::try_from(buffer), false);
-        let peer: PublicKey = public_key.into();
+        let peer = PublicKey(*public_key);
         let proto = ip.get_next_level_protocol();
 
         let whitelist = unwrap_lock_or_return!(self.whitelist.read(), false);

--- a/crates/telio-relay/src/derp.rs
+++ b/crates/telio-relay/src/derp.rs
@@ -41,10 +41,8 @@ use telio_utils::{
 use tokio::sync::mpsc::OwnedPermit;
 use tokio::{task::JoinHandle, time::sleep};
 
-use crypto_box::{
-    aead::{Aead, AeadCore, Error, Nonce, Payload},
-    ChaChaBox,
-};
+use crypto_box::aead::{AeadCore, Error, Nonce, Payload};
+use telio_crypto::chachabox::ChaChaBox;
 
 use generic_array::GenericArray;
 use rand::{rngs::StdRng, SeedableRng};
@@ -442,7 +440,7 @@ impl DerpRelay {
         }
 
         // new Box and convert telio-key to crypto_box format
-        let secret_box = ChaChaBox::new(&public_key.into(), &secret_key.into());
+        let secret_box = ChaChaBox::new(&public_key, &secret_key);
         let nonce = ChaChaBox::generate_nonce(rng);
         // Encrypt the message using the box
         match secret_box.encrypt(
@@ -513,7 +511,7 @@ impl DerpRelay {
                     .get(DerpRelay::NONCE_END_POS..data.len())
                     .ok_or(crypto_box::aead::Error)?;
 
-                let secret_box = ChaChaBox::new(&public_key.into(), &secret_key.into());
+                let secret_box = ChaChaBox::new(&public_key, &secret_key);
 
                 match secret_box.decrypt(
                     &nonce,


### PR DESCRIPTION
### Problem
There is a vulnerability in the `curve25519-dalek` crate in the currently used version - unfortunately we cannot update it simply, because it requires changing the version of the `crypto_box` crate, which changed the `ChaChaBox` implementation and thus it would make our client incompatible with the older versions.

### Solution
This commit bumps the `crypto_box` and `curve25519-dalek` crates while replacing the `crypto_box::ChaChaBox` with our wrapper around `chacha20poly1305::XChaCha20Poly1305` crypto box.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
