### PR TITLE
Revert port mapping improvement

### DIFF
--- a/nat-lab/docker-compose.yml
+++ b/nat-lab/docker-compose.yml
@@ -72,7 +72,7 @@ services:
       cone-net-01:
         ipv4_address: 192.168.101.104
     ports:
-      - "8081"
+      - "58001:58001"
     ulimits:
       core:
         soft: -1
@@ -96,7 +96,7 @@ services:
       cone-net-02:
         ipv4_address: 192.168.102.54
     ports:
-      - "8082"
+      - "58002:58002"
     environment:
       CLIENT_GATEWAY_PRIMARY: 192.168.102.254
   # Client that shares two cone networks on different interfaces
@@ -109,7 +109,7 @@ services:
       cone-net-05:
         ipv4_address: 192.168.113.67
     ports:
-      - "8083"
+      - "58003:58003"
     environment:
       CLIENT_GATEWAY_PRIMARY: 192.168.101.254
       CLIENT_GATEWAY_SECONDARY: 192.168.113.254
@@ -122,7 +122,7 @@ services:
       internet:
         ipv4_address: 10.0.11.2
     ports:
-      - "8084"
+      - "58004:58004"
     environment:
       CLIENT_GATEWAY_PRIMARY: none
   open-internet-client-02:
@@ -132,7 +132,7 @@ services:
       internet:
         ipv4_address: 10.0.11.3
     ports:
-      - "8085"
+      - "58005:58005"
     environment:
       CLIENT_GATEWAY_PRIMARY: none
   # Open internet client used on ipv6 tests
@@ -144,7 +144,7 @@ services:
         ipv4_address: 10.0.11.4
         ipv6_address: 2001:db8:85a4::dead:beef:ceed
     ports:
-      - "8086"
+      - "58006:58006"
     environment:
       CLIENT_GATEWAY_PRIMARY: none
     extra_hosts:
@@ -161,7 +161,7 @@ services:
       fullcone-net-01:
         ipv4_address: 192.168.109.88
     ports:
-      - "8087"
+      - "58007:58007"
     environment:
       CLIENT_GATEWAY_PRIMARY: 192.168.109.254
   fullcone-client-02:
@@ -171,7 +171,7 @@ services:
       fullcone-net-02:
         ipv4_address: 192.168.106.88
     ports:
-      - "8088"
+      - "58008:58008"
     environment:
       CLIENT_GATEWAY_PRIMARY: 192.168.106.254
 
@@ -182,7 +182,7 @@ services:
       upnp-net-01:
         ipv4_address: 192.168.105.88
     ports:
-      - "8089"
+      - "58009:58009"
     environment:
       CLIENT_GATEWAY_PRIMARY: 192.168.105.254
   upnp-client-02:
@@ -192,7 +192,7 @@ services:
       upnp-net-02:
         ipv4_address: 192.168.112.88
     ports:
-      - "8090"
+      - "58010:58010"
     environment:
       CLIENT_GATEWAY_PRIMARY: 192.168.112.254
 
@@ -203,7 +203,7 @@ services:
       hsymmetric-net-01:
         ipv4_address: 192.168.103.88
     ports:
-      - "8091"
+      - "58011:58011"
     environment:
       CLIENT_GATEWAY_PRIMARY: 192.168.103.254
   symmetric-client-02:
@@ -213,7 +213,7 @@ services:
       hsymmetric-net-02:
         ipv4_address: 192.168.104.88
     ports:
-      - "8092"
+      - "58012:58012"
     environment:
       CLIENT_GATEWAY_PRIMARY: 192.168.104.254
   internal-symmetric-client-01:
@@ -226,7 +226,7 @@ services:
       hsymmetric-internal-net-01:
         ipv4_address: 192.168.114.88
     ports:
-      - "8093"
+      - "58013:58013"
 
   udp-block-client-01:
     hostname: udp-block-client-01
@@ -235,7 +235,7 @@ services:
       udp-block-net-01:
         ipv4_address: 192.168.110.100
     ports:
-      - "8094"
+      - "58014:58014"
     environment:
       CLIENT_GATEWAY_PRIMARY: 192.168.110.254
   udp-block-client-02:
@@ -245,7 +245,7 @@ services:
       udp-block-net-02:
         ipv4_address: 192.168.111.100
     ports:
-      - "8095"
+      - "58015:58015"
     environment:
       CLIENT_GATEWAY_PRIMARY: 192.168.111.254
 


### PR DESCRIPTION
### Problem
CI started running into issues around the time the port mapping improvement was merged. It's unlikely that the port mapping change was the cause, but it's possible.

### Solution
Revert port mapping improvement and see if it solves the issue


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
