### PR TITLE
Lock boringtun to 4 threads on android

### DIFF
--- a/.unreleased/lock_android_cores
+++ b/.unreleased/lock_android_cores
@@ -1,0 +1,1 @@
+Lock boringtun to 4 threads on Android

--- a/crates/telio-wg/src/adapter/boring.rs
+++ b/crates/telio-wg/src/adapter/boring.rs
@@ -38,7 +38,11 @@ impl BoringTun {
         let config = DeviceConfig {
             // Apple's Boringtun device runs most efficiently on a single perf-core
             n_threads: {
-                if cfg!(not(any(
+                if cfg!(target_os = "android") {
+                    // A large set of supported android devices
+                    // have 4 "performance" cores
+                    4
+                } else if cfg!(not(any(
                     target_os = "ios",
                     target_os = "macos",
                     target_os = "tvos"


### PR DESCRIPTION
### Problem
In our analyzis a big set of supported devices have 4 "performance" cores Some have 4/4 (mid/low), others 1/3/4 (high/mid/low).
For now locking to 4 seems to give biggest speed improvements while using all cores, causes unreliable performance.

### Solution
Lock boringtun to 4 threads on android


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
