### PR TITLE
Run conntracker before starting up meshnet in test_session_keeper

### DIFF
--- a/nat-lab/tests/utils/vm/container_util.py
+++ b/nat-lab/tests/utils/vm/container_util.py
@@ -5,7 +5,7 @@ from utils.connection import Connection, DockerConnection
 from utils.router.linux_router import INTERFACE_NAME
 
 
-async def _prepare(connection: Connection, remove_existing_interfaces: bool) -> None:
+async def _prepare(connection: Connection) -> None:
     await connection.create_process(["conntrack", "-F"]).execute()
     await connection.create_process(
         ["iptables-save", "-f", "iptables_backup"]
@@ -13,13 +13,13 @@ async def _prepare(connection: Connection, remove_existing_interfaces: bool) -> 
     await connection.create_process(
         ["ip6tables-save", "-f", "ip6tables_backup"]
     ).execute()
-    if remove_existing_interfaces:
-        try:
-            await connection.create_process(
-                ["ip", "link", "delete", INTERFACE_NAME]
-            ).execute()
-        except:
-            pass  # Most of the time there will be no interface to be deleted
+
+    try:
+        await connection.create_process(
+            ["ip", "link", "delete", INTERFACE_NAME]
+        ).execute()
+    except:
+        pass  # Most of the time there will be no interface to be deleted
 
 
 async def _reset(connection: Connection) -> None:
@@ -33,14 +33,12 @@ async def _reset(connection: Connection) -> None:
 
 
 @asynccontextmanager
-async def get(
-    docker: Docker, container_name: str, remove_existing_interfaces: bool = True
-) -> AsyncIterator[DockerConnection]:
+async def get(docker: Docker, container_name: str) -> AsyncIterator[DockerConnection]:
     connection = DockerConnection(
         await docker.containers.get(container_name), container_name
     )
     try:
-        await _prepare(connection, remove_existing_interfaces)
+        await _prepare(connection)
         yield connection
     finally:
         await _reset(connection)


### PR DESCRIPTION
### Problem

Conntrack may rebuild existing TCP connections, which would report out-of-limits in `test_session_keeper`. Instead of building to separate conntrackers (which in the middle would execute `conntrack -F` causing all kinds of issues), setup conntracking at the beginning of the test, and avoid creating connections with side effects (like cleaning up conntrack table) in the middle of test-run.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
