### PR TITLE
Conntracker sync

### DIFF
--- a/nat-lab/tests/helpers.py
+++ b/nat-lab/tests/helpers.py
@@ -296,7 +296,7 @@ async def setup_environment(
         print(datetime.now(), "Checking connection limits")
         for conn_manager in connection_managers:
             if conn_manager.tracker:
-                limits = conn_manager.tracker.get_out_of_limits()
+                limits = await conn_manager.tracker.get_out_of_limits()
                 assert limits is None, f"conntracker reported out of limits {limits}"
     finally:
         stop_tcpdump([server["container"] for server in WG_SERVERS])

--- a/nat-lab/tests/test_events.py
+++ b/nat-lab/tests/test_events.py
@@ -703,5 +703,5 @@ async def test_event_content_meshnet_node_upgrade_direct(
             alpha_node_state.endpoint and alpha_public_ip in alpha_node_state.endpoint
         )
 
-        assert alpha_conn_tracker.get_out_of_limits() is None
-        assert beta_conn_tracker.get_out_of_limits() is None
+        assert await alpha_conn_tracker.get_out_of_limits() is None
+        assert await beta_conn_tracker.get_out_of_limits() is None

--- a/nat-lab/tests/test_lana.py
+++ b/nat-lab/tests/test_lana.py
@@ -403,9 +403,9 @@ async def run_default_scenario(
     )
     assert gamma_events
 
-    assert alpha_conn_tracker.get_out_of_limits() is None
-    assert beta_conn_tracker.get_out_of_limits() is None
-    assert gamma_conn_tracker.get_out_of_limits() is None
+    assert await alpha_conn_tracker.get_out_of_limits() is None
+    assert await beta_conn_tracker.get_out_of_limits() is None
+    assert await gamma_conn_tracker.get_out_of_limits() is None
 
     (alpha_expected_states, beta_expected_states, gamma_expected_states) = (
         [
@@ -1420,8 +1420,8 @@ async def test_lana_with_meshnet_exit_node(
         # Validate all nodes have the same meshnet id
         assert alpha_events[0].fp == beta_events[0].fp
 
-        assert alpha_conn_tracker.get_out_of_limits() is None
-        assert beta_conn_tracker.get_out_of_limits() is None
+        assert await alpha_conn_tracker.get_out_of_limits() is None
+        assert await beta_conn_tracker.get_out_of_limits() is None
 
         # LLT-5532: To be cleaned up...
         client_alpha.allow_errors(
@@ -1823,8 +1823,8 @@ async def test_lana_with_disconnected_node(
             == beta_events[0].fp
             == beta_events[1].fp
         )
-        assert alpha_conn_tracker.get_out_of_limits() is None
-        assert beta_conn_tracker.get_out_of_limits() is None
+        assert await alpha_conn_tracker.get_out_of_limits() is None
+        assert await beta_conn_tracker.get_out_of_limits() is None
 
 
 @pytest.mark.moose
@@ -1918,8 +1918,8 @@ async def test_lana_with_second_node_joining_later_meshnet_id_can_change(
         else:
             assert False, "[PANIC] Public keys match!"
 
-        assert alpha_conn_tracker.get_out_of_limits() is None
-        assert beta_conn_tracker.get_out_of_limits() is None
+        assert await alpha_conn_tracker.get_out_of_limits() is None
+        assert await beta_conn_tracker.get_out_of_limits() is None
 
         # LLT-5532: To be cleaned up...
         client_alpha.allow_errors(

--- a/nat-lab/tests/test_mesh_exit_through_peer.py
+++ b/nat-lab/tests/test_mesh_exit_through_peer.py
@@ -294,5 +294,5 @@ async def test_ipv6_exit_node(
         ip_beta = await stun.get(connection_beta, config.STUNV6_SERVER)
         assert ip_alpha == ip_beta
 
-        assert alpha_conn_tracker.get_out_of_limits() is None
-        assert beta_conn_tracker.get_out_of_limits() is None
+        assert await alpha_conn_tracker.get_out_of_limits() is None
+        assert await beta_conn_tracker.get_out_of_limits() is None

--- a/nat-lab/tests/test_mesh_plus_vpn.py
+++ b/nat-lab/tests/test_mesh_plus_vpn.py
@@ -362,8 +362,8 @@ async def test_vpn_plus_mesh(
         ip = await stun.get(connection_alpha, config.STUN_SERVER)
         assert ip == wg_server["ipv4"], f"wrong public IP when connected to VPN {ip}"
 
-        assert alpha_conn_tracker.get_out_of_limits() is None
-        assert beta_conn_tracker.get_out_of_limits() is None
+        assert await alpha_conn_tracker.get_out_of_limits() is None
+        assert await beta_conn_tracker.get_out_of_limits() is None
 
 
 @pytest.mark.asyncio

--- a/nat-lab/tests/test_pinging.py
+++ b/nat-lab/tests/test_pinging.py
@@ -160,8 +160,8 @@ async def test_session_keeper(
 
         async def wait_for_conntracker() -> None:
             while True:
-                alpha_limits = alpha_conntrack.get_out_of_limits()
-                beta_limits = beta_conntrack.get_out_of_limits()
+                alpha_limits = await alpha_conntrack.get_out_of_limits()
+                beta_limits = await beta_conntrack.get_out_of_limits()
                 print(datetime.now(), "Conntracker state: ", alpha_limits, beta_limits)
                 if alpha_limits is None and beta_limits is None:
                     return
@@ -280,8 +280,9 @@ async def test_qos(
 
         async def wait_for_conntracker() -> None:
             while True:
-                print("wait_for_conntracker(): ", alpha_conntrack.get_out_of_limits())
-                if alpha_conntrack.get_out_of_limits() is None:
+                alpha_limits = await alpha_conntrack.get_out_of_limits()
+                print("wait_for_conntracker(): ", alpha_limits)
+                if alpha_limits is None:
                     return
                 await asyncio.sleep(1.0)
 

--- a/nat-lab/tests/test_telio_version_compatibility.py
+++ b/nat-lab/tests/test_telio_version_compatibility.py
@@ -138,5 +138,5 @@ async def test_connect_different_telio_version_through_relay(
             testing.unpack_optional(beta.get_ip_address(IPProto.IPv4)),
         )
 
-        assert alpha_conn_tracker.get_out_of_limits() is None
-        assert beta_conn_tracker.get_out_of_limits() is None
+        assert await alpha_conn_tracker.get_out_of_limits() is None
+        assert await beta_conn_tracker.get_out_of_limits() is None

--- a/nat-lab/tests/utils/connection_tracker.py
+++ b/nat-lab/tests/utils/connection_tracker.py
@@ -121,7 +121,6 @@ class ConnectionTracker:
 
                 self._events.append(connection)
 
-
     async def execute(self) -> None:
         if platform.system() == "Darwin":
             return None
@@ -193,6 +192,5 @@ class ConnectionTracker:
         async with self._process.run(stdout_callback=self.on_stdout):
             await self._process.wait_stdin_ready()
             # initialization is just waiting for first conntrack event
-            await asyncio.sleep(0.1)  # take a nap to settle things in
             await self.synchronize()
             yield self


### PR DESCRIPTION
### Problem
Nat-lab tests with ConnectionTracker `get_out_of_limits()` sometimes fail, even though in the logs the connections are present.

### Solution
- Add lock to ensure thread safe operation.
- Add mechanism to ensure we synchronized to a known event.
- Add more logs.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
