### PR TITLE
[LLT-5488] Allow only to download artifacts from main/nightly/staging builds when commit sha matches

### DIFF
--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -31,4 +31,4 @@ jobs:
           project-id: ${{ secrets.PROJECT_ID }}
           schedule: ${{ github.event_name == 'schedule' }}
           cancel-outdated-pipelines: ${{ github.ref_name != 'main' }}
-          triggered-ref: v1.2.11 # REMEMBER to also update in .gitlab-ci.yml
+          triggered-ref: v1.2.12 # REMEMBER to also update in .gitlab-ci.yml

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,4 +15,4 @@ libtelio-build-pipeline:
 
   trigger:
     project: $LIBTELIO_BUILD_PROJECT_PATH
-    branch: v1.2.11 # REMEMBER to also update in .github/workflows/gitlab.yml
+    branch: v1.2.12 # REMEMBER to also update in .github/workflows/gitlab.yml

--- a/ci/build_libtelio.py
+++ b/ci/build_libtelio.py
@@ -348,10 +348,19 @@ def try_download_artifacts(
             "Cannot download artifacts for uniffi and moose at the same time"
         )
 
+    if "LIBTELIO_COMMIT_SHA" not in os.environ:
+        raise ValueError(
+            "Environment variable LIBTELIO_COMMIT_SHA is not set. "
+            "If you are running this script please set it to current commit hash"
+        )
+    else:
+        commit_sha = os.environ["LIBTELIO_COMMIT_SHA"]
+
     ArtifactsDownloader(
         target_os,
         target_arch,
         token,
+        commit_sha,
         path_to_save,
         root_dir,
         tag_prefix,

--- a/ci/build_libtelio.py
+++ b/ci/build_libtelio.py
@@ -348,29 +348,24 @@ def try_download_artifacts(
             "Cannot download artifacts for uniffi and moose at the same time"
         )
 
-    try:
-        if ArtifactsDownloader(
-            target_os,
-            target_arch,
-            token,
-            path_to_save,
-            root_dir,
-            tag_prefix,
-        ).download():
-            if moose and target_os in ["linux", "windows", "android"]:
-                moose_utils.fetch_moose_dependencies(target_os, MOOSE_MAP[target_arch])
-            return True
-        else:
-            print(f'Failed to download artifacts from "{tag_prefix}" pipeline')
-    except Exception as e:
-        print(f'Error while downloading artifacts from "{tag_prefix}" pipeline: {e}')
+    ArtifactsDownloader(
+        target_os,
+        target_arch,
+        token,
+        path_to_save,
+        root_dir,
+        tag_prefix,
+    ).download()
 
-    return False
+    if moose and target_os in ["linux", "windows", "android"]:
+        moose_utils.fetch_moose_dependencies(target_os, MOOSE_MAP[target_arch])
 
 
 def exec_bindings(args):
     if args.try_fetch_from_pipeline:
-        print("Trying to download uniffi artifacts ...")
+        print(
+            f"Trying to download uniffi artifacts from {args.try_fetch_from_pipeline} track..."
+        )
         try_download_artifacts(
             args.try_fetch_from_pipeline,
             PROJECT_ROOT,
@@ -391,7 +386,9 @@ def exec_bindings(args):
 
 def exec_build(args):
     if args.try_fetch_from_pipeline:
-        print("Trying to download build artifacts ...")
+        print(
+            f"Trying to download build artifacts from {args.try_fetch_from_pipeline} track..."
+        )
         try_download_artifacts(
             args.try_fetch_from_pipeline,
             PROJECT_ROOT,

--- a/ci/fetch_artifacts.py
+++ b/ci/fetch_artifacts.py
@@ -14,6 +14,7 @@ class ArtifactsDownloader:
         target_os,
         target_arch,
         token,
+        commit_sha,
         path_to_save="./",
         repo_dir="./",
         tag_prefix="nightly",
@@ -21,6 +22,7 @@ class ArtifactsDownloader:
         self.target_os = target_os
         self.target_arch = target_arch
         self.token = token
+        self.commit_sha = commit_sha
         self.path_to_save = path_to_save
         self.repo_dir = repo_dir
         self.tag_prefix = tag_prefix
@@ -51,7 +53,14 @@ class ArtifactsDownloader:
 
         tags = (
             subprocess.check_output(
-                ["git", "-C", self.repo_dir, "tag", "--sort=-creatordate"]
+                [
+                    "git",
+                    "-C",
+                    self.repo_dir,
+                    "tag",
+                    "--sort=-creatordate",
+                    f"--points-at={self.commit_sha}",
+                ]
             )
             .decode()
             .splitlines()

--- a/ci/fetch_artifacts.py
+++ b/ci/fetch_artifacts.py
@@ -25,15 +25,11 @@ class ArtifactsDownloader:
         self.repo_dir = repo_dir
         self.tag_prefix = tag_prefix
 
-    def download(self) -> bool:
-        _, tag_msg = self._get_latest_tag()
+    def download(self):
+        tag, tag_msg = self._get_latest_tag()
 
-        if tag_msg:
-            return self._get_pipeline_build_artifacts(tag_msg)
-        else:
-            print(f"No {self.tag_prefix} tag found.")
-
-        return False
+        print(f"Selected {tag} for artifact download")
+        self._get_pipeline_build_artifacts(tag_msg)
 
     def _extract_date(self, tag):
         """Extract the date from the tag name."""
@@ -67,9 +63,13 @@ class ArtifactsDownloader:
 
         for tag in tags:
             date_str = self._extract_date(tag)
+            if date_str is None:
+                continue
+
             date = datetime.strptime(
                 date_str, "%y%m%d" if len(date_str) == 6 else "%y%m%d%H%M"
             )
+
             if latest_date is None or date > latest_date:
                 latest_tag = tag
                 latest_date = date
@@ -85,7 +85,7 @@ class ArtifactsDownloader:
             )
             return latest_tag, message
 
-        return None, None
+        raise Exception("No suitable build tag was found")
 
     def _get_remote_path(self) -> str:
         LIBTELIO_BUILD_PROJECT_ID = 6299
@@ -125,14 +125,8 @@ class ArtifactsDownloader:
             zip_ref.extractall(self.path_to_save)
 
     def _get_pipeline_build_artifacts(self, tag_msg):
-        pipeline_id = None
-
-        try:
-            tag_data = json.loads(tag_msg)
-            pipeline_id = tag_data["pipeline_id"]
-        except json.JSONDecodeError as e:
-            print("Error parsing JSON from tag msg: ", e)
-            return False
+        tag_data = json.loads(tag_msg)
+        pipeline_id = tag_data["pipeline_id"]
 
         for job in json.loads(
             self._get_api(
@@ -141,17 +135,18 @@ class ArtifactsDownloader:
                 )
             )
         ):
-            if job["stage"] == "build":
-                if self.target_os == "uniffi" and job["name"] == "uniffi-bindings":
-                    self._get_artifacts(job)
-                    return True
-                else:
-                    if (
-                        self.target_os in job["name"]
-                        if self.target_os is not None
-                        else True
-                    ) and self.target_arch in job["name"]:
-                        self._get_artifacts(job, unzip=True)
-                        return True
+            # Uniffi bindings
+            if (
+                job["stage"] == "build"
+                and self.target_os == "uniffi"
+                and job["name"] == "uniffi-bindings"
+            ):
+                self._get_artifacts(job)
 
-        return False
+            # Binary builds
+            if (
+                job["stage"] == "build"
+                and self.target_os in job["name"]
+                and self.target_arch in job["name"]
+            ):
+                self._get_artifacts(job, unzip=True)


### PR DESCRIPTION
### Problem
`./ci/fetch_artifacts.py` should only allow to download artifacts when SHA of the tagged build and download destination build matches.

In the meantime, some error-handling refactoring was done in order to have more consistent exception-based error handling instead of returning `bool`.



### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
