### PR TITLE
Log conntrack events in test logs

### DIFF
--- a/nat-lab/tests/test_pinging.py
+++ b/nat-lab/tests/test_pinging.py
@@ -2,6 +2,7 @@ import asyncio
 import pytest
 import telio
 from contextlib import AsyncExitStack
+from datetime import datetime
 from helpers import setup_mesh_nodes, SetupParameters
 from telio import PathType, State
 from telio_features import TelioFeatures, Direct, Nurse, Qos, Lana
@@ -149,12 +150,12 @@ async def test_session_keeper(
 
         async def wait_for_conntracker() -> None:
             while True:
-                if (
-                    alpha_conn_tracker.get_out_of_limits() is None
-                    and beta_conn_tracker.get_out_of_limits() is None
-                ):
+                alpha_limits = alpha_conn_tracker.get_out_of_limits()
+                beta_limits = beta_conn_tracker.get_out_of_limits()
+                print(datetime.now(), "Conntracker state: ", alpha_limits, beta_limits)
+                if alpha_limits is None and beta_limits is None:
                     return
-                await asyncio.sleep(0.1)
+                await asyncio.sleep(1)
 
         await asyncio.gather(
             alpha_client.wait_for_state_peer(

--- a/nat-lab/tests/utils/connection_tracker.py
+++ b/nat-lab/tests/utils/connection_tracker.py
@@ -4,6 +4,7 @@ import re
 import time
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Optional, List, Dict, AsyncIterator
 from utils.connection import Connection
 from utils.ping import Ping
@@ -46,6 +47,8 @@ class ConnectionTrackerConfig:
 
 def parse_input(input_string) -> FiveTuple:
     five_tuple = FiveTuple()
+
+    print(datetime.now(), "Conntracker reported new connection:", input_string)
 
     match = re.search(r"\[NEW\] (\w+)", input_string)
     if match:


### PR DESCRIPTION
### Problem
Seems like previous root cause for `test_session_keeper` failures was incorrect, and we still have flakyness in the test. Therefore this PR allows to collect more information from the tests, to aid root-cause search.



### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
