### PR TITLE
Absolute path to ci/env.py

### DIFF
--- a/ci/env.sh
+++ b/ci/env.sh
@@ -1,3 +1,3 @@
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 $($SCRIPT_DIR/env.py)
 unset SCRIPT_DIR


### PR DESCRIPTION
### Problem
Trying to run `env.sh` from outside of the `ci` directory fails.

### Solution
Make the path absolute instead of relative to where the script is run from.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
