### PR TITLE
[LLT-5492] Fix typing errors when arch is not specified

### DIFF
--- a/ci/fetch_artifacts.py
+++ b/ci/fetch_artifacts.py
@@ -137,6 +137,8 @@ class ArtifactsDownloader:
         tag_data = json.loads(tag_msg)
         pipeline_id = tag_data["pipeline_id"]
 
+        job_found = False
+
         for job in json.loads(
             self._get_api(
                 (
@@ -151,6 +153,7 @@ class ArtifactsDownloader:
                 and job["name"] == "uniffi-bindings"
             ):
                 self._get_artifacts(job)
+                job_found = True
 
             # Binary builds
             if (
@@ -160,3 +163,9 @@ class ArtifactsDownloader:
                 and self.target_arch in job["name"]
             ):
                 self._get_artifacts(job, unzip=True)
+                job_found = True
+
+        if not job_found:
+            raise Exception(
+                f"No matching job found for {self.target_os} {self.target_arch} download"
+            )

--- a/ci/fetch_artifacts.py
+++ b/ci/fetch_artifacts.py
@@ -156,6 +156,7 @@ class ArtifactsDownloader:
             if (
                 job["stage"] == "build"
                 and self.target_os in job["name"]
+                and self.target_arch is not None
                 and self.target_arch in job["name"]
             ):
                 self._get_artifacts(job, unzip=True)


### PR DESCRIPTION
### Problem
A case was missed where `self.target_os` may be `None` [here](https://github.com/NordSecurity/libtelio/blob/main-2408061718-43ef9e7/ci/fetch_artifacts.py#L158) was missed causing typing errors during runtime. This PR adds filter for target_arch to be not none when attempting to download binary artifacts.

In addition requirement was added that at least one pipeline must match the filters, such that we would raise an error if download was skipped due to non-matching pipelines.

Failed run can be observed in pipeline `2379654`



### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
