### PR TITLE
LLT-5540: macOS python path

### DIFF
--- a/nat-lab/tests/test_vpn.py
+++ b/nat-lab/tests/test_vpn.py
@@ -13,6 +13,7 @@ from utils.connection_tracker import ConnectionLimits, ConnectionTrackerConfig
 from utils.connection_util import generate_connection_tracker_config, ConnectionTag
 from utils.output_notifier import OutputNotifier
 from utils.ping import ping
+from utils.python import get_python_binary
 from utils.router import IPProto, IPStack
 
 VAGRANT_LIBVIRT_MANAGEMENT_IP = "192.168.121"
@@ -182,10 +183,8 @@ async def test_vpn_connection(
         client_alpha, *_ = env.clients
 
         if alpha_setup_params.connection_tag == ConnectionTag.MAC_VM:
-            # Using the 'env python3' at the beginning of the script fails with:
-            # xcode-select: error: no developer tools were found at '/Applications/Xcode.app', and no install could be requested (perhaps no UI is present), please install manually from 'developer.apple.com'.
             process = await client_conn.create_process([
-                "/usr/local/bin/python3",
+                get_python_binary(client_conn),
                 f"{config.LIBTELIO_BINARY_PATH_MAC_VM}/list_interfaces_with_router_property.py",
             ]).execute()
             interfaces_with_router_prop = process.get_stdout().splitlines()

--- a/nat-lab/tests/utils/multicast.py
+++ b/nat-lab/tests/utils/multicast.py
@@ -6,14 +6,7 @@ from datetime import datetime
 from typing import AsyncIterator
 from utils.connection import Connection, TargetOS
 from utils.process import Process
-
-
-def _get_python(connection: Connection) -> str:
-    if connection.target_os == TargetOS.Windows:
-        return "python"
-    if connection.target_os == TargetOS.Mac:
-        return "/usr/local/bin/python3"
-    return "python3"
+from utils.python import get_python_binary
 
 
 def _get_multicast_script_path(connection: Connection) -> str:
@@ -31,7 +24,7 @@ class MulticastClient:
     def __init__(self, connection: Connection, protocol: str) -> None:
         self._connection = connection
         self._process = connection.create_process([
-            _get_python(connection),
+            get_python_binary(connection),
             _get_multicast_script_path(connection),
             f"--{protocol}",
             "-c",
@@ -52,7 +45,7 @@ class MulticastServer:
         self._connection = connection
         self._server_ready_event = Event()
         self._process = connection.create_process([
-            _get_python(connection),
+            get_python_binary(connection),
             _get_multicast_script_path(connection),
             f"--{protocol}",
             "-s",

--- a/nat-lab/tests/utils/python.py
+++ b/nat-lab/tests/utils/python.py
@@ -1,0 +1,18 @@
+from utils.connection import Connection, TargetOS
+
+
+def get_python_binary(connection: Connection) -> str:
+    """
+    Returns the correct python binary name for each platform or the
+    full path where needed.
+    """
+    if connection.target_os == TargetOS.Windows:
+        return "python"
+    if connection.target_os == TargetOS.Mac:
+        # Using the 'env python3' on macOS fails with:
+        # xcode-select: error: no developer tools were found at '/Applications/Xcode.app',
+        # and no install could be requested (perhaps no UI is present), please install manually from 'developer.apple.com'.
+        #
+        # we need to specify the exact path of the custom installed python
+        return "/usr/local/bin/python3"
+    return "python3"


### PR DESCRIPTION
### Problem
On the vagrant macOS box we have a manual installing of python. When running python commands in nat-lab, `connection.create_process()` doesn’t see the new python installation path, since `/etc/profile` is not sourced. And tries to run the default system python, which fails with:
```
xcode-select: error: no developer tools were found at '/Applications/Xcode.app', and no install could be requested (perhaps no UI is present), please install manually from 'developer.apple.com'
```

### Solution
Simplify the way python scripts are executed on macOS, by providing a helper function that gives the full path to the python installation.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
