### PR TITLE
[LLT-5359] Log DNS request packet in case of DNS failure

### DIFF
--- a/.unreleased/LLT-5359
+++ b/.unreleased/LLT-5359
@@ -1,0 +1,1 @@
+Expand logging to help catch DNS failures on Android

--- a/crates/telio-dns/src/forward.rs
+++ b/crates/telio-dns/src/forward.rs
@@ -217,6 +217,10 @@ impl Authority for ForwardAuthority {
         telio_log_debug!("forwarding lookup: {} {}", name, rtype);
         let resolve = self.resolver.lookup(name.clone(), rtype).await;
 
+        if resolve.is_err() {
+            telio_log_warn!("DNS name resolution failed with {:?}", resolve);
+        }
+
         resolve
             .map(ForwardLookup)
             .map_err(|code| match code.kind() {

--- a/crates/telio-dns/src/nameserver.rs
+++ b/crates/telio-dns/src/nameserver.rs
@@ -161,7 +161,11 @@ impl LocalNameServer {
                         {
                             Ok(length) => length,
                             Err(e) => {
-                                telio_log_error!("[DNS] {}", e);
+                                telio_log_error!(
+                                    "[DNS] {}. Offending request packet: {:?}",
+                                    e,
+                                    packet
+                                );
                                 return;
                             }
                         };


### PR DESCRIPTION
### Problem
Sometimes we are getting quite a few:
```
2024-06-16 09:45:49.249 INFO  VPN - "telio_dns::nameserver":160 [DNS] Lookup failed Error performing lookup: Unknown response code [DefaultDispatcher-worker-12]
```
errors, during DNS resolution. But we are not sure yet exactly the root cause for it. Thus this PR continues the Root cause hunt by adding more detailed DNS error  describtion when it occurs.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
