### PR TITLE
Update conntrack trigger rule to be actually noop

### DIFF
--- a/nat-lab/bin/client
+++ b/nat-lab/bin/client
@@ -11,8 +11,8 @@ sleep 5
 # Add conntrack states to iptables, since running dockers on ubuntu
 # conntrack doesn't find flow entries by default somehow. Works when running dockers on debian tho.
 # ref: https://serverfault.com/a/978715
-iptables -A INPUT -m conntrack --ctstate ESTABLISHED -j ACCEPT
-ip6tables -A INPUT -m conntrack --ctstate ESTABLISHED -j ACCEPT
+iptables -A INPUT -m conntrack --ctstate ESTABLISHED -j LOG --log-level debug
+ip6tables -A INPUT -m conntrack --ctstate ESTABLISHED -j LOG --log-level debug
 
 /libtelio/nat-lab/bin/configure_route.sh primary
 


### PR DESCRIPTION
### Problem
In Non-Initial network namespaces conntrack is deactivated until some reference is created. We have been using:
```
iptables -A INPUT -m conntrack --ctstate ESTABLISHED -j ACCEPT
```
to add a reference, but this rule is a bit too intrusive and may cause spurious packets being accepted inside testing containers. Therefore I am proposing to change it to:
```
iptables -A INPUT -m conntrack --ctstate ESTABLISHED -j LOG --log-level debug
```
in this PR.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
