### PR TITLE
[LLT-5519] Fix roaming vs cross_ping_check racing

### DIFF
--- a/.unreleased/LLT-5519
+++ b/.unreleased/LLT-5519
@@ -1,0 +1,1 @@
+Fixed a low-probability race-condition which may cause unnecessary path transitions

--- a/crates/telio-traversal/src/connectivity_check.rs
+++ b/crates/telio-traversal/src/connectivity_check.rs
@@ -8,6 +8,7 @@ use telio_model::{features::EndpointProvider, SocketAddr};
 
 use telio_crypto::PublicKey;
 use telio_proto::{CallMeMaybeMsg, Session};
+use tokio::time::Instant;
 
 #[derive(Debug, TError)]
 pub enum Error {
@@ -23,7 +24,7 @@ pub enum Error {
     ),
     #[error("Error publishing WG endpoint")]
     PublishingWireGuardEndpointError(
-        #[from] tokio::sync::mpsc::error::SendError<WireGuardEndpointCandidateChangeEvent>,
+        #[from] Box<tokio::sync::mpsc::error::SendError<WireGuardEndpointCandidateChangeEvent>>,
     ),
     #[error("Task Execution error")]
     TaskExecError(#[from] telio_task::ExecError),
@@ -37,4 +38,5 @@ pub struct WireGuardEndpointCandidateChangeEvent {
     pub remote_endpoint: (SocketAddr, EndpointProvider),
     pub local_endpoint: (SocketAddr, EndpointProvider),
     pub session: Session,
+    pub changed_at: Instant,
 }

--- a/crates/telio-traversal/src/endpoint_providers/stun.rs
+++ b/crates/telio-traversal/src/endpoint_providers/stun.rs
@@ -1955,7 +1955,6 @@ mod tests {
             async fn del_peer(&self, key: PublicKey) -> Result<(), Error>;
             async fn drop_connected_sockets(&self) -> Result<(), Error>;
             async fn time_since_last_rx(&self, public_key: PublicKey) -> Result<Option<Duration>, Error>;
-            async fn time_since_last_endpoint_change(&self, public_key: PublicKey) -> Result<Option<Duration>, Error>;
             async fn stop(self);
             async fn reset_existing_connections(&self, exit_pubkey: PublicKey, exit_ipv4: Ipv4Addr) -> Result<(), Error>;
         }

--- a/crates/telio-traversal/src/endpoint_providers/upnp.rs
+++ b/crates/telio-traversal/src/endpoint_providers/upnp.rs
@@ -729,7 +729,6 @@ mod tests {
             async fn del_peer(&self, key: PublicKey) -> Result1<()>;
             async fn drop_connected_sockets(&self) -> Result1<()>;
             async fn time_since_last_rx(&self, public_key: PublicKey) -> Result1<Option<Duration>>;
-            async fn time_since_last_endpoint_change(&self, public_key: PublicKey) -> Result1<Option<Duration>>;
             async fn stop(self);
             async fn reset_existing_connections(&self, exit_pubkey: PublicKey, exit_ipv4: Ipv4Addr) -> Result1<()>;
         }

--- a/crates/telio-wg/src/uapi.rs
+++ b/crates/telio-wg/src/uapi.rs
@@ -34,6 +34,8 @@ pub struct Peer {
     pub public_key: PublicKey,
     /// Peer's endpoint with `IP address` and `UDP port` number
     pub endpoint: Option<SocketAddr>,
+    /// At what point in time, was last endpoint changed
+    pub endpoint_changed_at: Option<tokio::time::Instant>,
     /// Mesh's IP addresses of peer
     pub ip_addresses: Vec<IpAddr>,
     /// Keep alive interval, `seconds` or `None`
@@ -60,6 +62,8 @@ impl From<get::Peer> for Peer {
         Self {
             public_key: PublicKey(item.public_key),
             endpoint: item.endpoint,
+            // Unknown here
+            endpoint_changed_at: None,
             ip_addresses: Default::default(),
             persistent_keepalive_interval: Some(item.persistent_keepalive_interval.into()),
             allowed_ips: item


### PR DESCRIPTION
### Problem

Until now it was possible that wg event comming into device.rs and
tick happening in device.rs, could lead to invalid race condition.

If in that situation, select pick's consilidation step, while
old endpoint exists in cross ping check, and peer just downgraded
to relay do to roaming, wg_controller would again put that
peer to an invalid direct connection.

### Solution
Eposed Instant information, next to compared endpoints to ensure correct causality order

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
