### PR TITLE
[LLT-5394] Shutdown libtelio upon tests shutdown

### DIFF
--- a/nat-lab/tests/uniffi/libtelio_remote.py
+++ b/nat-lab/tests/uniffi/libtelio_remote.py
@@ -101,6 +101,8 @@ class LibtelioWrapper:
         libtelio.set_global_logger(libtelio.TelioLogLevel.DEBUG, self._logger_cb)
 
     def shutdown(self):
+        if self._libtelio is not None:
+            self._libtelio.shutdown()
         self._daemon.shutdown()
 
     @serialize_error


### PR DESCRIPTION
### Problem
Libtelio instance is not shutdown upon test cleanup. This PR updates the `libtelio_remote.py` shutdown method to include libtelio shutdown. 

Additionally it adds a little bit of logging upon test cleanup to show in more detail what is happening at that time.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
