### PR TITLE
fix version compatability test

### DIFF
--- a/nat-lab/tests/test_telio_version_compatibility.py
+++ b/nat-lab/tests/test_telio_version_compatibility.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import pytest
+import shlex
 import telio
 from contextlib import AsyncExitStack
 from mesh_api import API
@@ -48,7 +49,6 @@ UHP_conn_client_types = [
     "endpoint_providers, client1_type, client2_type, adapter_type",
     UHP_conn_client_types,
 )
-@pytest.mark.skip("Disabled for now, until LLT-5428 is resolved")
 async def test_connect_different_telio_version_through_relay(
     endpoint_providers,
     client1_type,
@@ -123,9 +123,12 @@ async def test_connect_different_telio_version_through_relay(
         await started_event.wait()
         await beta_router.setup_interface(beta.ip_addresses)
         await beta_router.create_meshnet_route()
-        await beta_client_v3_6.escape_and_write_stdin(
-            ["mesh", "config", json.dumps(api.get_meshmap(beta.id))]
-        )
+
+        await beta_client_v3_6.escape_and_write_stdin([
+            "mesh",
+            "config",
+            shlex.quote(json.dumps(api.get_meshmap(beta.id))),
+        ])
 
         await alpha_client.wait_for_state_on_any_derp([telio.State.Connected])
         await alpha_client.wait_for_state_peer(beta.public_key, [telio.State.Connected])


### PR DESCRIPTION
### Problem
During removal of tcli from natlab it was noticed that version_compatability_test was not working. I've attempted to rewrite it that time, but failed. Decided to come for it later.

### Solution
Fix test that was not working


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
