### PR TITLE
LLT-5448 Move nightly scheduled pipelines 1 hour back

### DIFF
--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -7,8 +7,8 @@ on:
     # Avoid running on 0 since a lot of other workflows on github start at that
     # time and this can cause delays or even dropping of jobs:
     # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
-    - cron: 18,48 18-23 * * *
-    - cron: 17,47 0-5 * * *
+    - cron: 18,48 17-23 * * *
+    - cron: 17,47 0-4 * * *
 permissions: {}
 
 jobs:


### PR DESCRIPTION
### Problem
Sometimes nightly pipelines statistics does not catch all the pipelines, that were ran during the night.

### Solution
Move the nightly pipelines 1 hour back.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
