### PR TITLE
Fix endpoint race between device tick and wg event

### DIFF
--- a/crates/telio-wg/src/link_detection.rs
+++ b/crates/telio-wg/src/link_detection.rs
@@ -57,10 +57,10 @@ impl LinkDetection {
         &mut self,
         public_key: &PublicKey,
         node_addresses: Vec<IpAddr>,
-        push: bool,
+        from_telio: bool,
     ) -> LinkDetectionUpdateResult {
-        // We want to update info only on pull
-        if push {
+        // We want to update info only then infromation is comes from adapter
+        if from_telio {
             return self.push_update(public_key);
         }
 

--- a/crates/telio-wg/src/uapi.rs
+++ b/crates/telio-wg/src/uapi.rs
@@ -34,6 +34,8 @@ pub struct Peer {
     pub public_key: PublicKey,
     /// Peer's endpoint with `IP address` and `UDP port` number
     pub endpoint: Option<SocketAddr>,
+    /// Peer's enpoint roamed, changed from adapter not wg_controller
+    pub endpoint_roamed: bool,
     /// Mesh's IP addresses of peer
     pub ip_addresses: Vec<IpAddr>,
     /// Keep alive interval, `seconds` or `None`
@@ -60,6 +62,7 @@ impl From<get::Peer> for Peer {
         Self {
             public_key: PublicKey(item.public_key),
             endpoint: item.endpoint,
+            endpoint_roamed: false,
             ip_addresses: Default::default(),
             persistent_keepalive_interval: Some(item.persistent_keepalive_interval.into()),
             allowed_ips: item


### PR DESCRIPTION
### Problem
We have scenarios there wireguard's peer endpoint can be changed not by wg_controller but wireguard it self, specifically by it's roaming logic.

Until now in downgrade scenario: then remote node goes back to relay state and local node roams to relay proxy; was handled by device wait loop by reacting to events generated by DynamicWg polls.

This could race with device tick + wg_cotroller.

### Solution
To fix this, roaming detection is added to wg.rs that is then handled by wg_controller. This ensures that wg is a singular state of truth, and wg_controller is a singular point of reaction, removing possible racing.

### :ballot_box_with_check: Definition of Done checklist
- [ ] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [ ] README.md is updated
- [ ] Functionality is covered by unit or integration tests
