### PR TITLE
LLT-4494: Add tool to build defaults for individual features

### DIFF
--- a/.unreleased/LLT-5494
+++ b/.unreleased/LLT-5494
@@ -1,0 +1,1 @@
+Added a builder for feature config

--- a/nat-lab/tests/test_features_builder.py
+++ b/nat-lab/tests/test_features_builder.py
@@ -1,0 +1,95 @@
+from uniffi import FeaturesDefaultsBuilder, deserialize_feature_config
+
+
+def test_telio_features_builder_empty():
+    built = FeaturesDefaultsBuilder().build()
+    json = """
+    {
+        "lana": null,
+        "nurse": null,
+        "direct": null,
+        "derp": null,
+        "link_detection": null,
+        "pmtu_discovery": null,
+        "flush_events_on_stop_timeout_seconds": null,
+        "multicast": false,
+        "ipv6": false,
+        "nicknames": false
+    }
+    """
+    expect = deserialize_feature_config(json)
+
+    assert expect == built
+
+
+def test_telio_features_builder_lana():
+    built = FeaturesDefaultsBuilder().enable_lana("some/path", False).build()
+    json = """
+    {
+        "lana": {
+            "event_path": "some/path",
+            "prod": false
+        },
+        "nurse": null,
+        "direct": null,
+        "derp": null,
+        "link_detection": null,
+        "pmtu_discovery": null,
+        "flush_events_on_stop_timeout_seconds": null,
+        "multicast": false,
+        "ipv6": false,
+        "nicknames": false
+    }
+    """
+    expect = deserialize_feature_config(json)
+
+    assert expect == built
+
+
+def test_telio_features_builder_all_defaults():
+    built = (
+        FeaturesDefaultsBuilder()
+        .enable_nurse()
+        .enable_direct()
+        .enable_firewall_connection_reset()
+        .enable_battery_saving_defaults()
+        .enable_link_detection()
+        .enable_pmtu_discovery()
+        .enable_flush_events_on_stop_timeout_seconds()
+        .enable_multicast()
+        .enable_ipv6()
+        .enable_nicknames()
+        .build()
+    )
+    json = """
+    {
+        "lana": null,
+        "wireguard": {
+            "persistent_keepalive": {
+                "vpn": 115,
+                "direct": 10,
+                "proxying": 125,
+                "stun": 125
+            }
+        },
+        "derp": {
+            "enable_polling": true,
+            "tcp_keepalive": 125,
+            "derp_keepalive": 125
+        },
+        "nurse": {},
+        "firewall": {
+            "boringtun_reset_conns": true
+        },
+        "direct": {},
+        "link_detection": {},
+        "pmtu_discovery": {},
+        "flush_events_on_stop_timeout_seconds": 0,
+        "multicast": true,
+        "ipv6": true,
+        "nicknames": true
+    }
+    """
+    expect = deserialize_feature_config(json)
+
+    assert expect == built, f"json:\n{expect}\n\nbuilt:\n{built}"

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1,3 +1,4 @@
+pub mod defaults_builder;
 pub mod logging;
 pub mod types;
 

--- a/src/ffi/defaults_builder.rs
+++ b/src/ffi/defaults_builder.rs
@@ -1,0 +1,146 @@
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use telio_model::features::{
+    FeatureDerp, FeatureLana, FeaturePersistentKeepalive, FeatureValidateKeys, FeatureWireguard,
+    Features,
+};
+
+pub struct FeaturesDefaultsBuilder {
+    config: Mutex<Features>,
+}
+
+impl FeaturesDefaultsBuilder {
+    pub fn new() -> Self {
+        let config = Features {
+            wireguard: default(),
+            validate_keys: default(),
+            firewall: default(),
+            post_quantum_vpn: default(),
+            dns: default(),
+            nurse: None,
+            lana: None,
+            paths: None,
+            direct: None,
+            is_test_env: None,
+            // All inner values of derp are None's or false's
+            // and as it does not actualy control derp
+            // builder part is not added
+            derp: None,
+            link_detection: None,
+            pmtu_discovery: None,
+            flush_events_on_stop_timeout_seconds: None,
+            multicast: false,
+            ipv6: false,
+            nicknames: false,
+        };
+
+        Self {
+            config: Mutex::new(config),
+        }
+    }
+
+    /// Build final config
+    pub fn build(self: Arc<Self>) -> Features {
+        self.config.lock().clone()
+    }
+
+    /// Enable lana, this requires input from apps
+    pub fn enable_lana(self: Arc<Self>, event_path: String, prod: bool) -> Arc<Self> {
+        self.config.lock().lana = Some(FeatureLana { event_path, prod });
+        self
+    }
+
+    /// Enable nurse with defaults
+    pub fn enable_nurse(self: Arc<Self>) -> Arc<Self> {
+        self.config.lock().nurse = Some(default());
+        self
+    }
+
+    /// Enable direct connections with defaults;
+    pub fn enable_direct(self: Arc<Self>) -> Arc<Self> {
+        self.config.lock().direct = Some(default());
+        self
+    }
+
+    /// Enable firewall connection resets when boringtun is enabled
+    pub fn enable_firewall_connection_reset(self: Arc<Self>) -> Arc<Self> {
+        self.config.lock().firewall.boringtun_reset_conns = true;
+        self
+    }
+
+    /// Enable default wireguard timings, derp timings and other features for best battery performance
+    pub fn enable_battery_saving_defaults(self: Arc<Self>) -> Arc<Self> {
+        {
+            let mut cfg = self.config.lock();
+            cfg.wireguard = FeatureWireguard {
+                persistent_keepalive: FeaturePersistentKeepalive {
+                    vpn: Some(115),
+                    direct: 10,
+                    proxying: Some(125),
+                    stun: Some(125),
+                },
+            };
+            let prev = cfg.derp.as_ref().cloned().unwrap_or_default();
+            cfg.derp = Some(FeatureDerp {
+                tcp_keepalive: Some(125),
+                derp_keepalive: Some(125),
+                enable_polling: Some(true),
+                ..prev
+            });
+        }
+        self
+    }
+
+    /// Enable key valiation in set_config call with defaults
+    pub fn enable_validate_keys(self: Arc<Self>) -> Arc<Self> {
+        self.config.lock().validate_keys = FeatureValidateKeys(true);
+        self
+    }
+
+    /// Enable IPv6 with defaults
+    pub fn enable_ipv6(self: Arc<Self>) -> Arc<Self> {
+        self.config.lock().ipv6 = true;
+        self
+    }
+
+    /// Enable nicknames with defaults
+    pub fn enable_nicknames(self: Arc<Self>) -> Arc<Self> {
+        self.config.lock().nicknames = true;
+        self
+    }
+
+    /// Enable blocking event flush with timout on stop with defaults
+    pub fn enable_flush_events_on_stop_timeout_seconds(self: Arc<Self>) -> Arc<Self> {
+        self.config.lock().flush_events_on_stop_timeout_seconds = Some(0);
+        self
+    }
+
+    /// Enable Link detection mechanism with defaults
+    pub fn enable_link_detection(self: Arc<Self>) -> Arc<Self> {
+        self.config.lock().link_detection = Some(default());
+        self
+    }
+
+    /// Enable PMTU discovery with defaults
+    pub fn enable_pmtu_discovery(self: Arc<Self>) -> Arc<Self> {
+        self.config.lock().pmtu_discovery = Some(default());
+        self
+    }
+
+    /// Eanable multicast with defaults
+    pub fn enable_multicast(self: Arc<Self>) -> Arc<Self> {
+        self.config.lock().multicast = true;
+        self
+    }
+}
+
+impl Default for FeaturesDefaultsBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn default<T: Default>() -> T {
+    T::default()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ pub mod _telio_integration_documentation {
 
 pub mod ffi;
 pub use crate::ffi::*;
-use crate::types::*;
+use crate::{defaults_builder::FeaturesDefaultsBuilder, types::*};
 pub use ffi::types as ffi_types;
 
 /// cbindgen:ignore

--- a/src/libtelio.udl
+++ b/src/libtelio.udl
@@ -447,6 +447,68 @@ callback interface TelioProtectCb {
     void protect(i32 socket_id);
 };
 
+/// A [Features] builder that allows a simpler initialization of
+/// features with defaults comming from libtelio lib.
+///
+/// !!! Should only be used then remote config is inaccessible !!!
+/// 
+interface FeaturesDefaultsBuilder {
+    /// Create a builder for Features with minimal defaults.
+    constructor();
+
+    /// Build final config
+    Features build();
+
+    /// Enable lana, this requires input from apps
+    [Self=ByArc]
+    FeaturesDefaultsBuilder enable_lana(string event_path, boolean is_prod);    
+    
+    /// Enable nurse with defaults
+    [Self=ByArc]
+    FeaturesDefaultsBuilder enable_nurse();
+
+    /// Enable firewall connection resets when boringtun is used
+    [Self=ByArc]
+    FeaturesDefaultsBuilder enable_firewall_connection_reset();
+    
+    /// Enable direct connections with defaults;
+    [Self=ByArc]
+    FeaturesDefaultsBuilder enable_direct();
+    
+    /// Enable default wireguard timings, derp timings and other features for best battery performance
+    [Self=ByArc]
+    FeaturesDefaultsBuilder enable_battery_saving_defaults();
+    
+    /// Enable key valiation in set_config call with defaults
+    [Self=ByArc]
+    FeaturesDefaultsBuilder enable_validate_keys();
+    
+    /// Enable IPv6 with defaults
+    [Self=ByArc]
+    FeaturesDefaultsBuilder enable_ipv6();
+    
+    /// Enable nicknames with defaults
+    [Self=ByArc]
+    FeaturesDefaultsBuilder enable_nicknames();
+    
+    /// Enable blocking event flush with timout on stop with defaults
+    [Self=ByArc]
+    FeaturesDefaultsBuilder enable_flush_events_on_stop_timeout_seconds();
+
+    /// Enable Link detection mechanism with defaults
+    [Self=ByArc]
+    FeaturesDefaultsBuilder enable_link_detection();
+
+    /// Enable PMTU discovery with defaults;
+    [Self=ByArc]
+    FeaturesDefaultsBuilder enable_pmtu_discovery();
+    
+    /// Eanable multicast with defaults
+    [Self=ByArc]
+    FeaturesDefaultsBuilder enable_multicast();
+};
+
+
 /// Encompasses all of the possible features that can be enabled
 dictionary Features {
     /// Additional wireguard configuration


### PR DESCRIPTION
### Problem
When a consumer of this library wants to construct feature config, until now he was
forced to use JSON, or provide all default features himself.

This either easily leads to miss-configuration due to typos, or making
code not forward compatible.

### Solution
A new ffi added, FeaturesDefaultsBuilder, that allows to construct individual features, with libtelio prefered defaults.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
