### PR TITLE
LLT-5310: Make nurse state duration cap configurable

### DIFF
--- a/.unreleased/LLT-5310
+++ b/.unreleased/LLT-5310
@@ -1,0 +1,1 @@
+Add feature config option for nurse state duration cap

--- a/crates/telio-nurse/src/config.rs
+++ b/crates/telio-nurse/src/config.rs
@@ -81,13 +81,16 @@ impl QoSConfig {
 }
 
 /// Configuration for Aggregator component from Nurse
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct AggregatorConfig {
     /// Collect relay events
     pub relay_events: bool,
 
     /// Collect nat traversal events
     pub nat_traversal_events: bool,
+
+    /// Maximum session length before forced collection
+    pub state_duration_cap: Duration,
 }
 
 impl AggregatorConfig {
@@ -96,6 +99,17 @@ impl AggregatorConfig {
         Self {
             relay_events: features.enable_relay_conn_data,
             nat_traversal_events: features.enable_nat_traversal_conn_data,
+            state_duration_cap: Duration::from_secs(features.state_duration_cap),
+        }
+    }
+}
+
+impl Default for AggregatorConfig {
+    fn default() -> Self {
+        Self {
+            relay_events: Default::default(),
+            nat_traversal_events: Default::default(),
+            state_duration_cap: Duration::from_secs(60 * 60 * 24),
         }
     }
 }

--- a/nat-lab/tests/telio_features.py
+++ b/nat-lab/tests/telio_features.py
@@ -73,6 +73,7 @@ class Nurse(DataClassJsonMixin):
     enable_nat_type_collection: bool = False
     enable_relay_conn_data: bool = False
     enable_nat_traversal_conn_data: bool = False
+    state_duration_cap: int = 60 * 60 * 24
 
 
 @dataclass_json(undefined=Undefined.EXCLUDE)

--- a/nat-lab/tests/test_telio_features.py
+++ b/nat-lab/tests/test_telio_features.py
@@ -48,10 +48,11 @@ def test_telio_features():
             initial_heartbeat_interval=10,
             enable_relay_conn_data=False,
             enable_nat_type_collection=False,
+            state_duration_cap=123,
         )
     )
     expected_nurse_qos = TelioFeatures.from_json(
-        """{"is_test_env": true, "exit_dns": {"auto_switch_dns_ips": true}, "nurse": {"fingerprint": "fingerprint", "qos": {"rtt_interval": 5, "rtt_tries": 3, "rtt_types": ["Ping"], "buckets": 5}, "heartbeat_interval": 3600, "initial_heartbeat_interval": 10, "enable_nat_type_collection": false, "enable_relay_conn_data": false}}"""
+        """{"is_test_env": true, "exit_dns": {"auto_switch_dns_ips": true}, "nurse": {"fingerprint": "fingerprint", "qos": {"rtt_interval": 5, "rtt_tries": 3, "rtt_types": ["Ping"], "buckets": 5}, "heartbeat_interval": 3600, "initial_heartbeat_interval": 10, "enable_nat_type_collection": false, "enable_relay_conn_data": false, "state_duration_cap": 123}}"""
     )
     assert nurse_qos_features == expected_nurse_qos
     assert nurse_qos_features.to_json() == expected_nurse_qos.to_json()

--- a/src/libtelio.udl
+++ b/src/libtelio.udl
@@ -474,6 +474,8 @@ dictionary FeatureNurse {
     boolean enable_relay_conn_data;
     /// Enable/disable NAT-traversal connections data
     boolean enable_nat_traversal_conn_data;
+    /// How long a session can exist before it is forcibly reported, in seconds. Default value is 24h.
+    u64 state_duration_cap;
 };
 
 /// QoS configuration options


### PR DESCRIPTION
### Problem
Analytics may be skewed by sessions being forcibly reported after 24h, which is the default time limit, and POs want to make the time limit configurable

### Solution
Add `state_duration_cap` to nurse config and use it in nurse


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
