### PR TITLE
LLT-5498 Add ip stack check for modules with Pinger

### DIFF
--- a/.unreleased/LLT-5498
+++ b/.unreleased/LLT-5498
@@ -1,0 +1,1 @@
+Pinger should not ping the address class, if the ip stack does not match

--- a/crates/telio-model/src/mesh.rs
+++ b/crates/telio-model/src/mesh.rs
@@ -12,26 +12,6 @@ use super::config::{Config, Peer, PeerBase};
 pub use ipnet::IpNet;
 pub use std::net::{Ipv4Addr, SocketAddr};
 
-/// Possible errors from node
-#[derive(Debug, thiserror::Error)]
-pub enum Error {
-    /// No IPs are assigned to node
-    #[error("Node does not have IP addresses assigned")]
-    NoIPsFound,
-}
-
-/// Stack in-use by node
-#[derive(Clone, Default, PartialEq, Eq)]
-pub enum IpStack {
-    /// Node can be reached only through IPv4 address
-    #[default]
-    IPv4,
-    /// Node can be reached only through IPv6 address
-    IPv6,
-    /// Node can be reached through IPv4 or IPv6 addresses
-    IPv4v6,
-}
-
 /// Description of a Node
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize)]
 pub struct Node {
@@ -194,25 +174,5 @@ impl From<&Config> for Map {
                 })
                 .unwrap_or_default(),
         }
-    }
-}
-
-/// Returns IP stack used in node
-pub fn get_ip_stack(ip_addresses: &[IpAddr]) -> Result<IpStack, Error> {
-    let (mut v4, mut v6) = (false, false);
-
-    for addr in ip_addresses.iter() {
-        if addr.is_ipv4() {
-            v4 = true;
-        } else {
-            v6 = true;
-        }
-    }
-
-    match (v4, v6) {
-        (false, false) => Err(Error::NoIPsFound),
-        (true, false) => Ok(IpStack::IPv4),
-        (false, true) => Ok(IpStack::IPv6),
-        (true, true) => Ok(IpStack::IPv4v6),
     }
 }

--- a/crates/telio-nurse/src/data.rs
+++ b/crates/telio-nurse/src/data.rs
@@ -1,9 +1,7 @@
 use std::collections::{BTreeSet, HashMap};
 use telio_crypto::PublicKey;
-use telio_model::{
-    config::Config,
-    mesh::{get_ip_stack, IpStack},
-};
+use telio_model::config::Config;
+use telio_utils::{get_ip_stack, IpStack};
 
 /// Information about a heartbeat, for analytics.
 #[derive(Clone, Debug, Default)]

--- a/crates/telio-nurse/src/heartbeat.rs
+++ b/crates/telio-nurse/src/heartbeat.rs
@@ -17,11 +17,7 @@ use std::{
     sync::Arc,
 };
 use telio_crypto::{meshnet_canonical_key_order, PublicKey, SecretKey};
-use telio_model::config::Server;
-use telio_model::{
-    event::Event,
-    mesh::{get_ip_stack, IpStack, NodeState},
-};
+use telio_model::{config::Server, event::Event, mesh::NodeState};
 use telio_nat_detect::nat_detection::{retrieve_single_nat, NatData};
 use telio_proto::{HeartbeatMessage, HeartbeatNatType, HeartbeatStatus, HeartbeatType};
 use telio_task::{
@@ -29,7 +25,8 @@ use telio_task::{
     Runtime, RuntimeExt, WaitResponse,
 };
 use telio_utils::{
-    interval_at, map_enum, telio_log_debug, telio_log_error, telio_log_trace, telio_log_warn,
+    get_ip_stack, interval_at, map_enum, telio_log_debug, telio_log_error, telio_log_trace,
+    telio_log_warn, IpStack,
 };
 use telio_wg::uapi::PeerState;
 use tokio::time::{sleep, Duration, Instant, Interval, Sleep};

--- a/crates/telio-nurse/src/nurse.rs
+++ b/crates/telio-nurse/src/nurse.rs
@@ -58,9 +58,10 @@ impl Nurse {
         config: Config,
         io: NurseIo<'_>,
         aggregator: Arc<ConnectivityDataAggregator>,
+        ipv6_enabled: bool,
     ) -> Self {
         Self {
-            task: Task::start(State::new(public_key, config, io, aggregator).await),
+            task: Task::start(State::new(public_key, config, io, aggregator, ipv6_enabled).await),
         }
     }
 
@@ -127,6 +128,7 @@ impl State {
         config: Config,
         io: NurseIo<'_>,
         aggregator: Arc<ConnectivityDataAggregator>,
+        ipv6_enabled: bool,
     ) -> Self {
         let meshnet_id = Self::meshnet_id();
 
@@ -174,7 +176,9 @@ impl State {
                 QoSIo {
                     wg_channel,
                     manual_trigger_channel: qos_trigger_channel.subscribe(),
+                    config_update_channel: config_update_channel.subscribe(),
                 },
+                ipv6_enabled,
             )))
         } else {
             None

--- a/crates/telio-traversal/src/endpoint_providers/stun.rs
+++ b/crates/telio-traversal/src/endpoint_providers/stun.rs
@@ -1049,6 +1049,7 @@ mod tests {
     use telio_task::io::Chan;
     use telio_test::await_timeout;
     use telio_utils::exponential_backoff::MockBackoff;
+    use telio_utils::ip_stack::IpStack;
     use telio_wg::{
         uapi::{Interface, Peer},
         Error,
@@ -1958,6 +1959,7 @@ mod tests {
             async fn time_since_last_endpoint_change(&self, public_key: PublicKey) -> Result<Option<Duration>, Error>;
             async fn stop(self);
             async fn reset_existing_connections(&self, exit_pubkey: PublicKey, exit_ipv4: Ipv4Addr) -> Result<(), Error>;
+            async fn set_ip_stack(&self, ip_stack: Option<IpStack>) -> Result<(), Error>;
         }
     }
 

--- a/crates/telio-traversal/src/endpoint_providers/upnp.rs
+++ b/crates/telio-traversal/src/endpoint_providers/upnp.rs
@@ -705,6 +705,7 @@ mod tests {
     use telio_model::mesh::LinkState;
     use telio_sockets::{NativeProtector, SocketPool};
     use telio_utils::exponential_backoff::MockBackoff;
+    use telio_utils::ip_stack::IpStack;
     use telio_wg::uapi::{Interface, Peer};
     use telio_wg::Error as wgError;
     use telio_wg::WireGuard;
@@ -732,6 +733,7 @@ mod tests {
             async fn time_since_last_endpoint_change(&self, public_key: PublicKey) -> Result1<Option<Duration>>;
             async fn stop(self);
             async fn reset_existing_connections(&self, exit_pubkey: PublicKey, exit_ipv4: Ipv4Addr) -> Result1<()>;
+            async fn set_ip_stack(&self, ip_stack: Option<IpStack>) -> Result1<()>;
         }
     }
 

--- a/crates/telio-utils/src/dual_target.rs
+++ b/crates/telio-utils/src/dual_target.rs
@@ -1,5 +1,7 @@
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
+use crate::IpStack;
+
 /// Possible [DualTarget] errors.
 #[derive(thiserror::Error, Debug)]
 pub enum DualTargetError {
@@ -29,6 +31,18 @@ impl DualTarget {
         }
 
         Ok(DualTarget { target })
+    }
+
+    /// Delete target address(es)
+    pub fn delete_address(&mut self, ip_stack: IpStack) {
+        match ip_stack {
+            IpStack::IPv4 => self.target.0 = None,
+            IpStack::IPv6 => self.target.1 = None,
+            IpStack::IPv4v6 => {
+                self.target.0 = None;
+                self.target.1 = None;
+            }
+        }
     }
 
     /// Get target IPs

--- a/crates/telio-utils/src/ip_stack.rs
+++ b/crates/telio-utils/src/ip_stack.rs
@@ -1,0 +1,41 @@
+use std::net::IpAddr;
+
+/// Possible errors from node
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// No IPs are assigned to node
+    #[error("Node does not have IP addresses assigned")]
+    NoIPsFound,
+}
+
+/// Stack in-use by node
+#[derive(Clone, Default, Debug, PartialEq, Eq)]
+pub enum IpStack {
+    /// Node can be reached only through IPv4 address
+    #[default]
+    IPv4,
+    /// Node can be reached only through IPv6 address
+    IPv6,
+    /// Node can be reached through IPv4 or IPv6 addresses
+    IPv4v6,
+}
+
+/// Returns IP stack used in node
+pub fn get_ip_stack(ip_addresses: &[IpAddr]) -> Result<IpStack, Error> {
+    let (mut v4, mut v6) = (false, false);
+
+    for addr in ip_addresses.iter() {
+        if addr.is_ipv4() {
+            v4 = true;
+        } else {
+            v6 = true;
+        }
+    }
+
+    match (v4, v6) {
+        (false, false) => Err(Error::NoIPsFound),
+        (true, false) => Ok(IpStack::IPv4),
+        (false, true) => Ok(IpStack::IPv6),
+        (true, true) => Ok(IpStack::IPv4v6),
+    }
+}

--- a/crates/telio-utils/src/lib.rs
+++ b/crates/telio-utils/src/lib.rs
@@ -43,6 +43,10 @@ pub use lru_cache::*;
 pub mod interval;
 pub use interval::*;
 
+/// IPstack helper
+pub mod ip_stack;
+pub use ip_stack::*;
+
 /// Basic ICMP Pinger
 pub mod pinger;
 pub use pinger::*;

--- a/crates/telio-wg/src/link_detection/enhanced_detection.rs
+++ b/crates/telio-wg/src/link_detection/enhanced_detection.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use std::net::IpAddr;
 
 use telio_task::{io::chan, task_exec, Runtime, RuntimeExt, Task, WaitResponse};
-use telio_utils::{DualTarget, Pinger};
+use telio_utils::{ip_stack, DualTarget, IpStack, Pinger};
 
 /// Component used to check the link state when we think it's down.
 ///
@@ -13,11 +13,12 @@ pub struct EnhancedDetection {
 
 impl EnhancedDetection {
     pub fn start_with(
-        ping_channel: chan::Rx<Vec<IpAddr>>,
+        ping_channel: chan::Rx<(Vec<IpAddr>, Option<IpStack>)>,
         no_of_pings: u32,
+        ipv6_enabled: bool,
     ) -> std::io::Result<Self> {
         Ok(Self {
-            task: Task::start(State::new(ping_channel, no_of_pings)?),
+            task: Task::start(State::new(ping_channel, no_of_pings, ipv6_enabled)?),
         })
     }
 
@@ -27,15 +28,19 @@ impl EnhancedDetection {
 }
 
 pub struct State {
-    pub ping_channel: chan::Rx<Vec<IpAddr>>,
+    pub ping_channel: chan::Rx<(Vec<IpAddr>, Option<IpStack>)>,
     pinger: Pinger,
 }
 
 impl State {
-    pub fn new(ping_channel: chan::Rx<Vec<IpAddr>>, no_of_pings: u32) -> std::io::Result<Self> {
+    pub fn new(
+        ping_channel: chan::Rx<(Vec<IpAddr>, Option<IpStack>)>,
+        no_of_pings: u32,
+        ipv6_enabled: bool,
+    ) -> std::io::Result<Self> {
         Ok(State {
             ping_channel,
-            pinger: Pinger::new(no_of_pings)?,
+            pinger: Pinger::new(no_of_pings, ipv6_enabled)?,
         })
     }
 }
@@ -49,13 +54,25 @@ impl Runtime for State {
     async fn wait(&mut self) -> WaitResponse<'_, Self::Err> {
         if let Some(targets) = self.ping_channel.recv().await {
             Self::guard(async move {
-                for target in targets {
-                    let t = match target {
-                        IpAddr::V4(v4) => (Some(v4), None),
-                        IpAddr::V6(v6) => (None, Some(v6)),
-                    };
-                    if let Ok(t) = DualTarget::new(t) {
-                        let _ = self.pinger.perform(t).await;
+                let curr_ip_stack = targets.1;
+
+                // We do not want to ping anything, unless we have an IP address assigned
+                if let Some(ips) = curr_ip_stack.as_ref() {
+                    for target in targets.0 {
+                        let t = match target {
+                            IpAddr::V4(v4) => (Some(v4), None),
+                            IpAddr::V6(v6) => (None, Some(v6)),
+                        };
+                        // Skip unsupported combinations
+                        match (ips, target) {
+                            (IpStack::IPv4, IpAddr::V6(_)) | (IpStack::IPv6, IpAddr::V4(_)) => {
+                                continue
+                            }
+                            _ => (),
+                        }
+                        if let Ok(t) = DualTarget::new(t) {
+                            let _ = self.pinger.perform(t).await;
+                        }
                     }
                 }
                 Ok(())

--- a/nat-lab/bin/cone-gw
+++ b/nat-lab/bin/cone-gw
@@ -16,6 +16,10 @@ iptables -t filter -A INPUT -i lo -j ACCEPT
 iptables -t filter -A INPUT -m state --state RELATED,ESTABLISHED -j ACCEPT
 iptables -t filter -P INPUT DROP
 
+# Drop all out-of-tunnel meshnet traffic
+iptables -t filter -A FORWARD -s 100.64.0.0/10 -j DROP
+iptables -t filter -A FORWARD -d 100.64.0.0/10 -j DROP
+
 # Configure standart linux NAT, this will be port restricted cone NAT
 iptables -t nat -A POSTROUTING -o $public_itf -j MASQUERADE
 

--- a/nat-lab/bin/fullcone-gw
+++ b/nat-lab/bin/fullcone-gw
@@ -19,6 +19,10 @@ iptables -t filter -A INPUT -i lo -j ACCEPT
 iptables -t filter -A INPUT -m state --state RELATED,ESTABLISHED -j ACCEPT
 iptables -t filter -P INPUT DROP
 
+# Drop all out-of-tunnel meshnet traffic
+iptables -t filter -A FORWARD -s 100.64.0.0/10 -j DROP
+iptables -t filter -A FORWARD -d 100.64.0.0/10 -j DROP
+
 # Configure Full-cone NAT
 iptables -t nat -A POSTROUTING -o $public_itf -j FULLCONENAT
 iptables -t nat -A PREROUTING -i $public_itf -j FULLCONENAT

--- a/nat-lab/bin/internal-symmetric-gw
+++ b/nat-lab/bin/internal-symmetric-gw
@@ -13,6 +13,10 @@ iptables -t filter -A INPUT -i lo -j ACCEPT
 iptables -t filter -A INPUT -m state --state RELATED,ESTABLISHED -j ACCEPT
 iptables -t filter -P INPUT DROP
 
+# Drop all out-of-tunnel meshnet traffic
+iptables -t filter -A FORWARD -s 100.64.0.0/10 -j DROP
+iptables -t filter -A FORWARD -d 100.64.0.0/10 -j DROP
+
 # Configure symmetric NAT
 iptables -t nat -A POSTROUTING -o eth1 -j MASQUERADE --random
 iptables -A FORWARD -i eth1 -o eth0 -m state --state RELATED,ESTABLISHED -j ACCEPT

--- a/nat-lab/bin/symmetric-gw
+++ b/nat-lab/bin/symmetric-gw
@@ -16,6 +16,10 @@ iptables -t filter -A INPUT -i lo -j ACCEPT
 iptables -t filter -A INPUT -m state --state RELATED,ESTABLISHED -j ACCEPT
 iptables -t filter -P INPUT DROP
 
+# Drop all out-of-tunnel meshnet traffic
+iptables -t filter -A FORWARD -s 100.64.0.0/10 -j DROP
+iptables -t filter -A FORWARD -d 100.64.0.0/10 -j DROP
+
 # Configure symmetric NAT
 iptables -t nat -A POSTROUTING -o $public_itf -j MASQUERADE --random
 iptables -A FORWARD -i $public_itf -o $private_itf -m state --state RELATED,ESTABLISHED -j ACCEPT

--- a/nat-lab/bin/udp-block-gw
+++ b/nat-lab/bin/udp-block-gw
@@ -14,6 +14,10 @@ public_itf=$(ip route show | awk '/10.0.0.0\/16.*dev [a-z0-0]+/ {print $3}')
 # Configure standart linux NAT, this will be port restricted cone NAT
 iptables -t nat -A POSTROUTING -p tcp -o $public_itf -j MASQUERADE
 
+# Drop all out-of-tunnel meshnet traffic
+iptables -t filter -A FORWARD -s 100.64.0.0/10 -j DROP
+iptables -t filter -A FORWARD -d 100.64.0.0/10 -j DROP
+
 # incase some1 will need dns, uncomment following lines
 # iptables -A INPUT -p udp --sport 53 -j ACCEPT
 # iptables -A INPUT -p udp --dport 53 -j ACCEPT

--- a/nat-lab/bin/upnp-gw
+++ b/nat-lab/bin/upnp-gw
@@ -13,6 +13,10 @@ upnpd eth0 eth1
 # Acquire public IP address
 public_itf=$(ip route show | awk '/10.0.0.0\/16.*dev [a-z0-0]+/ {print $3}')
 
+# Drop all out-of-tunnel meshnet traffic
+iptables -t filter -A FORWARD -s 100.64.0.0/10 -j DROP
+iptables -t filter -A FORWARD -d 100.64.0.0/10 -j DROP
+
 # Configure standart linux NAT, this will be port restricted cone NAT
 iptables -t nat -A POSTROUTING -o $public_itf -j MASQUERADE
 

--- a/nat-lab/tests/helpers.py
+++ b/nat-lab/tests/helpers.py
@@ -366,3 +366,30 @@ async def setup_mesh_nodes(
         await connection_future
 
     return env
+
+
+def connectivity_stack(node1_stack: IPStack, node2_stack: IPStack) -> Optional[IPStack]:
+    """
+    Checks, through which paths (v4, v6 or both) the nodes can communicate with each other.
+    """
+    if (
+        (node1_stack, node2_stack) == (IPStack.IPv4, IPStack.IPv4)
+        or (node1_stack, node2_stack) == (IPStack.IPv4, IPStack.IPv4v6)
+        or (node1_stack, node2_stack) == (IPStack.IPv4v6, IPStack.IPv4)
+    ):
+        return IPStack.IPv4
+    if (node1_stack, node2_stack) == (IPStack.IPv4, IPStack.IPv6) or (
+        node1_stack,
+        node2_stack,
+    ) == (IPStack.IPv6, IPStack.IPv4):
+        return None
+    if (
+        (node1_stack, node2_stack) == (IPStack.IPv6, IPStack.IPv6)
+        or (node1_stack, node2_stack) == (IPStack.IPv6, IPStack.IPv4v6)
+        or (node1_stack, node2_stack) == (IPStack.IPv4v6, IPStack.IPv6)
+    ):
+        return IPStack.IPv6
+    if (node1_stack, node2_stack) == (IPStack.IPv4v6, IPStack.IPv4v6):
+        return IPStack.IPv4v6
+
+    raise ValueError(f"Unsupported IPStack combination: {node1_stack}, {node2_stack}")

--- a/src/device.rs
+++ b/src/device.rs
@@ -73,7 +73,7 @@ use futures::FutureExt;
 use telio_utils::{
     commit_sha,
     exponential_backoff::ExponentialBackoffBounds,
-    interval, telio_log_debug, telio_log_error, telio_log_info, telio_log_warn,
+    get_ip_stack, interval, telio_log_debug, telio_log_error, telio_log_info, telio_log_warn,
     tokio::{Monitor, ThreadTracker},
     version_tag,
 };
@@ -1092,6 +1092,7 @@ impl Runtime {
                         firewall_reset_connections,
                     },
                     features.link_detection,
+                    features.ipv6,
                 )?);
                 let wg_events = wg_events.rx;
             } else {
@@ -1153,6 +1154,7 @@ impl Runtime {
                         NurseConfig::new(nurse_features),
                         nurse_io,
                         aggregator.clone(),
+                        features.ipv6,
                     )
                     .await,
                 ))
@@ -1736,6 +1738,15 @@ impl Runtime {
 
         // Update for proxy and derp config
         if let Some(config) = config {
+            let _ = get_ip_stack(config.this.ip_addresses.as_ref().map_or(&[], |v| v))
+                .ok()
+                .map(|ip_stack| async {
+                    self.entities
+                        .wireguard_interface
+                        .set_ip_stack(Some(ip_stack))
+                        .await
+                });
+
             let wg_port = self
                 .entities
                 .wireguard_interface
@@ -1846,6 +1857,8 @@ impl Runtime {
 
             self.upsert_dns_peers().await?;
         } else {
+            let _ = self.entities.wireguard_interface.set_ip_stack(None).await;
+
             // Nurse is keeping Arc to Derp, so we need to get rid of it before stopping Derp
             if let Some(nurse) = self.entities.nurse.as_ref() {
                 nurse.configure_meshnet(None).await;


### PR DESCRIPTION
### Problem
Libtelio modules, which uses `pinger`, did not checked the IP stack, which is currently used on adapter (`IPv4`, `IPv6`, or dual `IPv4v6`) and so `pinger` can actually open the `IPv4` socket, even if the current stack is `IPv6`, but the source address would be set (by OS) to out-of-tunnel address.

### Solution
Check, what stack is used, before performing ping requests in-tunnel.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
