### PR TITLE
natlab: Add support for faster debug builds

### DIFF
--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -31,4 +31,4 @@ jobs:
           project-id: ${{ secrets.PROJECT_ID }}
           schedule: ${{ github.event_name == 'schedule' }}
           cancel-outdated-pipelines: ${{ github.ref_name != 'main' }}
-          triggered-ref: v2.4.5 # REMEMBER to also update in .gitlab-ci.yml
+          triggered-ref: v2.4.6 # REMEMBER to also update in .gitlab-ci.yml

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,4 +15,4 @@ libtelio-build-pipeline:
 
   trigger:
     project: $LIBTELIO_BUILD_PROJECT_PATH
-    branch: v2.4.5 # REMEMBER to also update in .github/workflows/gitlab.yml
+    branch: v2.4.6 # REMEMBER to also update in .github/workflows/gitlab.yml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -206,6 +206,11 @@ lto = true
 codegen-units = 1
 debug = "full"
 
+[profile.dev]
+debug = 0
+strip = "debuginfo"
+overflow-checks = false
+
 #TODO: remove this when anyone starts using telio-starcast
 [workspace.metadata.cargo-udeps.ignore]
 normal = ["telio-starcast"]

--- a/ci/build_libtelio.py
+++ b/ci/build_libtelio.py
@@ -263,6 +263,7 @@ LIBTELIO_CONFIG = {
     "macos": {
         "packages": {
             "tcli": {"tcli": "tcli"},
+            "teliod": {"teliod": "teliod"},
             NAME: {f"lib{NAME}": f"lib{NAME}.dylib"},
         },
         "post_build": [post_copy_darwin_debug_symbols_to_distribution_dir],

--- a/ci/build_libtelio.py
+++ b/ci/build_libtelio.py
@@ -284,9 +284,10 @@ LIBTELIO_CONFIG = {
 
 def main() -> None:
     parser = rutils.create_cli_parser()
-    (build_parser, bindings_parser) = (
+    (build_parser, bindings_parser, lipo_parser) = (
         parser._subparsers._group_actions[0].choices["build"],
         parser._subparsers._group_actions[0].choices["bindings"],
+        parser._subparsers._group_actions[0].choices["lipo"],
     )
     build_parser.add_argument("--moose", action="store_true", help="Use libmoose")
     build_parser.add_argument(
@@ -302,6 +303,16 @@ def main() -> None:
         action="store_true",
         help="Generate python bindings with uniffi",
     )
+    build_parser.add_argument(
+        "--tcli",
+        action="store_true",
+        help="Include tcli package",
+    )
+    lipo_parser.add_argument(
+        "--tcli",
+        action="store_true",
+        help="Include tcli package",
+    )
 
     for parsers in [build_parser, bindings_parser]:
         parsers.add_argument(
@@ -315,6 +326,15 @@ def main() -> None:
     if "true" not in [os.getenv("GITLAB_CI"), os.getenv("GITHUB_ACTIONS")]:
         if "BYPASS_LLT_SECRETS" not in os.environ:
             check_llt_secrets()
+
+    # Remove tcli from packages when --debug AND NOT --tcli.
+    # Only relevant for lipo and build commands.
+    if args.command in ["lipo", "build"]:
+        target_os = "macos" if args.command == "lipo" else args.os
+
+        packages = LIBTELIO_CONFIG[target_os].get("packages", None)
+        if args.debug and not args.tcli and "tcli" in packages:
+            LIBTELIO_CONFIG[target_os]["packages"].pop("tcli")
 
     if args.command == "build":
         exec_build(args)
@@ -538,6 +558,9 @@ def copy_uniffi_files_for_testing(args):
         binary_dest = f"{uniffi_dir}telio.dll"
     else:
         pass
+
+    if args.debug:
+        binary_src = binary_src.replace("release", "debug")
 
     rutils.copy_tree_or_file(bindings_src, bindings_dest)
     if copy_binaries:

--- a/nat-lab/run_local.py
+++ b/nat-lab/run_local.py
@@ -132,7 +132,7 @@ def run_build_command(operating_system, args):
             operating_system,
         ]
     command.extend(["--uniffi-test-bindings"])
-    if args.debug_bin:
+    if args.telio_debug:
         command.append("--debug")
     if args.restart:
         command.append("--restart")

--- a/nat-lab/run_local.py
+++ b/nat-lab/run_local.py
@@ -48,12 +48,12 @@ def main() -> int:
     parser.add_argument(
         "--windows",
         action="store_true",
-        help="Build TCLI for Windows, run tests with 'windows' mark",
+        help="Windows build, run tests with 'windows' mark",
     )
     parser.add_argument(
         "--mac",
         action="store_true",
-        help="Build TCLI for Mac, run tests with 'mac' mark",
+        help="MacOS build, run tests with 'mac' mark",
     )
     parser.add_argument(
         "--linux-native", action="store_true", help="Run tests with 'linux_native' mark"
@@ -70,6 +70,11 @@ def main() -> int:
         "--no-verify-setup-correctness",
         action="store_true",
         help="Disable verification of setup correctness",
+    )
+    parser.add_argument(
+        "--telio-debug",
+        action="store_true",
+        help="Use libtelio debug build binaries",
     )
     args = parser.parse_args()
 
@@ -127,6 +132,8 @@ def run_build_command(operating_system, args):
             operating_system,
         ]
     command.extend(["--uniffi-test-bindings"])
+    if args.debug_bin:
+        command.append("--debug")
     if args.restart:
         command.append("--restart")
     if args.moose:
@@ -137,6 +144,11 @@ def run_build_command(operating_system, args):
 
 def get_pytest_arguments(options) -> List[str]:
     args = []
+
+    if options.telio_debug:
+        os.environ["TELIO_BIN_PROFILE"] = "debug"
+    else:
+        os.environ["TELIO_BIN_PROFILE"] = "release"
 
     if options.v:
         args.extend(["--capture=no"])

--- a/nat-lab/tests/config.py
+++ b/nat-lab/tests/config.py
@@ -57,11 +57,20 @@ IPERF_BINARY_WINDOWS = "C:/workspace/iperf3/iperf3.exe".replace("/", "\\")
 # since its stable unlike `libtelio/dist`.
 #
 # Libtelio binary path inside Docker containers.
+if os.getenv("TELIO_BIN_PROFILE") not in ["release", "debug"]:
+    raise ValueError(
+        'TELIO_BIN_PROFILE environment variable must be set to either "release" or "debug".'
+    )
+
 if platform.system() == "Darwin":
-    LIBTELIO_BINARY_PATH_DOCKER = "/libtelio/target/aarch64-unknown-linux-gnu/release/"
+    LIBTELIO_BINARY_PATH_DOCKER = (
+        f"/libtelio/target/aarch64-unknown-linux-gnu/{os.getenv('TELIO_BIN_PROFILE')}/"
+    )
 else:
     LIBTELIO_BINARY_PATH_DOCKER = (
-        "/libtelio/dist/linux/release/" + platform.uname().machine + "/"
+        f"/libtelio/dist/linux/{os.getenv('TELIO_BIN_PROFILE')}/"
+        + platform.uname().machine
+        + "/"
     )
 
 # Libtelio binary path inside Windows and Mac VMs

--- a/nat-lab/tests/conftest.py
+++ b/nat-lab/tests/conftest.py
@@ -158,8 +158,6 @@ async def perform_setup_checks() -> bool:
                 break
             except asyncio.TimeoutError:
                 print(f"{target}() timeout, retrying...")
-            except Exception as e:  # pylint: disable=broad-exception-caught
-                print(f"An error occurred: {e}, retrying...")
             retries -= 1
         else:
             return False

--- a/nat-lab/tests/test_teliod.py
+++ b/nat-lab/tests/test_teliod.py
@@ -1,11 +1,12 @@
 import asyncio
 import pytest
+from config import LIBTELIO_BINARY_PATH_DOCKER
 from contextlib import AsyncExitStack
 from helpers import setup_connections
 from utils.connection_util import ConnectionTag
 from utils.process.process import ProcessExecError
 
-TELIOD_EXEC_PATH = "/libtelio/dist/linux/release/x86_64/teliod"
+TELIOD_EXEC_PATH = f"{LIBTELIO_BINARY_PATH_DOCKER}/teliod"
 CONFIG_FILE_PATH = "/etc/teliod/config.json"
 SOCKET_FILE_PATH = "/run/teliod.sock"
 

--- a/nat-lab/tests/utils/vm/mac_vm_util.py
+++ b/nat-lab/tests/utils/vm/mac_vm_util.py
@@ -66,9 +66,7 @@ async def _copy_binaries(
     DIST_PATH = f"dist/darwin/macos/{os.getenv('TELIO_BIN_PROFILE')}/x86_64/"
     LOCAL_UNIFFI_PATH = "nat-lab/tests/uniffi/"
     LOCAL_BIN_DIR = "nat-lab/bin/"
-
     files_to_copy = [
-        (f"{DIST_PATH}tcli", f"{VM_TCLI_DIR}tcli", True),
         (
             f"{DIST_PATH}libtelio.dylib",
             f"{VM_UNIFFI_DIR}libtelio.dylib",

--- a/nat-lab/tests/utils/vm/mac_vm_util.py
+++ b/nat-lab/tests/utils/vm/mac_vm_util.py
@@ -1,4 +1,5 @@
 import asyncssh
+import os
 import subprocess
 from config import (
     get_root_path,
@@ -62,7 +63,7 @@ async def _copy_binaries(
                 raise exception
         await connection.create_process(["mkdir", "-p", directory]).execute()
 
-    DIST_PATH = "dist/darwin/macos/release/x86_64/"
+    DIST_PATH = f"dist/darwin/macos/{os.getenv('TELIO_BIN_PROFILE')}/x86_64/"
     LOCAL_UNIFFI_PATH = "nat-lab/tests/uniffi/"
     LOCAL_BIN_DIR = "nat-lab/bin/"
 

--- a/nat-lab/tests/utils/vm/windows_vm_util.py
+++ b/nat-lab/tests/utils/vm/windows_vm_util.py
@@ -1,4 +1,5 @@
 import asyncssh
+import os
 import subprocess
 from config import (
     get_root_path,
@@ -126,7 +127,7 @@ async def _copy_binaries(
             ):
                 raise exception
 
-    DIST_DIR = "dist/windows/release/x86_64/"
+    DIST_DIR = f"dist/windows/{os.getenv('TELIO_BIN_PROFILE')}/x86_64/"
     LOCAL_UNIFFI_DIR = "nat-lab/tests/uniffi/"
     LOCAL_BIN_DIR = "nat-lab/bin/"
 


### PR DESCRIPTION
By default release builds are used on build scripts, and release build profile is configured to use compiler size optimization flags which slows down compilation, taking around double the time than without optimizations. Also, `tcli` is no longer required to run nat-lab, therefore it shouldn't be built by default when running build scripts.

This commit adapts build scripts to make use of debug binaries and stop building tcli implicitly. 

Tcli is now built when `--tcli` flag is passed and debug builds are now fully supported for natlab and other build scripts functionalities.


Benchmarking results for release vs. optimized dev profile:

Linux:      **6m46s -> 1m50s**
Win:        **8m24s -> 1m40s**
macOS:  **9m33s -> 43s**
Android: **2m47s -> 1m05s**

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
