### PR TITLE
nat-lab: save moose DB files 

### DIFF
--- a/nat-lab/tests/conftest.py
+++ b/nat-lab/tests/conftest.py
@@ -135,7 +135,7 @@ async def setup_check_interderp():
 
 
 SETUP_CHECKS = [
-    (setup_check_interderp, 10.0),
+    (setup_check_interderp, 30.0),
 ]
 
 

--- a/nat-lab/tests/utils/analytics/event_validator.py
+++ b/nat-lab/tests/utils/analytics/event_validator.py
@@ -890,7 +890,9 @@ class EventValidator:
     def validate(self, event) -> tuple[bool, str]:
         for validator in self._validators:
             if not validator.validate(event):
-                return False, type(validator).__name__
+                return False, (
+                    "validator: " + type(validator).__name__ + ", event: " + str(event)
+                )
         return True, ""
 
 


### PR DESCRIPTION
### Problems
 - We do not get verbose information, when `lana` validators fail.
 - `interderp` pre-conditions timeout is too short.

### Solution
 - Print failing event, when validating and save `*-events.db` files to `logs` dir after each test.
 - Increase pre-conditions timeout to 30 secs.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
