### PR TITLE
Add tracing extra fields to logging callback

### DIFF
--- a/.unreleased/LLT-5430
+++ b/.unreleased/LLT-5430
@@ -1,0 +1,1 @@
+Additional information fields are now shown in logs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4281,6 +4281,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "tracing-subscriber",
  "uniffi",
  "uuid",
  "winapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ rand.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["full"] }
 tracing.workspace = true
+tracing-subscriber.workspace = true
 uniffi.workspace = true
 uuid.workspace = true
 

--- a/src/doc/integrating_telio.md
+++ b/src/doc/integrating_telio.md
@@ -21,7 +21,7 @@ use telio::{ffi::*, types::*};
 #[derive(Debug)]
 struct Logger;
 impl TelioLoggerCb for Logger {
-    fn log(&self, log_level: TelioLogLevel, payload: String) -> FFIResult<()> {
+    fn log(&self, log_level: TelioLogLevel, payload: String) -> FfiResult<()> {
         // report log level and payload to the app
         Ok(())
     }
@@ -96,7 +96,7 @@ use telio_model::event::Event;
 #[derive(Debug)]
 struct EventHandler;
 impl TelioEventCb for EventHandler {
-    fn event(&self, payload: Event) -> FFIResult<()> {
+    fn event(&self, payload: Event) -> FfiResult<()> {
         Ok(())
     }
 }
@@ -159,7 +159,7 @@ if let Some(nurse) = &mut feature_config.nurse {
 #[derive(Debug)]
 struct EventHandler;
 impl TelioEventCb for EventHandler {
-    fn event(&self, payload: Event) -> FFIResult<()> {
+    fn event(&self, payload: Event) -> FfiResult<()> {
         Ok(())
     }
 }
@@ -248,7 +248,7 @@ use telio_model::event::Event;
 #[derive(Debug)]
 struct EventHandler;
 impl TelioEventCb for EventHandler {
-    fn event(&self, payload: Event) -> FFIResult<()> {
+    fn event(&self, payload: Event) -> FfiResult<()> {
         // pass event to app
         Ok(())
     }
@@ -329,7 +329,7 @@ use telio_model::event::Event;
 #[derive(Debug)]
 struct EventHandler;
 impl TelioEventCb for EventHandler {
-    fn event(&self, payload: Event) -> FFIResult<()> {
+    fn event(&self, payload: Event) -> FfiResult<()> {
         Ok(())
     }
 }
@@ -440,7 +440,7 @@ use telio_model::event::Event;
 #[derive(Debug)]
 struct EventHandler;
 impl TelioEventCb for EventHandler {
-    fn event(&self, payload: Event) -> FFIResult<()> {
+    fn event(&self, payload: Event) -> FfiResult<()> {
         Ok(())
     }
 }
@@ -589,7 +589,7 @@ use telio_model::event::Event;
 #[derive(Debug)]
 struct EventHandler;
 impl TelioEventCb for EventHandler {
-    fn event(&self, payload: Event) -> FFIResult<()> {
+    fn event(&self, payload: Event) -> FfiResult<()> {
         Ok(())
     }
 }
@@ -735,7 +735,7 @@ use telio_model::event::Event;
 #[derive(Debug)]
 struct EventHandler;
 impl TelioEventCb for EventHandler {
-    fn event(&self, payload: Event) -> FFIResult<()> {
+    fn event(&self, payload: Event) -> FfiResult<()> {
         Ok(())
     }
 }
@@ -870,7 +870,7 @@ use telio_model::event::Event;
 #[derive(Debug)]
 struct EventHandler;
 impl TelioEventCb for EventHandler {
-    fn event(&self, payload: Event) -> FFIResult<()> {
+    fn event(&self, payload: Event) -> FfiResult<()> {
         Ok(())
     }
 }

--- a/src/ffi/logging.rs
+++ b/src/ffi/logging.rs
@@ -1,0 +1,224 @@
+use std::{
+    io::{self, ErrorKind},
+    str::from_utf8,
+    sync::{Arc, Mutex},
+};
+
+use tracing::{level_filters::LevelFilter, Subscriber};
+use tracing_subscriber::{
+    fmt::{self, FormatEvent, FormatFields, MakeWriter},
+    layer::SubscriberExt,
+    registry::LookupSpan,
+};
+
+use crate::{TelioLogLevel, TelioLoggerCb};
+
+/// Build a tracing subscriber for use in ffi
+pub fn build_subscriber(
+    log_level: crate::TelioLogLevel,
+    logger: Box<dyn TelioLoggerCb>,
+) -> impl Subscriber {
+    tracing_subscriber::registry()
+        .with(LevelFilter::from_level(log_level.into()))
+        .with(
+            fmt::layer()
+                .event_format(TelioEventFmt)
+                .with_ansi(false)
+                .with_writer(FfiCallback::new(logger)),
+        )
+}
+
+struct TelioEventFmt;
+
+impl<S, N> FormatEvent<S, N> for TelioEventFmt
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+    N: for<'a> FormatFields<'a> + 'static,
+{
+    fn format_event(
+        &self,
+        ctx: &fmt::FmtContext<'_, S, N>,
+        mut writer: fmt::format::Writer<'_>,
+        event: &tracing::Event<'_>,
+    ) -> std::fmt::Result {
+        let meta = event.metadata();
+        write!(
+            writer,
+            "{:?}:{} ",
+            meta.module_path().unwrap_or("<unknown module>"),
+            meta.line().unwrap_or(0),
+        )?;
+
+        ctx.format_fields(writer.by_ref(), event)?;
+
+        writeln!(writer)
+    }
+}
+
+pub struct FfiCallback {
+    callback: Arc<dyn TelioLoggerCb>,
+}
+impl FfiCallback {
+    fn new(logger: Box<dyn TelioLoggerCb>) -> Self {
+        Self {
+            callback: logger.into(),
+        }
+    }
+}
+
+impl<'a> MakeWriter<'a> for FfiCallback {
+    type Writer = FfiCallbackWriter;
+
+    fn make_writer(&self) -> Self::Writer {
+        unreachable!("`make_writer` should not be called, then `make_writer_for` is implemented")
+    }
+
+    fn make_writer_for(&self, meta: &tracing::Metadata<'_>) -> Self::Writer {
+        FfiCallbackWriter {
+            cb: self.callback.clone(),
+            level: (*meta.level()).into(),
+        }
+    }
+}
+
+pub struct FfiCallbackWriter {
+    cb: Arc<dyn TelioLoggerCb>,
+    level: TelioLogLevel,
+}
+
+impl io::Write for FfiCallbackWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        // We can be certain that buf fully represents one full event
+        //
+        // See https://github.com/tokio-rs/tracing/blob/tracing-subscriber-0.3.18/tracing-subscriber/src/fmt/fmt_layer.rs#L975
+        //
+        // Additional test added to double protect from future breakages
+
+        let msg = from_utf8(buf)
+            // Trim could be avoided by removing writeln! in formatter
+            // But this makes it more univesal for the future, then we dicide to
+            // switch to other formats
+            .map(|msg| msg.trim().to_string())
+            .map_err(|e| io::Error::new(ErrorKind::InvalidData, e))?;
+
+        if let Some(filtered_msg) = filter_log_message(msg) {
+            self.cb
+                .log(self.level, filtered_msg)
+                .map_err(io::Error::other)?;
+        }
+
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+struct LogStatus {
+    string: String,
+    counter: u32,
+}
+
+lazy_static::lazy_static! {
+    static ref LAST_LOG_STATUS: Mutex<LogStatus> = {
+        Mutex::new(LogStatus{string: String::default(), counter: 0})
+    };
+}
+
+fn filter_log_message(msg: String) -> Option<String> {
+    let mut log_status = match LAST_LOG_STATUS.lock() {
+        Ok(status) => status,
+        Err(_) => {
+            return None;
+        }
+    };
+
+    if !log_status.string.eq(&msg) {
+        log_status.string = msg.clone();
+        log_status.counter = 0;
+        return Some(msg);
+    }
+
+    if log_status.counter > 0 && log_status.counter % 100 == 0 {
+        log_status.counter += 1;
+        return Some(format!("[repeated 100 times!] {}", msg));
+    }
+
+    if log_status.counter < 10 {
+        log_status.counter += 1;
+        return Some(msg);
+    }
+
+    log_status.counter += 1;
+    None
+}
+
+#[cfg(test)]
+mod test {
+
+    /// Added in external crate to avoid line changes as much as possible
+    use tracing::{debug, info, trace, warn};
+
+    use super::*;
+
+    use std::{
+        fmt::Debug,
+        sync::{Arc, Mutex},
+    };
+
+    use crate::{TelioLogLevel, TelioLoggerCb};
+
+    #[test]
+    fn test_trace_via_telio_cb() {
+        let start = line!() + 1;
+        let act = || {
+            trace!("first message"); // +1
+            debug!("second message"); // +2
+            info!("third\nmutiline\nmessage"); // +3
+            warn!(
+                n = 2,
+                extra = "extra info",
+                "fourth message with {}",
+                "info"
+            ); // +4
+        };
+        let mpath = module_path!();
+        let expected = [
+            (
+                TelioLogLevel::Debug,
+                format!("{:?}:{} second message", mpath, start + 2),
+            ),
+            (
+                TelioLogLevel::Info,
+                format!("{:?}:{} third\nmutiline\nmessage", mpath, start + 3),
+            ),
+            (
+                TelioLogLevel::Warning,
+                format!(
+                    "{:?}:{} fourth message with info n=2 extra=\"extra info\"",
+                    mpath,
+                    start + 4
+                ),
+            ),
+        ];
+        let logs = Log::default();
+        let subscriber = build_subscriber(TelioLogLevel::Debug, Box::new(logs.clone()));
+
+        tracing::subscriber::with_default(subscriber, act);
+
+        let actual = logs.0.lock().unwrap().clone();
+
+        assert_eq!(&expected[..], &actual[..])
+    }
+
+    #[derive(Default, Clone, Debug)]
+    struct Log(Arc<Mutex<Vec<(TelioLogLevel, String)>>>);
+    impl TelioLoggerCb for Log {
+        fn log(&self, level: TelioLogLevel, payload: String) -> crate::FFIResult<()> {
+            let mut logs = self.0.lock().expect("Unable to lock");
+            logs.push((level, payload));
+            Ok(())
+        }
+    }
+}

--- a/src/ffi/logging.rs
+++ b/src/ffi/logging.rs
@@ -215,7 +215,7 @@ mod test {
     #[derive(Default, Clone, Debug)]
     struct Log(Arc<Mutex<Vec<(TelioLogLevel, String)>>>);
     impl TelioLoggerCb for Log {
-        fn log(&self, level: TelioLogLevel, payload: String) -> crate::FFIResult<()> {
+        fn log(&self, level: TelioLogLevel, payload: String) -> crate::FfiResult<()> {
             let mut logs = self.0.lock().expect("Unable to lock");
             logs.push((level, payload));
             Ok(())

--- a/src/ffi/types.rs
+++ b/src/ffi/types.rs
@@ -8,18 +8,18 @@ use std::panic::RefUnwindSafe;
 use crate::device::{AdapterType, Error as DevError};
 
 pub trait TelioEventCb: Send + Sync + std::fmt::Debug {
-    fn event(&self, payload: Event) -> FFIResult<()>;
+    fn event(&self, payload: Event) -> FfiResult<()>;
 }
 
 pub trait TelioLoggerCb: Send + Sync + std::fmt::Debug {
-    fn log(&self, log_level: TelioLogLevel, payload: String) -> FFIResult<()>;
+    fn log(&self, log_level: TelioLogLevel, payload: String) -> FfiResult<()>;
 }
 
 pub trait TelioProtectCb: Send + Sync + RefUnwindSafe + std::fmt::Debug {
-    fn protect(&self, socket_id: i32) -> FFIResult<()>;
+    fn protect(&self, socket_id: i32) -> FfiResult<()>;
 }
 
-pub type FFIResult<T> = Result<T, TelioError>;
+pub type FfiResult<T> = Result<T, TelioError>;
 
 #[derive(Debug, thiserror::Error)]
 pub enum TelioError {

--- a/src/ffi/types.rs
+++ b/src/ffi/types.rs
@@ -53,7 +53,7 @@ pub enum TelioAdapterType {
     WindowsNativeTun,
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 /// Possible log levels.
 pub enum TelioLogLevel {
     Error = 1,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,6 @@ pub mod ffi;
 pub use crate::ffi::*;
 use crate::types::*;
 pub use ffi::types as ffi_types;
-pub use ffi::TelioTracingSubscriber;
 
 /// cbindgen:ignore
 pub mod device;

--- a/tests/logger.rs
+++ b/tests/logger.rs
@@ -6,7 +6,7 @@ mod test_module {
         Arc,
     };
 
-    use telio::ffi_types::{FFIResult, TelioLoggerCb};
+    use telio::ffi_types::{FfiResult, TelioLoggerCb};
 
     use super::*;
 
@@ -26,7 +26,7 @@ mod test_module {
                 &self,
                 log_level: telio::ffi_types::TelioLogLevel,
                 payload: String,
-            ) -> FFIResult<()> {
+            ) -> FfiResult<()> {
                 assert!(matches!(log_level, telio::ffi_types::TelioLogLevel::Info));
                 assert_eq!(
                     format!(r#""logger::test_module":{INFO_LINE} test message"#),

--- a/tests/logger.rs
+++ b/tests/logger.rs
@@ -1,5 +1,4 @@
 use telio;
-use telio::TelioTracingSubscriber;
 
 mod test_module {
     use std::sync::{
@@ -13,6 +12,9 @@ mod test_module {
 
     #[test]
     fn test_logger() {
+        // Line number of tracing::info! location
+        const INFO_LINE: u32 = 50;
+
         let call_count = Arc::new(AtomicUsize::new(0));
 
         #[derive(Debug)]
@@ -26,7 +28,10 @@ mod test_module {
                 payload: String,
             ) -> FFIResult<()> {
                 assert!(matches!(log_level, telio::ffi_types::TelioLogLevel::Info));
-                assert_eq!(r#""logger::test_module":43 test message"#, payload);
+                assert_eq!(
+                    format!(r#""logger::test_module":{INFO_LINE} test message"#),
+                    payload
+                );
                 assert_eq!(0, self.call_count.fetch_add(1, Ordering::Relaxed));
                 Ok(())
             }
@@ -36,8 +41,10 @@ mod test_module {
             call_count: call_count.clone(),
         };
 
-        let tracing_subscriber =
-            TelioTracingSubscriber::new(Box::new(logger), tracing::Level::INFO);
+        let tracing_subscriber = telio::ffi::logging::build_subscriber(
+            telio::ffi_types::TelioLogLevel::Info,
+            Box::new(logger),
+        );
         tracing::subscriber::set_global_default(tracing_subscriber).unwrap();
 
         tracing::info!("test message");


### PR DESCRIPTION
### Problem
Until now some of information was lost then telio was used from ffi api, because non of the extra fields there send via telio log callback.

### Solution
Switched to tracing subscriber based implementation, as it correctly implements span logic, and will allow us to add additional systems in the future using layer approach.



### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
