### PR TITLE
Improve error handling for case when PingerClient creation fails

### DIFF
--- a/.unreleased/LLT-4641
+++ b/.unreleased/LLT-4641
@@ -1,1 +1,1 @@
-Make SessionKeeper startup failures non-fatal
+Make SessionKeeper startup failures non-fatal and improve error handling


### PR DESCRIPTION
### Problem
It's not 100% clear why surge ping fails to create a socket on windows for pinging.

### Solution
Surge returns an `io::Result` so not much we can do about it but maybe this only happens for one kind of IP (4/6) and this change will show this.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
