### PR TITLE
traversal: Remove SM crate from cross ping check [DUPLICATED]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3931,26 +3931,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sm"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e4a3f3651a411045a4324773afcf10d11919a90c006b94a4178da1d18e5769"
-dependencies = [
- "sm_macro",
-]
-
-[[package]]
-name = "sm_macro"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba245bc9067435452e4d8b9af04509929a9e99ce7273c82c2b8551e7f09ee861"
-dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "syn 0.15.44",
-]
-
-[[package]]
 name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4703,7 +4683,6 @@ version = "1.0.0"
 name = "telio-traversal"
 version = "0.1.0"
 dependencies = [
- "assert_matches",
  "async-trait",
  "base64 0.13.1",
  "boringtun",
@@ -4723,7 +4702,6 @@ dependencies = [
  "parking_lot",
  "rand",
  "rstest",
- "sm",
  "socket2 0.5.7",
  "strum",
  "stun_codec",

--- a/crates/telio-traversal/Cargo.toml
+++ b/crates/telio-traversal/Cargo.toml
@@ -11,7 +11,6 @@ bytecodec = "0.4.15"
 enum-map = "2.5.0"
 http = "0.2.8"
 igd = { version = "0.12.1", features = ["aio"], default-features = false }
-sm = "0.9.0"
 stun_codec = "0.1.13"
 
 async-trait.workspace = true
@@ -43,8 +42,6 @@ telio-utils.workspace = true
 telio-wg.workspace = true
 
 [dev-dependencies]
-assert_matches = "1.5.0"
-
 env_logger.workspace = true
 maplit.workspace = true
 mockall.workspace = true

--- a/crates/telio-traversal/src/endpoint_state.rs
+++ b/crates/telio-traversal/src/endpoint_state.rs
@@ -1,0 +1,120 @@
+use std::fmt;
+use telio_utils::telio_log_warn;
+
+#[derive(Debug, Default, PartialEq)]
+pub enum EndpointState {
+    #[default]
+    Disconnected,
+    EndpointGathering,
+    Ping,
+    Published,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum Event {
+    SendCallMeMaybeRequest,
+    ReceiveCallMeMaybeResponse,
+    Publish,
+    Timeout,
+    EndpointGone,
+}
+
+#[derive(Default, Debug)]
+pub struct EndpointStateMachine {
+    state: EndpointState,
+    last_event: Option<Event>,
+}
+
+impl EndpointStateMachine {
+    pub fn handle_event(&mut self, event: Event) {
+        match (&self.state, &event) {
+            (EndpointState::Disconnected, Event::SendCallMeMaybeRequest) => {
+                self.last_event = Some(event);
+                self.state = EndpointState::EndpointGathering;
+            }
+
+            (EndpointState::EndpointGathering, Event::ReceiveCallMeMaybeResponse) => {
+                self.last_event = Some(event);
+                self.state = EndpointState::Ping;
+            }
+
+            (EndpointState::Ping, Event::Publish) => {
+                self.last_event = Some(event);
+                self.state = EndpointState::Published;
+            }
+
+            (EndpointState::EndpointGathering, Event::Timeout)
+            | (EndpointState::Ping, Event::Timeout) => {
+                self.last_event = Some(event);
+                self.state = EndpointState::Disconnected;
+            }
+
+            (EndpointState::Published, Event::EndpointGone) => {
+                self.last_event = Some(event);
+                self.state = EndpointState::Disconnected;
+            }
+
+            (_, event) => {
+                telio_log_warn!("Invalid state transition {:?} -> {:?}", &self.state, event);
+            }
+        }
+    }
+
+    pub fn get(&self) -> &EndpointState {
+        &self.state
+    }
+
+    pub fn last_event(&self) -> &Option<Event> {
+        &self.last_event
+    }
+}
+
+impl PartialEq<EndpointState> for EndpointStateMachine {
+    fn eq(&self, other: &EndpointState) -> bool {
+        &self.state == other
+    }
+}
+
+impl PartialEq<(EndpointState, Option<Event>)> for EndpointStateMachine {
+    fn eq(&self, other: &(EndpointState, Option<Event>)) -> bool {
+        self.state == other.0 && self.last_event == other.1
+    }
+}
+
+impl fmt::Display for EndpointStateMachine {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self.state)
+    }
+}
+
+#[cfg(test)]
+impl EndpointStateMachine {
+    pub fn new(state: EndpointState, event: Option<Event>) -> EndpointStateMachine {
+        EndpointStateMachine {
+            state,
+            last_event: event,
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! do_state_transition {
+    ($ep: expr, $event: expr) => {{
+        if $ep.state.get() == &EndpointState::Published || $event == Event::Publish {
+            do_state_transition!($ep, $event, telio_log_info);
+        } else {
+            do_state_transition!($ep, $event, telio_log_debug);
+        }
+    }};
+    ($ep: expr, $event: expr, $log: ident) => {{
+        $log!(
+            "Node's {:?} EP {:?} state transition {:?} -> {:?}",
+            $ep.public_key,
+            $ep.local_endpoint_candidate.udp,
+            $ep.state,
+            $event
+        );
+        $ep.last_state_transition = Instant::now();
+        $ep.state.handle_event($event);
+    }};
+}

--- a/crates/telio-traversal/src/lib.rs
+++ b/crates/telio-traversal/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod connectivity_check;
 pub mod endpoint_providers;
+pub mod endpoint_state;
 pub mod error;
 pub mod last_rx_time_provider;
 pub mod ping_pong_handler;


### PR DESCRIPTION
### Problem
[SM crate ](https://crates.io/crates/sm) is deprecated and thus no longer maintaned. We've been using it to define a endpoint state machine for cross ping check component of telio-traversal:
```
 sm! {
     EndpointState {
         InitialStates { Disconnected }

         SendCallMeMaybeRequest {
             Disconnected => EndpointGathering
         }

         ReceiveCallMeMaybeResponse {
             EndpointGathering => Ping
         }

         Publish {
             Ping => Published
         }

         Timeout {
             EndpointGathering => Disconnected
             Ping => Disconnected
         }

         EndpointGone {
             Published => Disconnected
         }
     }
 }
```
Because of this dependency we've been required to keep old versions of `quote`, `proc-macro2` and `syn` crates.

### Solution
This PR replaces the FSM defined using the SM crate and removes that crate from libtelio workspace. 

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
