### PR TITLE
[LLT-5421] Remove rupnp crate from Telio

### DIFF
--- a/.unreleased/LLT-5124
+++ b/.unreleased/LLT-5124
@@ -1,0 +1,1 @@
+Remove unneeded rupnp crate

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -905,7 +905,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16182b4f39a82ec8a6851155cc4c0cda3065bb1db33651726a29e1951de0f009"
 dependencies = [
  "aead",
- "chacha20",
  "crypto_secretbox",
  "curve25519-dalek",
  "salsa20",
@@ -920,7 +919,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d6cf87adf719ddf43a805e92c6870a531aedda35ff640442cbaf8674e141e1"
 dependencies = [
  "aead",
- "chacha20",
  "cipher",
  "generic-array",
  "poly1305",
@@ -1571,22 +1569,6 @@ dependencies = [
  "pin-utils",
  "slab",
 ]
-
-[[package]]
-name = "genawaiter"
-version = "0.99.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c86bd0361bcbde39b13475e6e36cb24c329964aa2611be285289d1e4b751c1a0"
-dependencies = [
- "futures-core",
- "genawaiter-macro",
-]
-
-[[package]]
-name = "genawaiter-macro"
-version = "0.99.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b32dfe1fdfc0bbde1f22a5da25355514b5e450c33a6af6770884c8750aedfbc"
 
 [[package]]
 name = "generator"
@@ -3339,15 +3321,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "roxmltree"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf7d7b1ea646d380d0e8153158063a6da7efe30ddbf3184042848e3f8a6f671"
-dependencies = [
- "xmlparser",
-]
-
-[[package]]
 name = "rstest"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3358,21 +3331,6 @@ dependencies = [
  "quote 1.0.36",
  "rustc_version",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "rupnp"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290615ea804135942e0c3df3ed65ac1a4922b476c78534cc28686f6517aa8a55"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-util",
- "http",
- "hyper",
- "roxmltree",
- "ssdp-client",
 ]
 
 [[package]]
@@ -3944,18 +3902,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d4f0e86297cad2658d92a707320d87bf4e6ae1050287f51d19b67ef3f153a7b"
 dependencies = [
  "lock_api",
-]
-
-[[package]]
-name = "ssdp-client"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3798796e3e9e5d212cc4a70401cef6cd3796856715b97281263b775fc0c5dc8a"
-dependencies = [
- "futures-core",
- "genawaiter",
- "log",
- "tokio",
 ]
 
 [[package]]
@@ -4624,7 +4570,6 @@ dependencies = [
  "parking_lot",
  "rand",
  "rstest",
- "rupnp",
  "sm",
  "socket2 0.5.7",
  "strum",
@@ -5786,12 +5731,6 @@ name = "xml-rs"
 version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "791978798f0597cfc70478424c2b4fdc2b7a8024aaff78497ef00f24ef674193"
-
-[[package]]
-name = "xmlparser"
-version = "0.13.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "xmltree"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,7 @@ base64 = "0.13.0"
 bytes = "1"
 cc = "1.0"
 clap = { version = "3.1", features = ["derive"] }
-crypto_box = { version = "0.9.1", features = ["std", "chacha20"]}
+crypto_box = { version = "0.9.1", features = ["std"] }
 env_logger = "0.9.0"
 futures = "0.3"
 hashlink = "0.8.3"
@@ -134,7 +134,6 @@ proptest-derive = "0.3.0"
 protobuf-codegen-pure = "2"
 rand = "0.8"
 rstest = "0.11.0"
-rupnp = { version = "1.1.0", default-features = false }
 rustc-hash = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/telio-relay/src/derp.rs
+++ b/crates/telio-relay/src/derp.rs
@@ -10,8 +10,6 @@
 pub mod http;
 pub mod proto;
 
-use mockall_double::double;
-
 use async_trait::async_trait;
 use futures::{future::select_all, Future};
 use generic_array::typenum::Unsigned;
@@ -25,7 +23,7 @@ use telio_model::{
     config::{RelayState, Server},
     features::FeatureDerp,
 };
-#[double]
+#[mockall_double::double]
 use telio_nurse::aggregator::ConnectivityDataAggregator;
 use telio_proto::{
     Codec, DerpPollRequestMsg, PacketControl, PacketRelayed, PacketTypeRelayed, PeersStatesMap,

--- a/crates/telio-traversal/Cargo.toml
+++ b/crates/telio-traversal/Cargo.toml
@@ -26,7 +26,6 @@ tracing.workspace = true
 mockall = { workspace = true, optional = true }
 parking_lot.workspace = true
 rand.workspace = true
-rupnp.workspace = true
 socket2.workspace = true
 strum.workspace = true
 surge-ping.workspace = true

--- a/crates/telio-traversal/src/endpoint_providers.rs
+++ b/crates/telio-traversal/src/endpoint_providers.rs
@@ -36,8 +36,6 @@ pub enum Error {
     NoWGListenPort,
     #[error(transparent)]
     PacketParserError(#[from] telio_proto::CodecError),
-    #[error(transparent)]
-    UpnpError(#[from] rupnp::Error),
     #[error("Missing IGD gateway")]
     NoIGDGateway,
     #[error("The existing Upnp endpoint is invalid")]

--- a/crates/telio-traversal/src/endpoint_providers/upnp.rs
+++ b/crates/telio-traversal/src/endpoint_providers/upnp.rs
@@ -12,7 +12,6 @@ use igd::{
 };
 use ipnet::Ipv4Net;
 use rand::Rng;
-use rupnp::Error::HttpErrorCode;
 use std::fmt::Debug;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4};
 use std::pin::Pin;
@@ -515,13 +514,12 @@ impl<Wg: WireGuard, I: UpnpEpCommands, E: Backoff> State<Wg, I, E> {
                 }
             }
             Err(e) => {
-                if let Error::UpnpError(HttpErrorCode(http::StatusCode::INTERNAL_SERVER_ERROR)) = e
-                {
+                if let Error::NoIGDGateway = e {
                     telio_log_info!("Failed to check route: route does not exist")
                 } else {
                     telio_log_info!("Error: {}", e);
 
-                    telio_log_info!("Deleting a old Upnp endpoint");
+                    telio_log_info!("Deleting an old Upnp endpoint");
                     let detete = self.igd_gw.delete_endpoint_routes(
                         self.proxy_port_mapping.external,
                         self.wg_port_mapping.external,


### PR DESCRIPTION
### Problem
Crate `rupnp` seems to be used only for an error which should be unused anyway

### Solution
Remove it

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
