### PR TITLE
LLT-5211 Wait for drivers loaded in Windows

### DIFF
--- a/.unreleased/LLT-5211
+++ b/.unreleased/LLT-5211
@@ -1,0 +1,1 @@
+Wait for windows services before starting adapters

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4594,7 +4594,7 @@ dependencies = [
  "tracing",
  "version-compare",
  "winapi",
- "windows 0.34.0",
+ "windows 0.56.0",
 ]
 
 [[package]]
@@ -4728,6 +4728,7 @@ dependencies = [
  "tracing",
  "wg-go-rust-wrapper",
  "winapi",
+ "windows 0.56.0",
  "wireguard-nt",
  "wireguard-uapi",
 ]
@@ -5518,19 +5519,6 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45296b64204227616fdbf2614cefa4c236b98ee64dfaaaa435207ed99fe7829f"
-dependencies = [
- "windows_aarch64_msvc 0.34.0",
- "windows_i686_gnu 0.34.0",
- "windows_i686_msvc 0.34.0",
- "windows_x86_64_gnu 0.34.0",
- "windows_x86_64_msvc 0.34.0",
-]
-
-[[package]]
-name = "windows"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
@@ -5544,7 +5532,17 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
 dependencies = [
- "windows-core",
+ "windows-core 0.52.0",
+ "windows-targets 0.52.5",
+]
+
+[[package]]
+name = "windows"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1de69df01bdf1ead2f4ac895dc77c9351aefff65b2f3db429a343f9cbf05e132"
+dependencies = [
+ "windows-core 0.56.0",
  "windows-targets 0.52.5",
 ]
 
@@ -5553,6 +5551,49 @@ name = "windows-core"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.5",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4698e52ed2d08f8658ab0c39512a7c00ee5fe2688c65f8c0a4f06750d729f2a6"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-result",
+ "windows-targets 0.52.5",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6fc35f58ecd95a9b71c4f2329b911016e6bec66b3f2e6a4aad86bd2e99e2f9b"
+dependencies = [
+ "proc-macro2 1.0.83",
+ "quote 1.0.36",
+ "syn 2.0.65",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc"
+dependencies = [
+ "proc-macro2 1.0.83",
+ "quote 1.0.36",
+ "syn 2.0.65",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
 dependencies = [
  "windows-targets 0.52.5",
 ]
@@ -5620,12 +5661,6 @@ checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17cffbe740121affb56fad0fc0e421804adf0ae00891205213b5cecd30db881d"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -5635,12 +5670,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2564fde759adb79129d9b4f54be42b32c89970c18ebf93124ca8870a498688ed"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5662,12 +5691,6 @@ checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cd9d32ba70453522332c14d38814bceeb747d80b3958676007acadd7e166956"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -5677,12 +5700,6 @@ name = "windows_i686_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfce6deae227ee8d356d19effc141a509cc503dfd1f850622ec4b0f84428e1f4"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5707,12 +5724,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d19538ccc21819d01deaf88d6a17eae6596a12e9aafdbb97916fb49896d89de9"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,6 +154,10 @@ uniffi = { git = "https://github.com/NordSecurity/uniffi-rs.git", tag = "v0.3.1+
 url = "2.2.2"
 uuid = { version = "1.1.2", features = ["v4"] }
 winapi = { version = "0.3", features = ["netioapi", "ws2def"] }
+windows = { version = "0.56", features = [
+    "Win32_Networking_WinSock",
+    "Win32_NetworkManagement_IpHelper",
+] }
 
 boringtun = { git = "https://github.com/NordSecurity/boringtun.git", tag = "v1.2.1", features = ["device"] }
 x25519-dalek = { version = "2.0.1", features = ["reusable_secrets", "static_secrets"] }

--- a/crates/telio-sockets/Cargo.toml
+++ b/crates/telio-sockets/Cargo.toml
@@ -44,8 +44,7 @@ winapi = { workspace = true, features = [
     "iphlpapi",
     "impl-default",
 ] }
-windows = { version = "0.34.0", features = [
-    "alloc",
+windows = { workspace = true, features = [
     "Win32_Networking_WinSock",
     "Win32_NetworkManagement_IpHelper",
 ] }

--- a/crates/telio-sockets/src/socket_params.rs
+++ b/crates/telio-sockets/src/socket_params.rs
@@ -68,11 +68,8 @@ impl TcpParams {
                 WinSock::setsockopt(
                     WinSock::SOCKET(socket.as_raw_socket() as usize),
                     WinSock::IPPROTO_TCP.0,
-                    WinSock::TCP_MAXRT as i32,
-                    String::from_utf8_unchecked(
-                        (user_timeout.as_secs() as u32).to_ne_bytes().to_vec(),
-                    ),
-                    4, /* value length */
+                    WinSock::TCP_MAXRT,
+                    Some((user_timeout.as_secs() as u32).to_ne_bytes().as_ref()),
                 )
             };
             if err != 0 {
@@ -91,9 +88,8 @@ impl TcpParams {
                 WinSock::setsockopt(
                     WinSock::SOCKET(socket.as_raw_socket() as usize),
                     WinSock::IPPROTO_TCP.0,
-                    WinSock::TCP_MAXRT as i32,
-                    String::from_utf8_unchecked((keepalive_cnt).to_ne_bytes().to_vec()),
-                    4, /* value length */
+                    WinSock::TCP_MAXRT,
+                    Some((keepalive_cnt).to_ne_bytes().as_ref()),
                 )
             };
             if err != 0 {

--- a/crates/telio-wg/Cargo.toml
+++ b/crates/telio-wg/Cargo.toml
@@ -58,3 +58,10 @@ winapi = { workspace = true, features = ["nldef"] }
 wireguard-nt = { git = "https://github.com/NordSecurity/wireguard-nt-rust-wrapper", tag = "v1.0.4" }
 
 wg-go-rust-wrapper = { path = "../../wireguard-go-rust-wrapper" }
+
+windows = { workspace = true, features = [
+    "Win32_Security",
+    "Win32_System",
+    "Win32_System_Services",
+    "Win32_Foundation"
+]}

--- a/crates/telio-wg/src/windows/mod.rs
+++ b/crates/telio-wg/src/windows/mod.rs
@@ -1,4 +1,5 @@
 #![cfg(windows)]
 
 pub(crate) mod cleanup;
+pub(crate) mod service;
 pub(crate) mod tunnel;

--- a/crates/telio-wg/src/windows/service.rs
+++ b/crates/telio-wg/src/windows/service.rs
@@ -1,0 +1,93 @@
+#![cfg(windows)]
+
+use std::convert::{TryFrom, TryInto};
+use std::time::{Duration, Instant};
+use telio_utils::{telio_log_debug, telio_log_warn};
+use windows::{
+    core::{w, Error, Result as WindowsResult, HRESULT, PCWSTR},
+    Win32::{
+        Security::SC_HANDLE,
+        System::Services::{
+            OpenSCManagerW, OpenServiceW, QueryServiceStatus, SC_MANAGER_CONNECT,
+            SERVICE_QUERY_STATUS, SERVICE_STATUS,
+        },
+    },
+};
+
+pub const DEFAULT_SERVICE_WAIT_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Debug)]
+enum WinServiceStatus {
+    Stopped = 1,
+    Starting = 2,
+    Stopping = 3,
+    Running = 4,
+    Continuing = 5,
+    Pausing = 6,
+    Paused = 7,
+}
+
+impl TryFrom<u32> for WinServiceStatus {
+    type Error = &'static str;
+
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        match value {
+            1 => Ok(WinServiceStatus::Stopped),
+            2 => Ok(WinServiceStatus::Starting),
+            3 => Ok(WinServiceStatus::Stopping),
+            4 => Ok(WinServiceStatus::Running),
+            5 => Ok(WinServiceStatus::Continuing),
+            6 => Ok(WinServiceStatus::Pausing),
+            7 => Ok(WinServiceStatus::Paused),
+            _ => Err("Unknown service state"),
+        }
+    }
+}
+
+pub fn wait_for_service(service_name: &str, timeout: Duration) -> bool {
+    let start = Instant::now();
+    while start.elapsed() < timeout {
+        match is_service_running(service_name) {
+            Ok(res) => {
+                telio_log_debug!("\"{}\" service is {:?}", service_name, res);
+                // TODO: do we need to know, in what exact state is service, or is it enough to know that it is loaded into OS ..?
+                return true;
+            }
+            Err(err) => {
+                telio_log_warn!(
+                    "Failed to check \"{}\" service status: {:?}",
+                    service_name,
+                    err
+                );
+            }
+        }
+    }
+
+    false
+}
+
+fn is_service_running(service_name: &str) -> WindowsResult<WinServiceStatus> {
+    let service_name_wide: Vec<u16> = service_name
+        .encode_utf16()
+        .chain(std::iter::once(0))
+        .collect();
+    let service_name_wide = PCWSTR(service_name_wide.as_ptr());
+
+    unsafe {
+        // Open a handle to the Service Control Manager
+        let sc_manager = OpenSCManagerW(PCWSTR::null(), PCWSTR::null(), SC_MANAGER_CONNECT)?;
+
+        // Open a handle to the service
+        let service = OpenServiceW(sc_manager, service_name_wide, SERVICE_QUERY_STATUS)?;
+
+        // Query the service status
+        let mut status = SERVICE_STATUS::default();
+        QueryServiceStatus(service, &mut status)?;
+
+        // Check the current state
+        match WinServiceStatus::try_from(status.dwCurrentState.0) {
+            Ok(res) => Ok(res),
+            Err(e) => Err(Error::new(HRESULT(1), e)),
+        }
+    }
+}


### PR DESCRIPTION
### Problem
In Windows, we're sometimes seeing the errors: `Telio::start_named: Err(Adapter(WireguardGo(FailedToStart(-1))))` (the same with WireguardNT adapter). Primary suspect is the `*.dll` loader mechanism, which returns, but still haven't fully initialized the library (error happens only on first library load).

### Solution
Add windows service checker for `Wintun` and `WireGuard` services.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
