### PR TITLE
LLT-5452: Remove fingerprint from nurse and enable nurse by default

### DIFF
--- a/.unreleased/LLT-5452
+++ b/.unreleased/LLT-5452
@@ -1,0 +1,1 @@
+Removed fingerprint from nurse feature config and made nurse enabled by default

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3901,6 +3901,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
+name = "smart-default"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eb01866308440fc64d6c44d9e86c5cc17adfe33c4d6eed55da9145044d0ffc1"
+dependencies = [
+ "proc-macro2 1.0.83",
+ "quote 1.0.36",
+ "syn 2.0.65",
+]
+
+[[package]]
 name = "smawk"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4356,6 +4367,7 @@ dependencies = [
  "pretty_assertions",
  "serde",
  "serde_json",
+ "smart-default",
  "strum",
  "strum_macros",
  "telio-crypto",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,6 +143,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10.6"
 slog = "2.7"
+smart-default = "0.7.1"
 sn_fake_clock = "0.4"
 socket2 = "0.5"
 strum = { version = "0.24.0", features = ["derive"] }

--- a/crates/telio-model/Cargo.toml
+++ b/crates/telio-model/Cargo.toml
@@ -20,6 +20,7 @@ modifier.workspace = true
 num_enum.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+smart-default.workspace = true
 strum.workspace = true
 thiserror.workspace = true
 tokio.workspace = true

--- a/crates/telio-nurse/src/config.rs
+++ b/crates/telio-nurse/src/config.rs
@@ -1,4 +1,6 @@
+use telio_lana::fetch_context_string;
 use telio_model::features::{FeatureNurse, FeatureQoS};
+use telio_utils::telio_log_warn;
 use tokio::time::Duration;
 
 use telio_model::features::RttType;
@@ -43,9 +45,16 @@ pub struct HeartbeatConfig {
 impl HeartbeatConfig {
     /// Create a new Heartbeat config
     pub(crate) fn new(features: &FeatureNurse) -> Self {
+        let fingerprint = match fetch_context_string("device.fp".to_owned()) {
+            Some(fingerprint) => fingerprint,
+            None => {
+                telio_log_warn!("No device fingerprint found in moose");
+                "missing-device-fingerprint".to_owned()
+            }
+        };
         Self {
             initial_collect_interval: Duration::from_secs(features.initial_heartbeat_interval),
-            fingerprint: features.fingerprint.clone(),
+            fingerprint,
             collect_interval: Duration::from_secs(features.heartbeat_interval),
             collect_answer_timeout: Duration::from_secs(10),
             is_nat_type_collection_enabled: features.enable_nat_type_collection,

--- a/nat-lab/bin/mac/list_interfaces_with_router_property.py
+++ b/nat-lab/bin/mac/list_interfaces_with_router_property.py
@@ -2,7 +2,6 @@
 # autoflake: skip_file
 # pylint: skip-file
 
-from sys import exit
 from SystemConfiguration import SCDynamicStoreCreate, SCDynamicStoreCopyValue
 
 

--- a/nat-lab/tests/helpers.py
+++ b/nat-lab/tests/helpers.py
@@ -53,6 +53,7 @@ class SetupParameters:
     )
     is_meshnet: bool = field(default=True)
     derp_servers: Optional[List[Dict[str, Any]]] = field(default=None)
+    fingerprint: str = ""
 
 
 @dataclass
@@ -161,6 +162,7 @@ async def setup_clients(
             Node,
             AdapterType,
             TelioFeatures,
+            str,
             Optional[Meshmap],
         ]
     ],
@@ -182,9 +184,11 @@ async def setup_clients(
 
     return await asyncio.gather(*[
         exit_stack.enter_async_context(
-            Client(connection, node, adapter_type, features).run(meshmap)
+            Client(
+                connection, node, adapter_type, features, fingerprint=fingerprint
+            ).run(meshmap)
         )
-        for connection, node, adapter_type, features, meshmap in client_parameters
+        for connection, node, adapter_type, features, fingerprint, meshmap in client_parameters
     ])
 
 
@@ -273,6 +277,7 @@ async def setup_environment(
                 nodes,
                 [instance.adapter_type for instance in instances],
                 [instance.features for instance in instances],
+                [instance.fingerprint for instance in instances],
                 [
                     (
                         api.get_meshmap(nodes[idx].id, instance.derp_servers)

--- a/nat-lab/tests/telio_features.py
+++ b/nat-lab/tests/telio_features.py
@@ -66,7 +66,6 @@ class Qos(DataClassJsonMixin):
 @dataclass_json(undefined=Undefined.EXCLUDE)
 @dataclass
 class Nurse(DataClassJsonMixin):
-    fingerprint: str
     heartbeat_interval: int = 3600
     initial_heartbeat_interval: int = 300
     qos: Optional[Qos] = None

--- a/nat-lab/tests/test_direct_connection.py
+++ b/nat-lab/tests/test_direct_connection.py
@@ -48,12 +48,12 @@ def _generate_setup_parameter_pair(
             features=TelioFeatures(
                 direct=Direct(providers=endpoint_providers),
                 nurse=Nurse(
-                    fingerprint=f"{conn_tag}",
                     enable_nat_traversal_conn_data=True,
                     enable_nat_type_collection=True,
                 ),
                 lana=Lana(prod=False, event_path="/event.db"),
             ),
+            fingerprint=f"{conn_tag}",
         )
         for conn_tag, endpoint_providers in cfg
     ]

--- a/nat-lab/tests/test_lana.py
+++ b/nat-lab/tests/test_lana.py
@@ -100,9 +100,7 @@ IP_STACK_TEST_CONFIGS = [
 ]
 
 
-def build_telio_features(
-    fingerprint: str, initial_heartbeat_interval: int = 300
-) -> TelioFeatures:
+def build_telio_features(initial_heartbeat_interval: int = 300) -> TelioFeatures:
     return TelioFeatures(
         lana=Lana(prod=False, event_path=CONTAINER_EVENT_PATH),
         direct=Direct(
@@ -115,7 +113,6 @@ def build_telio_features(
             ),
         ),
         nurse=Nurse(
-            fingerprint=fingerprint,
             heartbeat_interval=3600,
             initial_heartbeat_interval=initial_heartbeat_interval,
             qos=Qos(rtt_interval=RTT_INTERVAL, buckets=5, rtt_tries=1),
@@ -302,7 +299,8 @@ async def run_default_scenario(
         telio.Client(
             connection_alpha,
             alpha,
-            telio_features=build_telio_features(ALPHA_FINGERPRINT),
+            telio_features=build_telio_features(),
+            fingerprint=ALPHA_FINGERPRINT,
         ).run(api.get_meshmap(alpha.id))
     )
 
@@ -310,7 +308,8 @@ async def run_default_scenario(
         telio.Client(
             connection_beta,
             beta,
-            telio_features=build_telio_features(BETA_FINGERPRINT),
+            telio_features=build_telio_features(),
+            fingerprint=BETA_FINGERPRINT,
         ).run(api.get_meshmap(beta.id))
     )
 
@@ -318,7 +317,8 @@ async def run_default_scenario(
         telio.Client(
             connection_gamma,
             gamma,
-            telio_features=build_telio_features(GAMMA_FINGERPRINT),
+            telio_features=build_telio_features(),
+            fingerprint=GAMMA_FINGERPRINT,
         ).run(api.get_meshmap(gamma.id))
     )
 
@@ -1308,14 +1308,16 @@ async def test_lana_with_meshnet_exit_node(
             telio.Client(
                 connection_alpha,
                 alpha,
-                telio_features=build_telio_features(ALPHA_FINGERPRINT),
+                telio_features=build_telio_features(),
+                fingerprint=ALPHA_FINGERPRINT,
             ).run(api.get_meshmap(alpha.id))
         )
         client_beta = await exit_stack.enter_async_context(
             telio.Client(
                 connection_beta,
                 beta,
-                telio_features=build_telio_features(BETA_FINGERPRINT),
+                telio_features=build_telio_features(),
+                fingerprint=BETA_FINGERPRINT,
             ).run(api.get_meshmap(beta.id))
         )
 
@@ -1517,8 +1519,8 @@ async def test_lana_with_disconnected_node(
         await clean_container(connection_beta)
 
         # In this test, we'll manually trigger the collection of QoS
-        def get_features_with_long_qos(fingerprint: str) -> TelioFeatures:
-            features = build_telio_features(fingerprint)
+        def get_features_with_long_qos() -> TelioFeatures:
+            features = build_telio_features()
             assert features.nurse is not None
             assert features.nurse.qos is not None
             features.nurse.qos.rtt_interval = RTT_INTERVAL * 10
@@ -1528,14 +1530,16 @@ async def test_lana_with_disconnected_node(
             telio.Client(
                 connection_alpha,
                 alpha,
-                telio_features=get_features_with_long_qos(ALPHA_FINGERPRINT),
+                telio_features=get_features_with_long_qos(),
+                fingerprint=ALPHA_FINGERPRINT,
             ).run(api.get_meshmap(alpha.id))
         )
         client_beta = await exit_stack.enter_async_context(
             telio.Client(
                 connection_beta,
                 beta,
-                telio_features=get_features_with_long_qos(BETA_FINGERPRINT),
+                telio_features=get_features_with_long_qos(),
+                fingerprint=BETA_FINGERPRINT,
             ).run(api.get_meshmap(beta.id))
         )
 
@@ -1852,7 +1856,8 @@ async def test_lana_with_second_node_joining_later_meshnet_id_can_change(
             telio.Client(
                 connection_beta,
                 beta,
-                telio_features=build_telio_features(BETA_FINGERPRINT),
+                telio_features=build_telio_features(),
+                fingerprint=BETA_FINGERPRINT,
             ).run(api.get_meshmap(beta.id))
         )
 
@@ -1879,7 +1884,8 @@ async def test_lana_with_second_node_joining_later_meshnet_id_can_change(
             telio.Client(
                 connection_alpha,
                 alpha,
-                telio_features=build_telio_features(ALPHA_FINGERPRINT),
+                telio_features=build_telio_features(),
+                fingerprint=ALPHA_FINGERPRINT,
             ).run(api.get_meshmap(alpha.id))
         )
 
@@ -1938,7 +1944,8 @@ async def test_lana_same_meshnet_id_is_reported_after_a_restart(
         async with telio.Client(
             connection_beta,
             beta,
-            telio_features=build_telio_features(BETA_FINGERPRINT),
+            telio_features=build_telio_features(),
+            fingerprint=BETA_FINGERPRINT,
         ).run(api.get_meshmap(beta.id)) as client_beta:
 
             await client_beta.trigger_event_collection()
@@ -1959,7 +1966,8 @@ async def test_lana_same_meshnet_id_is_reported_after_a_restart(
             telio.Client(
                 connection_beta,
                 beta,
-                telio_features=build_telio_features(BETA_FINGERPRINT),
+                telio_features=build_telio_features(),
+                fingerprint=BETA_FINGERPRINT,
             ).run(api.get_meshmap(beta.id))
         )
 
@@ -1995,9 +2003,9 @@ async def test_lana_initial_heartbeat_no_trigger(
                 connection_alpha,
                 alpha,
                 telio_features=build_telio_features(
-                    ALPHA_FINGERPRINT,
                     initial_heartbeat_interval=initial_heartbeat_interval,
                 ),
+                fingerprint=ALPHA_FINGERPRINT,
             ).run(api.get_meshmap(alpha.id))
         )
 

--- a/nat-lab/tests/test_pinging.py
+++ b/nat-lab/tests/test_pinging.py
@@ -187,7 +187,6 @@ async def test_session_keeper(
                 features=TelioFeatures(
                     lana=Lana(prod=False, event_path="/event.db"),
                     nurse=Nurse(
-                        fingerprint="alpha_fingerprint",
                         qos=Qos(
                             rtt_interval=5, rtt_tries=1, rtt_types=["Ping"], buckets=1
                         ),
@@ -196,6 +195,7 @@ async def test_session_keeper(
                     ),
                     ipv6=True,
                 ),
+                fingerprint="alpha_fingerprint",
             )
         ),
         pytest.param(
@@ -209,7 +209,6 @@ async def test_session_keeper(
                 features=TelioFeatures(
                     lana=Lana(prod=False, event_path="/event.db"),
                     nurse=Nurse(
-                        fingerprint="alpha_fingerprint",
                         qos=Qos(
                             rtt_interval=5, rtt_tries=1, rtt_types=["Ping"], buckets=1
                         ),
@@ -218,6 +217,7 @@ async def test_session_keeper(
                     ),
                     ipv6=True,
                 ),
+                fingerprint="alpha_fingerprint",
             )
         ),
     ],

--- a/nat-lab/tests/test_telio_features.py
+++ b/nat-lab/tests/test_telio_features.py
@@ -34,16 +34,15 @@ def test_telio_features():
     assert lana_features == expected_lana
     assert lana_features.to_json() == expected_lana.to_json()
 
-    nurse_features = TelioFeatures(nurse=Nurse(fingerprint="fingerprint"))
+    nurse_features = TelioFeatures(nurse=Nurse())
     expected_nurse = TelioFeatures.from_json(
-        """{"is_test_env": true, "exit_dns": {"auto_switch_dns_ips": true}, "nurse": {"fingerprint": "fingerprint"}}"""
+        """{"is_test_env": true, "exit_dns": {"auto_switch_dns_ips": true}, "nurse": {}}"""
     )
     assert nurse_features == expected_nurse
     assert nurse_features.to_json() == expected_nurse.to_json()
 
     nurse_qos_features = TelioFeatures(
         nurse=Nurse(
-            fingerprint="fingerprint",
             qos=Qos(rtt_interval=5, rtt_tries=3, rtt_types=["Ping"], buckets=5),
             heartbeat_interval=3600,
             initial_heartbeat_interval=10,
@@ -53,7 +52,7 @@ def test_telio_features():
         )
     )
     expected_nurse_qos = TelioFeatures.from_json(
-        """{"is_test_env": true, "exit_dns": {"auto_switch_dns_ips": true}, "nurse": {"fingerprint": "fingerprint", "qos": {"rtt_interval": 5, "rtt_tries": 3, "rtt_types": ["Ping"], "buckets": 5}, "heartbeat_interval": 3600, "initial_heartbeat_interval": 10, "enable_nat_type_collection": false, "enable_relay_conn_data": false, "state_duration_cap": 123}}"""
+        """{"is_test_env": true, "exit_dns": {"auto_switch_dns_ips": true}, "nurse": {"qos": {"rtt_interval": 5, "rtt_tries": 3, "rtt_types": ["Ping"], "buckets": 5}, "heartbeat_interval": 3600, "initial_heartbeat_interval": 10, "enable_nat_type_collection": false, "enable_relay_conn_data": false, "state_duration_cap": 123}}"""
     )
     assert nurse_qos_features == expected_nurse_qos
     assert nurse_qos_features.to_json() == expected_nurse_qos.to_json()
@@ -63,7 +62,6 @@ def test_telio_features():
         direct=Direct(providers=["stun", "local"]),
         lana=Lana(prod=False, event_path="/"),
         nurse=Nurse(
-            fingerprint="alpha",
             qos=Qos(rtt_interval=5, rtt_tries=3, rtt_types=["Ping"], buckets=5),
             heartbeat_interval=3600,
             initial_heartbeat_interval=10,
@@ -79,7 +77,7 @@ def test_telio_features():
         ),
     )
     expected_full = TelioFeatures.from_json(
-        """{"is_test_env": false, "exit_dns": {"auto_switch_dns_ips": true}, "direct": {"providers": ["stun", "local"]}, "lana": {"prod": false, "event_path": "/"}, "nurse": {"fingerprint": "alpha", "qos": {"rtt_interval": 5, "rtt_tries": 3, "rtt_types": ["Ping"], "buckets": 5}, "heartbeat_interval": 3600, "initial_heartbeat_interval": 10, "enable_nat_type_collection": true, "enable_relay_conn_data": true}, "link_detection": {"rtt_seconds": 10, "no_of_pings": 1, "use_for_downgrade": true}}"""
+        """{"is_test_env": false, "exit_dns": {"auto_switch_dns_ips": true}, "direct": {"providers": ["stun", "local"]}, "lana": {"prod": false, "event_path": "/"}, "nurse": {"qos": {"rtt_interval": 5, "rtt_tries": 3, "rtt_types": ["Ping"], "buckets": 5}, "heartbeat_interval": 3600, "initial_heartbeat_interval": 10, "enable_nat_type_collection": true, "enable_relay_conn_data": true}, "link_detection": {"rtt_seconds": 10, "no_of_pings": 1, "use_for_downgrade": true}}"""
     )
     assert full_features == expected_full
     assert full_features.to_json() == expected_full.to_json()

--- a/nat-lab/tests/test_telio_tasks.py
+++ b/nat-lab/tests/test_telio_tasks.py
@@ -32,7 +32,6 @@ async def test_telio_tasks_with_all_features() -> None:
                         ),
                         lana=Lana(prod=False, event_path="/some_path"),
                         nurse=Nurse(
-                            fingerprint="alpha",
                             heartbeat_interval=3600,
                             initial_heartbeat_interval=10,
                             qos=Qos(
@@ -49,6 +48,7 @@ async def test_telio_tasks_with_all_features() -> None:
                             ttl_value=60,
                         ),
                     ),
+                    fingerprint="alpha",
                 )
             ],
         )

--- a/src/doc/integrating_telio.md
+++ b/src/doc/integrating_telio.md
@@ -152,9 +152,6 @@ let json_feature_config = "<feature config fetched from API>".to_owned();
 let mut feature_config = deserialize_feature_config(json_feature_config).unwrap();
 
 feature_config.lana = Some(FeatureLana {  event_path: "some/path.db".to_owned(), prod: true });
-if let Some(nurse) = &mut feature_config.nurse {
-    nurse.fingerprint = "me".to_owned();
-}
 
 #[derive(Debug)]
 struct EventHandler;

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -909,10 +909,7 @@ mod tests {
                     "stun": 50
                 }
             },
-            "nurse":
-            {
-                "fingerprint": "fingerprint_test"
-            },
+            "nurse":{},
             "lana":
             {
                 "event_path": "path/to/some/event/data",
@@ -936,10 +933,7 @@ mod tests {
                     "stun": 50
                 }
             },
-            "nurse":
-            {
-                "fingerprint": "fingerprint_test"
-            },
+            "nurse":{},
             "lana":
             {
                 "event_path": "path/to/some/event/data",

--- a/src/libtelio.udl
+++ b/src/libtelio.udl
@@ -505,8 +505,6 @@ dictionary FeaturePersistentKeepalive {
 
 /// Configurable features for Nurse module
 dictionary FeatureNurse {
-    /// The unique identifier of the device, used for meshnet ID
-    string fingerprint;
     /// Heartbeat interval in seconds. Default value is 3600.
     u64 heartbeat_interval;
     /// Initial heartbeat interval in seconds. Default value is None.


### PR DESCRIPTION
### Problem
We mandate that device fingerprint is set manually when activating nurse even though the fingerprint can be fetched from moose. If we remove fingerprint from the nurse feature config we can properly implement default for nurse and make it so that apps don't have to deal with the fingerprint

### Solution
Just remove it and make nurse active by default. The only issue with that strategy is that we have some natlab tests that use the device fingerprint so we need to keep those working. The strategy implemented here is that if moose doesn't contain a device fingerprint, we try to read it from a file (that is created by the natlab test) and if that fails, we use `missing-device-fp` so that it's easy to see in analytics that something went wrong.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
