### PR TITLE
Update rustc only for unused-features job

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -155,7 +155,8 @@ jobs:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       - uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.6
         with:
-          toolchain: 1.77.2
+          toolchain: 1.78.0
+          override: true
           default: true
       - uses: actions-rs/install@9da1d2adcfe5e7c16992e8242ca33a56b6d9b101
         with:


### PR DESCRIPTION
### Problem
Unused-features job is consistently failing due to too old rustc version. Update rustc version for this job.



### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
