### PR TITLE
Fix unused-features linter

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -155,7 +155,7 @@ jobs:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       - uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.6
         with:
-          toolchain: 1.78.0
+          toolchain: 1.79.0
           override: true
           default: true
       - uses: actions-rs/install@9da1d2adcfe5e7c16992e8242ca33a56b6d9b101


### PR DESCRIPTION
```
   error: failed to compile `cargo-unused-features: v0.2.0`, intermediate artifacts can be found at `/tmp/cargo-install3SVrCi`.
  To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.

  Caused by:
    rustc 1.78.0 is not supported by the following package:
      cargo-util@0.2.14 requires rustc 1.79
    Try re-running `cargo install` with `--locked`
```

### Problem
*--describe problem being solved--*

### Solution
*--describe selected solution--*


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
