### PR TITLE
LLT-5586: Conntracker TCP states

### DIFF
--- a/nat-lab/tests/test_connection_tracker.py
+++ b/nat-lab/tests/test_connection_tracker.py
@@ -1,66 +1,74 @@
-from utils.connection_tracker import parse_input, FiveTuple
+from utils.connection_tracker import parse_input, FiveTuple, EventType, TcpState
 
 
 def test_connection_tracker_parse_input():
     new_udp = parse_input(
         "[NEW] udp      17 30 src=127.0.0.1 dst=127.0.0.53 sport=34348 dport=53 [UNREPLIED] src=127.0.0.53 dst=127.0.0.1 sport=53 dport=34348"
     )
-    assert new_udp == FiveTuple(
+    assert new_udp.five_tuple == FiveTuple(
         protocol="udp",
         src_ip="127.0.0.1",
         src_port=34348,
         dst_ip="127.0.0.53",
         dst_port=53,
     )
+    assert new_udp.event_type == EventType.NEW
+    assert new_udp.tcp_state is None
 
     updated_udp = parse_input(
         "[UPDATE] udp      17 30 src=10.6.6.104 dst=8.8.8.8 sport=49922 dport=53 src=8.8.8.8 dst=10.6.6.104 sport=53 dport=49922"
     )
-    assert updated_udp == FiveTuple(
-        protocol=None,
+    assert updated_udp.five_tuple == FiveTuple(
+        protocol="udp",
         src_ip="10.6.6.104",
         src_port=49922,
         dst_ip="8.8.8.8",
         dst_port=53,
     )
+    assert updated_udp.event_type == EventType.UPDATE
+    assert updated_udp.tcp_state is None
 
     new_icmp_type8 = parse_input(
         "[NEW] icmp     1 30 src=10.6.6.104 dst=142.250.184.206 type=8 code=0 id=370 [UNREPLIED] src=142.250.184.206 dst=10.6.6.104 type=0 code=0 id=370"
     )
-    assert new_icmp_type8 == FiveTuple(
+    assert new_icmp_type8.five_tuple == FiveTuple(
         protocol="icmp",
         src_ip="10.6.6.104",
         src_port=None,
         dst_ip="142.250.184.206",
         dst_port=None,
     )
+    assert new_icmp_type8.event_type == EventType.NEW
+    assert new_icmp_type8.tcp_state is None
 
     updated_icmp_type8 = parse_input(
         "[UPDATE] icmp     1 30 src=10.6.6.104 dst=142.250.184.206 type=8 code=0 id=370 src=142.250.184.206 dst=10.6.6.104 type=0 code=0 id=370"
     )
-    assert updated_icmp_type8 == FiveTuple(
-        protocol=None,
-        src_ip="10.6.6.104",
-        src_port=None,
-        dst_ip="142.250.184.206",
-        dst_port=None,
-    )
-
-    new_icmp_type0 = parse_input(
-        "[NEW] icmp     1 30 src=10.6.6.104 dst=142.250.184.206 type=0 code=0 id=370 [UNREPLIED] src=142.250.184.206 dst=10.6.6.104 type=0 code=0 id=370"
-    )
-    assert new_icmp_type0 == FiveTuple(
+    assert updated_icmp_type8.five_tuple == FiveTuple(
         protocol="icmp",
         src_ip="10.6.6.104",
         src_port=None,
         dst_ip="142.250.184.206",
         dst_port=None,
     )
+    assert new_icmp_type8.event_type == EventType.NEW
+
+    new_icmp_type0 = parse_input(
+        "[NEW] icmp     1 30 src=10.6.6.104 dst=142.250.184.206 type=0 code=0 id=370 [UNREPLIED] src=142.250.184.206 dst=10.6.6.104 type=0 code=0 id=370"
+    )
+    assert new_icmp_type0.five_tuple == FiveTuple(
+        protocol="icmp",
+        src_ip="10.6.6.104",
+        src_port=None,
+        dst_ip="142.250.184.206",
+        dst_port=None,
+    )
+    assert new_icmp_type0.event_type == EventType.NEW
 
     new_icmp_type13 = parse_input(
         "[NEW] icmp     1 30 src=127.0.0.1 dst=127.0.0.1 type=13 code=0 id=44126 [UNREPLIED] src=127.0.0.1 dst=127.0.0.1 type=14 code=0 id=44126"
     )
-    assert new_icmp_type13 == FiveTuple(
+    assert new_icmp_type13.five_tuple == FiveTuple(
         protocol=None,
         src_ip="127.0.0.1",
         src_port=None,
@@ -71,7 +79,7 @@ def test_connection_tracker_parse_input():
     new_icmpv6_type128 = parse_input(
         "[NEW] icmpv6   58 30 src=2600:1f1a:4d5e:c200:2787:af77:9c40:1365 dst=2a05:f480:2400:1e9a:5400:4ff:fe25:e8f4 type=128 code=0 id=2 [UNREPLIED] src=2a05:f480:2400:1e9a:5400:4ff:fe25:e8f4 dst=2600:1f1a:4d5e:c200:2787:af77:9c40:1365 type=666 code=0 id=2"
     )
-    assert new_icmpv6_type128 == FiveTuple(
+    assert new_icmpv6_type128.five_tuple == FiveTuple(
         protocol="icmpv6",
         src_ip="2600:1f1a:4d5e:c200:2787:af77:9c40:1365",
         src_port=None,
@@ -81,7 +89,7 @@ def test_connection_tracker_parse_input():
     new_icmpv6_type129 = parse_input(
         "[NEW] icmpv6   58 30 src=2600:1f1a:4d5e:c200:2787:af77:9c40:1365 dst=2a05:f480:2400:1e9a:5400:4ff:fe25:e8f4 type=666 code=0 id=2 [UNREPLIED] src=2a05:f480:2400:1e9a:5400:4ff:fe25:e8f4 dst=2600:1f1a:4d5e:c200:2787:af77:9c40:1365 type=129 code=0 id=2"
     )
-    assert new_icmpv6_type129 == FiveTuple(
+    assert new_icmpv6_type129.five_tuple == FiveTuple(
         protocol="icmpv6",
         src_ip="2600:1f1a:4d5e:c200:2787:af77:9c40:1365",
         src_port=None,
@@ -91,10 +99,36 @@ def test_connection_tracker_parse_input():
     new_icmpv6_type130 = parse_input(
         "[NEW] icmpv6   58 30 src=2600:1f1a:4d5e:c200:2787:af77:9c40:1365 dst=2a05:f480:2400:1e9a:5400:4ff:fe25:e8f4 type=130 code=0 id=2 [UNREPLIED] src=2a05:f480:2400:1e9a:5400:4ff:fe25:e8f4 dst=2600:1f1a:4d5e:c200:2787:af77:9c40:1365 type=131 code=0 id=2"
     )
-    assert new_icmpv6_type130 == FiveTuple(
+    assert new_icmpv6_type130.five_tuple == FiveTuple(
         protocol=None,
         src_ip="2600:1f1a:4d5e:c200:2787:af77:9c40:1365",
         src_port=None,
         dst_ip="2a05:f480:2400:1e9a:5400:4ff:fe25:e8f4",
         dst_port=None,
     )
+
+    new_tcp = parse_input(
+        "    [NEW] tcp      6 120 SYN_SENT src=127.0.0.1 dst=127.0.0.1 sport=51222 dport=12345 [UNREPLIED] src=127.0.0.1 dst=127.0.0.1 sport=12345 dport=51222"
+    )
+    assert new_tcp.five_tuple == FiveTuple(
+        protocol="tcp",
+        src_ip="127.0.0.1",
+        src_port=51222,
+        dst_ip="127.0.0.1",
+        dst_port=12345,
+    )
+    assert new_tcp.event_type == EventType.NEW
+    assert new_tcp.tcp_state == TcpState.SYN_SENT
+
+    updated_tcp = parse_input(
+        "[UPDATE] tcp      6 60 SYN_RECV src=10.6.6.104 dst=8.8.8.8 sport=49922 dport=53 src=8.8.8.8 dst=10.6.6.104 sport=53 dport=49922"
+    )
+    assert updated_tcp.five_tuple == FiveTuple(
+        protocol="tcp",
+        src_ip="10.6.6.104",
+        src_port=49922,
+        dst_ip="8.8.8.8",
+        dst_port=53,
+    )
+    assert updated_tcp.event_type == EventType.UPDATE
+    assert updated_tcp.tcp_state == TcpState.SYN_RECV

--- a/nat-lab/tests/utils/connection_tracker.py
+++ b/nat-lab/tests/utils/connection_tracker.py
@@ -1,12 +1,14 @@
 import asyncio
 import platform
 import re
+from collections import defaultdict
 from contextlib import asynccontextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
+from enum import Enum
 from typing import Optional, List, Dict, AsyncIterator
 from utils.connection import Connection
-from utils.ping import Ping
+from utils.ping import ping
 from utils.process import Process
 
 
@@ -28,6 +30,37 @@ class FiveTuple:
         )
 
 
+class EventType(Enum):
+    """Event type reported by conntrack"""
+
+    NEW = "NEW"
+    UPDATE = "UPDATE"
+    DESTROY = "DESTROY"
+
+
+class TcpState(Enum):
+    """TCP specific state for an event"""
+
+    SYN_SENT = "SYN_SENT"
+    SYN_RECV = "SYN_RECV"
+    ESTABLISHED = "ESTABLISHED"
+    FIN_WAIT = "FIN_WAIT"
+    CLOSE_WAIT = "CLOSE_WAIT"
+    LAST_ACK = "LAST_ACK"
+    TIME_WAIT = "TIME_WAIT"
+    CLOSE = "CLOSE"
+    LISTEN = "LISTEN"
+
+
+@dataclass
+class ConntrackerEvent:
+    """Event reported by conntrack"""
+
+    event_type: Optional[EventType] = None
+    five_tuple: FiveTuple = field(default_factory=FiveTuple)
+    tcp_state: Optional[TcpState] = None
+
+
 @dataclass
 class ConnectionLimits:
     min: Optional[int] = None
@@ -44,39 +77,46 @@ class ConnectionTrackerConfig:
         return self.key
 
 
-def parse_input(input_string) -> FiveTuple:
-    five_tuple = FiveTuple()
+def parse_input(input_string) -> ConntrackerEvent:
+    event = ConntrackerEvent()
 
-    print(datetime.now(), "Conntracker reported new connection:", input_string)
-
-    match = re.search(r"\[NEW\] (\w+)", input_string)
+    print(datetime.now(), "Conntracker reported event:", input_string)
+    match = re.search(r"\[([A-Z]+)\] (\w+)", input_string)
     if match:
-        if match.group(1) == "icmp":
+        event.event_type = EventType(match.group(1))
+        protocol = match.group(2)
+
+        if protocol == "icmp":
             if "type=0" in input_string or "type=8" in input_string:
-                five_tuple.protocol = match.group(1)
-        elif match.group(1) == "icmpv6":
+                event.five_tuple.protocol = protocol
+        elif protocol == "icmpv6":
             if "type=128" in input_string or "type=129" in input_string:
-                five_tuple.protocol = match.group(1)
+                event.five_tuple.protocol = protocol
         else:
-            five_tuple.protocol = match.group(1)
+            event.five_tuple.protocol = protocol
+
+        if protocol == "tcp":
+            match = re.search(r"tcp\s+[\d+ ]+([A-Z_]+)", input_string)
+            if match:
+                event.tcp_state = TcpState(match.group(1))
 
     match = re.search(r"src=([^\s]+)", input_string)
     if match:
-        five_tuple.src_ip = match.group(1)
+        event.five_tuple.src_ip = match.group(1)
 
     match = re.search(r"dst=([^\s]+)", input_string)
     if match:
-        five_tuple.dst_ip = match.group(1)
+        event.five_tuple.dst_ip = match.group(1)
 
     match = re.search(r"sport=(\d+)", input_string)
     if match:
-        five_tuple.src_port = int(match.group(1))
+        event.five_tuple.src_port = int(match.group(1))
 
     match = re.search(r"dport=(\d+)", input_string)
     if match:
-        five_tuple.dst_port = int(match.group(1))
+        event.five_tuple.dst_port = int(match.group(1))
 
-    return five_tuple
+    return event
 
 
 class ConnectionTracker:
@@ -84,14 +124,17 @@ class ConnectionTracker:
         self,
         connection: Connection,
         configuration: Optional[List[ConnectionTrackerConfig]] = None,
+        process_update_events: bool = False,
     ):
-        self._process: Process = connection.create_process(
-            ["conntrack", "-E", "-e", "NEW"]
-        )
+        args = ["conntrack", "-E", "-e", "NEW"]
+        if process_update_events:
+            args.extend(["-e", "UPDATES"])
+        self._process: Process = connection.create_process(args)
         self._connection: Connection = connection
+        self._process_update_events = process_update_events
         self._config: Optional[List[ConnectionTrackerConfig]] = configuration
-        self._events: List[FiveTuple] = []
-        self._lock: asyncio.Lock = asyncio.Lock()
+        self._events: List[ConntrackerEvent] = []
+        self._tcp_state_events: Dict[TcpState, List[asyncio.Event]] = defaultdict(list)
         self._sync_event: asyncio.Event = asyncio.Event()
         self._sync_connection: FiveTuple = FiveTuple(
             protocol="icmp", dst_ip="127.0.0.2"
@@ -101,32 +144,41 @@ class ConnectionTracker:
         if not self._config:
             return
 
-        async with self._lock:
-            for line in stdout.splitlines():
-                connection = parse_input(line)
-                if connection is FiveTuple():
+        for line in stdout.splitlines():
+            event = parse_input(line)
+            connection = event.five_tuple
+            if connection is FiveTuple():
+                continue
+
+            if not self._sync_event.is_set():
+                if self._sync_connection.partial_eq(connection):
+                    self._sync_event.set()
                     continue
 
-                if not self._sync_event.is_set():
-                    if self._sync_connection.partial_eq(connection):
-                        self._sync_event.set()
-                        continue
+            # skip if we are only interested in new events
+            if not self._process_update_events and event.event_type != EventType.NEW:
+                continue
 
-                matching_configs = [
-                    cfg for cfg in self._config if cfg.target.partial_eq(connection)
-                ]
-                if not matching_configs:
-                    continue
+            matching_configs = [
+                cfg for cfg in self._config if cfg.target.partial_eq(connection)
+            ]
+            if not matching_configs:
+                continue
 
-                self._events.append(connection)
+            self._events.append(event)
+            self._check_tcp_state_for_events(event)
 
     async def execute(self) -> None:
         if platform.system() == "Darwin":
             return None
         if not self._config:
-            return
+            return None
 
         await self._process.execute(stdout_callback=self.on_stdout)
+
+    def notify_on_tcp_state(self, state: TcpState, event: asyncio.Event) -> None:
+        """Register an Event to be notified when a specific TCP state is reported"""
+        self._tcp_state_events[state].append(event)
 
     async def get_out_of_limits(self) -> Optional[Dict[str, int]]:
         if platform.system() == "Darwin":
@@ -134,15 +186,16 @@ class ConnectionTracker:
         if not self._config:
             return None
 
-        await self.synchronize()
+        await self._synchronize()
 
         out_of_limit_connections: Dict[str, int] = {}
 
         for cfg in self._config:
-            async with self._lock:
-                count = len(
-                    [event for event in self._events if cfg.target.partial_eq(event)]
-                )
+            count = len([
+                event
+                for event in self._events
+                if cfg.target.partial_eq(event.five_tuple)
+            ])
             if cfg.limits.max is not None:
                 if count > cfg.limits.max:
                     out_of_limit_connections[cfg.key] = count
@@ -174,30 +227,30 @@ class ConnectionTracker:
 
         return out_of_limit_connections if bool(out_of_limit_connections) else None
 
-    async def synchronize(self):
+    def _check_tcp_state_for_events(self, conntracker_event: ConntrackerEvent) -> None:
+        if tcp_state := conntracker_event.tcp_state:
+            try:
+                self._tcp_state_events[tcp_state].pop(0).set()
+            except IndexError:
+                pass
+
+    async def _synchronize(self) -> None:
         if not self._config:
             return None
 
+        print(datetime.now(), "ConnectionTracker waiting for _sync_event")
         # wait to synchronize over a known event
-        async with Ping(self._connection, "127.0.0.2").run():
-            print(datetime.now(), "ConnectionTracker waiting for _sync_event")
-            try:
-                await asyncio.wait_for(self._sync_event.wait(), timeout=10.0)
-                print(datetime.now(), "ConnectionTracker got _sync_event")
-            except TimeoutError:
-                print(datetime.now(), "ConnectionTracker sync timeout")
-            async with self._lock:
-                self._sync_event.clear()
+        while not self._sync_event.is_set():
+            # use ping helper, that returns after the first reply is received
+            await ping(self._connection, "127.0.0.2")
+
+        self._sync_event.clear()
 
     @asynccontextmanager
     async def run(self) -> AsyncIterator["ConnectionTracker"]:
         async with self._process.run(stdout_callback=self.on_stdout):
             await self._process.wait_stdin_ready()
 
-            # magic sleep, for unknown reason it takes a moment before
-            # conntrack on_stdout is ready to process events
-            await asyncio.sleep(0.1)
-
             # initialization is just waiting for first conntrack event
-            await self.synchronize()
+            await self._synchronize()
             yield self


### PR DESCRIPTION
### Problem
There are tests (like `test_mesh_firewall.py`) where we are manually starting `conntrack` in order to observe TCP state changes. Occasionally they fail because they might be missing the new connetion events, and `conntrack` does not report on subsequent states in that case. We need to make sure that `conntrack` is ready to process events before proceeding with the test.

### Solution

- Added mechanism to the existing `ConnectionTracker` class to track TCP states alongside connection limits, in order to utilize it's synchronization mechanism.
- Updated tests to use `ConnectionTracker` instead of manually starting `conntrack` process.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
