### PR TITLE
Temporaly enable tracing logs in release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -477,7 +477,7 @@ dependencies = [
 [[package]]
 name = "boringtun"
 version = "0.6.0"
-source = "git+https://github.com/NordSecurity/boringtun.git?tag=v1.2.6#ae0c7a7c9510c882c30633f4024833d89c885ae0"
+source = "git+https://github.com/NordSecurity/boringtun.git?branch=enable_tracing_logs_in_release#13929da2699af0146347b0e71dd8e75ae15d3a4b"
 dependencies = [
  "aead",
  "base64 0.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,7 +126,7 @@ ipnet = { version = "2.3", features = ["serde"] }
 itertools = "0.10"
 lazy_static = "1.4.0"
 libc = "0.2.112"
-tracing = { version = "0.1.37", features = ["max_level_trace", "release_max_level_debug"] }
+tracing = { version = "0.1.37", features = ["max_level_trace", "release_max_level_trace"] }
 maplit = "1"
 mockall = "0.11.3"
 modifier = "0.1.0"
@@ -168,7 +168,7 @@ windows = { version = "0.56", features = [
     "Win32_NetworkManagement_IpHelper",
 ] }
 
-boringtun = { git = "https://github.com/NordSecurity/boringtun.git", tag = "v1.2.6", features = ["device"] }
+boringtun = { git = "https://github.com/NordSecurity/boringtun.git", branch = "enable_tracing_logs_in_release", features = ["device"] }
 x25519-dalek = { version = "2.0.1", features = ["reusable_secrets", "static_secrets"] }
 
 

--- a/nat-lab/tests/uniffi/libtelio_remote.py
+++ b/nat-lab/tests/uniffi/libtelio_remote.py
@@ -107,7 +107,7 @@ class LibtelioWrapper:
         self._libtelio = None
         self._event_cb = TelioEventCbImpl()
         self._logger_cb = TelioLoggerCbImpl()
-        libtelio.set_global_logger(libtelio.TelioLogLevel.DEBUG, self._logger_cb)
+        libtelio.set_global_logger(libtelio.TelioLogLevel.TRACE, self._logger_cb)
 
     def shutdown(self):
         if self._libtelio is not None:


### PR DESCRIPTION
### Problem
We need a bit more info to investigate nat-lab issues

### Solution
Tracing logs are enabled for release, will be removed on Friday


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
