### PR TITLE
LLT-5339: Session Keeper ping packet batching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4229,6 +4229,7 @@ dependencies = [
  "slog-async",
  "slog-term",
  "smart-default",
+ "telio-batcher",
  "telio-crypto",
  "telio-dns",
  "telio-firewall",
@@ -4256,6 +4257,17 @@ dependencies = [
  "uuid",
  "winapi",
  "winres",
+]
+
+[[package]]
+name = "telio-batcher"
+version = "0.1.0"
+dependencies = [
+ "futures",
+ "telio-utils",
+ "thiserror",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -4627,6 +4639,7 @@ dependencies = [
  "strum",
  "stun_codec",
  "surge-ping",
+ "telio-batcher",
  "telio-crypto",
  "telio-model",
  "telio-nurse",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ telio-nat-detect.workspace = true
 telio-nurse.workspace = true
 telio-pmtu.workspace = true
 telio-proto.workspace = true
+telio-batcher.workspace = true
 telio-proxy.workspace = true
 telio-pq.workspace = true
 telio-relay.workspace = true
@@ -84,6 +85,7 @@ tokio = { workspace = true, features = ["test-util"] }
 telio-dns = { workspace = true, features = ["mockall"] }
 telio-firewall = { workspace = true, features = ["mockall"] }
 telio-proxy = { workspace = true, features = ["mockall"] }
+telio-batcher = { workspace = true }
 telio-pq = { workspace = true, features = ["mockall"] }
 telio-test.workspace = true
 telio-traversal = { workspace = true, features = ["mockall"] }
@@ -169,6 +171,7 @@ windows = { version = "0.56", features = [
 boringtun = { git = "https://github.com/NordSecurity/boringtun.git", tag = "v1.2.6", features = ["device"] }
 x25519-dalek = { version = "2.0.1", features = ["reusable_secrets", "static_secrets"] }
 
+
 telio-crypto = { version = "0.1.0", path = "./crates/telio-crypto" }
 telio-dns = { version = "0.1.0", path = "./crates/telio-dns" }
 telio-firewall = { version = "0.1.0", path = "./crates/telio-firewall" }
@@ -177,6 +180,7 @@ telio-model = { version = "0.1.0", path = "./crates/telio-model" }
 telio-nat-detect = { version = "0.1.0", path = "./crates/telio-nat-detect" }
 telio-nurse = { version = "0.1.0", path = "./crates/telio-nurse" }
 telio-proto = { version = "0.1.0", path = "./crates/telio-proto" }
+telio-batcher = { version = "0.1.0", path = "./crates/telio-batcher" }
 telio-proxy = { version = "0.1.0", path = "./crates/telio-proxy" }
 telio-relay = { version = "0.1.0", path = "./crates/telio-relay" }
 telio-sockets = { version = "0.1.0", path = "./crates/telio-sockets" }

--- a/crates/telio-batcher/Cargo.toml
+++ b/crates/telio-batcher/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "telio-batcher"
+version = "0.1.0"
+edition = "2021"
+license = "GPL-3.0-only"
+repository = "https://github.com/NordSecurity/libtelio"
+publish = false
+
+[dependencies]
+tokio = { workspace = true, features = ["net", "sync", "test-util"] }
+telio-utils.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
+futures.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["time", "rt", "macros", "test-util"] }

--- a/crates/telio-batcher/src/batcher.rs
+++ b/crates/telio-batcher/src/batcher.rs
@@ -1,0 +1,416 @@
+use futures::future::BoxFuture;
+use std::fmt::Debug;
+use std::hash::Hash;
+use std::{collections::HashMap, sync::Arc};
+
+use telio_utils::telio_log_debug;
+use tokio::time::sleep_until;
+
+type Action<V, R = std::result::Result<(), ()>> =
+    Arc<dyn for<'a> Fn(&'a mut V) -> BoxFuture<'a, R> + Sync + Send>;
+
+pub struct Batcher<K, V> {
+    actions: HashMap<K, (BatchEntry, Action<V>)>,
+    notify_add: tokio::sync::Notify,
+}
+
+struct BatchEntry {
+    deadline: tokio::time::Instant,
+    interval: std::time::Duration,
+    threshold: std::time::Duration,
+}
+
+impl<K, V> Default for Batcher<K, V>
+where
+    K: Eq + Hash + Send + Sync + Debug + Clone,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<K, V> Batcher<K, V>
+where
+    K: Eq + Hash + Send + Sync + Debug + Clone,
+{
+    pub fn new() -> Self {
+        Self {
+            actions: HashMap::new(),
+            notify_add: tokio::sync::Notify::new(),
+        }
+    }
+
+    /// Batching works by sleeping until the nearest future and then trying to batch more actions
+    /// based on the threshold value. Higher delay before calling the function will increase the chances of batching
+    /// because the deadlines will _probably_ be in the past already.
+    /// Adding a new action wakes up the batcher due to immediate trigger of the action.
+    pub async fn get_actions(&mut self) -> Vec<(K, Action<V>)> {
+        let mut batched_actions: Vec<(K, Action<V>)> = vec![];
+
+        loop {
+            if !self.actions.is_empty() {
+                let actions = &mut self.actions;
+
+                // TODO: This can be optimized by early breaking and precollecting items beforehand
+                if let Some(closest_entry) = actions.values().min_by_key(|entry| entry.0.deadline) {
+                    tokio::select! {
+                        _ = self.notify_add.notified() => {
+                            // Item was added, we need to immediately emit it
+                        }
+                        _ = sleep_until(closest_entry.0.deadline) => {
+                            // Closest action should now be emitted
+                        }
+                    }
+
+                    let now = tokio::time::Instant::now();
+                    // at this point in time we know we're at the earliest spot for batching, thus we can check if we have more actions to add
+                    for (key, action) in actions.iter_mut() {
+                        let adjusted_action_deadline = now + action.0.threshold;
+
+                        if action.0.deadline <= adjusted_action_deadline {
+                            action.0.deadline = now + action.0.interval;
+                            batched_actions.push((key.clone(), action.1.clone()));
+                        }
+                    }
+                }
+
+                return batched_actions;
+            } else {
+                let _ = self.notify_add.notified().await;
+            }
+        }
+    }
+
+    /// Remove batcher action. Action is no longer eligible for batching
+    pub fn remove(&mut self, key: &K) {
+        telio_log_debug!("removing item from batcher with key({:?})", key);
+        self.actions.remove(key);
+    }
+
+    /// Add batcher action. Batcher itself doesn't run the tasks and depends
+    /// on actions being manually invoked. Adding an action immediately triggers it
+    /// thus if the call site awaits for the future then it will resolve immediately after this
+    /// function call.
+    pub fn add(
+        &mut self,
+        key: K,
+        interval: std::time::Duration,
+        threshold: std::time::Duration,
+        action: Action<V>,
+    ) {
+        telio_log_debug!(
+            "adding item to batcher with key({:?}), interval({:?}), threshold({:?})",
+            key,
+            interval,
+            threshold,
+        );
+        let entry = BatchEntry {
+            deadline: tokio::time::Instant::now(),
+            interval,
+            threshold,
+        };
+
+        self.actions.insert(key, (entry, action));
+        self.notify_add.notify_waiters();
+    }
+}
+
+/// Tests provide near-perfect immediate sleeps due to how tokio runtime acts when it's paused(basically sleeps are resolved immediately)
+#[cfg(test)]
+mod tests {
+
+    pub struct TestChecker {
+        values: Vec<(String, tokio::time::Instant)>,
+    }
+
+    use std::{sync::Arc, time::Duration};
+
+    use crate::batcher::Batcher;
+
+    #[tokio::test(start_paused = true)]
+    async fn batch_one() {
+        let start_time = tokio::time::Instant::now();
+        let mut batcher = Batcher::<String, TestChecker>::new();
+        batcher.add(
+            "key".to_owned(),
+            Duration::from_secs(100),
+            Duration::from_secs(0),
+            Arc::new(|s: _| {
+                Box::pin(async move {
+                    s.values
+                        .push(("key".to_owned(), tokio::time::Instant::now()));
+                    Ok(())
+                })
+            }),
+        );
+
+        let mut test_checker = TestChecker { values: Vec::new() };
+
+        // pick up the immediate fire
+        for ac in batcher.get_actions().await {
+            ac.1(&mut test_checker).await.unwrap();
+        }
+        assert!(test_checker.values.len() == 1);
+
+        // pick up the second event
+        for ac in batcher.get_actions().await {
+            ac.1(&mut test_checker).await.unwrap();
+        }
+
+        assert!(test_checker.values.len() == 2);
+
+        assert!(test_checker.values[0].1.duration_since(start_time) == Duration::from_secs(0));
+        assert!(test_checker.values[1].1.duration_since(start_time) == Duration::from_secs(100));
+
+        // after a pause of retrieving actions there will be a delay in signals as well as they are not active on their own
+        tokio::time::advance(Duration::from_secs(550)).await;
+        assert!(test_checker.values.len() == 2);
+
+        for ac in batcher.get_actions().await {
+            ac.1(&mut test_checker).await.unwrap();
+        }
+
+        assert!(test_checker.values.len() == 3);
+        assert!(test_checker.values[2].1.duration_since(start_time) == Duration::from_secs(650));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn batch_two_with_threshold_and_delay() {
+        let start_time = tokio::time::Instant::now();
+        let mut batcher = Batcher::<String, TestChecker>::new();
+        batcher.add(
+            "key0".to_owned(),
+            Duration::from_secs(100),
+            Duration::from_secs(50),
+            Arc::new(|s: _| {
+                Box::pin(async move {
+                    s.values
+                        .push(("key0".to_owned(), tokio::time::Instant::now()));
+                    Ok(())
+                })
+            }),
+        );
+
+        tokio::time::advance(Duration::from_secs(30)).await;
+
+        batcher.add(
+            "key1".to_owned(),
+            Duration::from_secs(100),
+            Duration::from_secs(50),
+            Arc::new(|s: _| {
+                Box::pin(async move {
+                    s.values
+                        .push(("key1".to_owned(), tokio::time::Instant::now()));
+                    Ok(())
+                })
+            }),
+        );
+
+        // At this point there are two actions added, one at t(0) and another at t(30).
+        let mut test_checker = TestChecker { values: Vec::new() };
+
+        // pick up the immediate fires
+        for ac in batcher.get_actions().await {
+            ac.1(&mut test_checker).await.unwrap();
+        }
+        assert!(test_checker.values.len() == 2);
+
+        // Do again and batching should be in action since the threshold of the second signal is bigger(50) than the delay between the packets(30)
+        for ac in batcher.get_actions().await {
+            ac.1(&mut test_checker).await.unwrap();
+        }
+
+        assert!(test_checker.values.len() == 4);
+
+        let key0_entries: Vec<tokio::time::Duration> = test_checker
+            .values
+            .iter()
+            .filter(|e| e.0 == "key0")
+            .map(|e| e.1.duration_since(start_time))
+            .collect();
+        let key1_entries: Vec<tokio::time::Duration> = test_checker
+            .values
+            .iter()
+            .filter(|e| e.0 == "key1")
+            .map(|e| e.1.duration_since(start_time))
+            .collect();
+
+        // Immediate fires were supressed because we need to poll them and we did so only after 30seconds
+        // Thus everything will be aligned at 30seconds
+
+        assert!(key0_entries[0] == Duration::from_secs(30));
+        assert!(key1_entries[0] == Duration::from_secs(30));
+
+        assert!(key0_entries[1] == Duration::from_secs(130));
+        assert!(key1_entries[1] == Duration::from_secs(130));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn batch_two_no_threshold_delayed_check() {
+        let _start_time = tokio::time::Instant::now();
+        let mut batcher = Batcher::<String, TestChecker>::new();
+        batcher.add(
+            "key0".to_owned(),
+            Duration::from_secs(100),
+            Duration::from_secs(0),
+            Arc::new(|s: _| {
+                Box::pin(async move {
+                    s.values
+                        .push(("key0".to_owned(), tokio::time::Instant::now()));
+                    Ok(())
+                })
+            }),
+        );
+
+        tokio::time::advance(Duration::from_secs(30)).await;
+
+        batcher.add(
+            "key1".to_owned(),
+            Duration::from_secs(100),
+            Duration::from_secs(0),
+            Arc::new(|s: _| {
+                Box::pin(async move {
+                    s.values
+                        .push(("key1".to_owned(), tokio::time::Instant::now()));
+                    Ok(())
+                })
+            }),
+        );
+
+        // At this point there are two actions added, one at t(0) and another at t(30).
+        let mut test_checker = TestChecker { values: Vec::new() };
+
+        // pick up the immediate fire
+        for ac in batcher.get_actions().await {
+            ac.1(&mut test_checker).await.unwrap();
+        }
+        assert!(
+            test_checker.values.len() == 2,
+            "Both actions should be emitted immediately"
+        );
+
+        for ac in batcher.get_actions().await {
+            ac.1(&mut test_checker).await.unwrap();
+        }
+
+        assert!(test_checker.values.len() == 4, "Even though there was no threshold and actions were added at different times, we query only after adding the second one which resets both deadlines and aligns them");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn batch_two_no_threshold_nodelay_check() {
+        let start_time = tokio::time::Instant::now();
+        let mut batcher = Batcher::<String, TestChecker>::new();
+        batcher.add(
+            "key0".to_owned(),
+            Duration::from_secs(100),
+            Duration::from_secs(0),
+            Arc::new(|s: _| {
+                Box::pin(async move {
+                    s.values
+                        .push(("key0".to_owned(), tokio::time::Instant::now()));
+                    Ok(())
+                })
+            }),
+        );
+
+        let mut test_checker = TestChecker { values: Vec::new() };
+        // pick up the immediate fire
+        for ac in batcher.get_actions().await {
+            ac.1(&mut test_checker).await.unwrap();
+        }
+        assert!(test_checker.values.len() == 1);
+
+        tokio::time::advance(Duration::from_secs(30)).await;
+
+        batcher.add(
+            "key1".to_owned(),
+            Duration::from_secs(100),
+            Duration::from_secs(0),
+            Arc::new(|s: _| {
+                Box::pin(async move {
+                    s.values
+                        .push(("key1".to_owned(), tokio::time::Instant::now()));
+                    Ok(())
+                })
+            }),
+        );
+
+        // pick up the immediate fire from the second action
+        for ac in batcher.get_actions().await {
+            ac.1(&mut test_checker).await.unwrap();
+        }
+        assert!(test_checker.values.len() == 2);
+
+        for ac in batcher.get_actions().await {
+            ac.1(&mut test_checker).await.unwrap();
+        }
+
+        assert!(
+            test_checker.values.len() == 3,
+            "No threshold but a delay was given, thus one signal should have resolved"
+        );
+
+        test_checker.values = vec![];
+        for _ in 0..12 {
+            for ac in batcher.get_actions().await {
+                ac.1(&mut test_checker).await.unwrap();
+            }
+        }
+
+        let key0sum: tokio::time::Duration = test_checker
+            .values
+            .iter()
+            .filter(|e| e.0 == "key0")
+            .map(|e| e.1.duration_since(start_time))
+            .collect::<Vec<Duration>>()
+            .windows(2)
+            .map(|w| w[1] - w[0])
+            .sum();
+
+        let key1sum: tokio::time::Duration = test_checker
+            .values
+            .iter()
+            .filter(|e| e.0 == "key1")
+            .map(|e| e.1.duration_since(start_time))
+            .collect::<Vec<Duration>>()
+            .windows(2)
+            .map(|w| w[1] - w[0])
+            .sum();
+
+        // Because of misalignment, each call produces only one action instead of both
+        assert!(key0sum == Duration::from_secs(500));
+        assert!(key1sum == Duration::from_secs(500));
+
+        // Now let's wait a bit so upon iterating again signals would be aligned
+        test_checker.values = vec![];
+        tokio::time::advance(tokio::time::Duration::from_secs(500)).await;
+        for _i in 0..11 {
+            for ac in batcher.get_actions().await {
+                ac.1(&mut test_checker).await.unwrap();
+            }
+        }
+
+        let key0sum: tokio::time::Duration = test_checker
+            .values
+            .iter()
+            .filter(|e| e.0 == "key0")
+            .map(|e| e.1.duration_since(start_time))
+            .collect::<Vec<Duration>>()
+            .windows(2)
+            .map(|w| w[1] - w[0])
+            .sum();
+
+        let key1sum: tokio::time::Duration = test_checker
+            .values
+            .iter()
+            .filter(|e| e.0 == "key1")
+            .map(|e| e.1.duration_since(start_time))
+            .collect::<Vec<Duration>>()
+            .windows(2)
+            .map(|w| w[1] - w[0])
+            .sum();
+
+        assert!(key0sum == Duration::from_secs(1000));
+        assert!(key1sum == Duration::from_secs(1000));
+    }
+}

--- a/crates/telio-batcher/src/lib.rs
+++ b/crates/telio-batcher/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod batcher;

--- a/crates/telio-model/src/features.rs
+++ b/crates/telio-model/src/features.rs
@@ -54,6 +54,17 @@ pub struct Features {
     pub pmtu_discovery: Option<FeaturePmtuDiscovery>,
     /// Multicast support
     pub multicast: bool,
+    /// Batching feature configuration, disabled by default, used for batching keep-alives
+    pub batching: Option<FeatureBatching>,
+}
+
+/// Configure keepalive batching
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, SmartDefault)]
+#[serde(default)]
+pub struct FeatureBatching {
+    /// Direct connection threshold when batching (in seconds) [default 0s]
+    #[default(0)]
+    pub direct_connection_threshold: u32,
 }
 
 /// Configurable features for Wireguard peers
@@ -487,7 +498,10 @@ mod tests {
             "pmtu_discovery": {
                 "response_wait_timeout_s": 20
             },
-            "multicast": true
+            "multicast": true,
+            "batching": {
+                "direct_connection_threshold": 60
+            }
         }
         "#;
             let actual = from_str::<Features>(json).unwrap();
@@ -569,6 +583,9 @@ mod tests {
                     response_wait_timeout_s: 20,
                 }),
                 multicast: true,
+                batching: Some(FeatureBatching {
+                    direct_connection_threshold: 60,
+                }),
             };
 
             assert_eq!(actual, expected);

--- a/crates/telio-traversal/Cargo.toml
+++ b/crates/telio-traversal/Cargo.toml
@@ -32,6 +32,7 @@ surge-ping.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["full"] }
 
+telio-batcher.workspace = true
 telio-crypto.workspace = true
 telio-model.workspace = true
 telio-nurse.workspace = true

--- a/nat-lab/tests/conftest.py
+++ b/nat-lab/tests/conftest.py
@@ -58,6 +58,7 @@ def event_loop():
             loop.close()
 
 
+# Keep in mind that Windows can consider the filesize too big if parameters are not stripped
 def pytest_make_parametrize_id(config, val):
     param_id = ""
     if isinstance(val, (List, Tuple)):
@@ -75,6 +76,9 @@ def pytest_make_parametrize_id(config, val):
         ):
             for provider in val.features.direct.providers:
                 param_id += f"-{provider}"
+
+        if val.features.batching is not None:
+            param_id += f"-{str(val.features.batching).replace('direct_connection_threshold', 'dir').replace('Batching', 'Batch')}"
     elif isinstance(val, (ConnectionTag,)):
         param_id = val.name.removeprefix("DOCKER_")
     elif isinstance(val, (AdapterType,)):

--- a/nat-lab/tests/telio_features.py
+++ b/nat-lab/tests/telio_features.py
@@ -77,6 +77,12 @@ class Nurse(DataClassJsonMixin):
 
 @dataclass_json(undefined=Undefined.EXCLUDE)
 @dataclass
+class Batching(DataClassJsonMixin):
+    direct_connection_threshold: int = 0
+
+
+@dataclass_json(undefined=Undefined.EXCLUDE)
+@dataclass
 class LinkDetection(DataClassJsonMixin):
     rtt_seconds: Optional[int] = None
     no_of_pings: Optional[int] = 0
@@ -144,3 +150,4 @@ class TelioFeatures(DataClassJsonMixin):
         )
     )
     multicast: bool = False
+    batching: Optional[Batching] = None

--- a/nat-lab/tests/test_features_builder.py
+++ b/nat-lab/tests/test_features_builder.py
@@ -59,6 +59,7 @@ def test_telio_features_builder_all_defaults():
         .enable_multicast()
         .enable_ipv6()
         .enable_nicknames()
+        .enable_batching()
         .build()
     )
     json = """
@@ -87,7 +88,10 @@ def test_telio_features_builder_all_defaults():
         "flush_events_on_stop_timeout_seconds": 0,
         "multicast": true,
         "ipv6": true,
-        "nicknames": true
+        "nicknames": true,
+        "batching": {
+            "direct_connection_threshold": 0
+        }
     }
     """
     expect = deserialize_feature_config(json)

--- a/src/device.rs
+++ b/src/device.rs
@@ -21,17 +21,20 @@ use telio_task::{
     io::{chan, mc_chan, mc_chan::Tx, Chan, McChan},
     task_exec, BoxAction, Runtime as TaskRuntime, Task,
 };
+use telio_traversal::SessionKeeperTrait;
 use telio_traversal::{
     connectivity_check,
     cross_ping_check::{CrossPingCheck, CrossPingCheckTrait, Io as CpcIo, UpgradeController},
     endpoint_providers::{
-        self, local::LocalInterfacesEndpointProvider, stun::StunEndpointProvider, stun::StunServer,
-        upnp::UpnpEndpointProvider, EndpointProvider,
+        self,
+        local::LocalInterfacesEndpointProvider,
+        stun::{StunEndpointProvider, StunServer},
+        upnp::UpnpEndpointProvider,
+        EndpointProvider,
     },
     last_rx_time_provider::{TimeSinceLastRxProvider, WireGuardTimeSinceLastRxProvider},
     ping_pong_handler::PingPongHandler,
-    SessionKeeper, SessionKeeperTrait, UpgradeRequestChangeEvent, UpgradeSync,
-    WireGuardEndpointCandidateChangeEvent,
+    SessionKeeper, UpgradeRequestChangeEvent, UpgradeSync, WireGuardEndpointCandidateChangeEvent,
 };
 
 #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
@@ -958,6 +961,7 @@ impl MeshnetEntities {
                 }
             }}
         }
+
         macro_rules! stop_arc_entity {
             ($entity: expr, $name: expr) => {{
                 stop_entity!(Arc::try_unwrap($entity), $name)
@@ -987,6 +991,7 @@ impl MeshnetEntities {
 
         stop_arc_entity!(self.multiplexer, "Multiplexer");
         stop_arc_entity!(self.derp, "Derp");
+
         let endpoint_map = self.proxy.get_endpoint_map().await.unwrap_or_default();
         stop_arc_entity!(self.proxy, "UdpProxy");
         if let Some(starcast) = self.starcast {

--- a/src/ffi/defaults_builder.rs
+++ b/src/ffi/defaults_builder.rs
@@ -33,6 +33,7 @@ impl FeaturesDefaultsBuilder {
             multicast: false,
             ipv6: false,
             nicknames: false,
+            batching: None,
         };
 
         Self {
@@ -131,6 +132,11 @@ impl FeaturesDefaultsBuilder {
     /// Eanable multicast with defaults
     pub fn enable_multicast(self: Arc<Self>) -> Arc<Self> {
         self.config.lock().multicast = true;
+        self
+    }
+
+    pub fn enable_batching(self: Arc<Self>) -> Arc<Self> {
+        self.config.lock().batching = Some(default());
         self
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,9 @@ pub use ffi::types as ffi_types;
 pub mod device;
 
 /// cbindgen:ignore
+pub use telio_batcher as batcher;
+
+/// cbindgen:ignore
 pub use telio_crypto as crypto;
 
 /// cbindgen:ignore
@@ -245,7 +248,7 @@ mod uniffi_libtelio {
         #[case(SecretKey::gen().public())]
         #[case(SecretKey::gen().public())]
         fn test_public_key_conversion(#[case] key: PublicKey) {
-            let serialized = PublicKey::from_custom(key.clone());
+            let serialized = PublicKey::from_custom(key);
             let deserialized = PublicKey::into_custom(serialized).unwrap();
 
             assert_eq!(deserialized, key);
@@ -255,7 +258,7 @@ mod uniffi_libtelio {
         #[case(SecretKey::gen())]
         #[case(SecretKey::gen())]
         fn test_secret_key_conversion(#[case] key: SecretKey) {
-            let serialized = SecretKey::from_custom(key.clone());
+            let serialized = SecretKey::from_custom(key);
             let deserialized = SecretKey::into_custom(serialized).unwrap();
 
             assert_eq!(deserialized, key);

--- a/src/libtelio.udl
+++ b/src/libtelio.udl
@@ -506,6 +506,10 @@ interface FeaturesDefaultsBuilder {
     /// Eanable multicast with defaults
     [Self=ByArc]
     FeaturesDefaultsBuilder enable_multicast();
+
+    /// Enable keepalive batching feature
+    [Self=ByArc]
+    FeaturesDefaultsBuilder enable_batching();
 };
 
 
@@ -545,6 +549,13 @@ dictionary Features {
     FeaturePmtuDiscovery? pmtu_discovery;
     /// Multicast support
     boolean multicast;
+    /// Batching
+    FeatureBatching? batching;
+};
+
+dictionary FeatureBatching {
+    /// direct connection threshold for batching
+    u32 direct_connection_threshold;
 };
 
 /// Configurable features for Wireguard peers


### PR DESCRIPTION
### Problem
According to empirical testing and some research it appears that sending more data at once is beneficial to battery instead of sending sporadically.

### Solution
- SessionKeeper is modified to hold both `RepeatedActions` and `Batcher` instances and uses each one depending on the passed enum parameter. This is done for safety so the chances of problems introduced.

Having no batcher option should not ever trigger it.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
