### PR TITLE
LLT-5450 Bump boringtun to v1.2.6

### DIFF
--- a/.unreleased/LLT-5450
+++ b/.unreleased/LLT-5450
@@ -1,0 +1,1 @@
+Improved boringtun speeds ~20% compared in v4.x telio

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "boringtun"
 version = "0.6.0"
-source = "git+https://github.com/NordSecurity/boringtun.git?tag=v1.2.5#0f25ad1116edd122894e95f0c60116d106c5a5ad"
+source = "git+https://github.com/NordSecurity/boringtun.git?tag=v1.2.6#ae0c7a7c9510c882c30633f4024833d89c885ae0"
 dependencies = [
  "aead",
  "base64 0.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,7 +162,7 @@ windows = { version = "0.56", features = [
     "Win32_NetworkManagement_IpHelper",
 ] }
 
-boringtun = { git = "https://github.com/NordSecurity/boringtun.git", tag = "v1.2.5", features = ["device"] }
+boringtun = { git = "https://github.com/NordSecurity/boringtun.git", tag = "v1.2.6", features = ["device"] }
 x25519-dalek = { version = "2.0.1", features = ["reusable_secrets", "static_secrets"] }
 
 telio-crypto = { version = "0.1.0", path = "./crates/telio-crypto" }


### PR DESCRIPTION
### Problem
There was a regression in speed going from v0.5.2 to v0.6.0 boringtun

### Solution
Minimized boringtun thread contention, speed increased ~20% compared to v0.5.2


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
