### PR TITLE
Make more logs respect NATLAB_SAVE_LOGS env var

### DIFF
--- a/nat-lab/natlab.py
+++ b/nat-lab/natlab.py
@@ -61,13 +61,16 @@ def start():
 
         check_containers()
     finally:
-        log_dir = "logs"
-        os.makedirs(log_dir, exist_ok=True)
-        dmesg = get_dmesg_from_host()
-        if dmesg:
-            with open(os.path.join(log_dir, "dmesg.txt"), "w", encoding="utf-8") as f:
-                f.write(dmesg)
-        save_audit_log()
+        if os.environ.get("NATLAB_SAVE_LOGS") is not None:
+            log_dir = "logs"
+            os.makedirs(log_dir, exist_ok=True)
+            dmesg = get_dmesg_from_host()
+            if dmesg:
+                with open(
+                    os.path.join(log_dir, "dmesg.txt"), "w", encoding="utf-8"
+                ) as f:
+                    f.write(dmesg)
+            save_audit_log()
 
 
 def get_dmesg_from_host():

--- a/nat-lab/tests/conftest.py
+++ b/nat-lab/tests/conftest.py
@@ -266,6 +266,9 @@ def pytest_runtest_setup():
 
 # pylint: disable=unused-argument
 def pytest_sessionfinish(session, exitstatus):
+    if os.environ.get("NATLAB_SAVE_LOGS") is None:
+        return
+
     if not session.config.option.collectonly:
         num_containers = 3
 


### PR DESCRIPTION
### Problem
Some places where we save logs aren't respecting the `NATLAB_SAVE_LOGS` environment variable

### Solution
Make those places respect the env var


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
