### PR TITLE
Lukasp/enable batching natlab direct conns

### DIFF
--- a/nat-lab/tests/conftest.py
+++ b/nat-lab/tests/conftest.py
@@ -80,7 +80,9 @@ def pytest_make_parametrize_id(config, val):
                 param_id += f"-{provider}"
 
         if val.features.batching is not None:
-            param_id += f"-{str(val.features.batching).replace('direct_connection_threshold', 'dir').replace('Batching', 'Batch')}"
+            param_id += (
+                f"-batch-{str(val.features.batching.direct_connection_threshold)}"
+            )
     elif isinstance(val, (ConnectionTag,)):
         param_id = val.name.removeprefix("DOCKER_")
     elif isinstance(val, (AdapterType,)):

--- a/nat-lab/tests/test_direct_connection.py
+++ b/nat-lab/tests/test_direct_connection.py
@@ -28,7 +28,7 @@ from utils.connection_util import ConnectionTag
 from utils.ping import ping
 
 # Testing if batching being disabled or not there doesn't affect anything
-DISABLED_BATCHING_OPTIONS = (None, Batching(direct_connection_threshold=0))
+DISABLED_BATCHING_OPTIONS = (None, Batching(direct_connection_threshold=5))
 ANY_PROVIDERS = ["local", "stun"]
 
 DOCKER_CONE_GW_2_IP = "10.0.254.2"
@@ -53,6 +53,9 @@ def _generate_setup_parameter_pair(
             features=TelioFeatures(
                 direct=Direct(providers=endpoint_providers),
                 batching=batching,
+                wireguard=Wireguard(
+                    persistent_keepalive=PersistentKeepalive(direct=10),
+                ),
             ),
             fingerprint=f"{conn_tag}",
         )


### PR DESCRIPTION
Previously batcher was only used in a disabled form(feature was set to `None`) or with threshold of 0, effectively simulating no batching at all. This PR adds non-zero batcher to direct connection tests to prove a point that it doesn't break direct connections when enabled.

The threshold and keepalive adhere to the rule of threshold being half the period.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
