### PR TITLE
Nat-lab: Allow more error logs

### DIFF
--- a/nat-lab/tests/test_connection_states.py
+++ b/nat-lab/tests/test_connection_states.py
@@ -102,5 +102,6 @@ async def test_connected_state_after_routing(
 
         # LLT-5532: To be cleaned up...
         client_beta.allow_errors([
-            "boringtun::device.*Decapsulate error error=UnexpectedPacket public_key=.*"
+            "boringtun::device.*Decapsulate error error=UnexpectedPacket public_key=.*",
+            "telio_wg::adapter::wireguard_go.*wg_go.*Failed to derive keypair: invalid state for keypair derivation: handshakeInitiationConsumed",
         ])

--- a/nat-lab/tests/test_direct_connection.py
+++ b/nat-lab/tests/test_direct_connection.py
@@ -422,6 +422,11 @@ async def test_direct_working_paths_are_reestablished_and_correctly_reported_in_
         ]
         assert expected == deduplicated_lines
 
+        # This is expected. Clients can still receive messages from
+        # the previous sessions.
+        alpha_client.allow_errors(["boringtun::device.*Decapsulate error"])
+        beta_client.allow_errors(["boringtun::device.*Decapsulate error"])
+
         # LLT-5532: To be cleaned up...
         alpha_client.allow_errors(
             ["telio_proxy::proxy.*Unable to send. WG Address not available"]
@@ -613,6 +618,10 @@ async def test_direct_working_paths_with_skip_unresponsive_peers(
 
         await ping(alpha_connection, beta.ip_addresses[0])
 
+        # This is expected. Alpha client can still receive messages from
+        # the previous session from beta after the restart.
+        alpha_client.allow_errors(["boringtun::device.*Decapsulate error"])
+
         # LLT-5532: To be cleaned up...
         alpha_client.allow_errors(
             ["telio_proxy::proxy.*Unable to send. WG Address not available"]
@@ -728,6 +737,13 @@ async def test_direct_connection_endpoint_gone(
         )
 
         await _check_if_true_direct_connection()
+
+        # This is expected. Clients can still receive messages from
+        # the previous sessions.
+        alpha_client.allow_errors(["boringtun::device.*Decapsulate error"])
+        beta_client.allow_errors([
+            "boringtun::device.*Decapsulate error",
+        ])
 
         # LLT-5532: To be cleaned up...
         alpha_client.allow_errors(

--- a/nat-lab/tests/test_lana.py
+++ b/nat-lab/tests/test_lana.py
@@ -1926,6 +1926,14 @@ async def test_lana_with_second_node_joining_later_meshnet_id_can_change(
         assert alpha_conn_tracker.get_out_of_limits() is None
         assert beta_conn_tracker.get_out_of_limits() is None
 
+        # LLT-5532: To be cleaned up...
+        client_alpha.allow_errors(
+            ["telio_proxy::proxy.*Unable to send. WG Address not available"]
+        )
+        client_beta.allow_errors(
+            ["telio_proxy::proxy.*Unable to send. WG Address not available"]
+        )
+
 
 @pytest.mark.moose
 @pytest.mark.asyncio


### PR DESCRIPTION
### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
