### PR TITLE
Assume libmoose initialized after moose::init has successfully returned

### DIFF
--- a/.unreleased/LLT-5493
+++ b/.unreleased/LLT-5493
@@ -1,0 +1,1 @@
+ Assume libmoose initialized after moose::init has successfully returned

--- a/crates/telio-lana/Cargo.toml
+++ b/crates/telio-lana/Cargo.toml
@@ -14,7 +14,7 @@ tracing.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-time = { version = "=0.3.20" } # moose v5.0.0 requires this
+time.workspace = true
 cargo-platform = { version = "=0.1.7", optional = true  } # moose v5.0.0 requires this
 
 telio-utils.workspace = true


### PR DESCRIPTION
### Problem
During startup libtelio would wait for the moose init callback to be called. This is not needed since after init is completed, events will be saved.

### Solution
Don't wait for the init callback to be called during the startup.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
