### PR TITLE
Wait for the moose init callback logs success message before inserting fingerprint in tests

### DIFF
--- a/nat-lab/tests/telio.py
+++ b/nat-lab/tests/telio.py
@@ -990,6 +990,7 @@ class Client:
 
     async def maybe_write_device_fingerprint_to_moose_db(self):
         if self._fingerprint is not None:
+            self.wait_for_log("[Moose] Init callback success")
             database, fingerprint = self._fingerprint
             await self._connection.create_process([
                 "sqlite3",


### PR DESCRIPTION
### Problem
Lana test insert fingerprints via sqlite3 cli. Previously creating telio instance was blocking until lana init callback was initialized. After #753 this is no longer the case.

### Solution
Wait for the lana init callback success log directly in the test before trying to insert the fingerprint.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
