### PR TITLE
Add workaround for kernel bug

### DIFF
--- a/nat-lab/bin/client
+++ b/nat-lab/bin/client
@@ -2,6 +2,12 @@
 
 set -e
 
+# This is a workaround for 6.x kernel bug, which can cause NULL-deref when
+# iptables are executed too early at boot.
+# More details:
+# https://lore.kernel.org/netdev/20240731213046.6194-3-pablo@netfilter.org/T/#m597226ed32420a20bca5be58cf1c21073f06083b
+sleep 5
+
 # Add conntrack states to iptables, since running dockers on ubuntu
 # conntrack doesn't find flow entries by default somehow. Works when running dockers on debian tho.
 # ref: https://serverfault.com/a/978715

--- a/nat-lab/bin/client
+++ b/nat-lab/bin/client
@@ -16,4 +16,6 @@ ip6tables -A INPUT -m conntrack --ctstate ESTABLISHED -j ACCEPT
 
 /libtelio/nat-lab/bin/configure_route.sh primary
 
+touch /ready
+
 sleep infinity

--- a/nat-lab/bin/cone-gw
+++ b/nat-lab/bin/cone-gw
@@ -2,6 +2,12 @@
 
 set -e
 
+# This is a workaround for 6.x kernel bug, which can cause NULL-deref when
+# iptables are executed too early at boot.
+# More details:
+# https://lore.kernel.org/netdev/20240731213046.6194-3-pablo@netfilter.org/T/#m597226ed32420a20bca5be58cf1c21073f06083b
+sleep 5
+
 # Acquire public IP address
 public_itf=$(ip route show | awk '/10.0.0.0\/16.*dev [a-z0-0]+/ {print $3}')
 

--- a/nat-lab/bin/cone-gw
+++ b/nat-lab/bin/cone-gw
@@ -19,4 +19,6 @@ iptables -t filter -P INPUT DROP
 # Configure standart linux NAT, this will be port restricted cone NAT
 iptables -t nat -A POSTROUTING -o $public_itf -j MASQUERADE
 
+touch /ready
+
 sleep infinity

--- a/nat-lab/bin/fullcone-gw
+++ b/nat-lab/bin/fullcone-gw
@@ -23,4 +23,6 @@ iptables -t filter -P INPUT DROP
 iptables -t nat -A POSTROUTING -o $public_itf -j FULLCONENAT
 iptables -t nat -A PREROUTING -i $public_itf -j FULLCONENAT
 
+touch /ready
+
 sleep infinity

--- a/nat-lab/bin/fullcone-gw
+++ b/nat-lab/bin/fullcone-gw
@@ -2,6 +2,12 @@
 
 set -ex
 
+# This is a workaround for 6.x kernel bug, which can cause NULL-deref when
+# iptables are executed too early at boot.
+# More details:
+# https://lore.kernel.org/netdev/20240731213046.6194-3-pablo@netfilter.org/T/#m597226ed32420a20bca5be58cf1c21073f06083b
+sleep 5
+
 pushd /opt/iptables
 make install
 popd

--- a/nat-lab/bin/internal-symmetric-gw
+++ b/nat-lab/bin/internal-symmetric-gw
@@ -20,4 +20,6 @@ iptables -A FORWARD -i eth0 -o eth1 -j ACCEPT
 
 /libtelio/nat-lab/bin/configure_route.sh secondary
 
+touch /ready
+
 sleep infinity

--- a/nat-lab/bin/internal-symmetric-gw
+++ b/nat-lab/bin/internal-symmetric-gw
@@ -2,6 +2,12 @@
 
 set -e
 
+# This is a workaround for 6.x kernel bug, which can cause NULL-deref when
+# iptables are executed too early at boot.
+# More details:
+# https://lore.kernel.org/netdev/20240731213046.6194-3-pablo@netfilter.org/T/#m597226ed32420a20bca5be58cf1c21073f06083b
+sleep 5
+
 # Configure standard FW
 iptables -t filter -A INPUT -i lo -j ACCEPT
 iptables -t filter -A INPUT -m state --state RELATED,ESTABLISHED -j ACCEPT

--- a/nat-lab/bin/nordlynx
+++ b/nat-lab/bin/nordlynx
@@ -2,6 +2,12 @@
 
 set -eux
 
+# This is a workaround for 6.x kernel bug, which can cause NULL-deref when
+# iptables are executed too early at boot.
+# More details:
+# https://lore.kernel.org/netdev/20240731213046.6194-3-pablo@netfilter.org/T/#m597226ed32420a20bca5be58cf1c21073f06083b
+sleep 5
+
 mkdir -p /etc/nordlynx
 ip link add dev nordlynx0 type nordlynx
 ip addr add 10.5.0.1/16 dev nordlynx0  # VPN

--- a/nat-lab/bin/nordlynx
+++ b/nat-lab/bin/nordlynx
@@ -49,4 +49,6 @@ EOL
 
 /usr/bin/pq-upgrader &
 
+touch /ready
+
 sleep infinity

--- a/nat-lab/bin/pmtu-probe
+++ b/nat-lab/bin/pmtu-probe
@@ -2,6 +2,12 @@
 
 set -euxo pipefail
 
+# This is a workaround for 6.x kernel bug, which can cause NULL-deref when
+# iptables are executed too early at boot.
+# More details:
+# https://lore.kernel.org/netdev/20240731213046.6194-3-pablo@netfilter.org/T/#m597226ed32420a20bca5be58cf1c21073f06083b
+sleep 5
+
 iptables -I INPUT -m length --length 1301:1500 -j DROP
 
 sleep infinity

--- a/nat-lab/bin/pmtu-probe
+++ b/nat-lab/bin/pmtu-probe
@@ -10,4 +10,6 @@ sleep 5
 
 iptables -I INPUT -m length --length 1301:1500 -j DROP
 
+touch /ready
+
 sleep infinity

--- a/nat-lab/bin/symmetric-gw
+++ b/nat-lab/bin/symmetric-gw
@@ -2,6 +2,12 @@
 
 set -e
 
+# This is a workaround for 6.x kernel bug, which can cause NULL-deref when
+# iptables are executed too early at boot.
+# More details:
+# https://lore.kernel.org/netdev/20240731213046.6194-3-pablo@netfilter.org/T/#m597226ed32420a20bca5be58cf1c21073f06083b
+sleep 5
+
 public_itf=$(ip route show | awk '/10.0.0.0\/16.*dev [a-z0-0]+/ {print $3}')
 private_itf=$(ip route show | awk '/192.168.*\/24.*dev [a-z0-0]+/ {print $3}')
 

--- a/nat-lab/bin/symmetric-gw
+++ b/nat-lab/bin/symmetric-gw
@@ -21,4 +21,6 @@ iptables -t nat -A POSTROUTING -o $public_itf -j MASQUERADE --random
 iptables -A FORWARD -i $public_itf -o $private_itf -m state --state RELATED,ESTABLISHED -j ACCEPT
 iptables -A FORWARD -i $private_itf -o $public_itf -j ACCEPT
 
+touch /ready
+
 sleep infinity

--- a/nat-lab/bin/udp-block-gw
+++ b/nat-lab/bin/udp-block-gw
@@ -26,4 +26,6 @@ iptables -A INPUT -p udp -j DROP
 iptables -A OUTPUT -p udp -j DROP
 iptables -A FORWARD -p udp -j DROP
 
+touch /ready
+
 sleep infinity

--- a/nat-lab/bin/udp-block-gw
+++ b/nat-lab/bin/udp-block-gw
@@ -2,6 +2,12 @@
 
 set -e
 
+# This is a workaround for 6.x kernel bug, which can cause NULL-deref when
+# iptables are executed too early at boot.
+# More details:
+# https://lore.kernel.org/netdev/20240731213046.6194-3-pablo@netfilter.org/T/#m597226ed32420a20bca5be58cf1c21073f06083b
+sleep 5
+
 # Acquire public IP address
 public_itf=$(ip route show | awk '/10.0.0.0\/16.*dev [a-z0-0]+/ {print $3}')
 

--- a/nat-lab/bin/upnp-gw
+++ b/nat-lab/bin/upnp-gw
@@ -2,6 +2,12 @@
 
 set -e
 
+# This is a workaround for 6.x kernel bug, which can cause NULL-deref when
+# iptables are executed too early at boot.
+# More details:
+# https://lore.kernel.org/netdev/20240731213046.6194-3-pablo@netfilter.org/T/#m597226ed32420a20bca5be58cf1c21073f06083b
+sleep 5
+
 upnpd eth0 eth1
 
 # Acquire public IP address

--- a/nat-lab/bin/upnp-gw
+++ b/nat-lab/bin/upnp-gw
@@ -16,5 +16,7 @@ public_itf=$(ip route show | awk '/10.0.0.0\/16.*dev [a-z0-0]+/ {print $3}')
 # Configure standart linux NAT, this will be port restricted cone NAT
 iptables -t nat -A POSTROUTING -o $public_itf -j MASQUERADE
 
+touch /ready
+
 sleep infinity
 

--- a/nat-lab/bin/vpn-server
+++ b/nat-lab/bin/vpn-server
@@ -2,6 +2,12 @@
 
 set -euxo pipefail
 
+# This is a workaround for 6.x kernel bug, which can cause NULL-deref when
+# iptables are executed too early at boot.
+# More details:
+# https://lore.kernel.org/netdev/20240731213046.6194-3-pablo@netfilter.org/T/#m597226ed32420a20bca5be58cf1c21073f06083b
+sleep 5
+
 # Configure standart linux NAT, this will be port restricted cone NAT
 iptables -t nat -A POSTROUTING -s 100.64.0.0/10 ! -o wg0 -j MASQUERADE
 

--- a/nat-lab/bin/vpn-server
+++ b/nat-lab/bin/vpn-server
@@ -11,4 +11,6 @@ sleep 5
 # Configure standart linux NAT, this will be port restricted cone NAT
 iptables -t nat -A POSTROUTING -s 100.64.0.0/10 ! -o wg0 -j MASQUERADE
 
+touch /ready
+
 sleep infinity

--- a/nat-lab/docker-compose.yml
+++ b/nat-lab/docker-compose.yml
@@ -36,6 +36,8 @@ services:
     volumes:
       - ./:/sync
       - ../:/libtelio
+    healthcheck:
+      test: "ls /ready"
 
   ###########################################################
   #                         CLIENTS                         #
@@ -90,6 +92,8 @@ services:
       - "pmtu-probe:10.0.80.84"
     volumes:
       - ../:/libtelio
+    healthcheck:
+      test: "ls /ready"
   cone-client-02:
     hostname: cone-client-02
     <<: *common-client
@@ -241,6 +245,8 @@ services:
       - net.ipv4.ip_forward=1
     security_opt:
       - no-new-privileges:true
+    healthcheck:
+      test: "ls /ready"
     networks:
       internet:
         ipv4_address: 10.0.254.1
@@ -414,6 +420,8 @@ services:
     volumes:
       - ./data/nordderper/config1.yml:/etc/nordderper/config.yml
     working_dir: /etc/nordderper
+    healthcheck:
+      test: "curl http://localhost:8765" # Here the port comes from nat-lab/data/nordderper/config*.yml
   derp-02:
     hostname: derp-02
     <<: *common-derp
@@ -453,6 +461,8 @@ services:
     logging:
       options:
         max-size: 50m
+    healthcheck:
+      test: "stunclient 10.0.1.1 3478 | grep success"
 
   # Two VPN servers
   vpn-01: &common-vpn
@@ -504,6 +514,8 @@ services:
         source: ./data/photo.png
         target: /srv/www/photo.png
         read_only: true
+    healthcheck:
+      test: "curl http://localhost"
 
   # Just some publicly-routable UDP server. To access
   # it just simply run `nc -u udp-server 2000`
@@ -519,6 +531,8 @@ services:
       internet:
         ipv4_address: 10.0.80.81
         ipv6_address: 2001:db8:85a4::adda:edde:6
+    healthcheck:
+      test: "netstat -ul | grep 2000"
 
   dns-server-1:
     hostname: dns-server-1
@@ -530,6 +544,8 @@ services:
       internet:
         ipv4_address: 10.0.80.82
         ipv6_address: 2001:db8:85a4::adda:edde:7
+    healthcheck:
+      test: "nslookup google.com localhost"
   dns-server-2:
     hostname: dns-server-2
     image: nat-lab:base
@@ -540,6 +556,9 @@ services:
       internet:
         ipv4_address: 10.0.80.83
         ipv6_address: 2001:db8:85a4::adda:edde:8
+    healthcheck:
+      test: "nslookup google.com localhost"
+
 
   # A host which drop all packets with size larger than 1300
   pmtu-probe:
@@ -559,6 +578,8 @@ services:
         ipv6_address: 2001:db8:85a4::adda:edde:9
     volumes:
       - ../:/libtelio
+    healthcheck:
+      test: "ls /ready"
 
 networks:
   # Network representing public internet,

--- a/nat-lab/natlab.py
+++ b/nat-lab/natlab.py
@@ -55,7 +55,7 @@ def start():
             },
         )
         run_command(
-            ["docker", "compose", "up", "-d"],
+            ["docker", "compose", "up", "-d", "--wait"],
             env={"COMPOSE_DOCKER_CLI_BUILD": "1", "DOCKER_BUILDKIT": "1"},
         )
 


### PR DESCRIPTION
### Problem
We have been observing `iptables` process being killed by kernel in the testing environment. Recently  we have added [kernel logs capturing](https://github.com/NordSecurity/libtelio/pull/725), and observed that we are hitting NULL pointer deref. With the following stack trace:
```
[Tue Aug  6 01:19:33 2024 <    0.000194>]  ? __die_body.cold+0x1a/0x1f
[Tue Aug  6 01:19:33 2024 <    0.000201>]  ? page_fault_oops+0xd2/0x2b0
[Tue Aug  6 01:19:33 2024 <    0.000197>]  ? exc_page_fault+0x70/0x170
[Tue Aug  6 01:19:33 2024 <    0.000200>]  ? asm_exc_page_fault+0x22/0x30
[Tue Aug  6 01:19:33 2024 <    0.000198>]  ? iptable_nat_table_init+0xe1/0x168 [iptable_nat]
[Tue Aug  6 01:19:33 2024 <    0.000202>]  xt_find_table_lock+0x127/0x1b0 [x_tables]
[Tue Aug  6 01:19:33 2024 <    0.000204>]  xt_request_find_table_lock+0x1a/0x70 [x_tables]
[Tue Aug  6 01:19:33 2024 <    0.000202>]  get_info+0xbe/0x390 [ip_tables]
[Tue Aug  6 01:19:33 2024 <    0.000199>]  ? apparmor_capable+0x74/0x170
[Tue Aug  6 01:19:33 2024 <    0.000200>]  do_ipt_get_ctl+0x74/0x3b0 [ip_tables]
[Tue Aug  6 01:19:33 2024 <    0.000200>]  nf_getsockopt+0x44/0x80
[Tue Aug  6 01:19:33 2024 <    0.000206>]  ip_getsockopt+0x80/0xc0
[Tue Aug  6 01:19:33 2024 <    0.000198>]  __sys_getsockopt+0xc7/0x1e0
[Tue Aug  6 01:19:33 2024 <    0.000197>]  __x64_sys_getsockopt+0x1b/0x30
[Tue Aug  6 01:19:33 2024 <    0.000196>]  do_syscall_64+0x55/0xb0
[Tue Aug  6 01:19:33 2024 <    0.000193>]  ? do_fcntl+0x437/0x690
[Tue Aug  6 01:19:33 2024 <    0.000195>]  ? audit_filter_inodes.part.0+0x2e/0x120
[Tue Aug  6 01:19:33 2024 <    0.000204>]  ? audit_reset_context+0x232/0x300
[Tue Aug  6 01:19:33 2024 <    0.000197>]  ? exit_to_user_mode_prepare+0x44/0x1f0
[Tue Aug  6 01:19:33 2024 <    0.000194>]  ? syscall_exit_to_user_mode+0x1e/0x40
[Tue Aug  6 01:19:33 2024 <    0.000193>]  ? do_syscall_64+0x61/0xb0
```
Which looks almost identical to the one reported here: https://lore.kernel.org/netdev/20240731213046.6194-3-pablo@netfilter.org/T/#m597226ed32420a20bca5be58cf1c21073f06083b

This PR introduces a workaround for the issue by delaying iptables initialization for several seconds at the bootup. 


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
