### PR TITLE
Warn on unnexpected errors in logs

### DIFF
--- a/nat-lab/tests/telio.py
+++ b/nat-lab/tests/telio.py
@@ -7,6 +7,7 @@ import platform
 import re
 import uniffi.telio_bindings as libtelio  # type: ignore
 import uuid
+import warnings
 from collections import Counter
 from config import DERP_SERVERS
 from contextlib import asynccontextmanager
@@ -1174,7 +1175,8 @@ class Client:
                 if not self._allowed_errors or not any(
                     allowed.search(line) for allowed in self._allowed_errors
                 ):
-                    raise Exception(
+                    # TODO: convert back to `raise Exception()` once we are ready to investigate
+                    warnings.warn(
                         f"Unexpected error found in {self._node.name} log: {line}"
                     )
 


### PR DESCRIPTION
### Problem
Currently we are checking for errors in our logs. And if some are found we are failing the tests, though some errors in logs are expected and not an issue.

### Solution
Temporarily disable failing the pipeline on errors in logs until we have the capacity to investigate which ones are acceptable.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
