### PR TITLE
Llt 5483 big batching test

### DIFF
--- a/nat-lab/Pipfile
+++ b/nat-lab/Pipfile
@@ -49,7 +49,7 @@ psutil = "*"
 types-psutil = "*"
 asyncssh = "==2.14.2"
 aiodocker = "*"
-
+scapy="*"
 [dev-packages]
 
 [requires]

--- a/nat-lab/Pipfile.lock
+++ b/nat-lab/Pipfile.lock
@@ -953,6 +953,14 @@
             "markers": "python_version >= '3.8'",
             "version": "==2.32.3"
         },
+        "scapy": {
+            "hashes": [
+                "sha256:5b260c2b754fd8d409ba83ee7aee294ecdbb2c235f9f78fe90bc11cb6e5debc2"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3' and python_version < '4'",
+            "version": "==2.5.0"
+        },
         "serpent": {
             "hashes": [
                 "sha256:0407035fe3c6644387d48cff1467d5aa9feff814d07372b78677ed0ee3ed7095",

--- a/nat-lab/tests/telio.py
+++ b/nat-lab/tests/telio.py
@@ -526,6 +526,15 @@ class Client:
         if telio_features.nurse is not None and telio_features.lana is not None:
             self._fingerprint = telio_features.lana.event_path, fingerprint
 
+    def is_node(self, node: Node) -> bool:
+        return self._node == node
+
+    def get_connection(self):
+        return self._connection
+
+    def get_proxy_port(self):
+        return self._proxy_port
+
     @asynccontextmanager
     async def run(self, meshmap: Optional[Meshmap] = None) -> AsyncIterator["Client"]:
         if isinstance(self._connection, DockerConnection):

--- a/nat-lab/tests/test_batching.py
+++ b/nat-lab/tests/test_batching.py
@@ -1,0 +1,189 @@
+# Packet captures and histograms are used to visually and in-code observe the batching in action.
+import asyncio
+import os
+import pytest
+import telio
+from contextlib import AsyncExitStack
+from helpers import setup_mesh_nodes, SetupParameters
+from itertools import product
+from scapy.layers.inet import IP, UDP  # type: ignore
+from scapy.layers.inet6 import ICMPv6EchoRequest, IPv6  # type: ignore
+from telio import PathType, State, AdapterType
+from telio_features import (
+    Batching,
+    LinkDetection,
+    PersistentKeepalive,
+    TelioFeatures,
+    Direct,
+    Wireguard,
+)
+from typing import List
+from utils.batching import capture_traffic, save_histogram, generate_histogram_from_pcap
+from utils.connection import DockerConnection
+from utils.connection_util import DOCKER_GW_MAP, ConnectionTag, container_id
+
+
+def _generate_setup_parameters(
+    conn_tag: ConnectionTag,
+    adapter: telio.AdapterType,
+    endpoint_providers: List[str],
+    direct_enabled: bool,
+    batching_enabled: bool,
+) -> SetupParameters:
+    features = TelioFeatures(
+        direct=Direct(providers=endpoint_providers) if direct_enabled else None,
+        link_detection=LinkDetection(
+            use_for_downgrade=True, rtt_seconds=1, no_of_pings=1
+        ),
+        wireguard=Wireguard(
+            persistent_keepalive=PersistentKeepalive(
+                direct=70,
+                proxying=70,
+                stun=70,
+                vpn=70,
+            )
+        ),
+        batching=Batching(direct_connection_threshold=35) if batching_enabled else None,
+    )
+
+    item = SetupParameters(
+        connection_tag=conn_tag,
+        adapter_type=adapter,
+        features=features,
+    )
+
+    return item
+
+
+@pytest.mark.batching
+@pytest.mark.asyncio
+@pytest.mark.timeout(200)
+@pytest.mark.parametrize(
+    "setup_params,misalign_sleep_amount",
+    [
+        pytest.param(
+            [
+                _generate_setup_parameters(
+                    ConnectionTag.DOCKER_CONE_CLIENT_1,
+                    AdapterType.LinuxNativeWg,
+                    ["stun", "upnp", "local"],
+                    direct_enabled=True,
+                    batching_enabled=True,
+                ),
+                _generate_setup_parameters(
+                    ConnectionTag.DOCKER_CONE_CLIENT_2,
+                    AdapterType.LinuxNativeWg,
+                    ["stun", "upnp", "local"],
+                    direct_enabled=True,
+                    batching_enabled=True,
+                ),
+                _generate_setup_parameters(
+                    ConnectionTag.DOCKER_UPNP_CLIENT_1,
+                    AdapterType.LinuxNativeWg,
+                    ["stun", "upnp", "local"],
+                    direct_enabled=True,
+                    batching_enabled=True,
+                ),
+                _generate_setup_parameters(
+                    ConnectionTag.DOCKER_UPNP_CLIENT_2,
+                    AdapterType.LinuxNativeWg,
+                    ["stun", "upnp", "local"],
+                    direct_enabled=True,
+                    batching_enabled=True,
+                ),
+            ],
+            6,
+            marks=[pytest.mark.small_batch],
+        ),
+    ],
+)
+async def test_batching_star(
+    setup_params: List[SetupParameters], misalign_sleep_amount: int
+) -> None:
+    async with AsyncExitStack() as exit_stack:
+        capture_duration = 100
+
+        env = await setup_mesh_nodes(exit_stack, setup_params)
+
+        await asyncio.gather(*(
+            client.wait_for_state_peer(
+                peer_node.public_key, [State.Connected], [PathType.Direct]
+            )
+            for client, peer_node in product(env.clients, env.nodes)
+            if not client.is_node(peer_node)
+        ))
+
+        # Capturing the traffic can be done on nodes or gateways
+        # On gateways there's a guarantee that the traffic has arrived
+        # however we can't decrypt it easily.
+        # On nodes there's no guarantee the packet left the network adapter
+        # but we can inspect the packet before it hit the TUN device.
+        # Here we capture on both
+        gateways = [DOCKER_GW_MAP[param.connection_tag] for param in setup_params]
+        gateway_container_names = [container_id(conn_tag) for conn_tag in gateways]
+        conns = [client.get_connection() for client in env.clients]
+        node_container_names = [
+            conn.container_name()
+            for conn in conns
+            if isinstance(conn, DockerConnection)
+        ]
+
+        container_names = gateway_container_names + node_container_names
+        # TODO: assert these are docker connections
+        print("Will capture batching on containers: ", container_names)
+        cnodes = zip(env.clients, env.nodes)
+
+        # the plan is to misalign the peers for better batcing observation. WIthout misalignment
+        # peers will form a meshnet almost immediately, already achieving the desired batching effect.
+        for client in env.clients:
+            await client.stop_device()
+
+        # TODO: this is possible to refactor and use `start_tcpdump` and `stop_tcpdump`
+        pcap_capture_tasks = []
+        for name in container_names:
+            task = asyncio.create_task(
+                capture_traffic(
+                    name,
+                    capture_duration,
+                )
+            )
+            pcap_capture_tasks.append(task)
+
+        # misalign the peers by sleeping some before starting each node again
+        for client, node in cnodes:
+            await asyncio.sleep(misalign_sleep_amount)
+            await client.simple_start()
+            await client.set_meshmap(env.api.get_meshmap(node.id))
+
+        await asyncio.gather(*(
+            client.wait_for_state_peer(
+                peer_node.public_key, [State.Connected], [PathType.Direct]
+            )
+            for client, peer_node in product(env.clients, env.nodes)
+            if not client.is_node(peer_node)
+        ))
+
+        pcap_paths = await asyncio.gather(*pcap_capture_tasks)
+
+        filters = [
+            None,
+            ("icmpv6echorequest", lambda p: p.haslayer(ICMPv6EchoRequest)),
+            (
+                "ipv46 udp",
+                lambda p: (
+                    (p.haslayer(IP) or p.haslayer(IPv6)) if p.haslayer(UDP) else True
+                ),
+            ),
+        ]
+
+        for container, pcap_path in zip(container_names, pcap_paths):
+            for filt in filters:
+                filter_name = filt[0] if filt else "none"
+                hs = generate_histogram_from_pcap(
+                    pcap_path, capture_duration, filt[1] if filt else None
+                )
+                title = f"{container}-filter({filter_name})"
+                save_histogram(title, hs, "logs", max_height=12)
+
+        for p in pcap_paths:
+            os.unlink(p)

--- a/nat-lab/tests/utils/batching.py
+++ b/nat-lab/tests/utils/batching.py
@@ -1,0 +1,138 @@
+import asyncio
+import math
+import os
+import pytest
+import subprocess
+import typing
+from scapy.all import PcapReader, Packet  # type: ignore
+from typing import Callable, List, Optional
+
+
+def _generate_histogram(
+    data: list[int], buckets: int, bucket_size: int = 1
+) -> List[int]:
+    assert len(data) > 0
+    max_val = max(data)
+
+    if max_val >= buckets * bucket_size:
+        raise ValueError(
+            f"Histogram doesn't fit the data({max_val}). The max value is {max_val} but the histogram has {buckets} buckets with a width of"
+            f" {bucket_size}, the maximum value it can fit is {buckets * bucket_size}"
+        )
+
+    hs = [0] * buckets
+
+    for v in data:
+        bucket_index = int(v / bucket_size)
+        hs[bucket_index] += 1
+
+    return hs
+
+
+async def capture_traffic(container_name: str, duration_s: int) -> str:
+    cmd_rm = f"docker exec --privileged {container_name} rm /home/capture.pcap"
+    os.system(cmd_rm)
+
+    iface = "any"
+    capture_path = "/home/capture.pcap"
+
+    cmd = f"docker exec -d --privileged {container_name} tcpdump -i {iface} -U -w {capture_path}"
+    res = os.system(cmd)
+    if res != 0:
+        raise RuntimeError(f"Failed to launch tcpdump on {container_name}")
+
+    await asyncio.sleep(duration_s)
+
+    local_path = f"{container_name}.pcap"
+    subprocess.run([
+        "docker",
+        "cp",
+        container_name + ":" + "/home/capture.pcap",
+        local_path,
+    ])
+
+    cmd_rm = f"docker exec --privileged {container_name} pkill tcpdump"
+    os.system(cmd_rm)
+
+    return local_path
+
+
+# Render ASCII histogram drawing for visual inspection
+def save_histogram(name: str, data: List[int], save_dir: str, max_height=None):
+    output = []
+    if not data:
+        output.append(f"No data provided for {name}")
+        return
+
+    max_value = max(data)
+
+    if max_height is None:
+        max_height = max_value
+
+    scaled_data = [math.ceil((value / max_value) * max_height) for value in data]
+    for row in range(max_height, 0, -1):
+        line = ""
+        for value in scaled_data:
+            if value >= row:
+                line += "█"
+            else:
+                line += " "
+        line = "|" + line
+        output.append(line)
+
+    output.append(f"+{'-' * (len(data))}")
+    output.append(f"0{' ' * (len(data)-1)}{len(data)}")
+    output.append(f"^-Histogram of {name}")
+
+    # try to save `name.hist` and warn if it already exists by asserting false
+    file_name = f"{name}.hist"
+    file_path = os.path.join(save_dir, file_name)
+
+    with open(file_path, "w", encoding="utf-8") as f:
+        f.write("\n".join(output))
+
+    print(f"Histogram saved successfully as '{file_name}' in '{save_dir}'.")
+
+
+def generate_histogram_from_pcap(
+    pcap_path: str,
+    buckets: int,
+    packet_filter: Optional[Callable[[Packet], bool]],
+) -> typing.List[int]:
+    print("Looking for a pcap at", pcap_path)
+
+    first_packet_time = None
+    timestamps = []
+
+    with PcapReader(pcap_path) as pcap_reader:
+        first_packet = True
+        for pkt in pcap_reader:
+            if first_packet:
+                first_packet_time = pkt.time
+                first_packet = False
+
+            if packet_filter and not packet_filter(pkt):
+                continue
+
+            timestamps.append(pkt.time - first_packet_time)
+
+    # we either filtered out everything or didn't receive any traffic
+    if len(timestamps) == 0:
+        return []
+
+    return _generate_histogram(timestamps, buckets)
+
+
+@pytest.mark.asyncio
+async def test_histogram():
+    data = []
+    for _ in range(10):
+        data.append(2)
+        data.append(3)
+
+    for _ in range(50):
+        data.append(4)
+
+    data.append(9)
+
+    assert _generate_histogram(data, 10, 1) == [0, 0, 10, 10, 50, 0, 0, 0, 0, 1]


### PR DESCRIPTION
### Problem
Batching tests, as per design session, should be star-like with multiple different nodes and idling. Then we should observe batching over the course of the time and see that it's working.

### Solution
Setup preferred meshnet topology, launch tcpdump on nodes of interest, then aggregate packet captures by using filters into histograms and display them.

Existing configuration in this PR is pretty minimal, just few directly connected nodes. Windows, MacOS, VPN, Proxied peers will be added next.

As a result currently we can see some histograms but we still need to:
- add proper configuration
- add various filters to observation while we don't have fully implemented the batching

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
