### PR TITLE
copy all binaries when running locally during collection

### DIFF
--- a/nat-lab/tests/conftest.py
+++ b/nat-lab/tests/conftest.py
@@ -189,37 +189,68 @@ async def perform_pretest_cleanups():
         await cleanup()
 
 
+async def _copy_binaries_on_ci(session):
+    mac_vm, win_vm_1, win_vm_2 = False, False, False
+
+    for item in session.items:
+        if "WINDOWS_VM_1" in item.name:
+            win_vm_1 = True
+
+        if "WINDOWS_VM_2" in item.name:
+            win_vm_2 = True
+
+        if "MAC_VM" in item.name:
+            mac_vm = True
+
+    if win_vm_1:
+        async with windows_vm_util.new_connection(
+            LAN_ADDR_MAP[ConnectionTag.WINDOWS_VM_1], copy_binaries=True
+        ):
+            pass
+
+    if win_vm_2:
+        async with windows_vm_util.new_connection(
+            LAN_ADDR_MAP[ConnectionTag.WINDOWS_VM_2], copy_binaries=True
+        ):
+            pass
+
+    if mac_vm:
+        async with mac_vm_util.new_connection(copy_binaries=True):
+            pass
+
+
+async def _copy_binaries_on_local_run():
+    try:
+        async with windows_vm_util.new_connection(
+            LAN_ADDR_MAP[ConnectionTag.WINDOWS_VM_1], copy_binaries=True
+        ):
+            pass
+    except OSError as e:
+        print(e)
+
+    try:
+        async with windows_vm_util.new_connection(
+            LAN_ADDR_MAP[ConnectionTag.WINDOWS_VM_2], copy_binaries=True
+        ):
+            pass
+    except OSError as e:
+        print(e)
+
+    try:
+        async with mac_vm_util.new_connection(copy_binaries=True):
+            pass
+    except OSError as e:
+        print(e)
+
+
 def pytest_collection_finish(session):
-    async def copy_binaries():
-        mac_vm, win_vm_1, win_vm_2 = False, False, False
-
-        for item in session.items:
-            if "WINDOWS_VM_1" in item.name:
-                win_vm_1 = True
-
-            if "WINDOWS_VM_2" in item.name:
-                win_vm_2 = True
-
-            if "MAC_VM" in item.name:
-                mac_vm = True
-
-        if win_vm_1:
-            async with windows_vm_util.new_connection(
-                LAN_ADDR_MAP[ConnectionTag.WINDOWS_VM_1], copy_binaries=True
-            ):
-                pass
-
-        if win_vm_2:
-            async with windows_vm_util.new_connection(
-                LAN_ADDR_MAP[ConnectionTag.WINDOWS_VM_2], copy_binaries=True
-            ):
-                pass
-
-        if mac_vm:
-            async with mac_vm_util.new_connection(copy_binaries=True):
-                pass
-
-    asyncio.run(copy_binaries())
+    is_ci = os.environ.get("CUSTOM_ENV_GITLAB_CI") is not None and os.environ.get(
+        "CUSTOM_ENV_GITLAB_CI"
+    )
+    if is_ci:
+        asyncio.run(_copy_binaries_on_ci(session))
+    else:
+        asyncio.run(_copy_binaries_on_local_run())
 
     if not asyncio.run(perform_setup_checks()):
         pytest.exit("Setup checks failed, exiting ...")


### PR DESCRIPTION
### Problem
When running tests locally 1 by 1, not always there will be test name, that would include `["windows', "mac"]` strings in it. If tests name doesn't contain those string, binaries won't be copied to VMs. Doesn't apply to CI, since it is running all tests, which certainly includes those strings.

### Solution
Add separate binary copying according to `CUSTOM_ENV_GITLAB_CI` variable, indicating if it is run in CI or not.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
