### PR TITLE
Nat-lab: Check logs for errors

### DIFF
--- a/nat-lab/tests/test_adapter.py
+++ b/nat-lab/tests/test_adapter.py
@@ -72,6 +72,12 @@ async def test_adapter_gone_event(alpha_setup_params: SetupParameters) -> None:
             ErrorEvent(ErrorLevel.Critical, ErrorCode.Unknown, "Interface gone")
         )
 
+        client.allow_errors([
+            "boringtun::device.*Fatal read error on tun interface",
+            "telio_wg::adapter::wireguard_go.*Failed to read packet from TUN device: Driver indicated EOF while reading from tunnel",
+            "telio_wg::adapter::linux_native_wg.*LinuxNativeWg: \\[GET01\\] Unable to get interface from WireGuard. Make sure it exists and you have permissions to access it.",
+        ])
+
 
 @pytest.mark.parametrize(
     "alpha_setup_params",

--- a/nat-lab/tests/test_connection_states.py
+++ b/nat-lab/tests/test_connection_states.py
@@ -99,3 +99,8 @@ async def test_connected_state_after_routing(
         await client_alpha.disconnect_from_exit_node(beta.public_key)
 
         await ping(conn_alpha.connection, beta.ip_addresses[0])
+
+        # LLT-5532: To be cleaned up...
+        client_beta.allow_errors([
+            "boringtun::device.*Decapsulate error error=UnexpectedPacket public_key=.*"
+        ])

--- a/nat-lab/tests/test_direct_connection.py
+++ b/nat-lab/tests/test_direct_connection.py
@@ -276,6 +276,14 @@ async def test_direct_working_paths(
 
         await ping(alpha_connection, beta.ip_addresses[0])
 
+        # LLT-5532: To be cleaned up...
+        alpha_client.allow_errors(
+            ["telio_proxy::proxy.*Unable to send. WG Address not available"]
+        )
+        beta_client.allow_errors(
+            ["telio_proxy::proxy.*Unable to send. WG Address not available"]
+        )
+
 
 @pytest.mark.moose
 @pytest.mark.asyncio
@@ -414,6 +422,14 @@ async def test_direct_working_paths_are_reestablished_and_correctly_reported_in_
         ]
         assert expected == deduplicated_lines
 
+        # LLT-5532: To be cleaned up...
+        alpha_client.allow_errors(
+            ["telio_proxy::proxy.*Unable to send. WG Address not available"]
+        )
+        beta_client.allow_errors(
+            ["telio_proxy::proxy.*Unable to send. WG Address not available"]
+        )
+
 
 @pytest.mark.asyncio
 async def test_direct_working_paths_stun_ipv6() -> None:
@@ -450,6 +466,14 @@ async def test_direct_working_paths_stun_ipv6() -> None:
 
         await ping(alpha_connection, beta.ip_addresses[0])
 
+        # LLT-5532: To be cleaned up...
+        alpha_client.allow_errors(
+            ["telio_proxy::proxy.*Unable to send. WG Address not available"]
+        )
+        beta_client.allow_errors(
+            ["telio_proxy::proxy.*Unable to send. WG Address not available"]
+        )
+
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("setup_params, reflexive_ip", UHP_WORKING_PATHS)
@@ -459,7 +483,7 @@ async def test_direct_short_connection_loss(
     async with AsyncExitStack() as exit_stack:
         env = await setup_mesh_nodes(exit_stack, setup_params)
         _, beta = env.nodes
-        alpha_client, _ = env.clients
+        alpha_client, beta_client = env.clients
         alpha_connection, beta_connection = [
             conn.connection for conn in env.connections
         ]
@@ -489,6 +513,14 @@ async def test_direct_short_connection_loss(
                 await asyncio.wait_for(task, 1)
 
         await ping(alpha_connection, beta.ip_addresses[0])
+
+        # LLT-5532: To be cleaned up...
+        alpha_client.allow_errors(
+            ["telio_proxy::proxy.*Unable to send. WG Address not available"]
+        )
+        beta_client.allow_errors(
+            ["telio_proxy::proxy.*Unable to send. WG Address not available"]
+        )
 
 
 @pytest.mark.asyncio
@@ -580,6 +612,14 @@ async def test_direct_working_paths_with_skip_unresponsive_peers(
         )
 
         await ping(alpha_connection, beta.ip_addresses[0])
+
+        # LLT-5532: To be cleaned up...
+        alpha_client.allow_errors(
+            ["telio_proxy::proxy.*Unable to send. WG Address not available"]
+        )
+        beta_client.allow_errors(
+            ["telio_proxy::proxy.*Unable to send. WG Address not available"]
+        )
 
 
 ENDPOINT_GONE_PARAMS = [
@@ -689,6 +729,14 @@ async def test_direct_connection_endpoint_gone(
 
         await _check_if_true_direct_connection()
 
+        # LLT-5532: To be cleaned up...
+        alpha_client.allow_errors(
+            ["telio_proxy::proxy.*Unable to send. WG Address not available"]
+        )
+        beta_client.allow_errors(
+            ["telio_proxy::proxy.*Unable to send. WG Address not available"]
+        )
+
 
 @pytest.mark.asyncio
 # Regression test for LLT-4306
@@ -775,7 +823,7 @@ async def test_direct_working_paths_with_pausing_upnp_and_stun(
 
         env = await setup_mesh_nodes(exit_stack, setup_params)
         _, beta = env.nodes
-        alpha_client, _ = env.clients
+        alpha_client, beta_client = env.clients
         alpha_connection, _ = [conn.connection for conn in env.connections]
 
         await ping(alpha_connection, beta.ip_addresses[0])
@@ -820,3 +868,11 @@ async def test_direct_working_paths_with_pausing_upnp_and_stun(
         ]
 
         assert len(stun_upnp_requests) == 0
+
+        # LLT-5532: To be cleaned up...
+        alpha_client.allow_errors(
+            ["telio_proxy::proxy.*Unable to send. WG Address not available"]
+        )
+        beta_client.allow_errors(
+            ["telio_proxy::proxy.*Unable to send. WG Address not available"]
+        )

--- a/nat-lab/tests/test_dns.py
+++ b/nat-lab/tests/test_dns.py
@@ -261,6 +261,9 @@ async def test_dns_port(alpha_ip_stack: IPStack) -> None:
                 dns_server_address_alpha,
             )
 
+        # LLT-5532: To be cleaned up...
+        client_alpha.allow_errors(["telio_dns::nameserver.*Invalid DNS port"])
+
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
@@ -608,6 +611,11 @@ async def test_dns_update(alpha_ip_stack: IPStack) -> None:
         await query_dns(
             connection, "google.com", ["Name:	google.com\nAddress:"], dns_server_address
         )
+
+        # LLT-5532: To be cleaned up...
+        client_alpha.allow_errors([
+            "telio_dns::nameserver.*Lookup failed Error performing lookup: Unknown response code"
+        ])
 
 
 @pytest.mark.asyncio

--- a/nat-lab/tests/test_dns_through_exit.py
+++ b/nat-lab/tests/test_dns_through_exit.py
@@ -180,3 +180,11 @@ async def test_dns_through_exit(
             dns_server=dns_server_address_local,
             expected_output=["Name:.*google.com.*Address"],
         )
+
+        # LLT-5532: To be cleaned up...
+        client_alpha.allow_errors(
+            ["telio_dns::nameserver.*Invalid protocol for DNS request"]
+        )
+        client_exit.allow_errors(
+            ["telio_dns::nameserver.*Invalid protocol for DNS request"]
+        )

--- a/nat-lab/tests/test_lana.py
+++ b/nat-lab/tests/test_lana.py
@@ -1473,6 +1473,14 @@ async def test_lana_with_meshnet_exit_node(
         assert alpha_conn_tracker.get_out_of_limits() is None
         assert beta_conn_tracker.get_out_of_limits() is None
 
+        # LLT-5532: To be cleaned up...
+        client_alpha.allow_errors(
+            ["telio_proxy::proxy.*Unable to send. WG Address not available"]
+        )
+        client_beta.allow_errors(
+            ["telio_proxy::proxy.*Unable to send. WG Address not available"]
+        )
+
 
 @pytest.mark.moose
 @pytest.mark.asyncio

--- a/nat-lab/tests/test_mesh_off.py
+++ b/nat-lab/tests/test_mesh_off.py
@@ -81,6 +81,14 @@ async def test_mesh_off(direct) -> None:
         await ping(connection_alpha, beta.ip_addresses[0])
         await ping(connection_beta, alpha.ip_addresses[0])
 
+        # LLT-5532: To be cleaned up...
+        client_alpha.allow_errors(
+            ["telio_proxy::proxy.*Unable to send. WG Address not available"]
+        )
+        client_beta.allow_errors(
+            ["telio_proxy::proxy.*Unable to send. WG Address not available"]
+        )
+
 
 @pytest.mark.asyncio
 @pytest.mark.timeout(TEST_MESH_STATE_AFTER_DISCONNECTING_NODE_TIMEOUT)
@@ -130,4 +138,12 @@ async def test_mesh_state_after_disconnecting_node() -> None:
 
         await client_alpha.wait_for_state_peer(
             beta.public_key, [State.Connected], [PathType.Direct]
+        )
+
+        # LLT-5532: To be cleaned up...
+        client_alpha.allow_errors(
+            ["boringtun::noise::timers.*CONNECTION_EXPIRED\\(REKEY_ATTEMPT_TIME\\)"]
+        )
+        client_beta.allow_errors(
+            ["boringtun::noise::timers.*CONNECTION_EXPIRED\\(REKEY_ATTEMPT_TIME\\)"]
         )

--- a/nat-lab/tests/test_mesh_plus_vpn.py
+++ b/nat-lab/tests/test_mesh_plus_vpn.py
@@ -505,6 +505,14 @@ async def test_vpn_plus_mesh_over_direct(
                 public_ip == wg_server["ipv4"]
             ), f"wrong public IP when connected to VPN {public_ip}"
 
+        # LLT-5532: To be cleaned up...
+        client_alpha.allow_errors(
+            ["telio_proxy::proxy.*Unable to send. WG Address not available"]
+        )
+        client_beta.allow_errors(
+            ["telio_proxy::proxy.*Unable to send. WG Address not available"]
+        )
+
 
 @pytest.mark.asyncio
 @pytest.mark.timeout(
@@ -668,3 +676,11 @@ async def test_vpn_plus_mesh_over_different_connection_types(
             assert (
                 public_ip == wg_server["ipv4"]
             ), f"wrong public IP when connected to VPN {public_ip}"
+
+        # LLT-5532: To be cleaned up...
+        client_alpha.allow_errors(
+            ["telio_proxy::proxy.*Unable to send. WG Address not available"]
+        )
+        client_beta.allow_errors(
+            ["telio_proxy::proxy.*Unable to send. WG Address not available"]
+        )

--- a/nat-lab/tests/test_network_switch.py
+++ b/nat-lab/tests/test_network_switch.py
@@ -320,3 +320,11 @@ async def test_mesh_network_switch_direct(
             await direct
 
         await ping(alpha_connection, beta.ip_addresses[0])
+
+        # LLT-5532: To be cleaned up...
+        alpha_client.allow_errors([
+            "telio_traversal::endpoint_providers::stun.*Starting session failed.*A socket operation was attempted to an unreachable network"
+        ])
+        beta_client.allow_errors([
+            "telio_traversal::endpoint_providers::stun.*Starting session failed.*A socket operation was attempted to an unreachable network"
+        ])

--- a/nat-lab/tests/test_proxy.py
+++ b/nat-lab/tests/test_proxy.py
@@ -40,6 +40,11 @@ async def test_proxy_endpoint_map_update() -> None:
         else:
             assert False, "Endpoint wasn't successfully updated"
 
+        # LLT-5532: To be cleaned up...
+        alpha_client.allow_errors(
+            ["telio_proxy::proxy.*Unable to send. Operation not permitted"]
+        )
+
 
 def node_port(peer_info: Optional[PeerInfo]) -> int:
     assert peer_info

--- a/nat-lab/tests/test_upnp_connection.py
+++ b/nat-lab/tests/test_upnp_connection.py
@@ -80,6 +80,14 @@ async def test_upnp_route_removed(
         await ping(beta_conn.connection, alpha.ip_addresses[0])
         await ping(alpha_conn.connection, beta.ip_addresses[0])
 
+        # LLT-5532: To be cleaned up...
+        alpha_client.allow_errors(
+            ["telio_proxy::proxy.*Unable to send. WG Address not available"]
+        )
+        beta_client.allow_errors(
+            ["telio_proxy::proxy.*Unable to send. WG Address not available"]
+        )
+
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(


### PR DESCRIPTION
Introduce checking for errors in our logs. It is possible that some tests like e.g. test_adapter_gone_event will emit error logs and this is expected. For that reason self._allowed_errors was introduced in telio.py. But most happy path tests should not emit them. Tests that should be checked and cleaned up are marked with LLT-5532 tag and the jira task is created for it. 

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
