### PR TITLE
Fix a race in test_init_lana_with_failing_moose_init_cb

### DIFF
--- a/crates/telio-lana/src/lib.rs
+++ b/crates/telio-lana/src/lib.rs
@@ -304,7 +304,7 @@ mod test {
     fn test_init_lana_with_failing_moose_init() {
         let _wrapper = MooseStubWrapper::new(MooseStub::new(
             false,
-            Ok(moose::TrackerState::Ready),
+            Err(moose::MooseError::StorageEngine),
             Some(Arc::new(Barrier::new(1))),
         ));
 
@@ -335,6 +335,9 @@ mod test {
         assert!(is_lana_initialized());
 
         init_cb_barrier.wait();
+        // The barrier only unblocks the callback, it's not the same as the init callback finishing.
+        // This means that we need to wait for the effects of callback to happen.
+        while is_lana_initialized() {}
         assert!(!is_lana_initialized());
 
         teardown();


### PR DESCRIPTION
### Problem
The test waited until the callback was called, not until the callback finished.

### Solution
Wait for the results of calling the callback to happen. Additionally a bug in `test_init_lana_with_failing_moose_init` is fixed - init returning true but calling callback with success would be a bug in moose.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
