### PR TITLE
Audit kills during docker containers startup

### DIFF
--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -31,4 +31,4 @@ jobs:
           project-id: ${{ secrets.PROJECT_ID }}
           schedule: ${{ github.event_name == 'schedule' }}
           cancel-outdated-pipelines: ${{ github.ref_name != 'main' }}
-          triggered-ref: v1.2.9 # REMEMBER to also update in .gitlab-ci.yml
+          triggered-ref: v1.2.10 # REMEMBER to also update in .gitlab-ci.yml

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,4 +15,4 @@ libtelio-build-pipeline:
 
   trigger:
     project: $LIBTELIO_BUILD_PROJECT_PATH
-    branch: v1.2.9 # REMEMBER to also update in .github/workflows/gitlab.yml
+    branch: v1.2.10 # REMEMBER to also update in .github/workflows/gitlab.yml

--- a/nat-lab/natlab.py
+++ b/nat-lab/natlab.py
@@ -2,6 +2,7 @@
 
 import argparse
 import os
+import shutil
 import subprocess
 import sys
 from typing import List
@@ -66,6 +67,7 @@ def start():
         if dmesg:
             with open(os.path.join(log_dir, "dmesg.txt"), "w", encoding="utf-8") as f:
                 f.write(dmesg)
+        save_audit_log()
 
 
 def get_dmesg_from_host():
@@ -79,6 +81,17 @@ def get_dmesg_from_host():
     except subprocess.CalledProcessError as e:
         print(f"Error executing dmesg: {e}")
         return None
+
+
+def save_audit_log():
+    try:
+        source_path = "/var/log/audit/audit.log"
+        if os.path.exists(source_path):
+            shutil.copy2(source_path, "logs/audit.log")
+        else:
+            print(f"The audit file {source_path} does not exist.")
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        print(f"An error occurred when processing audit log: {e}")
 
 
 def stop():


### PR DESCRIPTION
### Problem
Something is killing iptables and we don't know what it is and why.

### Solution
Add audit log collection. Once we configure our VM(s) with correct audit rules, we will see all kill syscalls and their issuers.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
