### PR TITLE
LLT-5358: Let Pyro5 select port automatically

### DIFF
--- a/nat-lab/tests/uniffi/libtelio_remote.py
+++ b/nat-lab/tests/uniffi/libtelio_remote.py
@@ -189,6 +189,10 @@ def main():
 
     try:
         daemon = Pyro5.server.Daemon(host=container_ip, port=port)
+        _, port = daemon.sock.getsockname()
+        print(f"libtelio-port:{port}")
+        sys.stdout.flush()
+
         wrapper = LibtelioWrapper(daemon)
         daemon.register(wrapper, objectId=object_name)
 


### PR DESCRIPTION
 ### Problem
We occasionally have problems in CI that the socket we ask Pyro5 to bind is busy, causing the pipeline to fail even though nothing is wrong with the code. This problem has only happened with docker containers in CI so far, so it's only fixed for that scenario (not just for CI, but any system running linux as the host OS) but can be expanded to other platforms if needed

### Solution
Pyro5 can automatically select an available port and we can find out about the port afterwards


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
