### PR TITLE
Bump to boringtun with more logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "boringtun"
 version = "0.6.0"
-source = "git+https://github.com/NordSecurity/boringtun.git?tag=v1.2.1#e79fb28784fa6b3416525c6298364afef0d94b95"
+source = "git+https://github.com/NordSecurity/boringtun.git?tag=v1.2.2#79b5790ca0e21a1c9294d0efee52f2d2ac6acbc5"
 dependencies = [
  "aead",
  "base64 0.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,7 +159,7 @@ windows = { version = "0.56", features = [
     "Win32_NetworkManagement_IpHelper",
 ] }
 
-boringtun = { git = "https://github.com/NordSecurity/boringtun.git", tag = "v1.2.1", features = ["device"] }
+boringtun = { git = "https://github.com/NordSecurity/boringtun.git", tag = "v1.2.2", features = ["device"] }
 x25519-dalek = { version = "2.0.1", features = ["reusable_secrets", "static_secrets"] }
 
 telio-crypto = { version = "0.1.0", path = "./crates/telio-crypto" }


### PR DESCRIPTION
### Problem
Need a new boringtun that logs details about ioctl failures

### Solution
bumped to v1.2.2

### Notes
did quick test, now if ioctl fails we will see something like:
```
ERROR boringtun::device::tun: 105: Failed to configure tunnel error=IOCtl(Os { code: 22, kind: InvalidInput, message: "Invalid argument" }) op="TUNSETIFF" name="pna_beta" flags="1101"
```


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
