### PR TITLE
[LLT-4929] traversal: Remove SM crate from cross ping check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3931,26 +3931,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sm"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e4a3f3651a411045a4324773afcf10d11919a90c006b94a4178da1d18e5769"
-dependencies = [
- "sm_macro",
-]
-
-[[package]]
-name = "sm_macro"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba245bc9067435452e4d8b9af04509929a9e99ce7273c82c2b8551e7f09ee861"
-dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "syn 0.15.44",
-]
-
-[[package]]
 name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4703,7 +4683,6 @@ version = "1.0.0"
 name = "telio-traversal"
 version = "0.1.0"
 dependencies = [
- "assert_matches",
  "async-trait",
  "base64 0.13.1",
  "boringtun",
@@ -4723,7 +4702,6 @@ dependencies = [
  "parking_lot",
  "rand",
  "rstest",
- "sm",
  "socket2 0.5.7",
  "strum",
  "stun_codec",

--- a/crates/telio-traversal/Cargo.toml
+++ b/crates/telio-traversal/Cargo.toml
@@ -11,7 +11,6 @@ bytecodec = "0.4.15"
 enum-map = "2.5.0"
 http = "0.2.8"
 igd = { version = "0.12.1", features = ["aio"], default-features = false }
-sm = "0.9.0"
 stun_codec = "0.1.13"
 
 async-trait.workspace = true
@@ -43,8 +42,6 @@ telio-utils.workspace = true
 telio-wg.workspace = true
 
 [dev-dependencies]
-assert_matches = "1.5.0"
-
 env_logger.workspace = true
 maplit.workspace = true
 mockall.workspace = true

--- a/crates/telio-traversal/src/connectivity_check/cross_ping_check.rs
+++ b/crates/telio-traversal/src/connectivity_check/cross_ping_check.rs
@@ -1,16 +1,17 @@
 use super::{Error, WireGuardEndpointCandidateChangeEvent};
 use crate::{
+    do_state_transition,
     endpoint_providers::{
         EndpointCandidate, EndpointCandidatesChangeEvent, EndpointProvider, EndpointProviderType,
         Error as EndPointError, PongEvent,
     },
+    endpoint_state::{EndpointState, EndpointStateMachine, Event},
     last_rx_time_provider::{is_peer_alive, TimeSinceLastRxProvider},
     ping_pong_handler::PingPongHandler,
 };
 use async_trait::async_trait;
 use enum_map::EnumMap;
 use futures::Future;
-use sm::sm;
 use std::fmt::Debug;
 use std::sync::Arc;
 use std::time::Duration;
@@ -32,56 +33,6 @@ use tokio::time::{Instant, Interval};
 const CPC_TIMEOUT: Duration = Duration::from_secs(10);
 const UPGRADE_TIMEOUT: Duration = Duration::from_secs(60);
 const MAX_SESSION_CANDIDATES: usize = 512;
-
-// Cross ping state machine definintion
-sm! {
-    EndpointState {
-        InitialStates { Disconnected }
-
-        SendCallMeMaybeRequest {
-            Disconnected => EndpointGathering
-        }
-
-        ReceiveCallMeMaybeResponse {
-            EndpointGathering => Ping
-        }
-
-        Publish {
-            Ping => Published
-        }
-
-        Timeout {
-            EndpointGathering => Disconnected
-            Ping => Disconnected
-        }
-
-        EndpointGone {
-            Published => Disconnected
-        }
-    }
-}
-use EndpointState::Variant::*;
-use EndpointState::*;
-macro_rules! do_state_transition {
-    ($machine: expr, $event: expr, $ep: expr) => {{
-        if $machine.state() == EndpointState::Published || $event == EndpointState::Publish {
-            do_state_transition!($machine, $event, $ep, telio_log_info);
-        } else {
-            do_state_transition!($machine, $event, $ep, telio_log_debug);
-        }
-    }};
-    ($machine: expr, $event: expr, $ep: expr, $log: ident) => {{
-        $log!(
-            "Node's {:?} EP {:?} state transition {:?} -> {:?}",
-            $ep.public_key,
-            $ep.local_endpoint_candidate.udp,
-            $machine.state(),
-            $event
-        );
-        $ep.last_state_transition = Instant::now();
-        $ep.state = $machine.transition($event).as_enum();
-    }};
-}
 
 #[cfg_attr(any(test, feature = "mockall"), mockall::automock)]
 #[async_trait]
@@ -278,8 +229,8 @@ impl CrossPingCheckTrait for CrossPingCheck {
                 Ok(s.endpoint_connectivity_check_state
                     .iter()
                     .filter_map(
-                        |(session, v)| match (v.state.clone(), v.last_validated_endpoint) {
-                            (PublishedByPublish(_), Some(ep)) => Some((
+                        |(session, v)| match (v.state.get(), v.last_validated_endpoint) {
+                            (EndpointState::Published, Some(ep)) => Some((
                                 v.public_key,
                                 WireGuardEndpointCandidateChangeEvent {
                                     public_key: v.public_key,
@@ -312,7 +263,7 @@ impl CrossPingCheckTrait for CrossPingCheck {
                 .values_mut()
                 .filter(|v| v.public_key == public_key);
             for session in sessions {
-                session.handle_endpoint_succesfull_notification();
+                session.handle_endpoint_successful_notification();
             }
             Ok(())
         })
@@ -398,7 +349,7 @@ impl<E: Backoff> State<E> {
                     let session = EndpointConnectivityCheckState {
                         public_key: added_node,
                         local_endpoint_candidate: endpoint.clone(),
-                        state: Machine::new(Disconnected).as_enum(),
+                        state: EndpointStateMachine::default(),
                         last_state_transition: Instant::now(),
                         last_validated_endpoint: None,
                         last_rx_time_provider: self.last_rx_time_provider.clone(),
@@ -463,7 +414,7 @@ impl<E: Backoff> State<E> {
                     public_key: node,
                     local_endpoint_candidate: added_endpoint.clone(),
                     local_session: session_id,
-                    state: Machine::new(Disconnected).as_enum(),
+                    state: EndpointStateMachine::default(),
                     last_state_transition: Instant::now(),
                     last_validated_endpoint: None,
                     last_rx_time_provider: self.last_rx_time_provider.clone(),
@@ -737,7 +688,7 @@ pub struct EndpointConnectivityCheckState<E: Backoff> {
     public_key: PublicKey,
     local_endpoint_candidate: EndpointCandidate,
     local_session: Session,
-    state: EndpointState::Variant,
+    state: EndpointStateMachine,
     last_state_transition: Instant,
     last_validated_endpoint: Option<(SocketAddr, ApiEndpointProvider)>,
     last_rx_time_provider: Option<Arc<dyn TimeSinceLastRxProvider>>,
@@ -792,18 +743,18 @@ impl<E: Backoff> EndpointConnectivityCheckState<E> {
     }
 
     async fn handle_endpoint_gone_notification(&mut self) -> Result<(), Error> {
-        if let PublishedByPublish(m) = self.state.clone() {
+        if self.state.get() == EndpointState::Published {
             telio_log_info!(
                 "Endpoint gone, next retry after {}s",
                 self.exponential_backoff.get_backoff().as_secs_f64()
             );
-            do_state_transition!(m, EndpointGone, self);
+            do_state_transition!(self, Event::EndpointGone);
         }
         Ok(())
     }
 
-    fn handle_endpoint_succesfull_notification(&mut self) {
-        if let PublishedByPublish(_) = self.state.clone() {
+    fn handle_endpoint_successful_notification(&mut self) {
+        if self.state.get() == EndpointState::Published {
             self.exponential_backoff.reset();
         }
     }
@@ -814,8 +765,8 @@ impl<E: Backoff> EndpointConnectivityCheckState<E> {
         (public_key, message): (PublicKey, CallMeMaybeMsg),
         ep_providers: Vec<Arc<dyn EndpointProvider>>,
     ) -> Result<(), Error> {
-        match self.state.clone() {
-            EndpointGatheringBySendCallMeMaybeRequest(m) => {
+        match self.state.get() {
+            EndpointState::EndpointGathering => {
                 telio_log_debug!(
                     "Received a CMM response from {:?}: {:?}",
                     public_key,
@@ -832,7 +783,7 @@ impl<E: Backoff> EndpointConnectivityCheckState<E> {
                     .await?;
                 }
 
-                do_state_transition!(m, ReceiveCallMeMaybeResponse, self);
+                do_state_transition!(self, Event::ReceiveCallMeMaybeResponse);
             }
             _ => {
                 telio_log_warn!("Received a CMM response for session {:?} during non-gather state {:?}. Ignoring", message.get_session(), self.state);
@@ -847,8 +798,8 @@ impl<E: Backoff> EndpointConnectivityCheckState<E> {
         event: PongEvent,
         wg_ep_publisher: chan::Tx<WireGuardEndpointCandidateChangeEvent>,
     ) -> Result<(), Error> {
-        match self.state.clone() {
-            PingByReceiveCallMeMaybeResponse(m) => {
+        match self.state.get() {
+            EndpointState::Ping => {
                 let nice_ep_provider = matches!(
                     event.msg.get_ponging_ep_provider(),
                     Ok(Some(telio_model::features::EndpointProvider::Local))
@@ -868,7 +819,7 @@ impl<E: Backoff> EndpointConnectivityCheckState<E> {
                             }
                         };
 
-                        do_state_transition!(m, Publish, self);
+                        do_state_transition!(self, Event::Publish);
                         let wg_publish_event = WireGuardEndpointCandidateChangeEvent {
                             public_key: self.public_key,
                             remote_endpoint: (remote_endpoint, remote_endpoint_type),
@@ -949,32 +900,32 @@ impl<E: Backoff> EndpointConnectivityCheckState<E> {
         let duration_in_state = Instant::now() - self.last_state_transition;
         let timeout = CPC_TIMEOUT; // TODO: make configurable
 
-        match self.state.clone() {
-            EndpointGatheringBySendCallMeMaybeRequest(m) => {
+        match self.state.get() {
+            EndpointState::EndpointGathering => {
                 if duration_in_state > timeout {
                     // Timeout occured
                     telio_log_debug!(
                         "Timeout waiting for CMM response, next retry after {}s",
                         self.exponential_backoff.get_backoff().as_secs_f64()
                     );
-                    do_state_transition!(m, Timeout, self);
+                    do_state_transition!(self, Event::Timeout);
                 }
             }
-            PingByReceiveCallMeMaybeResponse(m) => {
+            EndpointState::Ping => {
                 if duration_in_state > timeout {
                     // Timeout occured
                     telio_log_debug!(
                         "Timeout waiting for pongs, next retry after {}s",
                         self.exponential_backoff.get_backoff().as_secs_f64()
                     );
-                    do_state_transition!(m, Timeout, self);
+                    do_state_transition!(self, Event::Timeout);
                 }
             }
-            InitialDisconnected(m) => {
+            EndpointState::Disconnected(Event::StartUp) => {
                 self.send_call_me_maybe_request(session, intercoms).await?;
-                do_state_transition!(m, SendCallMeMaybeRequest, self);
+                do_state_transition!(self, Event::SendCallMeMaybeRequest);
             }
-            DisconnectedByTimeout(m) => {
+            EndpointState::Disconnected(Event::Timeout) => {
                 match self
                     .should_resend_call_me_maybe_request(duration_in_state)
                     .await
@@ -982,7 +933,7 @@ impl<E: Backoff> EndpointConnectivityCheckState<E> {
                     ShouldSendCMMResult::Yes => {
                         self.exponential_backoff.next_backoff();
                         self.send_call_me_maybe_request(session, intercoms).await?;
-                        do_state_transition!(m, SendCallMeMaybeRequest, self);
+                        do_state_transition!(self, Event::SendCallMeMaybeRequest);
                     }
                     reason => {
                         telio_log_debug!(
@@ -992,7 +943,7 @@ impl<E: Backoff> EndpointConnectivityCheckState<E> {
                     }
                 }
             }
-            DisconnectedByEndpointGone(m) => {
+            EndpointState::Disconnected(Event::EndpointGone) => {
                 match self
                     .should_resend_call_me_maybe_request(duration_in_state)
                     .await
@@ -1000,7 +951,7 @@ impl<E: Backoff> EndpointConnectivityCheckState<E> {
                     ShouldSendCMMResult::Yes => {
                         self.exponential_backoff.next_backoff();
                         self.send_call_me_maybe_request(session, intercoms).await?;
-                        do_state_transition!(m, SendCallMeMaybeRequest, self);
+                        do_state_transition!(self, Event::SendCallMeMaybeRequest);
                     }
                     reason => {
                         telio_log_debug!(
@@ -1038,8 +989,6 @@ mod tests {
         sync::mpsc::{Receiver, Sender},
         time::{self, Instant},
     };
-
-    use assert_matches::assert_matches;
 
     use telio_crypto::{PublicKey, SecretKey};
     use telio_model::{
@@ -1155,7 +1104,7 @@ mod tests {
     }
 
     fn prepare_test_session_in_state(
-        state: EndpointState::Variant,
+        state: EndpointStateMachine,
         endpoint: SocketAddr,
         last_rx_time_provider: Arc<dyn TimeSinceLastRxProvider>,
     ) -> EndpointConnectivityCheckState<MockBackoff> {
@@ -1242,7 +1191,7 @@ mod tests {
     async fn endpoint_connectivity_check_state_send_cmm_request() {
         let last_rx_time_provider_mock = Arc::new(Mutex::new(MockTimeSinceLastRxProvider::new()));
         let mut endpoint_connectivity_check_state = prepare_test_session_in_state(
-            Machine::new(Disconnected).as_enum(),
+            EndpointStateMachine::new(EndpointState::Disconnected(Event::StartUp)),
             SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)), 8080),
             last_rx_time_provider_mock,
         );
@@ -1253,9 +1202,9 @@ mod tests {
             .await
             .unwrap();
 
-        assert_matches!(
+        assert_eq!(
             endpoint_connectivity_check_state.state,
-            EndpointGatheringBySendCallMeMaybeRequest(_)
+            EndpointState::EndpointGathering,
         );
     }
 
@@ -1268,9 +1217,7 @@ mod tests {
             .expect_send_ping()
             .returning(|_, _, _| Ok(()));
         let mut endpoint_connectivity_check_state = prepare_test_session_in_state(
-            Machine::new(Disconnected)
-                .transition(SendCallMeMaybeRequest)
-                .as_enum(),
+            EndpointStateMachine::new(EndpointState::EndpointGathering),
             endpoint,
             last_rx_time_provider_mock.clone(),
         );
@@ -1285,10 +1232,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_matches!(
-            endpoint_connectivity_check_state.state,
-            PingByReceiveCallMeMaybeResponse(_)
-        );
+        assert_eq!(endpoint_connectivity_check_state.state, EndpointState::Ping);
     }
 
     #[tokio::test]
@@ -1296,10 +1240,7 @@ mod tests {
         let last_rx_time_provider_mock = Arc::new(Mutex::new(MockTimeSinceLastRxProvider::new()));
         let endpoint = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)), 8080);
         let mut endpoint_connectivity_check_state = prepare_test_session_in_state(
-            Machine::new(Disconnected)
-                .transition(SendCallMeMaybeRequest)
-                .transition(ReceiveCallMeMaybeResponse)
-                .as_enum(),
+            EndpointStateMachine::new(EndpointState::Ping),
             endpoint,
             last_rx_time_provider_mock.clone(),
         );
@@ -1323,9 +1264,9 @@ mod tests {
             .await
             .unwrap();
 
-        assert_matches!(
+        assert_eq!(
             endpoint_connectivity_check_state.state,
-            PublishedByPublish(_)
+            EndpointState::Published
         );
     }
 
@@ -1333,11 +1274,7 @@ mod tests {
     async fn endpoint_connectivity_check_state_endpoint_gone() {
         let last_rx_time_provider_mock = Arc::new(Mutex::new(MockTimeSinceLastRxProvider::new()));
         let mut endpoint_connectivity_check_state = prepare_test_session_in_state(
-            Machine::new(Disconnected)
-                .transition(SendCallMeMaybeRequest)
-                .transition(ReceiveCallMeMaybeResponse)
-                .transition(Publish)
-                .as_enum(),
+            EndpointStateMachine::new(EndpointState::Published),
             SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)), 8080),
             last_rx_time_provider_mock.clone(),
         );
@@ -1347,9 +1284,9 @@ mod tests {
             .await
             .unwrap();
 
-        assert_matches!(
+        assert_eq!(
             endpoint_connectivity_check_state.state,
-            DisconnectedByEndpointGone(_)
+            (EndpointState::Disconnected(Event::EndpointGone))
         );
     }
 
@@ -1357,9 +1294,7 @@ mod tests {
     async fn endpoint_connectivity_check_state_timeout_endpoint_gathering() {
         let last_rx_time_provider_mock = Arc::new(Mutex::new(MockTimeSinceLastRxProvider::new()));
         let mut endpoint_connectivity_check_state = prepare_test_session_in_state(
-            Machine::new(Disconnected)
-                .transition(SendCallMeMaybeRequest)
-                .as_enum(),
+            EndpointStateMachine::new(EndpointState::EndpointGathering),
             SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)), 8080),
             last_rx_time_provider_mock.clone(),
         );
@@ -1370,9 +1305,9 @@ mod tests {
             .await
             .unwrap();
 
-        assert_matches!(
+        assert_eq!(
             endpoint_connectivity_check_state.state,
-            DisconnectedByTimeout(_)
+            (EndpointState::Disconnected(Event::Timeout))
         );
     }
 
@@ -1380,9 +1315,7 @@ mod tests {
     async fn endpoint_connectivity_check_state_timeout_ping() {
         let last_rx_time_provider_mock = Arc::new(Mutex::new(MockTimeSinceLastRxProvider::new()));
         let mut endpoint_connectivity_check_state = prepare_test_session_in_state(
-            Machine::new(Disconnected)
-                .transition(SendCallMeMaybeRequest)
-                .as_enum(),
+            EndpointStateMachine::new(EndpointState::EndpointGathering),
             SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)), 8080),
             last_rx_time_provider_mock.clone(),
         );
@@ -1393,9 +1326,9 @@ mod tests {
             .await
             .unwrap();
 
-        assert_matches!(
+        assert_eq!(
             endpoint_connectivity_check_state.state,
-            DisconnectedByTimeout(_)
+            (EndpointState::Disconnected(Event::Timeout))
         );
     }
 
@@ -1408,7 +1341,7 @@ mod tests {
             .expect_max_no_rx_time()
             .return_const(Duration::from_secs(180));
         let mut endpoint_connectivity_check_state = prepare_test_session_in_state(
-            Machine::new(Disconnected).as_enum(),
+            EndpointStateMachine::new(EndpointState::Disconnected(Event::StartUp)),
             SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)), 8080),
             last_rx_time_provider_mock.clone(),
         );
@@ -1500,9 +1433,7 @@ mod tests {
             .returning(|_, _, _| Ok(()));
 
         let mut endpoint_connectivity_check_state = prepare_test_session_in_state(
-            Machine::new(Disconnected)
-                .transition(SendCallMeMaybeRequest)
-                .as_enum(),
+            EndpointStateMachine::new(EndpointState::EndpointGathering),
             endpoint,
             last_rx_time_provider_mock.clone(),
         );
@@ -1520,10 +1451,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_matches!(
-            endpoint_connectivity_check_state.state,
-            PingByReceiveCallMeMaybeResponse(_)
-        );
+        assert_eq!(endpoint_connectivity_check_state.state, EndpointState::Ping);
     }
 
     #[rstest]
@@ -1533,7 +1461,7 @@ mod tests {
     async fn failure_to_get_last_rx_time_means_peer_is_dead(#[case] which_error: u8) {
         let last_rx_time_provider_mock = Arc::new(Mutex::new(MockTimeSinceLastRxProvider::new()));
         let mut endpoint_connectivity_check_state = prepare_test_session_in_state(
-            Machine::new(Disconnected).as_enum(),
+            EndpointStateMachine::new(EndpointState::Disconnected(Event::StartUp)),
             SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)), 8080),
             last_rx_time_provider_mock.clone(),
         );
@@ -1584,10 +1512,10 @@ mod tests {
             .await
             .unwrap();
 
-        assert!(matches!(
+        assert_eq!(
             endpoint_connectivity_check_state.state,
-            DisconnectedByTimeout(_)
-        ));
+            (EndpointState::Disconnected(Event::Timeout))
+        );
 
         // Skip the expected time
         let time_to_skip = Duration::from_millis(backoff + 1);

--- a/crates/telio-traversal/src/endpoint_state.rs
+++ b/crates/telio-traversal/src/endpoint_state.rs
@@ -1,0 +1,105 @@
+use std::fmt;
+use telio_utils::telio_log_warn;
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum EndpointState {
+    Disconnected(Event),
+    EndpointGathering,
+    Ping,
+    Published,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum Event {
+    StartUp,
+    SendCallMeMaybeRequest,
+    ReceiveCallMeMaybeResponse,
+    Publish,
+    Timeout,
+    EndpointGone,
+}
+
+impl Default for EndpointState {
+    fn default() -> Self {
+        EndpointState::Disconnected(Event::StartUp)
+    }
+}
+#[derive(Default, Debug)]
+pub struct EndpointStateMachine {
+    state: EndpointState,
+}
+
+impl EndpointStateMachine {
+    pub fn handle_event(&mut self, event: Event) {
+        match (&self.state, &event) {
+            (EndpointState::Disconnected(_), Event::SendCallMeMaybeRequest) => {
+                self.state = EndpointState::EndpointGathering;
+            }
+
+            (EndpointState::EndpointGathering, Event::ReceiveCallMeMaybeResponse) => {
+                self.state = EndpointState::Ping;
+            }
+
+            (EndpointState::Ping, Event::Publish) => {
+                self.state = EndpointState::Published;
+            }
+
+            (EndpointState::EndpointGathering | EndpointState::Ping, Event::Timeout) => {
+                self.state = EndpointState::Disconnected(event);
+            }
+
+            (EndpointState::Published, Event::EndpointGone) => {
+                self.state = EndpointState::Disconnected(event);
+            }
+
+            (_, event) => {
+                telio_log_warn!("Invalid state transition {:?} -> {:?}", &self.state, event);
+            }
+        }
+    }
+
+    pub fn get(&self) -> EndpointState {
+        self.state
+    }
+}
+
+impl PartialEq<EndpointState> for EndpointStateMachine {
+    fn eq(&self, other: &EndpointState) -> bool {
+        &self.state == other
+    }
+}
+
+impl fmt::Display for EndpointStateMachine {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self.state)
+    }
+}
+
+#[cfg(test)]
+impl EndpointStateMachine {
+    pub fn new(state: EndpointState) -> EndpointStateMachine {
+        EndpointStateMachine { state }
+    }
+}
+
+#[macro_export]
+macro_rules! do_state_transition {
+    ($ep: expr, $event: expr) => {{
+        if $ep.state.get() == EndpointState::Published || $event == Event::Publish {
+            do_state_transition!($ep, $event, telio_log_info);
+        } else {
+            do_state_transition!($ep, $event, telio_log_debug);
+        }
+    }};
+    ($ep: expr, $event: expr, $log: ident) => {{
+        $log!(
+            "Node's {:?} EP {:?} state transition {:?} -> {:?}",
+            $ep.public_key,
+            $ep.local_endpoint_candidate.udp,
+            $ep.state,
+            $event
+        );
+        $ep.last_state_transition = Instant::now();
+        $ep.state.handle_event($event);
+    }};
+}

--- a/crates/telio-traversal/src/lib.rs
+++ b/crates/telio-traversal/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod connectivity_check;
 pub mod endpoint_providers;
+pub mod endpoint_state;
 pub mod error;
 pub mod last_rx_time_provider;
 pub mod ping_pong_handler;


### PR DESCRIPTION
### Problem
[SM crate ](https://crates.io/crates/sm) is deprecated and thus no longer maintaned. We've been using it to define a endpoint state machine for cross ping check component of telio-traversal:
```
 sm! {
     EndpointState {
         InitialStates { Disconnected }

         SendCallMeMaybeRequest {
             Disconnected => EndpointGathering
         }

         ReceiveCallMeMaybeResponse {
             EndpointGathering => Ping
         }

         Publish {
             Ping => Published
         }

         Timeout {
             EndpointGathering => Disconnected
             Ping => Disconnected
         }

         EndpointGone {
             Published => Disconnected
         }
     }
 }
```
Because of this dependency we've been required to keep old versions of `quote`, `proc-macro2` and `syn` crates.

### Solution
This PR replaces the FSM defined using the SM crate and removes that crate from libtelio workspace. 

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
