### PR TITLE
Make it possible to control using the `hide_ips` if the IP addresses are hidden

### DIFF
--- a/.unreleased/LLT-5507
+++ b/.unreleased/LLT-5507
@@ -1,0 +1,1 @@
+Make it possible to control using the `hide_ips` if the IP addresses are hidden in logs

--- a/crates/telio-model/src/features.rs
+++ b/crates/telio-model/src/features.rs
@@ -31,6 +31,9 @@ pub struct Features {
     /// Test environment (natlab) requires binding feature disabled
     /// TODO: Remove it once mac integration tests support the binding mechanism
     pub is_test_env: Option<bool>,
+    /// Controll if IP addresses should be hidden in logs
+    #[default(true)]
+    pub hide_ips: bool,
     /// Derp server specific configuration
     pub derp: Option<FeatureDerp>,
     /// Flag to specify if keys should be validated
@@ -456,6 +459,7 @@ mod tests {
                 }
             },
             "is_test_env": true,
+            "hide_ips": false,
             "derp": {
                 "tcp_keepalive": 13,
                 "derp_keepalive": 14,
@@ -537,6 +541,7 @@ mod tests {
                     }),
                 }),
                 is_test_env: Some(true),
+                hide_ips: false,
                 derp: Some(FeatureDerp {
                     tcp_keepalive: Some(13),
                     derp_keepalive: Some(14),
@@ -735,6 +740,21 @@ mod tests {
             let actual = from_str::<Features>(json).unwrap().wireguard;
             let expected = FeatureWireguard::default();
             assert_eq!(actual, expected);
+        }
+
+        #[test]
+        fn test_hide_ips() {
+            let json = r#"{}"#;
+            let actual = from_str::<Features>(json).unwrap();
+            assert_eq!(actual.hide_ips, true);
+
+            let json = r#"{"hide_ips": false}"#;
+            let actual = from_str::<Features>(json).unwrap();
+            assert_eq!(actual.hide_ips, false);
+
+            let json = r#"{"hide_ips": true}"#;
+            let actual = from_str::<Features>(json).unwrap();
+            assert_eq!(actual.hide_ips, true);
         }
     }
 

--- a/nat-lab/tests/telio_features.py
+++ b/nat-lab/tests/telio_features.py
@@ -121,6 +121,7 @@ class Firewall(DataClassJsonMixin):
 @dataclass
 class TelioFeatures(DataClassJsonMixin):
     is_test_env: Optional[bool] = True
+    hide_ips: Optional[bool] = False
     direct: Optional[Direct] = None
     lana: Optional[Lana] = None
     nurse: Optional[Nurse] = None

--- a/src/device.rs
+++ b/src/device.rs
@@ -95,6 +95,8 @@ static NETWORK_PATH_MONITOR_START: std::sync::Once = std::sync::Once::new();
 #[cfg(test)]
 use wg::tests::AdapterExpectation;
 
+use crate::logging::LOG_CENSOR;
+
 #[derive(Debug, TError)]
 pub enum Error {
     #[error("Driver already started.")]
@@ -452,6 +454,8 @@ impl Device {
         event_cb: F,
         protect: Option<Arc<dyn Protector>>,
     ) -> Result<Self> {
+        LOG_CENSOR.set_enabled(features.hide_ips);
+
         let version_tag = version_tag();
         let commit_sha = commit_sha();
         telio_log_info!("Created libtelio instance {}, {}", version_tag, commit_sha);

--- a/src/device/wg_controller.rs
+++ b/src/device/wg_controller.rs
@@ -1444,6 +1444,7 @@ mod tests {
                     } else {
                         None
                     },
+                    hide_ips: false,
                     derp: None,
                     validate_keys: Default::default(),
                     ipv6: true,

--- a/src/ffi/defaults_builder.rs
+++ b/src/ffi/defaults_builder.rs
@@ -23,6 +23,7 @@ impl FeaturesDefaultsBuilder {
             paths: None,
             direct: None,
             is_test_env: None,
+            hide_ips: true,
             // All inner values of derp are None's or false's
             // and as it does not actualy control derp
             // builder part is not added

--- a/src/libtelio.udl
+++ b/src/libtelio.udl
@@ -523,6 +523,8 @@ dictionary Features {
     FeatureDirect? direct;
     /// Should only be set for macos sideload
     boolean? is_test_env;
+    /// Controll if IP addresses should be hidden in logs
+    boolean hide_ips;
     /// Derp server specific configuration
     FeatureDerp? derp;
     /// Flag to specify if keys should be validated


### PR DESCRIPTION
IPs should always be hidden in production, but hiding them makes it hard to investigate bugs found in the nat-lab tests. This is why a flag to control IP hiding has been added. While it defaults to hiding the IPs, for the nat-lab tests (and only for that case) it defaults to show IPs by changing pytests default value.

Additionally, as a side effect, the log censoring functionality no longer makes copies of log message strings when they haven't been modified.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
