### PR TITLE
Add env var to skip natlab setup checks

### DIFF
--- a/nat-lab/tests/conftest.py
+++ b/nat-lab/tests/conftest.py
@@ -147,6 +147,9 @@ SETUP_CHECKS = [
 
 
 async def perform_setup_checks() -> bool:
+    if "NATLAB_SKIP_SETUP_CHECKS" in os.environ:
+        return True
+
     for target, timeout, retries in SETUP_CHECKS:
         while retries > 0:
             try:


### PR DESCRIPTION
### Problem
Sometimes if you just want to run a quick natlab test or two, adding in the derp checks adds unnecessary time

### Solution
Add an environment variable that lets you skip the setup checks, with the default being to run them


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
