### PR TITLE
Fix Boringtun issues causing slower network speeds

### DIFF
--- a/.unreleased/LLT-5351
+++ b/.unreleased/LLT-5351
@@ -1,0 +1,1 @@
+Fix Boringtun issues resulting in ~50 times slower network speeds.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "boringtun"
 version = "0.6.0"
-source = "git+https://github.com/NordSecurity/boringtun.git?tag=v1.2.2#79b5790ca0e21a1c9294d0efee52f2d2ac6acbc5"
+source = "git+https://github.com/NordSecurity/boringtun.git?tag=v1.2.3#717a882950ea4727a7b5e45d906627c034cc91b1"
 dependencies = [
  "aead",
  "base64 0.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,7 +159,7 @@ windows = { version = "0.56", features = [
     "Win32_NetworkManagement_IpHelper",
 ] }
 
-boringtun = { git = "https://github.com/NordSecurity/boringtun.git", tag = "v1.2.2", features = ["device"] }
+boringtun = { git = "https://github.com/NordSecurity/boringtun.git", tag = "v1.2.3", features = ["device"] }
 x25519-dalek = { version = "2.0.1", features = ["reusable_secrets", "static_secrets"] }
 
 telio-crypto = { version = "0.1.0", path = "./crates/telio-crypto" }


### PR DESCRIPTION
### Problem

During testing it was detected that libtelio 5.0.x versions had ~50 times slower network speed than 4.x.y versions. The main change was that Boringtun had been rebased on a newer upstream branch and there were issues introduced in both the upstream code and during the rebase itself which resulted in connected sockets not working properly which in turn made boringtun default to using the listening socket for all communication.

### Solution

Fixed connected socket misconfigurations and a deadlock in the connected socket handler. These changes had been done on Nordsecurity/Boringtun repo and had already passed review. Besides that a unit test was added to prevent connected socket misconfigurations and an integration test is being added by another dev with LLT-253 to ensure that connected socket is working properly.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
