### PR TITLE
Make output notifier possible as stdout/stderr callback in natlab

### DIFF
--- a/nat-lab/tests/telio.py
+++ b/nat-lab/tests/telio.py
@@ -215,10 +215,10 @@ class Runtime:
         self._stopped_tasks = []
         self.allowed_pub_keys = set()
 
-    def handle_output_line(self, line) -> bool:
+    async def handle_output_line(self, line) -> bool:
         return (
             self._handle_node_event(line)
-            or self._output_notifier.handle_output(line)
+            or await self._output_notifier.handle_output(line)
             or self._handle_derp_event(line)
             or self._handle_task_information(line)
             or self._handle_error_event(line)
@@ -541,13 +541,13 @@ class Client:
                 if not any(string in line for string in supress_print_list):
                     print(f"[{self._node.name}]: stdout: {line}")
                 if self._runtime:
-                    self._runtime.handle_output_line(line)
+                    await self._runtime.handle_output_line(line)
 
-        async def on_stderr(stdout: str) -> None:
-            for line in stdout.splitlines():
+        async def on_stderr(stderr: str) -> None:
+            for line in stderr.splitlines():
                 print(f"[{self._node.name}]: stderr: {line}")
                 if self._runtime:
-                    self._runtime.handle_output_line(line)
+                    await self._runtime.handle_output_line(line)
 
         self._runtime = Runtime()
         self._events = Events(self._runtime)
@@ -1013,7 +1013,7 @@ class Client:
                 while event:
                     if self._runtime:
                         print(f"[{self._node.name}]: event [{datetime.now()}]: {event}")
-                        self._runtime.handle_output_line(event)
+                        await self._runtime.handle_output_line(event)
                         event = self.get_proxy().next_event()
                 await asyncio.sleep(1)
             except:

--- a/nat-lab/tests/telio_test.py
+++ b/nat-lab/tests/telio_test.py
@@ -38,11 +38,11 @@ class TestRuntime:
         ]) as future_list:
             await asyncio.sleep(0)
 
-            assert runtime.handle_output_line("- started telio...")
-            assert not runtime.handle_output_line("- started telio...")
+            assert await runtime.handle_output_line("- started telio...")
+            assert not await runtime.handle_output_line("- started telio...")
 
-            assert runtime.handle_output_line("natlab injected")
-            assert not runtime.handle_output_line("natlab injected")
+            assert await runtime.handle_output_line("natlab injected")
+            assert not await runtime.handle_output_line("natlab injected")
 
             for future in future_list:
                 await future
@@ -147,7 +147,7 @@ class TestRuntime:
     async def test_handle_derp_event(self) -> None:
         runtime = Runtime()
 
-        assert runtime.handle_output_line(
+        assert await runtime.handle_output_line(
             '{"type":"relay","body":{"region_code":"test","name":"test","hostname"'
             + ':"test","ipv4":"1.1.1.1","relay_port":1111,"stun_port":1111,'
             + '"stun_plaintext_port":1111,"public_key":"test","weight":1,'
@@ -161,7 +161,7 @@ class TestRuntime:
         runtime = Runtime()
         runtime.allowed_pub_keys = set(["AAA"])
 
-        assert runtime.handle_output_line(
+        assert await runtime.handle_output_line(
             '{"type":"node","body":'
             + '{"identifier":"tcli","public_key":"AAA","state":"connected","is_exit":true,'
             + '"is_vpn":true,"ip_addresses":[],"allowed_ips":[],"endpoint":null,"hostname":null,'

--- a/nat-lab/tests/test_telio_version_compatibility.py
+++ b/nat-lab/tests/test_telio_version_compatibility.py
@@ -106,7 +106,7 @@ async def test_connect_different_telio_version_through_relay(
 
         async def on_stdout_stderr(output):
             print(f"[{beta.name}]: stdout: {output}")
-            output_notifier.handle_output(output)
+            await output_notifier.handle_output(output)
 
         beta_router = new_router(beta_conn, beta.ip_stack)
         beta_client_v3_6 = await exit_stack.enter_async_context(

--- a/nat-lab/tests/utils/iperf3.py
+++ b/nat-lab/tests/utils/iperf3.py
@@ -64,9 +64,9 @@ class IperfServer:
         await event.wait()
 
     async def on_stdout(self, stdout: str) -> None:
+        await self._output_notifier.handle_output(stdout)
         self._stdout += stdout
         for line in stdout.splitlines():
-            self._output_notifier.handle_output(line)
             if self._verbose:
                 print(f"[{self._log_prefix}] - Server: {line}")
 
@@ -157,7 +157,7 @@ class IperfClient:
         return int(match.group(1))
 
     async def on_stdout(self, stdout: str) -> None:
-        self._output_notifier.handle_output(stdout)
+        await self._output_notifier.handle_output(stdout)
         self._stdout += stdout
         for line in stdout.splitlines():
             if self._verbose:

--- a/nat-lab/tests/utils/output_notifier.py
+++ b/nat-lab/tests/utils/output_notifier.py
@@ -6,11 +6,11 @@ from typing import List, Dict, Set, Iterator
 class OutputCapture:
     def __init__(self, what: str) -> None:
         self.what: str = what
-        self.lines: List[str] = []
+        self.matches: List[str] = []
 
-    def handle_output(self, line: str) -> None:
-        if self.what in line:
-            self.lines.append(line)
+    def handle_output(self, output: str) -> None:
+        if self.what in output:
+            self.matches.append(output)
 
 
 class OutputNotifier:
@@ -37,12 +37,12 @@ class OutputNotifier:
         finally:
             self._captures.remove(capture)
 
-    def handle_output(self, line) -> bool:
+    async def handle_output(self, output: str) -> bool:
         if not self._case_sensitive:
-            line = line.lower()
+            output = output.lower()
 
         hit_list: Set[str] = set(
-            filter(lambda what: what in line, self._output_events.keys())
+            filter(lambda what: what in output, self._output_events.keys())
         )
 
         for what in hit_list:
@@ -51,6 +51,6 @@ class OutputNotifier:
                 event.set()
 
         for capture in self._captures:
-            capture.handle_output(line)
+            capture.handle_output(output)
 
         return len(hit_list) > 0

--- a/nat-lab/tests/utils/process/process.py
+++ b/nat-lab/tests/utils/process/process.py
@@ -1,8 +1,8 @@
 from abc import ABC, abstractmethod
 from contextlib import asynccontextmanager
-from typing import List, Optional, Callable, Awaitable, AsyncIterator
+from typing import List, Optional, Callable, Awaitable, AsyncIterator, Any
 
-StreamCallback = Callable[[str], Awaitable[None]]
+StreamCallback = Callable[[str], Awaitable[Any]]
 
 
 class ProcessExecError(Exception):


### PR DESCRIPTION
### Problem
To be able to pass output notifier as process callback, we have to wrap it in `on_stdout` function to work, which makes no sense, when we should be able to pass `output_notifier.handle_output` as callback.

### Solution
Make output notifier handle output function possible as callback of process in natlab

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
