### PR TITLE
Use batcher for stun, vpn and proxied peers keepalives

### DIFF
--- a/.unreleased/LLT-5402
+++ b/.unreleased/LLT-5402
@@ -1,0 +1,1 @@
+Use batcher for stun, vpn and proxied peers persistent keepalives

--- a/crates/telio-batcher/src/batcher.rs
+++ b/crates/telio-batcher/src/batcher.rs
@@ -113,6 +113,12 @@ where
         self.actions.insert(key, (entry, action));
         self.notify_add.notify_waiters();
     }
+
+    pub fn get_interval(&self, key: &K) -> Option<u32> {
+        self.actions
+            .get(key)
+            .and_then(|(entry, _)| entry.interval.as_secs().try_into().ok())
+    }
 }
 
 /// Tests provide near-perfect immediate sleeps due to how tokio runtime acts when it's paused(basically sleeps are resolved immediately)

--- a/crates/telio-utils/src/dual_target.rs
+++ b/crates/telio-utils/src/dual_target.rs
@@ -16,6 +16,22 @@ pub type Result<T> = std::result::Result<T, DualTargetError>;
 /// Target input with IPv4 and IPv6 addresses
 pub type Target = (Option<Ipv4Addr>, Option<Ipv6Addr>);
 
+/// Builds Target from a list of ip addresses
+pub fn build_ping_endpoint(ip_addresses: &Vec<IpAddr>, use_ipv6: bool) -> Target {
+    let mut ipv4 = None;
+    let mut ipv6 = None;
+
+    for ip in ip_addresses {
+        match (ip, ipv4, ipv6, use_ipv6) {
+            (IpAddr::V4(v4), None, _, _) => ipv4 = Some(*v4),
+            (IpAddr::V6(v6), _, None, true) => ipv6 = Some(*v6),
+            _ => (),
+        }
+    }
+
+    (ipv4, ipv6)
+}
+
 /// DualTarget wrapper
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct DualTarget {

--- a/crates/telio-utils/src/repeated_actions.rs
+++ b/crates/telio-utils/src/repeated_actions.rs
@@ -119,6 +119,13 @@ where
             .ok_or(RepeatedActionError::RepeatedActionNotFound)
             .map(|(s, f)| (s, f.clone()))
     }
+
+    /// Returns the interval period in seconds
+    pub fn get_interval(&self, key: &K) -> Option<u32> {
+        self.actions
+            .get(key)
+            .and_then(|(i, _)| i.period().as_secs().try_into().ok())
+    }
 }
 
 impl<K, C, R, const N: usize> From<[Action<K, C, R>; N]> for RepeatedActions<K, C, R>


### PR DESCRIPTION
Disable Wireguard keepalives for stun, vpn and proxied peers and use the session keeper intead because we want them to be batched for battery lifetime improvements.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
