### PR TITLE
Change process of detecting llt-secrets hook

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,27 +1,105 @@
-use anyhow::Result;
-use std::{env, path::Path};
+use anyhow::{bail, Context, Result};
+use std::env;
+use std::path::PathBuf;
+use std::process::Command;
 
-fn build() -> Result<cc::Build> {
+fn check_git_secrets() -> Result<()> {
+    match Command::new("git").args(["secrets", "--list"]).output() {
+        Ok(output) => match output.status.code() {
+            Some(0) => {
+                let output = String::from_utf8(output.stdout)?;
+                for line in output.lines() {
+                    if line.ends_with("llt-secrets/secrets")
+                        || line.ends_with("llt-secrets\\secrets")
+                    {
+                        return Ok(());
+                    }
+                }
+                bail!("llt-secrets not found in git-secrets providers list!")
+            }
+            Some(1) => {
+                let stderr = String::from_utf8(output.stderr)?;
+                if let Some(true) = stderr
+                    .lines()
+                    .next()
+                    .map(|line| line.starts_with("git: 'secrets' is not a git command."))
+                {
+                    bail!("git-secrets not installed!")
+                }
+                bail!("llt-secrets not found in git-secrets providers list!")
+            }
+            _ => {
+                bail!(
+                    "git-secrets failed with status code: {}\nstdout:\n{}\nstderr:\n{}\n",
+                    output.status,
+                    String::from_utf8(output.stdout).unwrap_or_default(),
+                    String::from_utf8(output.stderr).unwrap_or_default(),
+                )
+            }
+        },
+        Err(error) => {
+            bail!("git failed with unexpected error: {error}")
+        }
+    }
+}
+
+fn get_git_path() -> Result<PathBuf> {
+    match Command::new("git")
+        .args(["rev-parse", "--git-dir"])
+        .output()
+    {
+        Ok(output) => Ok(String::from_utf8(output.stdout)?.trim().into()),
+        Err(_) => {
+            bail!("Failed to get git directory. git rev-parse --git-dir failed.")
+        }
+    }
+}
+
+fn check_git_hooks() -> Result<()> {
+    let hooks_path = get_git_path()
+        .context("Checking git hooks failed")?
+        .join("hooks");
+    let hooks = vec![
+        hooks_path.join("commit-msg"),
+        hooks_path.join("pre-commit"),
+        hooks_path.join("prepare-commit-msg"),
+    ];
+    for hook in hooks {
+        if !hook.exists() {
+            bail!("Hook {:?} not installed", hook)
+        }
+    }
+    Ok(())
+}
+
+fn verify_llt_secrets() {
+    println!("cargo:rerun-if-changed=./crates");
+    println!("cargo:rerun-if-changed=./src");
+
     if !env::var("GITLAB_CI")
         .or(env::var("GITHUB_ACTIONS"))
         .is_ok_and(|value| value == "true")
     {
-        println!("cargo:rerun-if-changed=.prepared_llt_secrets");
-        println!("cargo:rerun-if-env-changed=BYPASS_LLT_SECRETS");
+        if env::var("BYPASS_LLT_SECRETS").is_ok() {
+            println!("cargo:warning=BYPASS_LLT_SECRETS IS SET, COMMIT CAREFULLY!!");
+            return;
+        }
 
-        // Check for sec scan
-        let prepared_path = Path::new(".prepared_llt_secrets");
         #[allow(clippy::panic)]
-        if !prepared_path.is_file() {
-            match env::var("BYPASS_LLT_SECRETS") {
-                Ok(_) => println!("cargo:warning=BYPASS_LLT_SECRETS IS SET, COMMIT CAREFULLY!!"),
-                Err(_) => {
-                    panic!("Hooks not found, either run checkout scripts or run with BYPASS_LLT_SECRETS environment variable set");
-                }
+        match check_git_secrets().and_then(|_| check_git_hooks()) {
+            Ok(_) => {}
+            Err(err) => {
+                panic!(
+                    "Secrets scanning seems to be missing or misconfigured. Either run checkout scripts \
+                    or run with BYPASS_LLT_SECRETS environment variable set\nError: {:#}",
+                    err
+                );
             }
         }
     }
+}
 
+fn build() -> Result<cc::Build> {
     let target_os = env::var("CARGO_CFG_TARGET_OS")?;
 
     let mut build = cc::Build::new();
@@ -40,24 +118,24 @@ fn build() -> Result<cc::Build> {
 fn main() -> Result<()> {
     uniffi::generate_scaffolding("./src/libtelio.udl")?;
 
-    let target_os = env::var("CARGO_CFG_TARGET_OS")?;
+    verify_llt_secrets();
 
-    {
-        let path = "suppress_source_fortification_check.c";
-        println!("cargo:rerun-if-changed={}", &path);
-        // The culprit for breaking the MSVC build is "-Werror", because cl.exe requires a numeric parameter.
-        if cfg!(target_env = "msvc") {
-            build()?
-                .file(path)
-                .compile("suppressSourceFortificationCheck");
-        } else {
-            build()?
-                .file(path)
-                .flag("-Werror")
-                .flag("-O3")
-                .compile("suppressSourceFortificationCheck");
-        }
+    let path = "suppress_source_fortification_check.c";
+    println!("cargo:rerun-if-changed={}", &path);
+    // The culprit for breaking the MSVC build is "-Werror", because cl.exe requires a numeric parameter.
+    if cfg!(target_env = "msvc") {
+        build()?
+            .file(path)
+            .compile("suppressSourceFortificationCheck");
+    } else {
+        build()?
+            .file(path)
+            .flag("-Werror")
+            .flag("-O3")
+            .compile("suppressSourceFortificationCheck");
     }
+
+    let target_os = env::var("CARGO_CFG_TARGET_OS")?;
 
     if target_os == "android" {
         let pkg_name = env!("CARGO_PKG_NAME");


### PR DESCRIPTION
Instead of using artifact file from installation script check if git-secrets tool is installed, that llt-secrets are added as a provider and that the hooks in the repo are enabled.



### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
