### PR TITLE
[LLT-5453] Fix ping race which may cause two ping requests being sent-out

### DIFF
--- a/nat-lab/tests/test_connection_states.py
+++ b/nat-lab/tests/test_connection_states.py
@@ -4,7 +4,7 @@ from contextlib import AsyncExitStack
 from helpers import SetupParameters, setup_mesh_nodes
 from utils.connection_tracker import ConnectionLimits
 from utils.connection_util import generate_connection_tracker_config, ConnectionTag
-from utils.ping import Ping
+from utils.ping import ping
 
 
 @pytest.mark.asyncio
@@ -98,5 +98,4 @@ async def test_connected_state_after_routing(
         await client_alpha.connect_to_exit_node(beta.public_key)
         await client_alpha.disconnect_from_exit_node(beta.public_key)
 
-        async with Ping(conn_alpha.connection, beta.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
+        await ping(conn_alpha.connection, beta.ip_addresses[0])

--- a/nat-lab/tests/test_derp_connect.py
+++ b/nat-lab/tests/test_derp_connect.py
@@ -7,7 +7,7 @@ from helpers import SetupParameters, setup_mesh_nodes
 from telio import State
 from typing import List
 from utils.connection_util import ConnectionTag
-from utils.ping import Ping
+from utils.ping import ping
 
 DERP1_IP = str(DERP_PRIMARY["ipv4"])
 DERP2_IP = str(DERP_SECONDARY["ipv4"])
@@ -40,8 +40,7 @@ async def test_derp_reconnect_2clients(setup_params: List[SetupParameters]) -> N
         #   /           \
         # [ALPHA]     [BETA]
 
-        async with Ping(alpha_connection, beta.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
+        await ping(alpha_connection, beta.ip_addresses[0])
 
         # ==============================================================
         # Break the connection:
@@ -76,8 +75,7 @@ async def test_derp_reconnect_2clients(setup_params: List[SetupParameters]) -> N
         await beta_client.wait_for_state_derp(DERP2_IP, [State.Connected])
 
         # Ping peer to check if connection truly works
-        async with Ping(alpha_connection, beta.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
+        await ping(alpha_connection, beta.ip_addresses[0])
 
 
 @pytest.mark.asyncio
@@ -113,17 +111,16 @@ async def test_derp_reconnect_3clients(setup_params: List[SetupParameters]) -> N
         # [ALPHA]    [BETA]     [GAMMA]
 
         # Ping ALPHA --> BETA
-        async with Ping(alpha_connection, beta.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
+        await ping(alpha_connection, beta.ip_addresses[0])
+
         # Ping ALPHA --> GAMMA
-        async with Ping(alpha_connection, gamma.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
+        await ping(alpha_connection, gamma.ip_addresses[0])
+
         # Ping BETA --> GAMMA
-        async with Ping(beta_connection, gamma.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
+        await ping(beta_connection, gamma.ip_addresses[0])
+
         # Ping GAMMA --> BETA
-        async with Ping(gamma_connection, beta.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
+        await ping(gamma_connection, beta.ip_addresses[0])
 
         # ==============================================================
         # Break BETA-DERP1 and GAMMA-DERP1 connections:
@@ -210,17 +207,16 @@ async def test_derp_reconnect_3clients(setup_params: List[SetupParameters]) -> N
         )
 
         # Ping ALPHA --> BETA
-        async with Ping(alpha_connection, beta.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
+        await ping(alpha_connection, beta.ip_addresses[0])
+
         # Ping ALPHA --> GAMMA
-        async with Ping(alpha_connection, gamma.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
+        await ping(alpha_connection, gamma.ip_addresses[0])
+
         # Ping BETA --> GAMMA
-        async with Ping(beta_connection, gamma.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
+        await ping(beta_connection, gamma.ip_addresses[0])
+
         # Ping GAMMA --> BETA
-        async with Ping(gamma_connection, beta.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
+        await ping(gamma_connection, beta.ip_addresses[0])
 
 
 @pytest.mark.asyncio
@@ -292,17 +288,16 @@ async def test_derp_restart(setup_params: List[SetupParameters]) -> None:
         # (w1: DERP->weight=1 for that client):
 
         # Ping ALPHA --> BETA
-        async with Ping(alpha_connection, beta.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
+        await ping(alpha_connection, beta.ip_addresses[0])
+
         # Ping ALPHA --> GAMMA
-        async with Ping(alpha_connection, gamma.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
+        await ping(alpha_connection, gamma.ip_addresses[0])
+
         # Ping BETA --> GAMMA
-        async with Ping(beta_connection, gamma.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
+        await ping(beta_connection, gamma.ip_addresses[0])
+
         # Ping GAMMA --> BETA
-        async with Ping(gamma_connection, beta.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
+        await ping(gamma_connection, beta.ip_addresses[0])
 
         # ==============================================================
         # DERP-1 restart:
@@ -324,17 +319,16 @@ async def test_derp_restart(setup_params: List[SetupParameters]) -> None:
         )
 
         # Ping ALPHA --> BETA
-        async with Ping(alpha_connection, beta.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
+        await ping(alpha_connection, beta.ip_addresses[0])
+
         # Ping ALPHA --> GAMMA
-        async with Ping(alpha_connection, gamma.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
+        await ping(alpha_connection, gamma.ip_addresses[0])
+
         # Ping BETA --> GAMMA
-        async with Ping(beta_connection, gamma.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
+        await ping(beta_connection, gamma.ip_addresses[0])
+
         # Ping GAMMA --> BETA
-        async with Ping(gamma_connection, beta.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
+        await ping(gamma_connection, beta.ip_addresses[0])
 
         # ==============================================================
         # DERP-2 restart
@@ -356,17 +350,16 @@ async def test_derp_restart(setup_params: List[SetupParameters]) -> None:
         )
 
         # Ping ALPHA --> BETA
-        async with Ping(alpha_connection, beta.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
+        await ping(alpha_connection, beta.ip_addresses[0])
+
         # Ping ALPHA --> GAMMA
-        async with Ping(alpha_connection, gamma.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
+        await ping(alpha_connection, gamma.ip_addresses[0])
+
         # Ping BETA --> GAMMA
-        async with Ping(beta_connection, gamma.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
+        await ping(beta_connection, gamma.ip_addresses[0])
+
         # Ping GAMMA --> BETA
-        async with Ping(gamma_connection, beta.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
+        await ping(gamma_connection, beta.ip_addresses[0])
 
         # ==============================================================
         # DERP-3 restart
@@ -388,17 +381,16 @@ async def test_derp_restart(setup_params: List[SetupParameters]) -> None:
         )
 
         # Ping ALPHA --> BETA
-        async with Ping(alpha_connection, beta.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
+        await ping(alpha_connection, beta.ip_addresses[0])
+
         # Ping ALPHA --> GAMMA
-        async with Ping(alpha_connection, gamma.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
+        await ping(alpha_connection, gamma.ip_addresses[0])
+
         # Ping BETA --> GAMMA
-        async with Ping(beta_connection, gamma.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
+        await ping(beta_connection, gamma.ip_addresses[0])
+
         # Ping GAMMA --> BETA
-        async with Ping(gamma_connection, beta.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
+        await ping(gamma_connection, beta.ip_addresses[0])
 
         # ==============================================================
         # Final state:
@@ -429,8 +421,7 @@ async def test_derp_server_list_exhaustion(setup_params: List[SetupParameters]) 
         _, beta_client = env.clients
         alpha_connection, _ = [conn.connection for conn in env.connections]
 
-        async with Ping(alpha_connection, beta.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
+        await ping(alpha_connection, beta.ip_addresses[0])
 
         # Insert iptables rules to block connection for every Derp server
         async with AsyncExitStack() as exit_stack_iptables:
@@ -448,5 +439,4 @@ async def test_derp_server_list_exhaustion(setup_params: List[SetupParameters]) 
         await beta_client.wait_for_state_on_any_derp([State.Connected])
 
         # Ping peer to check if connection truly works
-        async with Ping(alpha_connection, beta.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
+        await ping(alpha_connection, beta.ip_addresses[0])

--- a/nat-lab/tests/test_downgrade.py
+++ b/nat-lab/tests/test_downgrade.py
@@ -12,7 +12,7 @@ from telio_features import (
 )
 from typing import List, Tuple
 from utils.connection_util import ConnectionTag
-from utils.ping import Ping
+from utils.ping import ping
 
 
 def long_persistent_keepalive_periods() -> Wireguard:
@@ -68,10 +68,8 @@ async def test_downgrade_using_link_detection(
         # We have established a direct connection between the peers
 
         # Generate some traffic
-        async with Ping(alpha_connection, beta.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping(15)
-        async with Ping(beta_connection, alpha.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping(15)
+        await ping(alpha_connection, beta.ip_addresses[0], 15)
+        await ping(beta_connection, alpha.ip_addresses[0], 15)
 
         # Break the direct connection
         await exit_stack.enter_async_context(
@@ -87,11 +85,9 @@ async def test_downgrade_using_link_detection(
 
         # Generate some traffic to trigger link detection
         with pytest.raises(asyncio.TimeoutError):
-            async with Ping(alpha_connection, beta.ip_addresses[0]).run() as ping:
-                await ping.wait_for_next_ping(5)
+            await ping(alpha_connection, beta.ip_addresses[0], 5)
         with pytest.raises(asyncio.TimeoutError):
-            async with Ping(beta_connection, alpha.ip_addresses[0]).run() as ping:
-                await ping.wait_for_next_ping(5)
+            await ping(beta_connection, alpha.ip_addresses[0], 5)
 
         # Expect downgrade to relay
         await asyncio.gather(
@@ -104,10 +100,8 @@ async def test_downgrade_using_link_detection(
         )
 
         # Check the relayed connection
-        async with Ping(alpha_connection, beta.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping(15)
-        async with Ping(beta_connection, alpha.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping(15)
+        await ping(alpha_connection, beta.ip_addresses[0], 15)
+        await ping(beta_connection, alpha.ip_addresses[0], 15)
 
 
 @pytest.mark.asyncio
@@ -136,10 +130,8 @@ async def test_downgrade_using_link_detection_with_silent_connection(
         # We have established a direct connection between the peers
 
         # Generate some traffic
-        async with Ping(alpha_connection, beta.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping(15)
-        async with Ping(beta_connection, alpha.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping(15)
+        await ping(alpha_connection, beta.ip_addresses[0], 15)
+        await ping(beta_connection, alpha.ip_addresses[0], 15)
 
         # Wait for connection to stabilize
         # Leave time for the passive keepalives to be send
@@ -171,11 +163,9 @@ async def test_downgrade_using_link_detection_with_silent_connection(
 
         # Generate some traffic to trigger link detection
         with pytest.raises(asyncio.TimeoutError):
-            async with Ping(alpha_connection, beta.ip_addresses[0]).run() as ping:
-                await ping.wait_for_next_ping(5)
+            await ping(alpha_connection, beta.ip_addresses[0], 5)
         with pytest.raises(asyncio.TimeoutError):
-            async with Ping(beta_connection, alpha.ip_addresses[0]).run() as ping:
-                await ping.wait_for_next_ping(5)
+            await ping(beta_connection, alpha.ip_addresses[0], 5)
 
         # Expect downgrade to relay
         await asyncio.gather(
@@ -188,7 +178,5 @@ async def test_downgrade_using_link_detection_with_silent_connection(
         )
 
         # Check the relayed connection
-        async with Ping(alpha_connection, beta.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping(15)
-        async with Ping(beta_connection, alpha.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping(15)
+        await ping(alpha_connection, beta.ip_addresses[0], 15)
+        await ping(beta_connection, alpha.ip_addresses[0], 15)

--- a/nat-lab/tests/test_events.py
+++ b/nat-lab/tests/test_events.py
@@ -9,7 +9,7 @@ from telio_features import TelioFeatures, Direct
 from utils import stun
 from utils.connection_tracker import ConnectionLimits
 from utils.connection_util import generate_connection_tracker_config, ConnectionTag
-from utils.ping import Ping
+from utils.ping import ping
 from utils.router import IPStack
 
 
@@ -103,10 +103,8 @@ async def test_event_content_meshnet(
             conn.connection for conn in env.connections
         ]
 
-        async with Ping(connection_alpha, beta.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
-        async with Ping(connection_beta, alpha.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
+        await ping(connection_alpha, beta.ip_addresses[0])
+        await ping(connection_beta, alpha.ip_addresses[0])
 
         assert client_alpha.get_node_state(beta.public_key) == PeerInfo(
             identifier=beta.id,
@@ -145,8 +143,7 @@ async def test_event_content_meshnet(
         await client_alpha.set_meshmap(api.get_meshmap(alpha.id))
 
         with pytest.raises(asyncio.TimeoutError):
-            async with Ping(connection_alpha, beta.ip_addresses[0]).run() as ping:
-                await ping.wait_for_next_ping(5)
+            await ping(connection_alpha, beta.ip_addresses[0], 5)
 
         await asyncio.sleep(1)
 
@@ -265,8 +262,7 @@ async def test_event_content_vpn_connection(
             str(wg_server["ipv4"]), int(wg_server["port"]), str(wg_server["public_key"])
         )
 
-        async with Ping(connection, config.PHOTO_ALBUM_IP).run() as ping:
-            await ping.wait_for_next_ping()
+        await ping(connection, config.PHOTO_ALBUM_IP)
 
         assert client_alpha.get_node_state(str(wg_server["public_key"])) == PeerInfo(
             identifier="natlab",
@@ -408,8 +404,7 @@ async def test_event_content_exit_through_peer(
         ]
         client_alpha, client_beta = env.clients
 
-        async with Ping(connection_alpha, beta.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
+        await ping(connection_alpha, beta.ip_addresses[0])
 
         assert client_alpha.get_node_state(beta.public_key) == PeerInfo(
             identifier=beta.id,
@@ -559,10 +554,8 @@ async def test_event_content_meshnet_node_upgrade_direct(
         ]
         client_alpha, client_beta = env.clients
 
-        async with Ping(connection_alpha, beta.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
-        async with Ping(connection_beta, alpha.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
+        await ping(connection_alpha, beta.ip_addresses[0])
+        await ping(connection_beta, alpha.ip_addresses[0])
 
         beta_node_state = client_alpha.get_node_state(beta.public_key)
         assert beta_node_state
@@ -629,10 +622,8 @@ async def test_event_content_meshnet_node_upgrade_direct(
             ),
         )
 
-        async with Ping(connection_alpha, beta.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
-        async with Ping(connection_beta, alpha.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
+        await ping(connection_alpha, beta.ip_addresses[0])
+        await ping(connection_beta, alpha.ip_addresses[0])
 
         beta_node_state = client_alpha.get_node_state(beta.public_key)
         assert beta_node_state

--- a/nat-lab/tests/test_events_link_state.py
+++ b/nat-lab/tests/test_events_link_state.py
@@ -6,7 +6,7 @@ from telio import AdapterType, LinkState
 from telio_features import TelioFeatures, LinkDetection, Wireguard, PersistentKeepalive
 from typing import List, Tuple
 from utils.connection_util import ConnectionTag
-from utils.ping import Ping
+from utils.ping import ping
 
 
 def long_persistent_keepalive_periods() -> Wireguard:
@@ -155,10 +155,8 @@ async def test_event_link_state_peers_exchanging_data_for_a_long_time(
 
         for _ in range(0, 40):
             await asyncio.sleep(1)
-            async with Ping(connection_alpha, beta.ip_addresses[0]).run() as ping:
-                await ping.wait_for_next_ping()
-            async with Ping(connection_beta, alpha.ip_addresses[0]).run() as ping:
-                await ping.wait_for_next_ping()
+            await ping(connection_alpha, beta.ip_addresses[0])
+            await ping(connection_beta, alpha.ip_addresses[0])
 
         # Expect no nolink event while peers are active
         alpha_events = client_beta.get_link_state_events(alpha.public_key)
@@ -182,18 +180,14 @@ async def test_event_link_state_peers_exchanging_data_then_idling_then_resume(
             conn.connection for conn in env.connections
         ]
 
-        async with Ping(connection_alpha, beta.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
-        async with Ping(connection_beta, alpha.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
+        await ping(connection_alpha, beta.ip_addresses[0])
+        await ping(connection_beta, alpha.ip_addresses[0])
 
         # Expect no link event while peers are idle
         await asyncio.sleep(20)
 
-        async with Ping(connection_alpha, beta.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
-        async with Ping(connection_beta, alpha.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
+        await ping(connection_alpha, beta.ip_addresses[0])
+        await ping(connection_beta, alpha.ip_addresses[0])
 
         alpha_events = client_beta.get_link_state_events(alpha.public_key)
         beta_events = client_alpha.get_link_state_events(beta.public_key)
@@ -216,18 +210,15 @@ async def test_event_link_state_peer_goes_offline(
             conn.connection for conn in env.connections
         ]
 
-        async with Ping(connection_alpha, beta.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
-        async with Ping(connection_beta, alpha.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
+        await ping(connection_alpha, beta.ip_addresses[0])
+        await ping(connection_beta, alpha.ip_addresses[0])
 
         await client_beta.stop_device()
 
         await asyncio.sleep(1)
 
         with pytest.raises(asyncio.TimeoutError):
-            async with Ping(connection_alpha, beta.ip_addresses[0]).run() as ping:
-                await ping.wait_for_next_ping(5)
+            await ping(connection_alpha, beta.ip_addresses[0], 5)
 
         await asyncio.sleep(25)
         alpha_events = client_beta.get_link_state_events(alpha.public_key)
@@ -257,10 +248,8 @@ async def test_event_link_state_feature_disabled(
             conn.connection for conn in env.connections
         ]
 
-        async with Ping(connection_alpha, beta.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
-        async with Ping(connection_beta, alpha.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
+        await ping(connection_alpha, beta.ip_addresses[0])
+        await ping(connection_beta, alpha.ip_addresses[0])
 
         await asyncio.sleep(30)
 

--- a/nat-lab/tests/test_fire_connecting_event.py
+++ b/nat-lab/tests/test_fire_connecting_event.py
@@ -6,7 +6,7 @@ from helpers import SetupParameters, setup_mesh_nodes
 from telio import AdapterType, State
 from utils.connection_tracker import ConnectionLimits
 from utils.connection_util import generate_connection_tracker_config, ConnectionTag
-from utils.ping import Ping
+from utils.ping import ping
 
 
 @pytest.mark.asyncio
@@ -46,13 +46,11 @@ async def test_fire_connecting_event(
         connection_alpha, _ = [conn.connection for conn in env.connections]
         client_alpha, client_beta = env.clients
 
-        async with Ping(connection_alpha, beta.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
+        await ping(connection_alpha, beta.ip_addresses[0])
 
         await client_beta.stop_device()
 
         with pytest.raises(asyncio.TimeoutError):
-            async with Ping(connection_alpha, beta.ip_addresses[0]).run() as ping:
-                await ping.wait_for_next_ping(15)
+            await ping(connection_alpha, beta.ip_addresses[0], 15)
 
         await client_alpha.wait_for_event_peer(beta.public_key, [State.Connecting])

--- a/nat-lab/tests/test_lana.py
+++ b/nat-lab/tests/test_lana.py
@@ -45,7 +45,7 @@ from utils.connection_util import (
     new_connection_by_tag,
     add_outgoing_packets_delay,
 )
-from utils.ping import Ping
+from utils.ping import ping
 from utils.router import IPStack, IPProto
 
 CONTAINER_EVENT_PATH = "/event.db"
@@ -191,11 +191,10 @@ async def ping_node(
         # Impossibru
         return
 
-    async with Ping(
+    await ping(
         initiator_conn,
         testing.unpack_optional(target.get_ip_address(proto)),
-    ).run() as ping:
-        await ping.wait_for_next_ping()
+    )
 
 
 def choose_peer_stack(node_one: IPStack, node_two: IPStack) -> Optional[IPStack]:
@@ -1333,14 +1332,12 @@ async def test_lana_with_meshnet_exit_node(
             ),
         )
 
-        async with Ping(
+        await ping(
             connection_alpha,
             testing.unpack_optional(
                 beta.get_ip_address(IPProto.IPv6 if is_stun6_needed else IPProto.IPv4)
             ),
-        ).run() as ping:
-            await ping.wait_for_next_ping()
-
+        )
         await client_beta.get_router().create_exit_node_route()
         await client_alpha.connect_to_exit_node(beta.public_key)
         ip_alpha = await stun.get(

--- a/nat-lab/tests/test_mesh_exit_through_peer.py
+++ b/nat-lab/tests/test_mesh_exit_through_peer.py
@@ -13,7 +13,7 @@ from utils.connection_util import (
     ConnectionTag,
     new_connection_with_conn_tracker,
 )
-from utils.ping import Ping
+from utils.ping import ping
 from utils.router import IPProto, IPStack
 
 
@@ -129,18 +129,15 @@ async def test_mesh_exit_through_peer(
         ]
 
         if exit_ip_stack is not IPStack.IPv6:
-            async with Ping(
+            await ping(
                 connection_alpha,
                 testing.unpack_optional(beta.get_ip_address(IPProto.IPv4)),
-            ).run() as ping:
-                await ping.wait_for_next_ping()
+            )
         else:
-            async with Ping(
+            await ping(
                 connection_alpha,
                 testing.unpack_optional(beta.get_ip_address(IPProto.IPv6)),
-            ).run() as ping6:
-                await ping6.wait_for_next_ping()
-
+            )
         await client_beta.get_router().create_exit_node_route()
 
         await client_alpha.connect_to_exit_node(beta.public_key)
@@ -283,18 +280,15 @@ async def test_ipv6_exit_node(
         )
 
         # Ping in-tunnel node with IPv6
-        async with Ping(
+        await ping(
             connection_alpha,
             testing.unpack_optional(beta.get_ip_address(IPProto.IPv6)),
-        ).run() as ping6:
-            await ping6.wait_for_next_ping()
-
+        )
         await client_beta.get_router().create_exit_node_route()
         await client_alpha.connect_to_exit_node(beta.public_key)
 
         # Ping out-tunnel target with IPv6
-        async with Ping(connection_alpha, config.PHOTO_ALBUM_IPV6).run() as ping6:
-            await ping6.wait_for_next_ping()
+        await ping(connection_alpha, config.PHOTO_ALBUM_IPV6)
 
         ip_alpha = await stun.get(connection_alpha, config.STUNV6_SERVER)
         ip_beta = await stun.get(connection_beta, config.STUNV6_SERVER)

--- a/nat-lab/tests/test_mesh_off.py
+++ b/nat-lab/tests/test_mesh_off.py
@@ -7,7 +7,7 @@ from telio import PathType, State
 from telio_features import TelioFeatures, Direct, LinkDetection
 from timeouts import TEST_MESH_STATE_AFTER_DISCONNECTING_NODE_TIMEOUT
 from utils.connection_util import ConnectionTag
-from utils.ping import Ping
+from utils.ping import ping
 
 
 # Marks in-tunnel stack only, exiting only through IPv4
@@ -78,10 +78,8 @@ async def test_mesh_off(direct) -> None:
             ),
         )
 
-        async with Ping(connection_alpha, beta.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
-        async with Ping(connection_beta, alpha.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
+        await ping(connection_alpha, beta.ip_addresses[0])
+        await ping(connection_beta, alpha.ip_addresses[0])
 
 
 @pytest.mark.asyncio
@@ -113,10 +111,8 @@ async def test_mesh_state_after_disconnecting_node() -> None:
             conn.connection for conn in env.connections
         ]
 
-        async with Ping(connection_alpha, beta.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
-        async with Ping(connection_beta, alpha.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
+        await ping(connection_alpha, beta.ip_addresses[0])
+        await ping(connection_beta, alpha.ip_addresses[0])
 
         await client_beta.stop_device()
 

--- a/nat-lab/tests/test_mesh_plus_vpn.py
+++ b/nat-lab/tests/test_mesh_plus_vpn.py
@@ -15,7 +15,7 @@ from utils.connection_util import (
     ConnectionTag,
     new_connection_with_conn_tracker,
 )
-from utils.ping import Ping
+from utils.ping import ping
 
 
 # Marks in-tunnel stack only, exiting only through IPv4
@@ -112,8 +112,7 @@ async def test_mesh_plus_vpn_one_peer(
         client_alpha, _ = env.clients
         connection_alpha, _ = [conn.connection for conn in env.connections]
 
-        async with Ping(connection_alpha, beta.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
+        await ping(connection_alpha, beta.ip_addresses[0])
 
         wg_server = config.WG_SERVER
 
@@ -121,11 +120,9 @@ async def test_mesh_plus_vpn_one_peer(
             str(wg_server["ipv4"]), int(wg_server["port"]), str(wg_server["public_key"])
         )
 
-        async with Ping(connection_alpha, beta.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
+        await ping(connection_alpha, beta.ip_addresses[0])
 
-        async with Ping(connection_alpha, config.STUN_SERVER).run() as ping:
-            await ping.wait_for_next_ping()
+        await ping(connection_alpha, config.STUN_SERVER)
 
         public_ip = await stun.get(connection_alpha, config.STUN_SERVER)
         assert (
@@ -229,8 +226,7 @@ async def test_mesh_plus_vpn_both_peers(
             conn.connection for conn in env.connections
         ]
 
-        async with Ping(connection_alpha, beta.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
+        await ping(connection_alpha, beta.ip_addresses[0])
 
         wg_server = config.WG_SERVER
 
@@ -247,15 +243,11 @@ async def test_mesh_plus_vpn_both_peers(
             ),
         )
 
-        async with Ping(connection_alpha, beta.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
-        async with Ping(connection_alpha, config.STUN_SERVER).run() as ping:
-            await ping.wait_for_next_ping()
+        await ping(connection_alpha, beta.ip_addresses[0])
+        await ping(connection_alpha, config.STUN_SERVER)
 
-        async with Ping(connection_beta, alpha.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
-        async with Ping(connection_beta, config.STUN_SERVER).run() as ping:
-            await ping.wait_for_next_ping()
+        await ping(connection_beta, alpha.ip_addresses[0])
+        await ping(connection_beta, config.STUN_SERVER)
 
         for connection in [connection_alpha, connection_beta]:
             public_ip = await stun.get(connection, config.STUN_SERVER)
@@ -340,8 +332,7 @@ async def test_vpn_plus_mesh(
             str(wg_server["ipv4"]), int(wg_server["port"]), str(wg_server["public_key"])
         )
 
-        async with Ping(connection_alpha, config.PHOTO_ALBUM_IP).run() as ping:
-            await ping.wait_for_next_ping()
+        await ping(connection_alpha, config.PHOTO_ALBUM_IP)
 
         ip = await stun.get(connection_alpha, config.STUN_SERVER)
         assert ip == wg_server["ipv4"], f"wrong public IP when connected to VPN {ip}"
@@ -361,8 +352,7 @@ async def test_vpn_plus_mesh(
             client_beta.wait_for_state_peer(alpha.public_key, [State.Connected]),
         )
 
-        async with Ping(connection_alpha, beta.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
+        await ping(connection_alpha, beta.ip_addresses[0])
 
         # Testing if the VPN node is not cleared after disabling meshnet. See LLT-4266 for more details.
         await client_alpha.set_mesh_off()
@@ -485,10 +475,8 @@ async def test_vpn_plus_mesh_over_direct(
             conn.connection for conn in env.connections
         ]
 
-        async with Ping(connection_alpha, beta.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
-        async with Ping(connection_beta, alpha.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
+        await ping(connection_alpha, beta.ip_addresses[0])
+        await ping(connection_beta, alpha.ip_addresses[0])
 
         wg_server = config.WG_SERVER
 
@@ -505,15 +493,11 @@ async def test_vpn_plus_mesh_over_direct(
             ),
         )
 
-        async with Ping(connection_alpha, beta.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
-        async with Ping(connection_alpha, config.STUN_SERVER).run() as ping:
-            await ping.wait_for_next_ping()
+        await ping(connection_alpha, beta.ip_addresses[0])
+        await ping(connection_alpha, config.STUN_SERVER)
 
-        async with Ping(connection_beta, alpha.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
-        async with Ping(connection_beta, config.STUN_SERVER).run() as ping:
-            await ping.wait_for_next_ping()
+        await ping(connection_beta, alpha.ip_addresses[0])
+        await ping(connection_beta, config.STUN_SERVER)
 
         for connection in [connection_alpha, connection_beta]:
             public_ip = await stun.get(connection, config.STUN_SERVER)
@@ -646,10 +630,8 @@ async def test_vpn_plus_mesh_over_different_connection_types(
         client_alpha, client_beta, client_gamma = env.clients
         alpha, beta, gamma = env.nodes
 
-        async with Ping(connection_alpha, beta.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
-        async with Ping(connection_alpha, gamma.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
+        await ping(connection_alpha, beta.ip_addresses[0])
+        await ping(connection_alpha, gamma.ip_addresses[0])
 
         wg_server = config.WG_SERVER
 
@@ -671,22 +653,15 @@ async def test_vpn_plus_mesh_over_different_connection_types(
             ),
         )
 
-        async with Ping(connection_alpha, beta.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
-        async with Ping(connection_alpha, gamma.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
-        async with Ping(connection_alpha, config.STUN_SERVER).run() as ping:
-            await ping.wait_for_next_ping()
+        await ping(connection_alpha, beta.ip_addresses[0])
+        await ping(connection_alpha, gamma.ip_addresses[0])
+        await ping(connection_alpha, config.STUN_SERVER)
 
-        async with Ping(connection_beta, alpha.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
-        async with Ping(connection_beta, config.STUN_SERVER).run() as ping:
-            await ping.wait_for_next_ping()
+        await ping(connection_beta, alpha.ip_addresses[0])
+        await ping(connection_beta, config.STUN_SERVER)
 
-        async with Ping(connection_gamma, alpha.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
-        async with Ping(connection_gamma, config.STUN_SERVER).run() as ping:
-            await ping.wait_for_next_ping()
+        await ping(connection_gamma, alpha.ip_addresses[0])
+        await ping(connection_gamma, config.STUN_SERVER)
 
         for connection in [connection_alpha, connection_beta, connection_gamma]:
             public_ip = await stun.get(connection, config.STUN_SERVER)

--- a/nat-lab/tests/test_network_switch.py
+++ b/nat-lab/tests/test_network_switch.py
@@ -16,7 +16,7 @@ from utils import stun
 from utils.asyncio_util import run_async_contexts
 from utils.connection import TargetOS
 from utils.connection_util import ConnectionTag
-from utils.ping import Ping
+from utils.ping import ping
 
 
 @pytest.mark.asyncio
@@ -121,17 +121,13 @@ async def test_mesh_network_switch(
         alpha_conn_mngr, *_ = env.connections
         client_alpha, _ = env.clients
 
-        async with Ping(alpha_conn_mngr.connection, beta.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
+        await ping(alpha_conn_mngr.connection, beta.ip_addresses[0])
 
         assert alpha_conn_mngr.network_switcher
         async with alpha_conn_mngr.network_switcher.switch_to_secondary_network():
             await client_alpha.notify_network_change()
 
-            async with Ping(
-                alpha_conn_mngr.connection, beta.ip_addresses[0]
-            ).run() as ping:
-                await ping.wait_for_next_ping()
+            await ping(alpha_conn_mngr.connection, beta.ip_addresses[0])
 
 
 @pytest.mark.asyncio
@@ -196,8 +192,7 @@ async def test_vpn_network_switch(alpha_setup_params: SetupParameters) -> None:
             str(wg_server["ipv4"]), int(wg_server["port"]), str(wg_server["public_key"])
         )
 
-        async with Ping(alpha_connection, config.PHOTO_ALBUM_IP).run() as ping:
-            await ping.wait_for_next_ping()
+        await ping(alpha_connection, config.PHOTO_ALBUM_IP)
 
         ip = await stun.get(alpha_connection, config.STUN_SERVER)
         assert ip == wg_server["ipv4"], f"wrong public IP when connected to VPN {ip}"
@@ -212,8 +207,7 @@ async def test_vpn_network_switch(alpha_setup_params: SetupParameters) -> None:
             if alpha_connection.target_os == TargetOS.Windows:
                 await asyncio.sleep(1.0)
 
-            async with Ping(alpha_connection, config.PHOTO_ALBUM_IP).run() as ping:
-                await ping.wait_for_next_ping()
+            await ping(alpha_connection, config.PHOTO_ALBUM_IP)
 
             ip = await stun.get(alpha_connection, config.STUN_SERVER)
             assert (
@@ -298,8 +292,7 @@ async def test_mesh_network_switch_direct(
         assert network_switcher
         alpha_client, beta_client = env.clients
 
-        async with Ping(alpha_connection, beta.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
+        await ping(alpha_connection, beta.ip_addresses[0])
 
         derp_connected_future = alpha_client.wait_for_event_on_any_derp(
             [State.Connected]
@@ -326,5 +319,4 @@ async def test_mesh_network_switch_direct(
             await relay
             await direct
 
-        async with Ping(alpha_connection, beta.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
+        await ping(alpha_connection, beta.ip_addresses[0])

--- a/nat-lab/tests/test_pmtu.py
+++ b/nat-lab/tests/test_pmtu.py
@@ -10,7 +10,7 @@ from utils.connection_util import (
     generate_connection_tracker_config,
     ConnectionLimits,
 )
-from utils.ping import Ping
+from utils.ping import ping
 from utils.router import IPStack
 
 
@@ -200,5 +200,4 @@ async def test_vpn_conn_with_pmtu_enabled(params: SetupParameters) -> None:
             str(config.WG_SERVER["public_key"]),
         )
 
-        async with Ping(vpn_conn.connection, alpha.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
+        await ping(vpn_conn.connection, alpha.ip_addresses[0])

--- a/nat-lab/tests/test_pq.py
+++ b/nat-lab/tests/test_pq.py
@@ -11,7 +11,7 @@ from utils.connection_util import (
     ConnectionTag,
     new_connection_by_tag,
 )
-from utils.ping import Ping
+from utils.ping import ping
 
 
 async def _connect_vpn_pq(
@@ -27,8 +27,7 @@ async def _connect_vpn_pq(
         pq=True,
     )
 
-    async with Ping(client_conn, config.PHOTO_ALBUM_IP).run() as ping:
-        await ping.wait_for_next_ping()
+    await ping(client_conn, config.PHOTO_ALBUM_IP)
 
     ip = await stun.get(client_conn, config.STUN_SERVER)
     assert ip == wg_server["ipv4"], f"wrong public IP when connected to VPN {ip}"
@@ -262,5 +261,4 @@ async def test_pq_vpn_rekey(
             ip == config.NLX_SERVER["ipv4"]
         ), f"wrong public IP when connected to VPN {ip}"
 
-        async with Ping(client_conn, config.PHOTO_ALBUM_IP).run() as ping:
-            await ping.wait_for_next_ping()
+        await ping(client_conn, config.PHOTO_ALBUM_IP)

--- a/nat-lab/tests/test_proxy.py
+++ b/nat-lab/tests/test_proxy.py
@@ -5,7 +5,7 @@ from helpers import SetupParameters, setup_mesh_nodes
 from telio import PeerInfo
 from typing import Optional
 from utils.connection_util import ConnectionTag
-from utils.ping import Ping
+from utils.ping import ping
 
 
 @pytest.mark.asyncio
@@ -29,10 +29,8 @@ async def test_proxy_endpoint_map_update() -> None:
             alpha_client.get_router().block_udp_port(port)
         )
 
-        async with Ping(alpha_connection, beta.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
-        async with Ping(beta_connection, alpha.ip_addresses[0]).run() as ping:
-            await ping.wait_for_next_ping()
+        await ping(alpha_connection, beta.ip_addresses[0])
+        await ping(beta_connection, alpha.ip_addresses[0])
 
         for _ in range(0, 5):
             new_port = node_port(alpha_client.get_node_state(beta.public_key))

--- a/nat-lab/tests/test_telio_version_compatibility.py
+++ b/nat-lab/tests/test_telio_version_compatibility.py
@@ -13,7 +13,7 @@ from utils.connection_util import (
     new_connection_with_conn_tracker,
 )
 from utils.output_notifier import OutputNotifier
-from utils.ping import Ping
+from utils.ping import ping
 from utils.router import IPProto, IPStack, new_router
 
 STUN_PROVIDER = ["stun"]
@@ -130,11 +130,10 @@ async def test_connect_different_telio_version_through_relay(
         await alpha_client.wait_for_state_on_any_derp([telio.State.Connected])
         await alpha_client.wait_for_state_peer(beta.public_key, [telio.State.Connected])
 
-        async with Ping(
+        await ping(
             alpha_conn,
             testing.unpack_optional(beta.get_ip_address(IPProto.IPv4)),
-        ).run() as ping:
-            await ping.wait_for_next_ping()
+        )
 
         assert alpha_conn_tracker.get_out_of_limits() is None
         assert beta_conn_tracker.get_out_of_limits() is None

--- a/nat-lab/tests/utils/ping.py
+++ b/nat-lab/tests/utils/ping.py
@@ -12,6 +12,13 @@ from utils.router import IPProto, REG_IPV6ADDR, get_ip_address_type
 # It should work for Linux, Windows and Mac.
 
 
+async def ping(
+    connection: Connection, ip: str, timeout: Optional[float] = None
+) -> None:
+    async with Ping(connection, ip).run() as ping_process:
+        await ping_process.wait_for_any_ping(timeout)
+
+
 class Ping:
     _ip: str
     _ip_proto: IPProto
@@ -53,6 +60,10 @@ class Ping:
 
     async def wait_for_next_ping(self, timeout: Optional[float] = None) -> None:
         self._next_ping_event.clear()
+        await asyncio.wait_for(self._next_ping_event.wait(), timeout)
+        self._next_ping_event.clear()
+
+    async def wait_for_any_ping(self, timeout: Optional[float] = None) -> None:
         await asyncio.wait_for(self._next_ping_event.wait(), timeout)
         self._next_ping_event.clear()
 


### PR DESCRIPTION
### Problem
There is a small race between ping utility receiving first response, and [.wait_for_next_ping](https://github.com/NordSecurity/libtelio/blob/v5.0.0-rc2/nat-lab/tests/utils/ping.py#L54) being called. 

So all Ping utility uses has this pattern, when using ping utility:
```python
        async with Ping(<connection>, <ping_target_ip_address>).run() as ping:
            await ping.wait_for_next_ping()
```

In this case, when [.run()](https://github.com/NordSecurity/libtelio/blob/v5.0.0-rc2/nat-lab/tests/utils/ping.py#L60) is called, `ping` process is started, and then after some time - [wait_for_next_ping()](https://github.com/NordSecurity/libtelio/blob/v5.0.0-rc2/nat-lab/tests/utils/ping.py#L55) is called, which may `.clear()` first ping response. 

In a test like [this](https://github.com/NordSecurity/libtelio/blob/v5.0.0-rc2/nat-lab/tests/test_events_link_state.py#L156) the race may prolong test execution significantly even hitting timeouts.

### Solution
Introduce a function `wait_for_any_ping()` which would not clear events at the start. Next, provide a wrapper function, which would do the pinging in one go. And refactor all tests to use this new function.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
