### PR TITLE
LLT-5531: Directory per test for logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ tcli.log
 /nat-lab/3rd-party/netfilter-full-cone-nat
 /nat-lab/tests/uniffi/telio_bindings.py
 /nat-lab/tests/uniffi/libtelio.so
+/nat-lab/logs
+/nat-lab/coredumps
 /src/telio.py
 /3rd-party/wireguard-go/*.lib
 /3rd-party/wireguard-go/*.h

--- a/nat-lab/tests/interderp_cli.py
+++ b/nat-lab/tests/interderp_cli.py
@@ -2,7 +2,6 @@ import os
 from utils.connection import Connection, TargetOS
 from utils.connection_util import get_libtelio_binary_path
 from utils.process import Process
-from utils.testing import format_path_string
 
 
 class InterDerpClient:
@@ -53,7 +52,7 @@ class InterDerpClient:
             await process.execute()
             container_id = process.get_stdout().strip()
         else:
-            container_id = format_path_string(str(self._connection.target_os))
+            container_id = str(self._connection.target_os.name)
 
         filename = (
             "preconditions_interderpcli_" + container_id + "_" + str(count) + ".log"

--- a/nat-lab/tests/interderp_cli.py
+++ b/nat-lab/tests/interderp_cli.py
@@ -2,6 +2,7 @@ import os
 from utils.connection import Connection, TargetOS
 from utils.connection_util import get_libtelio_binary_path
 from utils.process import Process
+from utils.testing import format_path_string
 
 
 class InterDerpClient:
@@ -52,7 +53,7 @@ class InterDerpClient:
             await process.execute()
             container_id = process.get_stdout().strip()
         else:
-            container_id = str(self._connection.target_os)
+            container_id = format_path_string(str(self._connection.target_os))
 
         filename = (
             "preconditions_interderpcli_" + container_id + "_" + str(count) + ".log"

--- a/nat-lab/tests/mesh_api.py
+++ b/nat-lab/tests/mesh_api.py
@@ -442,7 +442,7 @@ def start_tcpdump(container_name):
 def stop_tcpdump(container_names):
     if os.environ.get("NATLAB_SAVE_LOGS") is None:
         return
-    log_dir = get_current_test_log_path("logs")
+    log_dir = get_current_test_log_path()
     os.makedirs(log_dir, exist_ok=True)
     for container_name in container_names:
         cmd = f"docker exec --privileged {container_name} killall tcpdump"

--- a/nat-lab/tests/mesh_api.py
+++ b/nat-lab/tests/mesh_api.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from ipaddress import ip_address
 from typing import Dict, Any, List, Tuple, Optional
 from utils.router import IPStack, IPProto, get_ip_address_type
-from utils.testing import test_name_safe_for_file_name
+from utils.testing import get_current_test_log_path
 
 if platform.machine() != "x86_64":
     import pure_wg as Key
@@ -442,24 +442,23 @@ def start_tcpdump(container_name):
 def stop_tcpdump(container_names):
     if os.environ.get("NATLAB_SAVE_LOGS") is None:
         return
-    test_name = test_name_safe_for_file_name()
-    log_dir = "logs"
+    log_dir = get_current_test_log_path("logs")
     os.makedirs(log_dir, exist_ok=True)
     for container_name in container_names:
         cmd = f"docker exec --privileged {container_name} killall tcpdump"
         os.system(cmd)
-        path = find_unique_path_for_tcpdump(log_dir, test_name, container_name)
+        path = find_unique_path_for_tcpdump(log_dir, container_name)
         cmd = f"docker container cp {container_name}:{PCAP_FILE_PATH} {path}"
         os.system(cmd)
 
 
-def find_unique_path_for_tcpdump(log_dir, test_name, container_name):
-    candidate_path = f"./{log_dir}/{test_name}-{container_name}.pcap"
+def find_unique_path_for_tcpdump(log_dir, container_name):
+    candidate_path = f"./{log_dir}/{container_name}.pcap"
     counter = 1
     # NOTE: counter starting from '1' means that the file will either have no suffix or
     # will have a suffix starting from '2'. This is to make it clear that it's not the
     # first log for that container/client.
     while os.path.isfile(candidate_path):
         counter += 1
-        candidate_path = f"./{log_dir}/{test_name}-{container_name}-{counter}.pcap"
+        candidate_path = f"./{log_dir}/{container_name}-{counter}.pcap"
     return candidate_path

--- a/nat-lab/tests/telio.py
+++ b/nat-lab/tests/telio.py
@@ -30,9 +30,8 @@ from utils.router.linux_router import LinuxRouter, FWMARK_VALUE as LINUX_FWMARK_
 from utils.router.mac_router import MacRouter
 from utils.router.windows_router import WindowsRouter
 from utils.testing import (
-    format_path_string,
     get_current_test_log_path,
-    get_current_test_case_name,
+    get_current_test_case_and_parameters,
 )
 
 
@@ -1186,7 +1185,7 @@ class Client:
         if os.environ.get("NATLAB_SAVE_LOGS") is None:
             return
 
-        log_dir = get_current_test_log_path("logs")
+        log_dir = get_current_test_log_path()
         os.makedirs(log_dir, exist_ok=True)
 
         try:
@@ -1202,7 +1201,7 @@ class Client:
             await process.execute()
             container_id = process.get_stdout().strip()
         else:
-            container_id = format_path_string(str(self._connection.target_os))
+            container_id = str(self._connection.target_os.name)
 
         filename = container_id + ".log"
         if len(filename.encode("utf-8")) > 256:
@@ -1232,7 +1231,7 @@ class Client:
         if os.environ.get("NATLAB_SAVE_LOGS") is None:
             return
 
-        log_dir = get_current_test_log_path("logs")
+        log_dir = get_current_test_log_path()
         os.makedirs(log_dir, exist_ok=True)
 
         moose_db_files = glob.glob("*-events.db", recursive=False)
@@ -1248,12 +1247,12 @@ class Client:
         if self._connection.target_os != TargetOS.Mac:
             return
 
-        log_dir = get_current_test_log_path("logs")
+        log_dir = get_current_test_log_path()
         os.makedirs(log_dir, exist_ok=True)
 
         network_info_info = await self.get_network_info()
 
-        container_id = format_path_string(str(self._connection.target_os))
+        container_id = str(self._connection.target_os.name)
 
         filename = container_id + "_network_info.log"
         if len(filename.encode("utf-8")) > 256:
@@ -1323,7 +1322,7 @@ class Client:
         # if we collected some core dumps, copy them
         if isinstance(self._connection, DockerConnection) and should_copy_coredumps:
             container_name = self._connection.container_name()
-            test_name = get_current_test_case_name()
+            test_name = get_current_test_case_and_parameters()[0] or ""
             for i, file_path in enumerate(dump_files):
                 file_name = file_path.rsplit("/", 1)[-1]
                 core_dump_destination = (

--- a/nat-lab/tests/utils/testing.py
+++ b/nat-lab/tests/utils/testing.py
@@ -1,7 +1,8 @@
 import os
 import re
+import warnings
 from datetime import datetime
-from typing import Optional, TypeVar
+from typing import Optional, Tuple, TypeVar
 
 T = TypeVar("T")
 
@@ -12,99 +13,54 @@ def unpack_optional(opt: Optional[T]) -> T:
     return opt
 
 
-def get_current_test_file_name() -> str | None:
+def get_current_test_case_and_parameters() -> Tuple[Optional[str], Optional[str]]:
     """
-    Returns a string representing the filename of the currently running test.
+    Returns a tuple of strings representing the case name and parameters of the currently running test.
 
     The result is derived from PYTEST_CURRENT_TEST env variable.
-
-    For example:
-    "tests/test_mesh_plus_vpn.py" -> "test_mesh_plus_vpn"
     """
     test_name = os.environ.get("PYTEST_CURRENT_TEST")
-    if test_name is not None:
+    if test_name:
         try:
-            # take the file path part of the pytest string, remove extension and parent directory
-            file_part = test_name.split("::")[0].split(".")[0].split("/")[-1]
-            return format_path_string(file_part)
-        except IndexError:
-            print(datetime.now(), "get_current_test_file_name() IndexError", test_name)
-            return test_name
-    print(datetime.now(), "PYTEST_CURRENT_TEST is None")
-    return None
-
-
-def get_current_test_case_name() -> str | None:
-    """
-    Returns a string representing the case name of the currently running test.
-
-    The result is derived from PYTEST_CURRENT_TEST env variable.
-
-    For example:
-    "tests/test_mesh_plus_vpn.py::test_vpn_plus_mesh_over_direct" -> "test_vpn_plus_mesh_over_direct"
-    """
-    test_name = os.environ.get("PYTEST_CURRENT_TEST")
-    if test_name is not None:
-        try:
-            test_part = test_name.split("::", 1)[-1].split(" ")[0].split("[", 1)[0]
-            return format_path_string(test_part)
-        except IndexError:
-            print(datetime.now(), "get_current_test_case_name() IndexError", test_name)
-            return test_name
-    print(datetime.now(), "PYTEST_CURRENT_TEST is None")
-    return None
-
-
-def get_current_test_parameter_name() -> str | None:
-    """
-    Returns an optional string representing the parameters of the currently running test.
-
-    The result is derived from PYTEST_CURRENT_TEST env variable.
-
-    For example:
-    "[CONE_CLIENT_2-Default-local-stun-CONE_CLIENT_1-LinuxNativeWg-local-stun]" -> "CONE_CLIENT_2_Default_local_stun_CONE_CLIENT_1_LinuxNativeWg_local_stun"
-    """
-    test_name = os.environ.get("PYTEST_CURRENT_TEST")
-    if test_name is not None:
-        try:
-            parameter_part = test_name.split("::")[-1].split(" ")[0].split("[", 1)[1]
-            return format_path_string(parameter_part)
-        except IndexError:
-            print(
-                datetime.now(),
-                "get_current_test_parameter_name() IndexError",
-                test_name,
+            test_part, param_part = (
+                test_name.split("::", 1)[-1].split(" ")[0].split("[", 1)
             )
-            return None
+            if param_part:
+                return (format_path_string(test_part), format_path_string(param_part))
+            return (format_path_string(test_part), None)
+        except IndexError as e:
+            warnings.warn(
+                (
+                    f"get_current_test_case_and_parameters() for {test_name} exception:"
+                    f" {e} "
+                ),
+                RuntimeWarning,
+            )
+            return (format_path_string(test_name), None)
     print(datetime.now(), "PYTEST_CURRENT_TEST is None")
-    return None
+    return (None, None)
 
 
 def format_path_string(input_str: str) -> str:
     """
     Format the input string to be safely used as a system path or file name.
     """
-    # truncate if it's longer than 64 characters to limit long absolute paths
-    # replace any non-alphanumeric characters, and the last "_" if it is present
+    # truncate if it's longer than 64 characters
+    # replace any non-alphanumeric characters with "_"
+    # remove any trailing "_"
     return re.sub(r"\W+", "_", input_str[:64]).rstrip("_")
 
 
-def get_current_test_log_path(base_dir: str) -> str:
+def get_current_test_log_path(base_dir: str = "logs") -> str:
     """
     Returns a path to the log files of the currently running test.
     """
-    # format the base_dir
-    if base_dir == "":
-        base_dir = "logs"
-    else:
-        base_dir = format_path_string(base_dir)
-
+    base_dir = format_path_string(base_dir)
     # get current test case, if we are in a test
-    test_name = get_current_test_case_name()
+    test_name, test_parameters = get_current_test_case_and_parameters()
     if test_name:
         logs_dir = os.path.join(base_dir, test_name)
         # add the test parameters suffx
-        test_parameters = get_current_test_parameter_name()
         if test_parameters:
             return logs_dir + "_" + test_parameters
         # there were no parameters

--- a/nat-lab/tests/utils/testing.py
+++ b/nat-lab/tests/utils/testing.py
@@ -1,4 +1,6 @@
 import os
+import re
+from datetime import datetime
 from typing import Optional, TypeVar
 
 T = TypeVar("T")
@@ -10,8 +12,102 @@ def unpack_optional(opt: Optional[T]) -> T:
     return opt
 
 
-def test_name_safe_for_file_name():
+def get_current_test_file_name() -> str | None:
+    """
+    Returns a string representing the filename of the currently running test.
+
+    The result is derived from PYTEST_CURRENT_TEST env variable.
+
+    For example:
+    "tests/test_mesh_plus_vpn.py" -> "test_mesh_plus_vpn"
+    """
     test_name = os.environ.get("PYTEST_CURRENT_TEST")
     if test_name is not None:
-        return "".join([x if x.isalnum() else "_" for x in test_name.split(" ")[0]])
-    return test_name
+        try:
+            # take the file path part of the pytest string, remove extension and parent directory
+            file_part = test_name.split("::")[0].split(".")[0].split("/")[-1]
+            return format_path_string(file_part)
+        except IndexError:
+            print(datetime.now(), "get_current_test_file_name() IndexError", test_name)
+            return test_name
+    print(datetime.now(), "PYTEST_CURRENT_TEST is None")
+    return None
+
+
+def get_current_test_case_name() -> str | None:
+    """
+    Returns a string representing the case name of the currently running test.
+
+    The result is derived from PYTEST_CURRENT_TEST env variable.
+
+    For example:
+    "tests/test_mesh_plus_vpn.py::test_vpn_plus_mesh_over_direct" -> "test_vpn_plus_mesh_over_direct"
+    """
+    test_name = os.environ.get("PYTEST_CURRENT_TEST")
+    if test_name is not None:
+        try:
+            test_part = test_name.split("::", 1)[-1].split(" ")[0].split("[", 1)[0]
+            return format_path_string(test_part)
+        except IndexError:
+            print(datetime.now(), "get_current_test_case_name() IndexError", test_name)
+            return test_name
+    print(datetime.now(), "PYTEST_CURRENT_TEST is None")
+    return None
+
+
+def get_current_test_parameter_name() -> str | None:
+    """
+    Returns an optional string representing the parameters of the currently running test.
+
+    The result is derived from PYTEST_CURRENT_TEST env variable.
+
+    For example:
+    "[CONE_CLIENT_2-Default-local-stun-CONE_CLIENT_1-LinuxNativeWg-local-stun]" -> "CONE_CLIENT_2_Default_local_stun_CONE_CLIENT_1_LinuxNativeWg_local_stun"
+    """
+    test_name = os.environ.get("PYTEST_CURRENT_TEST")
+    if test_name is not None:
+        try:
+            parameter_part = test_name.split("::")[-1].split(" ")[0].split("[", 1)[1]
+            return format_path_string(parameter_part)
+        except IndexError:
+            print(
+                datetime.now(),
+                "get_current_test_parameter_name() IndexError",
+                test_name,
+            )
+            return None
+    print(datetime.now(), "PYTEST_CURRENT_TEST is None")
+    return None
+
+
+def format_path_string(input_str: str) -> str:
+    """
+    Format the input string to be safely used as a system path or file name.
+    """
+    # truncate if it's longer than 64 characters to limit long absolute paths
+    # replace any non-alphanumeric characters, and the last "_" if it is present
+    return re.sub(r"\W+", "_", input_str[:64]).rstrip("_")
+
+
+def get_current_test_log_path(base_dir: str) -> str:
+    """
+    Returns a path to the log files of the currently running test.
+    """
+    # format the base_dir
+    if base_dir == "":
+        base_dir = "logs"
+    else:
+        base_dir = format_path_string(base_dir)
+
+    # get current test case, if we are in a test
+    test_name = get_current_test_case_name()
+    if test_name:
+        logs_dir = os.path.join(base_dir, test_name)
+        # add the test parameters suffx
+        test_parameters = get_current_test_parameter_name()
+        if test_parameters:
+            return logs_dir + "_" + test_parameters
+        # there were no parameters
+        return logs_dir
+    # we are not in a test
+    return base_dir

--- a/nat-lab/tests/utils/testing.py
+++ b/nat-lab/tests/utils/testing.py
@@ -1,6 +1,5 @@
 import os
 import re
-import warnings
 from datetime import datetime
 from typing import Optional, Tuple, TypeVar
 
@@ -21,22 +20,13 @@ def get_current_test_case_and_parameters() -> Tuple[Optional[str], Optional[str]
     """
     test_name = os.environ.get("PYTEST_CURRENT_TEST")
     if test_name:
-        try:
-            test_part, param_part = (
-                test_name.split("::", 1)[-1].split(" ")[0].split("[", 1)
+        test_parts = test_name.split("::", 1)[-1].split(" ")[0].split("[", 1)
+        if len(test_parts) > 1:
+            return (
+                format_path_string(test_parts[0]),
+                format_path_string(test_parts[1]),
             )
-            if param_part:
-                return (format_path_string(test_part), format_path_string(param_part))
-            return (format_path_string(test_part), None)
-        except IndexError as e:
-            warnings.warn(
-                (
-                    f"get_current_test_case_and_parameters() for {test_name} exception:"
-                    f" {e} "
-                ),
-                RuntimeWarning,
-            )
-            return (format_path_string(test_name), None)
+        return (format_path_string(test_parts[0]), None)
     print(datetime.now(), "PYTEST_CURRENT_TEST is None")
     return (None, None)
 

--- a/nat-lab/tests/utils/testing.py
+++ b/nat-lab/tests/utils/testing.py
@@ -23,15 +23,15 @@ def get_current_test_case_and_parameters() -> Tuple[Optional[str], Optional[str]
         test_parts = test_name.split("::", 1)[-1].split(" ")[0].split("[", 1)
         if len(test_parts) > 1:
             return (
-                format_path_string(test_parts[0]),
-                format_path_string(test_parts[1]),
+                _format_path_string(test_parts[0]),
+                _format_path_string(test_parts[1]),
             )
-        return (format_path_string(test_parts[0]), None)
+        return (_format_path_string(test_parts[0]), None)
     print(datetime.now(), "PYTEST_CURRENT_TEST is None")
     return (None, None)
 
 
-def format_path_string(input_str: str) -> str:
+def _format_path_string(input_str: str) -> str:
     """
     Format the input string to be safely used as a system path or file name.
     """
@@ -45,7 +45,7 @@ def get_current_test_log_path(base_dir: str = "logs") -> str:
     """
     Returns a path to the log files of the currently running test.
     """
-    base_dir = format_path_string(base_dir)
+    base_dir = _format_path_string(base_dir)
     # get current test case, if we are in a test
     test_name, test_parameters = get_current_test_case_and_parameters()
     if test_name:


### PR DESCRIPTION
### Problem
Our nat-lab test log files are getting so long it sometimes manages to reach filename limit’s in Windows.
And it’s extremely hard to focus in on all of data produced for a singular tests. 

### Solution
Instead of storing all logging artifacts in one directory, with long names. Create a sub directories
for each test, that stores log for all logs/pcaps etc created for this test.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
