### PR TITLE
Remove native interfaces at the beginning of each test

### DIFF
--- a/nat-lab/tests/test_cleanup.py
+++ b/nat-lab/tests/test_cleanup.py
@@ -1,0 +1,52 @@
+import pytest
+import telio
+from contextlib import AsyncExitStack
+from helpers import SetupParameters, setup_environment
+from utils.connection_util import ConnectionTag, new_connection_raw
+from utils.vm.windows_vm_util import _get_network_interface_tunnel_keys
+
+
+@pytest.mark.asyncio
+@pytest.mark.windows
+@pytest.mark.parametrize(
+    "adapter_type, name",
+    [
+        (telio.AdapterType.WireguardGo, "Wintun Userspace Tunnel"),
+        (telio.AdapterType.WindowsNativeWg, "WireGuard Tunnel"),
+    ],
+)
+async def test_get_network_interface_tunnel_keys(adapter_type, name) -> None:
+    async with AsyncExitStack() as exit_stack:
+        connection = await exit_stack.enter_async_context(
+            new_connection_raw(ConnectionTag.WINDOWS_VM_1)
+        )
+        assert [] == await _get_network_interface_tunnel_keys(connection)
+        _env = await exit_stack.enter_async_context(
+            setup_environment(
+                exit_stack,
+                [
+                    SetupParameters(
+                        connection_tag=ConnectionTag.WINDOWS_VM_1,
+                        adapter_type=adapter_type,
+                    ),
+                    SetupParameters(
+                        connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2,
+                        adapter_type=telio.AdapterType.LinuxNativeWg,
+                    ),
+                ],
+            )
+        )
+
+        # This function is used during test startup to remove interfaces
+        # that might have managed to survive the end of the previous test.
+        keys = await _get_network_interface_tunnel_keys(connection)
+        assert [
+            "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Class\\{4d36e972-e325-11ce-bfc1-08002be10318}\\0005"
+        ] == keys
+
+        assert (
+            name
+            in (
+                await connection.create_process(["reg", "query", keys[0]]).execute()
+            ).get_stdout()
+        )

--- a/nat-lab/tests/test_pinging.py
+++ b/nat-lab/tests/test_pinging.py
@@ -39,7 +39,7 @@ async def get_in_node_tracker(
     exit_stack: AsyncExitStack, tag: ConnectionTag, conf: List[ConnectionTrackerConfig]
 ) -> Tuple[Connection, ConnectionTracker]:
     return await exit_stack.enter_async_context(
-        new_connection_with_node_tracker(tag, conf)
+        new_connection_with_node_tracker(tag, conf, remove_existing_interfaces=False)
     )
 
 

--- a/nat-lab/tests/utils/router/linux_router.py
+++ b/nat-lab/tests/utils/router/linux_router.py
@@ -18,6 +18,7 @@ FWMARK_VALUE = "11673110"  # LIBTELIO
 # 32766:  from all lookup main
 # 32767:  from all lookup default
 ROUTING_PRIORITY = "32111"
+INTERFACE_NAME = "tun10"
 
 
 class AddressError(Exception):
@@ -38,7 +39,7 @@ class LinuxRouter(Router):
     def __init__(self, connection: Connection, ip_stack: IPStack):
         super().__init__(ip_stack)
         self._connection = connection
-        self._interface_name = "tun10"
+        self._interface_name = INTERFACE_NAME
 
     def get_interface_name(self) -> str:
         return self._interface_name

--- a/nat-lab/tests/utils/vm/container_util.py
+++ b/nat-lab/tests/utils/vm/container_util.py
@@ -2,9 +2,10 @@ from aiodocker import Docker
 from contextlib import asynccontextmanager
 from typing import AsyncIterator
 from utils.connection import Connection, DockerConnection
+from utils.router.linux_router import INTERFACE_NAME
 
 
-async def _prepare(connection: Connection) -> None:
+async def _prepare(connection: Connection, remove_existing_interfaces: bool) -> None:
     await connection.create_process(["conntrack", "-F"]).execute()
     await connection.create_process(
         ["iptables-save", "-f", "iptables_backup"]
@@ -12,6 +13,13 @@ async def _prepare(connection: Connection) -> None:
     await connection.create_process(
         ["ip6tables-save", "-f", "ip6tables_backup"]
     ).execute()
+    if remove_existing_interfaces:
+        try:
+            await connection.create_process(
+                ["ip", "link", "delete", INTERFACE_NAME]
+            ).execute()
+        except:
+            pass  # Most of the time there will be no interface to be deleted
 
 
 async def _reset(connection: Connection) -> None:
@@ -25,12 +33,14 @@ async def _reset(connection: Connection) -> None:
 
 
 @asynccontextmanager
-async def get(docker: Docker, container_name: str) -> AsyncIterator[DockerConnection]:
+async def get(
+    docker: Docker, container_name: str, remove_existing_interfaces: bool = True
+) -> AsyncIterator[DockerConnection]:
     connection = DockerConnection(
         await docker.containers.get(container_name), container_name
     )
     try:
-        await _prepare(connection)
+        await _prepare(connection, remove_existing_interfaces)
         yield connection
     finally:
         await _reset(connection)


### PR DESCRIPTION
### Problem
Sometimes native interfaces survive until the next test and can impact them.

### Solution
Before each test, remove all native wireguard interfaces.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
