### PR TITLE
Llt 5309 integrate multicast components

### DIFF
--- a/.unreleased/LLT-5309
+++ b/.unreleased/LLT-5309
@@ -1,0 +1,1 @@
+Add starcast to Libtelio for multicast support

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4647,6 +4647,7 @@ version = "0.1.0"
 dependencies = [
  "futures",
  "hashlink",
+ "ipnet",
  "lru_time_cache",
  "maplit",
  "mockall",

--- a/crates/telio-model/src/constants.rs
+++ b/crates/telio-model/src/constants.rs
@@ -1,8 +1,24 @@
 //! Telio constants definition
 
+use std::net::{Ipv4Addr, Ipv6Addr};
+use telio_utils::const_ipnet::{ConstIpv4Net, ConstIpv6Net};
+
 /// VPN IPv4 Meshnet Address
-pub const VPN_INTERNAL_IPV4: [u8; 4] = [100, 64, 0, 1];
+pub const VPN_INTERNAL_IPV4: Ipv4Addr = Ipv4Addr::new(100, 64, 0, 1);
 /// VPN IPv6 Meshnet Address
-pub const VPN_INTERNAL_IPV6: [u16; 8] = [0xfd74, 0x656c, 0x696f, 0, 0, 0, 0, 1];
+pub const VPN_INTERNAL_IPV6: Ipv6Addr = Ipv6Addr::new(0xfd74, 0x656c, 0x696f, 0, 0, 0, 0, 1);
 /// VPN IPv4 Non-Meshnet Address
-pub const VPN_EXTERNAL_IPV4: [u8; 4] = [10, 5, 0, 1];
+pub const VPN_EXTERNAL_IPV4: Ipv4Addr = Ipv4Addr::new(10, 5, 0, 1);
+/// Ipv4 multicast range
+pub const IPV4_MULTICAST_NETWORK: ConstIpv4Net = ConstIpv4Net::new(Ipv4Addr::new(224, 0, 0, 0), 4);
+/// Ipv6 multicast range
+pub const IPV6_MULTICAST_NETWORK: ConstIpv6Net =
+    ConstIpv6Net::new(Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 0, 0xfb), 128);
+/// Ipv4 starcast's virtual peer address
+pub const IPV4_STARCAST_ADDRESS: Ipv4Addr = Ipv4Addr::new(100, 64, 0, 5);
+/// Ipv6 starcast's virtual peer address
+pub const IPV6_STARCAST_ADDRESS: Ipv6Addr = Ipv6Addr::new(0xfd74, 0x656c, 0x696f, 0, 0, 0, 0, 0x5);
+/// Ipv4 starcast's virtual peer network
+pub const IPV4_STARCAST_NETWORK: ConstIpv4Net = ConstIpv4Net::new(IPV4_STARCAST_ADDRESS, 32);
+/// Ipv6 starcast's virtual peer network
+pub const IPV6_STARCAST_NETWORK: ConstIpv6Net = ConstIpv6Net::new(IPV6_STARCAST_ADDRESS, 128);

--- a/crates/telio-nurse/src/qos.rs
+++ b/crates/telio-nurse/src/qos.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use histogram::Histogram;
 use std::collections::{BTreeSet, HashMap, HashSet};
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::net::IpAddr;
 use std::sync::Arc;
 use std::time::Instant;
 use telio_model::constants::{VPN_INTERNAL_IPV4, VPN_INTERNAL_IPV6};
@@ -541,11 +541,7 @@ impl Analytics {
 fn is_from_ignored_peer(event: &AnalyticsEvent) -> bool {
     // The only allowed virtual peer for analytics is the VPN peer.
     fn is_vpn(ip: IpAddr) -> bool {
-        [
-            IpAddr::V4(Ipv4Addr::from(VPN_INTERNAL_IPV4)),
-            IpAddr::V6(Ipv6Addr::from(VPN_INTERNAL_IPV6)),
-        ]
-        .contains(&ip)
+        [VPN_INTERNAL_IPV4.into(), VPN_INTERNAL_IPV6.into()].contains(&ip)
     }
     if event.is_from_virtual_peer() {
         !event

--- a/crates/telio-utils/Cargo.toml
+++ b/crates/telio-utils/Cargo.toml
@@ -12,6 +12,7 @@ sn_fake_clock = ["dep:sn_fake_clock"]
 [dependencies]
 futures.workspace = true
 hashlink.workspace = true
+ipnet.workspace = true
 mockall = { workspace = true, optional = true }
 parking_lot.workspace = true
 rand.workspace = true

--- a/crates/telio-utils/src/const_ipnet.rs
+++ b/crates/telio-utils/src/const_ipnet.rs
@@ -1,0 +1,77 @@
+//! This module can be removed once IpNet crate
+//! fixes this issue: https://github.com/krisprice/ipnet/issues/55
+
+use ipnet::{IpNet, Ipv4Net, Ipv6Net};
+use std::net::{Ipv4Addr, Ipv6Addr};
+
+/// Struct used to create const items of Ipv4Net type
+pub struct ConstIpv4Net {
+    ip: Ipv4Addr,
+    prefix_len: u8,
+}
+
+impl ConstIpv4Net {
+    /// Creates a new IPv4 network address from an `Ipv4Addr` and prefix
+    /// length. If called from a const context it will verify prefix length
+    /// at compile time. Otherwise it will panic at runtime if prefix length
+    /// is not less then or equal to 32.
+    pub const fn new(ip: Ipv4Addr, prefix_len: u8) -> Self {
+        assert!(
+            prefix_len <= 32,
+            "PREFIX_LEN must be less then or equal to 32 for ConstIpv4Net"
+        );
+        Self { ip, prefix_len }
+    }
+}
+
+impl From<ConstIpv4Net> for Ipv4Net {
+    fn from(value: ConstIpv4Net) -> Self {
+        // Allow unwrap since ConstIpv4Net is guaranteed to have the correct prefix_len
+        #[allow(clippy::unwrap_used, unwrap_check)]
+        Ipv4Net::new(value.ip, value.prefix_len).unwrap()
+    }
+}
+
+impl From<ConstIpv4Net> for IpNet {
+    fn from(value: ConstIpv4Net) -> Self {
+        // Allow unwrap since ConstIpv4Net is guaranteed to have the correct prefix_len
+        #[allow(clippy::unwrap_used, unwrap_check)]
+        IpNet::V4(Ipv4Net::new(value.ip, value.prefix_len).unwrap())
+    }
+}
+
+/// Struct used to create const items of Ipv4Net type
+pub struct ConstIpv6Net {
+    ip: Ipv6Addr,
+    prefix_len: u8,
+}
+
+impl ConstIpv6Net {
+    /// Creates a new IPv6 network address from an `Ipv6Addr` and prefix
+    /// length. If called from a const context it will verify prefix length
+    /// at compile time. Otherwise it will panic at runtime if prefix length
+    /// is not less then or equal to 128.
+    pub const fn new(ip: Ipv6Addr, prefix_len: u8) -> Self {
+        assert!(
+            prefix_len <= 128,
+            "PREFIX_LEN must be less then or equal to 128 for ConstIpv6Net"
+        );
+        Self { ip, prefix_len }
+    }
+}
+
+impl From<ConstIpv6Net> for Ipv6Net {
+    fn from(value: ConstIpv6Net) -> Self {
+        // Allow unwrap since ConstIpv4Net is guaranteed to have the correct prefix_len
+        #[allow(clippy::unwrap_used, unwrap_check)]
+        Ipv6Net::new(value.ip, value.prefix_len).unwrap()
+    }
+}
+
+impl From<ConstIpv6Net> for IpNet {
+    fn from(value: ConstIpv6Net) -> Self {
+        // Allow unwrap since ConstIpv4Net is guaranteed to have the correct prefix_len
+        #[allow(clippy::unwrap_used, unwrap_check)]
+        IpNet::V6(Ipv6Net::new(value.ip, value.prefix_len).unwrap())
+    }
+}

--- a/crates/telio-utils/src/lib.rs
+++ b/crates/telio-utils/src/lib.rs
@@ -49,3 +49,6 @@ pub use pinger::*;
 
 /// Testing tools
 pub mod test;
+
+/// IpNet const constructor
+pub mod const_ipnet;

--- a/nat-lab/bin/multicast.py
+++ b/nat-lab/bin/multicast.py
@@ -1,0 +1,108 @@
+import argparse
+import socket
+
+SSDP_IP: str = "239.255.255.250"
+SSDP_PORT: int = 1900
+SSDP_REQ: bytes = b"SSDP_REQUEST"
+SSDP_RESP: bytes = b"SSDP_RESPONSE"
+MDNS_IP: str = "224.0.0.251"
+MDNS_PORT: int = 5353
+MDNS_REQ: bytes = b"MDNS_REQUEST"
+MDNS_RESP: bytes = b"MDNS_RESPONSE"
+
+
+def ssdp_client(timeout: int):
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.settimeout(timeout)
+    s.bind(("0.0.0.0", 0))
+    s.sendto(SSDP_REQ, (SSDP_IP, SSDP_PORT))
+    buf = s.recv(2048)
+    assert buf == SSDP_RESP
+
+
+def ssdp_server(timeout: int):
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.settimeout(timeout)
+    s.bind(("0.0.0.0", SSDP_PORT))
+
+    mreq = socket.inet_aton(SSDP_IP) + socket.inet_aton("0.0.0.0")
+    s.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, mreq)
+
+    print("Listening", flush=True)
+    while True:
+        (buf, peer_addr) = s.recvfrom(2048)
+        if buf == SSDP_REQ:
+            s.sendto(SSDP_RESP, peer_addr)
+            break
+
+
+def mdns_client(timeout: int):
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.settimeout(timeout)
+    s.bind(("0.0.0.0", MDNS_PORT))
+
+    mreq = socket.inet_aton(MDNS_IP) + socket.inet_aton("0.0.0.0")
+    s.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, mreq)
+
+    s.sendto(MDNS_REQ, (MDNS_IP, MDNS_PORT))
+    while True:
+        buf = s.recv(2048)
+        if buf == MDNS_RESP:
+            break
+
+
+def mdns_server(timeout: int):
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.settimeout(timeout)
+    s.bind(("0.0.0.0", MDNS_PORT))
+
+    mreq = socket.inet_aton(MDNS_IP) + socket.inet_aton("0.0.0.0")
+    s.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, mreq)
+
+    print("Listening", flush=True)
+    while True:
+        buf = s.recv(2048)
+        if buf == MDNS_REQ:
+            s.sendto(MDNS_RESP, (MDNS_IP, MDNS_PORT))
+            break
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    protocol_group = parser.add_mutually_exclusive_group(required=True)
+    protocol_group.add_argument(
+        "-m",
+        "--mdns",
+        action="store_true",
+        help="use mdns-like protocol (multicast request, multicast response)",
+    )
+    protocol_group.add_argument(
+        "-u",
+        "--ssdp",
+        action="store_true",
+        help="use ssdp-like protocol (multicast request, unicast response)",
+    )
+    side_group = parser.add_mutually_exclusive_group(required=True)
+    side_group.add_argument("-c", "--client", action="store_true", help="act as client")
+    side_group.add_argument("-s", "--server", action="store_true", help="act as server")
+
+    parser.add_argument(
+        "-t", "--timeout", type=int, required=True, help="timeout for socket operations"
+    )
+
+    args = parser.parse_args()
+
+    if args.client:
+        if args.ssdp:
+            ssdp_client(args.timeout)
+        else:
+            mdns_client(args.timeout)
+    elif args.server:
+        if args.ssdp:
+            ssdp_server(args.timeout)
+        else:
+            mdns_server(args.timeout)
+
+
+if __name__ == "__main__":
+    main()

--- a/nat-lab/bin/multicast.py
+++ b/nat-lab/bin/multicast.py
@@ -23,6 +23,7 @@ def ssdp_client(timeout: int):
 def ssdp_server(timeout: int):
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     s.settimeout(timeout)
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     s.bind(("0.0.0.0", SSDP_PORT))
 
     mreq = socket.inet_aton(SSDP_IP) + socket.inet_aton("0.0.0.0")
@@ -39,6 +40,7 @@ def ssdp_server(timeout: int):
 def mdns_client(timeout: int):
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     s.settimeout(timeout)
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     s.bind(("0.0.0.0", MDNS_PORT))
 
     mreq = socket.inet_aton(MDNS_IP) + socket.inet_aton("0.0.0.0")
@@ -54,6 +56,7 @@ def mdns_client(timeout: int):
 def mdns_server(timeout: int):
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     s.settimeout(timeout)
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     s.bind(("0.0.0.0", MDNS_PORT))
 
     mreq = socket.inet_aton(MDNS_IP) + socket.inet_aton("0.0.0.0")

--- a/nat-lab/tests/test_multicast_connection.py
+++ b/nat-lab/tests/test_multicast_connection.py
@@ -1,0 +1,65 @@
+import pytest
+import telio
+from contextlib import AsyncExitStack
+from helpers import setup_mesh_nodes, SetupParameters
+from telio_features import TelioFeatures
+from typing import List
+from utils.connection_util import ConnectionTag
+from utils.multicast import MulticastClient, MulticastServer
+
+
+def generate_setup_parameter_pair(
+    cfg: List[ConnectionTag],
+) -> List[SetupParameters]:
+    return [
+        SetupParameters(
+            connection_tag=conn_tag,
+            adapter_type=telio.AdapterType.BoringTun,
+            features=TelioFeatures(
+                multicast=True,
+            ),
+        )
+        for conn_tag in cfg
+    ]
+
+
+MUILTICAST_TEST_PARAMS = [
+    pytest.param(
+        generate_setup_parameter_pair([
+            ConnectionTag.DOCKER_FULLCONE_CLIENT_1,
+            ConnectionTag.DOCKER_FULLCONE_CLIENT_2,
+        ]),
+        "ssdp",
+    ),
+    pytest.param(
+        generate_setup_parameter_pair([
+            ConnectionTag.DOCKER_FULLCONE_CLIENT_1,
+            ConnectionTag.DOCKER_FULLCONE_CLIENT_2,
+        ]),
+        "mdns",
+    ),
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("setup_params, protocol", MUILTICAST_TEST_PARAMS)
+async def test_multicast(setup_params: List[SetupParameters], protocol: str) -> None:
+    async with AsyncExitStack() as exit_stack:
+        env = await setup_mesh_nodes(exit_stack, setup_params)
+
+        alpha_connection, beta_connection = [
+            conn.connection for conn in env.connections
+        ]
+
+        ipconf = alpha_connection.create_process(
+            ["ip", "route", "add", "224.0.0.0/4", "dev", "tun10"]
+        )
+        await ipconf.execute()
+        ipconf = beta_connection.create_process(
+            ["ip", "route", "add", "224.0.0.0/4", "dev", "tun10"]
+        )
+        await ipconf.execute()
+
+        async with MulticastServer(beta_connection, protocol).run() as server:
+            await server.wait_till_ready()
+            await MulticastClient(alpha_connection, protocol).execute()

--- a/nat-lab/tests/test_multicast_connection.py
+++ b/nat-lab/tests/test_multicast_connection.py
@@ -1,44 +1,66 @@
 import pytest
-import telio
 from contextlib import AsyncExitStack
 from helpers import setup_mesh_nodes, SetupParameters
+from telio import AdapterType
 from telio_features import TelioFeatures
-from typing import List
-from utils.connection_util import ConnectionTag
+from typing import List, Tuple
+from utils.connection_util import ConnectionTag, Connection, TargetOS
 from utils.multicast import MulticastClient, MulticastServer
 
 
 def generate_setup_parameter_pair(
-    cfg: List[ConnectionTag],
+    cfg: List[Tuple[ConnectionTag, AdapterType]],
 ) -> List[SetupParameters]:
     return [
         SetupParameters(
             connection_tag=conn_tag,
-            adapter_type=telio.AdapterType.BoringTun,
+            adapter_type=adapter_type,
             features=TelioFeatures(
                 multicast=True,
             ),
         )
-        for conn_tag in cfg
+        for conn_tag, adapter_type in cfg
     ]
 
 
 MUILTICAST_TEST_PARAMS = [
     pytest.param(
         generate_setup_parameter_pair([
-            ConnectionTag.DOCKER_FULLCONE_CLIENT_1,
-            ConnectionTag.DOCKER_FULLCONE_CLIENT_2,
+            (ConnectionTag.DOCKER_FULLCONE_CLIENT_1, AdapterType.BoringTun),
+            (ConnectionTag.DOCKER_FULLCONE_CLIENT_2, AdapterType.BoringTun),
         ]),
         "ssdp",
     ),
     pytest.param(
         generate_setup_parameter_pair([
-            ConnectionTag.DOCKER_FULLCONE_CLIENT_1,
-            ConnectionTag.DOCKER_FULLCONE_CLIENT_2,
+            (ConnectionTag.DOCKER_SYMMETRIC_CLIENT_1, AdapterType.BoringTun),
+            (ConnectionTag.DOCKER_SYMMETRIC_CLIENT_2, AdapterType.BoringTun),
+        ]),
+        "mdns",
+    ),
+    pytest.param(
+        generate_setup_parameter_pair([
+            (ConnectionTag.WINDOWS_VM_1, AdapterType.WireguardGo),
+            (ConnectionTag.DOCKER_CONE_CLIENT_1, AdapterType.BoringTun),
+        ]),
+        "ssdp",
+    ),
+    pytest.param(
+        generate_setup_parameter_pair([
+            (ConnectionTag.DOCKER_CONE_CLIENT_1, AdapterType.BoringTun),
+            (ConnectionTag.WINDOWS_VM_1, AdapterType.WindowsNativeWg),
         ]),
         "mdns",
     ),
 ]
+
+
+async def add_multicast_route(connection: Connection) -> None:
+    if connection.target_os == TargetOS.Linux:
+        ipconf = connection.create_process(
+            ["ip", "route", "add", "224.0.0.0/4", "dev", "tun10"]
+        )
+        await ipconf.execute()
 
 
 @pytest.mark.asyncio
@@ -51,14 +73,8 @@ async def test_multicast(setup_params: List[SetupParameters], protocol: str) -> 
             conn.connection for conn in env.connections
         ]
 
-        ipconf = alpha_connection.create_process(
-            ["ip", "route", "add", "224.0.0.0/4", "dev", "tun10"]
-        )
-        await ipconf.execute()
-        ipconf = beta_connection.create_process(
-            ["ip", "route", "add", "224.0.0.0/4", "dev", "tun10"]
-        )
-        await ipconf.execute()
+        await add_multicast_route(alpha_connection)
+        await add_multicast_route(beta_connection)
 
         async with MulticastServer(beta_connection, protocol).run() as server:
             await server.wait_till_ready()

--- a/nat-lab/tests/utils/multicast.py
+++ b/nat-lab/tests/utils/multicast.py
@@ -1,0 +1,55 @@
+from asyncio import Event
+from contextlib import asynccontextmanager
+from typing import AsyncIterator
+from utils.connection import Connection
+from utils.process import Process
+
+
+class MulticastClient:
+    _process: Process
+    _connection: Connection
+
+    def __init__(self, connection: Connection, protocol: str) -> None:
+        self._connection = connection
+        self._process = connection.create_process([
+            "python3",
+            "/libtelio/nat-lab/bin/multicast.py",
+            f"--{protocol}",
+            "-c",
+            "-t",
+            "10",
+        ])
+
+    async def execute(self) -> None:
+        await self._process.execute()
+
+
+class MulticastServer:
+    _process: Process
+    _connection: Connection
+    _server_ready_event: Event
+
+    def __init__(self, connection: Connection, protocol: str) -> None:
+        self._connection = connection
+        self._server_ready_event = Event()
+        self._process = connection.create_process([
+            "python3",
+            "/libtelio/nat-lab/bin/multicast.py",
+            f"--{protocol}",
+            "-s",
+            "-t",
+            "10",
+        ])
+
+    async def on_stdout(self, stdout: str) -> None:
+        for line in stdout.splitlines():
+            if line.find("Listening") >= 0:
+                self._server_ready_event.set()
+
+    async def wait_till_ready(self) -> None:
+        await self._server_ready_event.wait()
+
+    @asynccontextmanager
+    async def run(self) -> AsyncIterator["MulticastServer"]:
+        async with self._process.run(stdout_callback=self.on_stdout):
+            yield self

--- a/nat-lab/tests/utils/multicast.py
+++ b/nat-lab/tests/utils/multicast.py
@@ -1,8 +1,23 @@
 from asyncio import Event
+from config import LIBTELIO_BINARY_PATH_MAC_VM, LIBTELIO_BINARY_PATH_WINDOWS_VM
 from contextlib import asynccontextmanager
 from typing import AsyncIterator
-from utils.connection import Connection
+from utils.connection import Connection, TargetOS
 from utils.process import Process
+
+
+def _get_python(connection: Connection) -> str:
+    if connection.target_os == TargetOS.Windows:
+        return "python"
+    return "python3"
+
+
+def _get_multicast_script_path(connection: Connection) -> str:
+    if connection.target_os == TargetOS.Linux:
+        return "/libtelio/nat-lab/bin/multicast.py"
+    if connection.target_os == TargetOS.Windows:
+        return LIBTELIO_BINARY_PATH_WINDOWS_VM + "multicast.py"
+    return LIBTELIO_BINARY_PATH_MAC_VM + "multicast.py"
 
 
 class MulticastClient:
@@ -12,8 +27,8 @@ class MulticastClient:
     def __init__(self, connection: Connection, protocol: str) -> None:
         self._connection = connection
         self._process = connection.create_process([
-            "python3",
-            "/libtelio/nat-lab/bin/multicast.py",
+            _get_python(connection),
+            _get_multicast_script_path(connection),
             f"--{protocol}",
             "-c",
             "-t",
@@ -33,8 +48,8 @@ class MulticastServer:
         self._connection = connection
         self._server_ready_event = Event()
         self._process = connection.create_process([
-            "python3",
-            "/libtelio/nat-lab/bin/multicast.py",
+            _get_python(connection),
+            _get_multicast_script_path(connection),
             f"--{protocol}",
             "-s",
             "-t",

--- a/nat-lab/tests/utils/vm/windows_vm_util.py
+++ b/nat-lab/tests/utils/vm/windows_vm_util.py
@@ -128,6 +128,7 @@ async def _copy_binaries(
 
     DIST_DIR = "dist/windows/release/x86_64/"
     LOCAL_UNIFFI_DIR = "nat-lab/tests/uniffi/"
+    LOCAL_BIN_DIR = "nat-lab/bin/"
 
     files_to_copy = [
         (f"{DIST_DIR}*", VM_TCLI_DIR, False),
@@ -137,6 +138,7 @@ async def _copy_binaries(
         (f"{DIST_DIR}sqlite3.dll", VM_UNIFFI_DIR, True),
         (f"{DIST_DIR}wireguard.dll", VM_UNIFFI_DIR, False),
         (f"{DIST_DIR}wintun.dll", VM_SYSTEM32, False),
+        (f"{LOCAL_BIN_DIR}multicast.py", VM_TCLI_DIR, False),
     ]
 
     for src, dst, allow_missing in files_to_copy:


### PR DESCRIPTION
### Problem
All the separate parts of starcast (see RFC LLT-0060) are ready to be integrated into Telio.

### Solution
This PR integrates all the separate starcast parts (virtual peer, transport and nat) into libtelio.
You can see the doc rs in code of every separate component to understand how they're supposed to be integrated into telio. 

The Nat-Lab test for multicast is being implemented with a separate PR, so this one is untested yet.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
