### PR TITLE
natlab: Add comments differenciating primary routes switch

### DIFF
--- a/nat-lab/tests/utils/network_switcher/network_switcher_docker.py
+++ b/nat-lab/tests/utils/network_switcher/network_switcher_docker.py
@@ -10,6 +10,7 @@ class NetworkSwitcherDocker(NetworkSwitcher):
 
     @asynccontextmanager
     async def switch_to_primary_network(self) -> AsyncIterator:
+        """Add route to the "internet" (10.0.0.0/16) through $CLIENT_GATEWAY_PRIMARY"""
         await self._connection.create_process(
             ["/libtelio/nat-lab/bin/configure_route.sh", "primary"]
         ).execute()
@@ -17,6 +18,7 @@ class NetworkSwitcherDocker(NetworkSwitcher):
 
     @asynccontextmanager
     async def switch_to_secondary_network(self) -> AsyncIterator:
+        """Add route to the "internet" (10.0.0.0/16) through $CLIENT_GATEWAY_SECONDARY (Not available for common clients)"""
         await self._connection.create_process(
             ["/libtelio/nat-lab/bin/configure_route.sh", "secondary"]
         ).execute()

--- a/nat-lab/tests/utils/network_switcher/network_switcher_mac.py
+++ b/nat-lab/tests/utils/network_switcher/network_switcher_mac.py
@@ -17,12 +17,12 @@ class NetworkSwitcherMac(NetworkSwitcher):
 
     @asynccontextmanager
     async def switch_to_primary_network(self) -> AsyncIterator:
-        await self._delete_existing_route()
+        """Set default route via Linux VM @ $LINUX_VM_PRIMARY_GATEWAY"""
 
+        await self._delete_existing_route()
         await self._connection.create_process(
             ["route", "add", "default", LINUX_VM_PRIMARY_GATEWAY]
         ).execute()
-
         await self._connection.create_process(
             ["route", "add", "-inet", VPN_SERVER_SUBNET, LINUX_VM_PRIMARY_GATEWAY]
         ).execute()
@@ -40,12 +40,12 @@ class NetworkSwitcherMac(NetworkSwitcher):
 
     @asynccontextmanager
     async def switch_to_secondary_network(self) -> AsyncIterator:
-        await self._delete_existing_route()
+        """Set default route via Linux VM @ $LINUX_VM_SECONDARY_GATEWAY"""
 
+        await self._delete_existing_route()
         await self._connection.create_process(
             ["route", "add", "default", LINUX_VM_SECONDARY_GATEWAY]
         ).execute()
-
         await self._connection.create_process(
             ["route", "add", "-inet", VPN_SERVER_SUBNET, LINUX_VM_SECONDARY_GATEWAY]
         ).execute()

--- a/nat-lab/tests/utils/network_switcher/network_switcher_windows.py
+++ b/nat-lab/tests/utils/network_switcher/network_switcher_windows.py
@@ -86,6 +86,8 @@ class NetworkSwitcherWindows(NetworkSwitcher):
 
     @asynccontextmanager
     async def switch_to_primary_network(self) -> AsyncIterator:
+        """Set default route via Linux VM @ $LINUX_VM_PRIMARY_GATEWAY"""
+
         await self._delete_existing_route()
         await self._connection.create_process([
             "netsh",
@@ -128,6 +130,8 @@ class NetworkSwitcherWindows(NetworkSwitcher):
 
     @asynccontextmanager
     async def switch_to_secondary_network(self) -> AsyncIterator:
+        """Set default route via Linux VM @ $LINUX_VM_SECONDARY_GATEWAY"""
+
         await self._delete_existing_route()
         await self._connection.create_process([
             "netsh",


### PR DESCRIPTION
### Problem
On natlab machines, switching to primary/secondary network has different implementations wether we're working with the Windows/Mac VM or the docker containers.
This is implicit knowledge, however the developer might not be aware of these differences and it can be a bug source in the future.

### Solution
Add function documentation to state what each network switch does.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
