### PR TITLE
Bump build version to one with lower shards

### DIFF
--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -31,4 +31,4 @@ jobs:
           project-id: ${{ secrets.PROJECT_ID }}
           schedule: ${{ github.event_name == 'schedule' }}
           cancel-outdated-pipelines: ${{ github.ref_name != 'main' }}
-          triggered-ref: v2.2.1 # REMEMBER to also update in .gitlab-ci.yml
+          triggered-ref: v2.2.2 # REMEMBER to also update in .gitlab-ci.yml

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,4 +15,4 @@ libtelio-build-pipeline:
 
   trigger:
     project: $LIBTELIO_BUILD_PROJECT_PATH
-    branch: v2.2.1 # REMEMBER to also update in .github/workflows/gitlab.yml
+    branch: v2.2.2 # REMEMBER to also update in .github/workflows/gitlab.yml


### PR DESCRIPTION
### Problem
Seems like we are hitting github pull limits

### Solution
Mitigate by using build with lower sharding

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
