### PR TITLE
[LLT-5393] Collect coredumps

### DIFF
--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -31,4 +31,4 @@ jobs:
           project-id: ${{ secrets.PROJECT_ID }}
           schedule: ${{ github.event_name == 'schedule' }}
           cancel-outdated-pipelines: ${{ github.ref_name != 'main' }}
-          triggered-ref: v1.2.5
+          triggered-ref: v1.2.7

--- a/nat-lab/docker-compose.yml
+++ b/nat-lab/docker-compose.yml
@@ -73,6 +73,10 @@ services:
         ipv4_address: 192.168.101.104
     ports:
       - "8081"
+    ulimits:
+      core:
+        soft: -1
+        hard: -1
     environment:
       CLIENT_GATEWAY_PRIMARY: 192.168.101.254
     extra_hosts:


### PR DESCRIPTION
### Problem

Sometimes the tests crash with a segmentation fault, but we do not have core-dumps to analyze the root cause.

### Solution

Enable, collect and attach core dumps to the CI runner artifacts.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
