### PR TITLE
LLT-5384: Handle non-UDP packets in telio-dns

### DIFF
--- a/.unreleased/LLT-5384
+++ b/.unreleased/LLT-5384
@@ -1,0 +1,1 @@
+Handle non-UDP packets more gracefully in telio-dns (UDP is still the only protocol we actually support for DNS)


### PR DESCRIPTION
### Problem
telio-dns only actually supports UDP packets, and while we don't intend to support any other protocol, we want to handle them more gracefully. 

### Solution
The logic for UDP packets remain unchanged, new logic is added for TCP packets so that telio-dns simply returns a TCP reset, and for other protocols we produce a silent error.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
