### PR TITLE
Fix telio shutdown

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -338,7 +338,7 @@ impl Telio {
             };
             let mut shutdown = false;
             if let Some(ref mut dev) = *dev {
-                shutdown = dev.try_shutdown(Duration::from_millis(1000)).is_ok();
+                shutdown = dev.try_shutdown_art(Duration::from_millis(1000)).is_ok();
             }
             *dev = None;
             Ok(shutdown)


### PR DESCRIPTION
Change shutdown_art and consequently Telio.shutdown implementation to blocking. The old implementation was using shutdown_background method which just left worker threads running without joining them. That could result in a crash e.g. in a scenario when the telio user called shutdown and then unloaded libtelio library. The new implemntation uses Runtime's Drop implementation which is blocking and joins all threads.


There are still issues I see when it comes to Telio's shutdown API but I think it can be done in the future PR:
1. In the current state both `shutdown` and `shutdown_hard` close runtime but only `shutdown_hard's` documentation mentions it.
2. `shutdown` closes runtime and after that there is no possibility to call anything else on it (Previous name destroy was better I guess). Given that why is it not destroying the Device? `shutdown_hard` does it correctly.
3. If we want to keep both I think both should destroy the Device with the only difference that `shutdown_hard` should do it via `shutdown_timeout` so it can try to recover even if something bad happens which could lead to a hang, although I'm not even convinced that this is a correct way to go (I would like to hear why it was introduced in the first place). 


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
