### PR TITLE
[LLT-5180] Fix lana Meshnet ID fetching

### DIFF
--- a/crates/telio-nurse/src/nurse.rs
+++ b/crates/telio-nurse/src/nurse.rs
@@ -346,7 +346,7 @@ impl State {
 
     fn meshnet_id() -> Uuid {
         telio_lana::fetch_context_string(String::from(
-            "context.application.libtelioapp.config.current_state.internal_meshnet.fp",
+            "application.libtelioapp.config.current_state.internal_meshnet.fp",
         ))
         .map(|fp| {
             Uuid::parse_str(&fp).unwrap_or_else(|_| {

--- a/nat-lab/tests/test_lana.py
+++ b/nat-lab/tests/test_lana.py
@@ -1883,9 +1883,6 @@ async def test_lana_with_second_node_joining_later_meshnet_id_can_change(
 
 @pytest.mark.moose
 @pytest.mark.asyncio
-@pytest.mark.skip(
-    reason="Test does not do what it's supposed to - JIRA issue: LLT-5180"
-)
 @pytest.mark.parametrize("alpha_ip_stack,beta_ip_stack", IP_STACK_TEST_CONFIGS)
 async def test_lana_same_meshnet_id_is_reported_after_a_restart(
     alpha_ip_stack: IPStack, beta_ip_stack: IPStack
@@ -1928,10 +1925,10 @@ async def test_lana_same_meshnet_id_is_reported_after_a_restart(
 
         await client_beta.trigger_event_collection()
         beta_events = await wait_for_event_dump(
-            ConnectionTag.DOCKER_CONE_CLIENT_2, BETA_EVENTS_PATH, nr_events=2
+            ConnectionTag.DOCKER_CONE_CLIENT_2, BETA_EVENTS_PATH, nr_events=3
         )
         assert beta_events
-        second_beta_meshnet_id = beta_events[0].fp
+        second_beta_meshnet_id = beta_events[2].fp
 
         assert initial_beta_meshnet_id == second_beta_meshnet_id
 


### PR DESCRIPTION
### Problem
Meshnet ID isn't properly fetched from Moose context and thus Telio changes it on rerun. There is a test which is supposed to test it but it doesn't work.

### Solution
Fix the Meshnet ID fetching and the corresponding test.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
