### PR TITLE
[LLT-5421] Cleanup hickory uses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1746,24 +1746,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hickory-client"
-version = "0.24.0"
-source = "git+https://github.com/NordSecurity/trust-dns.git?tag=v3.0.0#f3583ef082b448e808a492d034a2e30cda53dcdb"
-dependencies = [
- "cfg-if",
- "data-encoding",
- "futures-channel",
- "futures-util",
- "hickory-proto",
- "once_cell",
- "radix_trie",
- "rand",
- "thiserror",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "hickory-proto"
 version = "0.24.0"
 source = "git+https://github.com/NordSecurity/trust-dns.git?tag=v3.0.0#f3583ef082b448e808a492d034a2e30cda53dcdb"
@@ -4316,9 +4298,6 @@ dependencies = [
  "base64 0.13.1",
  "boringtun",
  "dns-parser",
- "hickory-client",
- "hickory-proto",
- "hickory-resolver",
  "hickory-server",
  "ipnetwork",
  "lazy_static",

--- a/crates/telio-dns/Cargo.toml
+++ b/crates/telio-dns/Cargo.toml
@@ -8,9 +8,6 @@ publish = false
 
 [dependencies]
 rand = { default-features = false, version = "0.8" }
-hickory-client = { git = "https://github.com/NordSecurity/trust-dns.git", tag = "v3.0.0" }
-hickory-proto = { git = "https://github.com/NordSecurity/trust-dns.git", tag = "v3.0.0" , default-features = false }
-hickory-resolver = { git = "https://github.com/NordSecurity/trust-dns.git", tag = "v3.0.0" , default-features = false }
 hickory-server = { git = "https://github.com/NordSecurity/trust-dns.git", tag = "v3.0.0", features = ["hickory-resolver"], default-features = false }
 async-trait.workspace = true
 base64.workspace = true

--- a/crates/telio-dns/src/forward.rs
+++ b/crates/telio-dns/src/forward.rs
@@ -9,17 +9,20 @@ use std::{
 };
 
 use async_trait::async_trait;
-use hickory_proto::rr::{LowerName, Name, RecordType};
-use hickory_proto::udp::DnsUdpSocket;
-use hickory_proto::{op::ResponseCode, rr::Record};
-use hickory_resolver::name_server::{GenericConnector, RuntimeProvider, TokioRuntimeProvider};
 use hickory_server::{
     authority::{
         Authority, LookupError, LookupObject, LookupOptions, MessageRequest, UpdateResult, ZoneType,
     },
-    proto::udp::UdpSocket as ProtoUdpSocket,
+    proto::{
+        op::ResponseCode,
+        rr::{LowerName, Name, Record, RecordType},
+        udp::{DnsUdpSocket, UdpSocket as ProtoUdpSocket},
+    },
     resolver::{
-        config::ResolverConfig, error::ResolveErrorKind, lookup::Lookup as ResolverLookup,
+        config::ResolverConfig,
+        error::ResolveErrorKind,
+        lookup::Lookup as ResolverLookup,
+        name_server::{GenericConnector, RuntimeProvider, TokioRuntimeProvider},
         AsyncResolver,
     },
     server::RequestInfo,

--- a/crates/telio-dns/src/nameserver.rs
+++ b/crates/telio-dns/src/nameserver.rs
@@ -4,10 +4,11 @@ use crate::{
 };
 use async_trait::async_trait;
 use boringtun::noise::{Tunn, TunnResult};
-use hickory_proto::rr::LowerName;
-use hickory_proto::serialize::binary::BinDecodable;
-use hickory_server::authority::MessageRequest;
-use hickory_server::server::{Protocol, Request};
+use hickory_server::{
+    authority::MessageRequest,
+    proto::{rr::LowerName, serialize::binary::BinDecodable},
+    server::{Protocol, Request},
+};
 use pnet_packet::{
     ip::IpNextHeaderProtocols,
     ipv4::{checksum, Ipv4Packet, MutableIpv4Packet},
@@ -566,13 +567,15 @@ impl NameServer for Arc<RwLock<LocalNameServer>> {
 #[cfg(test)]
 mod tests {
     use crate::zone::Records;
-    use hickory_proto::{
-        op::{Message, Query},
-        rr::Name,
-        serialize::binary::{BinDecodable, BinDecoder, BinEncodable},
+    use hickory_server::{
+        authority::MessageRequest,
+        proto::{
+            op::{Message, Query},
+            rr::Name,
+            serialize::binary::{BinDecodable, BinDecoder, BinEncodable},
+        },
+        server::Request,
     };
-    use hickory_server::authority::MessageRequest;
-    use hickory_server::server::Request;
     use std::{net::Ipv4Addr, str::FromStr};
 
     use super::*;

--- a/crates/telio-dns/src/resolver.rs
+++ b/crates/telio-dns/src/resolver.rs
@@ -1,6 +1,6 @@
-use hickory_proto::{rr::Record, serialize::binary::BinEncoder};
 use hickory_server::{
     authority::MessageResponse,
+    proto::{rr::Record, serialize::binary::BinEncoder},
     server::{ResponseHandler, ResponseInfo},
 };
 use std::io::{Error as IOError, Result as IOResult};

--- a/crates/telio-dns/src/zone.rs
+++ b/crates/telio-dns/src/zone.rs
@@ -1,12 +1,11 @@
 use async_trait::async_trait;
-use hickory_client::rr::{rdata::SOA, DNSClass, Name, RData, Record, RecordType};
-use hickory_proto::rr::{rdata, LowerName};
-use hickory_resolver::config::{NameServerConfigGroup, ResolverOpts};
 use hickory_server::{
     authority::{
         Authority, AuthorityObject, Catalog, LookupError, LookupOptions, MessageRequest,
         UpdateResult, ZoneType,
     },
+    proto::rr::{rdata, rdata::SOA, DNSClass, LowerName, Name, RData, Record, RecordType},
+    resolver::config::{NameServerConfigGroup, ResolverOpts},
     server::{Request, RequestInfo, ResponseHandler, ResponseInfo},
     store::{forwarder::ForwardConfig, in_memory::InMemoryAuthority},
 };


### PR DESCRIPTION
### Problem
The only hickory crate we need to use is hickory-server

### Solution
Rearrange imports and remove the other crates from `Cargo.toml` files

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
