### PR TITLE
Natlab: Do not crash on utf-8 decoding

### DIFF
--- a/nat-lab/tests/utils/connection/ssh_connection.py
+++ b/nat-lab/tests/utils/connection/ssh_connection.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from typing import List
 from utils import cmd_exe_escape
 from utils.process import Process, SshProcess
+from utils.testing import test_name_safe_for_file_name
 
 
 class SshConnection(Connection):
@@ -33,8 +34,22 @@ class SshConnection(Connection):
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_file_name = os.path.join(temp_dir, "temp")
             await asyncssh.scp((self._connection, path), temp_file_name)
-            with open(temp_file_name, encoding="utf-8") as f:
-                return f.read()
+            with open(temp_file_name, "rb") as f:
+                buf = f.read()
+                try:
+                    return buf.decode(encoding="utf-8", errors="strict")
+                except UnicodeDecodeError as e:
+                    log_dir = "logs"
+                    os.makedirs(log_dir, exist_ok=True)
+                    with open(
+                        os.path.join(
+                            log_dir, f"{test_name_safe_for_file_name()}_utf8error"
+                        ),
+                        "wb",
+                    ) as backup:
+                        backup.write(f"Exception occured: {e}\n\n".encode())
+                        backup.write(buf)
+                    return buf.decode(encoding="utf-8", errors="replace")
 
     async def get_ip_address(self) -> tuple[str, str]:
         ip = self._connection._host  # pylint: disable=protected-access


### PR DESCRIPTION
It seems that for some reason some log files from Windows machines contain bytes that are not valid utf-8 characters. Let's not crash in such case and additionally let's dump those bytes to be able to analyze what's happening


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
