### PR TITLE
LLT-5324 Bump boringtun to v1.2.4

### DIFF
--- a/.unreleased/LLT-5324
+++ b/.unreleased/LLT-5324
@@ -1,0 +1,1 @@
+Use single performance core on boringtun on Apple's devices

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,12 +452,13 @@ dependencies = [
 [[package]]
 name = "boringtun"
 version = "0.6.0"
-source = "git+https://github.com/NordSecurity/boringtun.git?tag=v1.2.3#717a882950ea4727a7b5e45d906627c034cc91b1"
+source = "git+https://github.com/NordSecurity/boringtun.git?tag=v1.2.4#1639233123ee5c02b431a03aed310e15ca3a3f63"
 dependencies = [
  "aead",
  "base64 0.13.1",
  "blake2",
  "chacha20poly1305",
+ "dispatch",
  "hex",
  "hmac",
  "ip_network",
@@ -4683,6 +4684,7 @@ dependencies = [
  "libc",
  "mockall",
  "ntest",
+ "num_cpus",
  "pretty_assertions",
  "proptest",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ pretend_to_be_macos = ["telio-model/pretend_to_be_macos"]
 [dependencies]
 cfg-if = "1.0.0"
 ffi_helpers = "0.3.0"
-num_cpus = "1.15.0"
 h2 = "=0.3.26" # RUSTSEC-2024-0332
 
 anyhow.workspace = true
@@ -27,6 +26,7 @@ ipnet.workspace = true
 lazy_static.workspace = true
 libc.workspace = true
 modifier.workspace = true
+num_cpus.workspace = true
 parking_lot.workspace = true
 serde.workspace = true
 serde_json.workspace = true
@@ -124,6 +124,7 @@ mockall = "0.11.3"
 modifier = "0.1.0"
 nat-detect = { git = "https://github.com/NordSecurity/nat-detect.git", tag = "v0.1.8" }
 ntest = "0.7"
+num_cpus = "1.15.0"
 num_enum = "0.6.1"
 once_cell = "1"
 parking_lot = "0.12"
@@ -158,7 +159,7 @@ windows = { version = "0.56", features = [
     "Win32_NetworkManagement_IpHelper",
 ] }
 
-boringtun = { git = "https://github.com/NordSecurity/boringtun.git", tag = "v1.2.3", features = ["device"] }
+boringtun = { git = "https://github.com/NordSecurity/boringtun.git", tag = "v1.2.4", features = ["device"] }
 x25519-dalek = { version = "2.0.1", features = ["reusable_secrets", "static_secrets"] }
 
 telio-crypto = { version = "0.1.0", path = "./crates/telio-crypto" }

--- a/crates/telio-wg/Cargo.toml
+++ b/crates/telio-wg/Cargo.toml
@@ -22,6 +22,7 @@ lazy_static.workspace = true
 libc.workspace = true
 tracing.workspace = true
 mockall = { workspace = true, optional = true }
+num_cpus.workspace = true
 rand.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/telio-wg/src/adapter/boring.rs
+++ b/crates/telio-wg/src/adapter/boring.rs
@@ -36,7 +36,18 @@ impl BoringTun {
         firewall_reset_connections_callback: super::FirewallResetConnsCb,
     ) -> Result<Self, AdapterError> {
         let config = DeviceConfig {
-            n_threads: 4,
+            // Apple's Boringtun device runs most efficiently on a single perf-core
+            n_threads: {
+                if cfg!(not(any(
+                    target_os = "ios",
+                    target_os = "macos",
+                    target_os = "tvos"
+                ))) {
+                    num_cpus::get()
+                } else {
+                    1
+                }
+            },
             use_connected_socket: cfg!(not(any(
                 target_os = "ios",
                 target_os = "macos",


### PR DESCRIPTION
### Problem
Boringtun runs on eco cores on Apple, sacrificing a performance.

### Solution
Put Boringtun thread on a single performance core on Apple.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
