### PR TITLE
Sanitize nicknames from logs

### DIFF
--- a/crates/telio-model/src/config.rs
+++ b/crates/telio-model/src/config.rs
@@ -29,7 +29,7 @@ pub struct PeerBase {
     /// Ip address of peer
     pub ip_addresses: Option<Vec<IpAddr>>,
     /// Nickname for the peer
-    pub nickname: Option<String>,
+    pub nickname: Option<Hidden<String>>,
 }
 
 /// Description of a peer
@@ -440,7 +440,7 @@ mod tests {
                     .unwrap(),
                 hostname: telio_utils::Hidden("everest-alice.nord".to_owned()),
                 ip_addresses: Some(vec!["198.51.100.42".parse().unwrap()]),
-                nickname: Some("bunnyg".to_owned()),
+                nickname: Some(telio_utils::Hidden("bunnyg".to_owned())),
             },
             peers: Some(vec![
                 Peer {
@@ -451,7 +451,7 @@ mod tests {
                             .unwrap(),
                         hostname: telio_utils::Hidden("everest-bob.nord".to_owned()),
                         ip_addresses: Some(vec!["198.51.100.43".parse().unwrap()]),
-                        nickname: Some("".to_owned()),
+                        nickname: Some(telio_utils::Hidden("".to_owned())),
                     },
                     is_local: true,
                     allow_incoming_connections: true,

--- a/crates/telio-model/src/mesh.rs
+++ b/crates/telio-model/src/mesh.rs
@@ -124,7 +124,10 @@ impl From<&PeerBase> for Node {
         Self {
             identifier: peer.identifier.clone(),
             public_key: peer.public_key,
-            nickname: peer.nickname.clone(),
+            nickname: peer
+                .nickname
+                .as_ref()
+                .map(|hidden_nick| hidden_nick.0.to_owned()),
             allowed_ips: peer
                 .ip_addresses
                 .as_ref()
@@ -140,7 +143,10 @@ impl From<&Peer> for Node {
     fn from(peer: &Peer) -> Self {
         Self {
             public_key: peer.public_key,
-            nickname: peer.nickname.clone(),
+            nickname: peer
+                .nickname
+                .as_ref()
+                .map(|hidden_nick| hidden_nick.0.to_owned()),
             allowed_ips: peer
                 .ip_addresses
                 .as_ref()

--- a/src/device.rs
+++ b/src/device.rs
@@ -934,9 +934,9 @@ impl RequestedState {
             })
             .filter(|(nick, _)| validate_nickname(nick))
             .fold(Records::new(), |mut records, (mut nick, ip)| {
-                nick += ".nord";
+                nick.0 += ".nord";
 
-                if let Entry::Vacant(e) = records.entry(nick.to_owned()) {
+                if let Entry::Vacant(e) = records.entry(nick.0.to_owned()) {
                     e.insert(ip);
                 } else {
                     telio_log_warn!("Nickname is already assigned: {nick:?}. Ignore");
@@ -2152,7 +2152,11 @@ impl Runtime {
                 Some(Node {
                     identifier: meshnet_peer.base.identifier.clone(),
                     public_key: meshnet_peer.base.public_key,
-                    nickname: meshnet_peer.base.nickname.clone(),
+                    nickname: meshnet_peer
+                        .base
+                        .nickname
+                        .as_ref()
+                        .map(|hidden_nick| hidden_nick.0.to_owned()),
                     state: state.unwrap_or_else(|| peer.state()),
                     link_state,
                     is_exit: peer
@@ -2499,7 +2503,9 @@ mod tests {
         PeerBase {
             hostname: telio_utils::Hidden(hostname),
             ip_addresses,
-            nickname,
+            nickname: nickname
+                .as_ref()
+                .map(|nick| telio_utils::Hidden(nick.to_owned())),
             ..Default::default()
         }
     }
@@ -2803,7 +2809,7 @@ mod tests {
             public_key: pubkey,
             hostname: telio_utils::Hidden("hostname".to_owned()),
             ip_addresses: Some(vec![IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))]),
-            nickname: Some("nickname".to_owned()),
+            nickname: Some(telio_utils::Hidden("nickname".to_owned())),
         };
         let get_config = Config {
             this: peer_base.clone(),
@@ -2879,7 +2885,7 @@ mod tests {
                 public_key: private_key.public(),
                 hostname: telio_utils::Hidden("hostname".to_owned()),
                 ip_addresses: Some(vec![IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))]),
-                nickname: Some("nickname".to_owned()),
+                nickname: Some(telio_utils::Hidden("nickname".to_owned())),
             },
             peers: Some(vec![
                 Peer {
@@ -2968,7 +2974,7 @@ mod tests {
             public_key: pubkey,
             hostname: telio_utils::Hidden("hostname".to_owned()),
             ip_addresses: Some(vec![IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))]),
-            nickname: Some("nickname".to_owned()),
+            nickname: Some(telio_utils::Hidden("nickname".to_owned())),
         };
         let config = Some(Config {
             this: peer_base.clone(),
@@ -3067,7 +3073,7 @@ mod tests {
             public_key: pubkey,
             hostname: telio_utils::Hidden("hostname".to_owned()),
             ip_addresses: Some(vec![IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))]),
-            nickname: Some("nickname".to_owned()),
+            nickname: Some(telio_utils::Hidden("nickname".to_owned())),
         };
         let config = Some(Config {
             this: peer_base.clone(),
@@ -3147,7 +3153,7 @@ mod tests {
             public_key: pubkey,
             hostname: telio_utils::Hidden("hostname".to_owned()),
             ip_addresses: Some(vec![IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))]),
-            nickname: Some("nickname".to_owned()),
+            nickname: Some(telio_utils::Hidden("nickname".to_owned())),
         };
         let config = Some(Config {
             this: peer_base.clone(),
@@ -3239,7 +3245,7 @@ mod tests {
             public_key: pubkey,
             hostname: telio_utils::Hidden("hostname".to_owned()),
             ip_addresses: Some(vec![IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))]),
-            nickname: Some("nickname".to_owned()),
+            nickname: Some(telio_utils::Hidden("nickname".to_owned())),
         };
         let config = Some(Config {
             this: peer_base.clone(),
@@ -3307,7 +3313,7 @@ mod tests {
                 public_key,
                 hostname: telio_utils::Hidden("hostname".to_owned()),
                 ip_addresses: Some(vec![IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))]),
-                nickname: Some("nickname".to_owned()),
+                nickname: Some(telio_utils::Hidden("nickname".to_owned())),
             };
             Config {
                 this: peer_base.clone(),
@@ -3403,7 +3409,7 @@ mod tests {
                 public_key,
                 hostname: telio_utils::Hidden("hostname".to_owned()),
                 ip_addresses: Some(vec![IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))]),
-                nickname: Some("nickname".to_owned()),
+                nickname: Some(telio_utils::Hidden("nickname".to_owned())),
             };
             Config {
                 this: peer_base.clone(),
@@ -3462,7 +3468,7 @@ mod tests {
             public_key: new_private_key.public(),
             hostname: telio_utils::Hidden("hostname".to_owned()),
             ip_addresses: Some(vec![IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))]),
-            nickname: Some("nickname".to_owned()),
+            nickname: Some(telio_utils::Hidden("nickname".to_owned())),
         };
         let config = Config {
             this: peer_base.clone(),
@@ -3575,7 +3581,7 @@ mod tests {
                 IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
                 IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0xc00a, 0x2ff)),
             ]),
-            nickname: Some("nickname".to_owned()),
+            nickname: Some(telio_utils::Hidden("nickname".to_owned())),
         };
         let config = Config {
             this: peer_base.clone(),

--- a/src/libtelio.udl
+++ b/src/libtelio.udl
@@ -733,7 +733,7 @@ dictionary PeerBase {
     /// Ip address of peer
     sequence<IpAddr>? ip_addresses;
     /// Nickname for the peer
-    string? nickname;
+    HiddenString? nickname;
 };
 
 /// Description of a peer


### PR DESCRIPTION
Sanitize nicknames making them hidden from the logs, just like hostnames, the difference is that nicknames are wrapped in an Option<>, telling if is whether or not set.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
