### PR TITLE
LLT-5534: Use generated meshnet config in natlab

### DIFF
--- a/nat-lab/tests/config.py
+++ b/nat-lab/tests/config.py
@@ -1,6 +1,7 @@
 import os
 import platform
 from typing import Dict, Union
+from utils.bindings import Server, RelayState
 
 if platform.machine() != "x86_64":
     import pure_wg as Key
@@ -129,58 +130,62 @@ WG_SERVERS = [WG_SERVER, WG_SERVER_2, NLX_SERVER]
 # and replace dictionaries with objects
 
 # DERP servers
-DERP_PRIMARY = {
-    "region_code": "nl",
-    "name": "Natlab #0001",
-    "hostname": "derp-01",
-    "ipv4": "10.0.10.1",
-    "relay_port": 8765,
-    "stun_port": 3479,
-    "stun_plaintext_port": 3478,
-    "public_key": "qK/ICYOGBu45EIGnopVu+aeHDugBrkLAZDroKGTuKU0=",  # NOTE: this is hardcoded key for transient docker container existing only during the tests
-    "weight": 1,
-    "use_plain_text": True,
-}
+DERP_PRIMARY = Server(
+    region_code="nl",
+    name="Natlab #0001",
+    hostname="derp-01",
+    ipv4="10.0.10.1",
+    relay_port=8765,
+    stun_port=3479,
+    stun_plaintext_port=3478,
+    public_key="qK/ICYOGBu45EIGnopVu+aeHDugBrkLAZDroKGTuKU0=",  # NOTE: this is hardcoded key for transient docker container existing only during the tests
+    weight=1,
+    use_plain_text=True,
+    conn_state=RelayState.DISCONNECTED,
+)
 
-DERP_FAKE = {
-    "region_code": "fk",
-    "name": "Natlab #0002-fake",
-    "hostname": "derp-00",
-    "ipv4": "10.0.10.245",
-    "relay_port": 8765,
-    "stun_port": 3479,
-    "stun_plaintext_port": 3478,
-    "public_key": "aAY0rU8pW8LV3BJlY5u5WYH7nbAwS5H0mBMJppVDRGs=",  # NOTE: this is hardcoded key for transient docker container existing only during the tests
-    "weight": 2,
-    "use_plain_text": True,
-}
+DERP_FAKE = Server(
+    region_code="fk",
+    name="Natlab #0002-fake",
+    hostname="derp-00",
+    ipv4="10.0.10.245",
+    relay_port=8765,
+    stun_port=3479,
+    stun_plaintext_port=3478,
+    public_key="aAY0rU8pW8LV3BJlY5u5WYH7nbAwS5H0mBMJppVDRGs=",  # NOTE: this is hardcoded key for transient docker container existing only during the tests
+    weight=2,
+    use_plain_text=True,
+    conn_state=RelayState.DISCONNECTED,
+)
 # we kept it because the test on  mesh_api
 
-DERP_SECONDARY = {
-    "region_code": "de",
-    "name": "Natlab #0002",
-    "hostname": "derp-02",
-    "ipv4": "10.0.10.2",
-    "relay_port": 8765,
-    "stun_port": 3479,
-    "stun_plaintext_port": 3478,
-    "public_key": "KmcnUJ7EfhCIF9o1S5ycShaNc3y1DmioKUlkMvEVoRI=",  # NOTE: this is hardcoded key for transient docker container existing only during the tests
-    "weight": 3,
-    "use_plain_text": True,
-}
+DERP_SECONDARY = Server(
+    region_code="de",
+    name="Natlab #0002",
+    hostname="derp-02",
+    ipv4="10.0.10.2",
+    relay_port=8765,
+    stun_port=3479,
+    stun_plaintext_port=3478,
+    public_key="KmcnUJ7EfhCIF9o1S5ycShaNc3y1DmioKUlkMvEVoRI=",  # NOTE: this is hardcoded key for transient docker container existing only during the tests
+    weight=3,
+    use_plain_text=True,
+    conn_state=RelayState.DISCONNECTED,
+)
 
-DERP_TERTIARY = {
-    "region_code": "us",
-    "name": "Natlab #0003",
-    "hostname": "derp-03",
-    "ipv4": "10.0.10.3",
-    "relay_port": 8765,
-    "stun_port": 3479,
-    "stun_plaintext_port": 3478,
-    "public_key": "A4ggUMw5DmMSjz1uSz3IkjM3A/CRgJxEHoGigwT0W3k=",  # NOTE: this is hardcoded key for transient docker container existing only during the tests
-    "weight": 4,
-    "use_plain_text": True,
-}
+DERP_TERTIARY = Server(
+    region_code="us",
+    name="Natlab #0003",
+    hostname="derp-03",
+    ipv4="10.0.10.3",
+    relay_port=8765,
+    stun_port=3479,
+    stun_plaintext_port=3478,
+    public_key="A4ggUMw5DmMSjz1uSz3IkjM3A/CRgJxEHoGigwT0W3k=",  # NOTE: this is hardcoded key for transient docker container existing only during the tests
+    weight=4,
+    use_plain_text=True,
+    conn_state=RelayState.DISCONNECTED,
+)
 
 
 # separating in objects

--- a/nat-lab/tests/helpers.py
+++ b/nat-lab/tests/helpers.py
@@ -5,10 +5,10 @@ from contextlib import AsyncExitStack, asynccontextmanager
 from dataclasses import dataclass, field
 from datetime import datetime
 from itertools import product, zip_longest
-from mesh_api import Node, Meshmap, API, stop_tcpdump
+from mesh_api import Node, API, stop_tcpdump
 from telio import Client, AdapterType, State, PathType
-from typing import AsyncIterator, List, Tuple, Optional, Union, Dict, Any
-from utils.bindings import default_features, Features
+from typing import AsyncIterator, List, Tuple, Optional, Union
+from utils.bindings import default_features, Features, Server, Config
 from utils.connection import Connection
 from utils.connection_tracker import ConnectionTrackerConfig
 from utils.connection_util import (
@@ -50,7 +50,7 @@ class SetupParameters:
     adapter_type: AdapterType = field(default=AdapterType.Default)
     features: Features = field(default_factory=default_features)
     is_meshnet: bool = field(default=True)
-    derp_servers: Optional[List[Dict[str, Any]]] = field(default=None)
+    derp_servers: Optional[List[Server]] = field(default=None)
     fingerprint: str = ""
 
 
@@ -161,7 +161,7 @@ async def setup_clients(
             AdapterType,
             Features,
             str,
-            Optional[Meshmap],
+            Optional[Config],
         ]
     ],
 ) -> List[Client]:
@@ -184,9 +184,9 @@ async def setup_clients(
         exit_stack.enter_async_context(
             Client(
                 connection, node, adapter_type, features, fingerprint=fingerprint
-            ).run(meshmap)
+            ).run(meshnet_config)
         )
-        for connection, node, adapter_type, features, fingerprint, meshmap in client_parameters
+        for connection, node, adapter_type, features, fingerprint, meshnet_config in client_parameters
     ])
 
 
@@ -278,7 +278,7 @@ async def setup_environment(
                 [instance.fingerprint for instance in instances],
                 [
                     (
-                        api.get_meshmap(nodes[idx].id, instance.derp_servers)
+                        api.get_meshnet_config(nodes[idx].id, instance.derp_servers)
                         if instance.is_meshnet
                         else None
                     )

--- a/nat-lab/tests/mesh_api.py
+++ b/nat-lab/tests/mesh_api.py
@@ -8,6 +8,7 @@ from config import DERP_SERVERS, LIBTELIO_IPV6_WG_SUBNET, WG_SERVERS
 from datetime import datetime
 from ipaddress import ip_address
 from typing import Dict, Any, List, Tuple, Optional
+from utils.bindings import Config, Server, Peer, PeerBase
 from utils.router import IPStack, IPProto, get_ip_address_type
 from utils.testing import get_current_test_log_path
 
@@ -15,8 +16,6 @@ if platform.machine() != "x86_64":
     import pure_wg as Key
 else:
     from python_wireguard import Key  # type: ignore
-
-Meshmap = Dict[str, Any]
 
 GREEK_ALPHABET = [
     "alpha",
@@ -150,21 +149,23 @@ class Node:
 
         return None
 
-    def to_peer_config_for_node(self, node) -> Dict[str, Any]:
+    def to_peer_config_for_node(self, node) -> Peer:
         firewall_config = node.get_firewall_config(self.id)
 
-        return {
-            "identifier": self.id,
-            "public_key": self.public_key,
-            "hostname": self.hostname,
-            "ip_addresses": self.ip_addresses,
-            "nickname": self.nickname,
-            "endpoints": self.endpoints,
-            "is_local": node.is_local and self.is_local,
-            "allow_connections": self.allow_connections,
-            "allow_incoming_connections": firewall_config.allow_incoming_connections,
-            "allow_peer_send_files": firewall_config.allow_peer_send_files,
-        }
+        return Peer(
+            base=PeerBase(
+                identifier=self.id,
+                public_key=self.public_key,
+                hostname=self.hostname,
+                ip_addresses=self.ip_addresses,
+                nickname=self.nickname,
+            ),
+            is_local=node.is_local and self.is_local,
+            allow_incoming_connections=firewall_config.allow_incoming_connections,
+            allow_peer_send_files=firewall_config.allow_peer_send_files,
+            allow_multicast=False,
+            peer_allows_multicast=False,
+        )
 
     def set_peer_firewall_settings(
         self,
@@ -260,28 +261,31 @@ class API:
         node = self._get_node(node_id)
         node.nickname = None
 
-    def get_meshmap(
-        self, node_id: str, derp_servers: Optional[List[Dict[str, Any]]] = None
-    ) -> Meshmap:
+    def get_meshnet_config(
+        self, node_id: str, derp_servers: Optional[List[Server]] = None
+    ) -> Config:
         node = self._get_node(node_id)
 
-        peers: List[Dict[str, Any]] = []
-        for key, other_node in self.nodes.items():
-            if key != node_id:
-                peers.append(other_node.to_peer_config_for_node(node))
+        peers = [
+            other_node.to_peer_config_for_node(node)
+            for key, other_node in self.nodes.items()
+            if key != node_id
+        ]
 
-        meshmap = {
-            "identifier": node.id,
-            "public_key": node.public_key,
-            "hostname": node.hostname,
-            "ip_addresses": node.ip_addresses,
-            "nickname": node.nickname,
-            "endpoints": node.endpoints,
-            "peers": peers,
-            "derp_servers": derp_servers if derp_servers is not None else DERP_SERVERS,
-        }
+        meshnet_config = Config(
+            this=PeerBase(
+                identifier=node.id,
+                public_key=node.public_key,
+                hostname=node.hostname,
+                ip_addresses=node.ip_addresses,
+                nickname=node.nickname,
+            ),
+            peers=peers,
+            derp_servers=derp_servers if derp_servers is not None else DERP_SERVERS,
+            dns=None,
+        )
 
-        return meshmap
+        return meshnet_config
 
     def default_config_one_node(
         self,

--- a/nat-lab/tests/telio.py
+++ b/nat-lab/tests/telio.py
@@ -1,11 +1,10 @@
 # pylint: disable=too-many-lines
 import asyncio
 import glob
-import json
 import os
 import platform
 import re
-import uniffi.telio_bindings as libtelio  # type: ignore
+import uniffi.telio_bindings as libtelio
 import uuid
 import warnings
 from collections import Counter
@@ -15,11 +14,11 @@ from dataclasses import dataclass, field
 from dataclasses_json import DataClassJsonMixin, dataclass_json
 from datetime import datetime
 from enum import Enum
-from mesh_api import Meshmap, Node, start_tcpdump, stop_tcpdump
+from mesh_api import Node, start_tcpdump, stop_tcpdump
 from typing import AsyncIterator, List, Optional, Set
 from uniffi.libtelio_proxy import LibtelioProxy, ProxyConnectionError
 from utils import asyncio_util
-from utils.bindings import default_features, Features, NatType
+from utils.bindings import default_features, Features, NatType, Config
 from utils.command_grepper import CommandGrepper
 from utils.connection import Connection, DockerConnection, TargetOS
 from utils.connection_util import get_uniffi_path
@@ -535,7 +534,9 @@ class Client:
         return self._proxy_port
 
     @asynccontextmanager
-    async def run(self, meshmap: Optional[Meshmap] = None) -> AsyncIterator["Client"]:
+    async def run(
+        self, meshnet_config: Optional[Config] = None
+    ) -> AsyncIterator["Client"]:
         if isinstance(self._connection, DockerConnection):
             start_tcpdump(self._connection.container_name())
             await self.clear_core_dumps()
@@ -627,8 +628,8 @@ class Client:
                     self.get_proxy().set_fwmark(int(LINUX_FWMARK_VALUE))
 
                 async with asyncio_util.run_async_context(self._event_request_loop()):
-                    if meshmap:
-                        await self.set_meshmap(meshmap)
+                    if meshnet_config:
+                        await self.set_meshnet_config(meshnet_config)
                     yield self
             finally:
                 print(datetime.now(), "Test cleanup: Saving logs")
@@ -738,7 +739,7 @@ class Client:
         self, states: List[State], timeout: Optional[float] = None
     ) -> None:
         async with asyncio_util.run_async_contexts([
-            self.get_events().wait_for_state_derp(str(derp["ipv4"]), states, timeout)
+            self.get_events().wait_for_state_derp(str(derp.ipv4), states, timeout)
             for derp in DERP_SERVERS
         ]) as futures:
             try:
@@ -752,7 +753,7 @@ class Client:
     ) -> None:
         async with asyncio_util.run_async_contexts([
             self.get_events().wait_for_state_derp(
-                str(derp["ipv4"]), [State.Disconnected, State.Connecting], timeout
+                str(derp.ipv4), [State.Disconnected, State.Connecting], timeout
             )
             for derp in DERP_SERVERS
         ]) as futures:
@@ -771,7 +772,7 @@ class Client:
         self, states: List[State], timeout: Optional[float] = None
     ) -> None:
         async with asyncio_util.run_async_contexts([
-            self.get_events().wait_for_event_derp(str(derp["ipv4"]), states, timeout)
+            self.get_events().wait_for_event_derp(str(derp.ipv4), states, timeout)
             for derp in DERP_SERVERS
         ]) as futures:
             try:
@@ -783,7 +784,7 @@ class Client:
     async def wait_for_event_error(self, err: ErrorEvent):
         await self.get_events().wait_for_event_error(err)
 
-    async def set_meshmap(self, meshmap: Meshmap) -> None:
+    async def set_meshnet_config(self, meshnet_config: Config) -> None:
         made_changes = await self._configure_interface()
 
         # Linux native WG takes ~1.5s to setup listen port for WG interface. Since
@@ -793,12 +794,12 @@ class Client:
         if made_changes and self._adapter_type == AdapterType.LinuxNativeWg:
             await asyncio.sleep(2)
 
-        if "peers" in meshmap:
-            peers = meshmap["peers"]
-            for peer in peers:
-                self.get_runtime().allowed_pub_keys.add(peer["public_key"])
+        if meshnet_config.peers is not None:
+            peer_pkeys = [peer.base.public_key for peer in meshnet_config.peers]
+            for peer_pkey in peer_pkeys:
+                self.get_runtime().allowed_pub_keys.add(peer_pkey)
 
-        self.get_proxy().set_meshnet(json.dumps(meshmap))
+        self.get_proxy().set_meshnet(meshnet_config)
 
     async def set_mesh_off(self):
         self.get_proxy().set_meshnet_off()

--- a/nat-lab/tests/test_batching.py
+++ b/nat-lab/tests/test_batching.py
@@ -205,7 +205,7 @@ async def test_batching(
         async def start_node_manually(client, node, sleep_min: int, sleep_max: int):
             await asyncio.sleep(random.randint(sleep_min, sleep_max))
             await client.simple_start()
-            await client.set_meshmap(env.api.get_meshmap(node.id))
+            await client.set_meshnet_config(env.api.get_meshnet_config(node.id))
 
         await asyncio.gather(*[
             start_node_manually(

--- a/nat-lab/tests/test_derp_connect.py
+++ b/nat-lab/tests/test_derp_connect.py
@@ -3,15 +3,16 @@ import os
 import pytest
 from config import DERP_PRIMARY, DERP_SECONDARY, DERP_TERTIARY, DERP_SERVERS
 from contextlib import AsyncExitStack
+from copy import deepcopy
 from helpers import SetupParameters, setup_mesh_nodes
 from telio import State
 from typing import List
 from utils.connection_util import ConnectionTag
 from utils.ping import ping
 
-DERP1_IP = str(DERP_PRIMARY["ipv4"])
-DERP2_IP = str(DERP_SECONDARY["ipv4"])
-DERP3_IP = str(DERP_TERTIARY["ipv4"])
+DERP1_IP = str(DERP_PRIMARY.ipv4)
+DERP2_IP = str(DERP_SECONDARY.ipv4)
+DERP3_IP = str(DERP_TERTIARY.ipv4)
 
 
 @pytest.mark.asyncio
@@ -233,35 +234,35 @@ async def test_derp_reconnect_3clients(setup_params: List[SetupParameters]) -> N
 async def test_derp_restart(setup_params: List[SetupParameters]) -> None:
     async with AsyncExitStack() as exit_stack:
         DERP_SERVERS1 = [
-            DERP_PRIMARY.copy(),
-            DERP_SECONDARY.copy(),
-            DERP_TERTIARY.copy(),
+            deepcopy(DERP_PRIMARY),
+            deepcopy(DERP_SECONDARY),
+            deepcopy(DERP_TERTIARY),
         ]
-        DERP_SERVERS1[0]["weight"] = 1
-        DERP_SERVERS1[1]["weight"] = 2
-        DERP_SERVERS1[2]["weight"] = 3
+        DERP_SERVERS1[0].weight = 1
+        DERP_SERVERS1[1].weight = 2
+        DERP_SERVERS1[2].weight = 3
 
         DERP_SERVERS2 = [
-            DERP_PRIMARY.copy(),
-            DERP_SECONDARY.copy(),
-            DERP_TERTIARY.copy(),
+            deepcopy(DERP_PRIMARY),
+            deepcopy(DERP_SECONDARY),
+            deepcopy(DERP_TERTIARY),
         ]
-        DERP_SERVERS2[0]["weight"] = 3
-        DERP_SERVERS2[1]["weight"] = 1
-        DERP_SERVERS2[2]["weight"] = 2
+        DERP_SERVERS2[0].weight = 3
+        DERP_SERVERS2[1].weight = 1
+        DERP_SERVERS2[2].weight = 2
 
         DERP_SERVERS3 = [
-            DERP_PRIMARY.copy(),
-            DERP_SECONDARY.copy(),
-            DERP_TERTIARY.copy(),
+            deepcopy(DERP_PRIMARY),
+            deepcopy(DERP_SECONDARY),
+            deepcopy(DERP_TERTIARY),
         ]
-        DERP_SERVERS3[0]["weight"] = 3
-        DERP_SERVERS3[1]["weight"] = 2
-        DERP_SERVERS3[2]["weight"] = 1
+        DERP_SERVERS3[0].weight = 3
+        DERP_SERVERS3[1].weight = 2
+        DERP_SERVERS3[2].weight = 1
 
-        _DERP1_IP = str(DERP_SERVERS1[0]["ipv4"])
-        _DERP2_IP = str(DERP_SERVERS1[1]["ipv4"])
-        _DERP3_IP = str(DERP_SERVERS1[2]["ipv4"])
+        _DERP1_IP = str(DERP_SERVERS1[0].ipv4)
+        _DERP2_IP = str(DERP_SERVERS1[1].ipv4)
+        _DERP3_IP = str(DERP_SERVERS1[2].ipv4)
 
         setup_params[0].derp_servers = DERP_SERVERS1
         setup_params[1].derp_servers = DERP_SERVERS2
@@ -428,7 +429,7 @@ async def test_derp_server_list_exhaustion(setup_params: List[SetupParameters]) 
             for derp_server in DERP_SERVERS:
                 await exit_stack_iptables.enter_async_context(
                     beta_client.get_router().break_tcp_conn_to_host(
-                        str(derp_server["ipv4"])
+                        str(derp_server.ipv4)
                     )
                 )
 

--- a/nat-lab/tests/test_direct_connection.py
+++ b/nat-lab/tests/test_direct_connection.py
@@ -251,10 +251,10 @@ async def test_direct_failing_paths(setup_params: List[SetupParameters]) -> None
 
         for server in DERP_SERVERS:
             await exit_stack.enter_async_context(
-                alpha_client.get_router().break_tcp_conn_to_host(str(server["ipv4"]))
+                alpha_client.get_router().break_tcp_conn_to_host(str(server.ipv4))
             )
             await exit_stack.enter_async_context(
-                beta_client.get_router().break_tcp_conn_to_host(str(server["ipv4"]))
+                beta_client.get_router().break_tcp_conn_to_host(str(server.ipv4))
             )
 
         await asyncio.gather(
@@ -280,10 +280,10 @@ async def test_direct_working_paths(
 
         for server in DERP_SERVERS:
             await exit_stack.enter_async_context(
-                alpha_client.get_router().break_tcp_conn_to_host(str(server["ipv4"]))
+                alpha_client.get_router().break_tcp_conn_to_host(str(server.ipv4))
             )
             await exit_stack.enter_async_context(
-                beta_client.get_router().break_tcp_conn_to_host(str(server["ipv4"]))
+                beta_client.get_router().break_tcp_conn_to_host(str(server.ipv4))
             )
 
         await ping(alpha_connection, beta.ip_addresses[0])
@@ -448,10 +448,10 @@ async def test_direct_working_paths_stun_ipv6() -> None:
 
         for server in DERP_SERVERS:
             await exit_stack.enter_async_context(
-                alpha_client.get_router().break_tcp_conn_to_host(str(server["ipv4"]))
+                alpha_client.get_router().break_tcp_conn_to_host(str(server.ipv4))
             )
             await exit_stack.enter_async_context(
-                beta_client.get_router().break_tcp_conn_to_host(str(server["ipv4"]))
+                beta_client.get_router().break_tcp_conn_to_host(str(server.ipv4))
             )
 
         await ping(alpha_connection, beta.ip_addresses[0])
@@ -589,7 +589,7 @@ async def test_direct_working_paths_with_skip_unresponsive_peers(
         )
 
         await alpha_client.simple_start()
-        await alpha_client.set_meshmap(api.get_meshmap(alpha.id))
+        await alpha_client.set_meshnet_config(api.get_meshnet_config(alpha.id))
 
         await asyncio.gather(
             alpha_client.wait_for_state_peer(
@@ -664,14 +664,10 @@ async def test_direct_connection_endpoint_gone(
             async with AsyncExitStack() as temp_exit_stack:
                 for derp in DERP_SERVERS:
                     await temp_exit_stack.enter_async_context(
-                        alpha_client.get_router().break_tcp_conn_to_host(
-                            str(derp["ipv4"])
-                        )
+                        alpha_client.get_router().break_tcp_conn_to_host(str(derp.ipv4))
                     )
                     await temp_exit_stack.enter_async_context(
-                        beta_client.get_router().break_tcp_conn_to_host(
-                            str(derp["ipv4"])
-                        )
+                        beta_client.get_router().break_tcp_conn_to_host(str(derp.ipv4))
                     )
 
                 await asyncio.gather(
@@ -761,7 +757,7 @@ async def test_infinite_stun_loop(setup_params: List[SetupParameters]) -> None:
 
         for server in config.DERP_SERVERS:
             await exit_stack.enter_async_context(
-                alpha_client.get_router().break_udp_conn_to_host(str(server["ipv4"]))
+                alpha_client.get_router().break_udp_conn_to_host(str(server.ipv4))
             )
 
         # 3478 and 3479 are STUN ports in natlab containers

--- a/nat-lab/tests/test_dns.py
+++ b/nat-lab/tests/test_dns.py
@@ -336,7 +336,9 @@ async def test_vpn_dns(alpha_ip_stack: IPStack) -> None:
 
         # Test interop with meshnet
         await client_alpha.enable_magic_dns(["10.0.80.82"])
-        await client_alpha.set_meshmap(api.get_meshmap(alpha.id, derp_servers=[]))
+        await client_alpha.set_meshnet_config(
+            api.get_meshnet_config(alpha.id, derp_servers=[])
+        )
 
         await query_dns(connection, "google.com", dns_server=dns_server_address)
 
@@ -508,7 +510,7 @@ async def test_dns_stability(alpha_ip_stack: IPStack) -> None:
         ),
     ],
 )
-async def test_set_meshmap_dns_update(
+async def test_set_meshnet_config_dns_update(
     alpha_ip_stack: IPStack,
 ) -> None:
     async with AsyncExitStack() as exit_stack:
@@ -546,7 +548,9 @@ async def test_set_meshmap_dns_update(
         beta = api.default_config_one_node(ip_stack=IPStack.IPv4v6)
 
         # Check if setting meshnet updates nord names for dns resolver
-        await client_alpha.set_meshmap(api.get_meshmap(alpha.id, derp_servers=[]))
+        await client_alpha.set_meshnet_config(
+            api.get_meshnet_config(alpha.id, derp_servers=[])
+        )
 
         await query_dns(
             connection_alpha, "beta.nord", [beta.ip_addresses[0]], dns_server_address
@@ -772,11 +776,15 @@ async def test_dns_change_nickname() -> None:
         await client_alpha.enable_magic_dns([])
         await client_beta.enable_magic_dns([])
 
-        # Set new meshmap with different nicknames
+        # Set new meshnet config with different nicknames
         api.assign_nickname(alpha.id, "rotten")
         api.assign_nickname(beta.id, "ono")
-        await client_alpha.set_meshmap(api.get_meshmap(alpha.id, derp_servers=[]))
-        await client_beta.set_meshmap(api.get_meshmap(beta.id, derp_servers=[]))
+        await client_alpha.set_meshnet_config(
+            api.get_meshnet_config(alpha.id, derp_servers=[])
+        )
+        await client_beta.set_meshnet_config(
+            api.get_meshnet_config(beta.id, derp_servers=[])
+        )
 
         with pytest.raises(ProcessExecError):
             await query_dns(connection_alpha, "yoko.nord")
@@ -793,11 +801,15 @@ async def test_dns_change_nickname() -> None:
         await query_dns(connection_beta, "rotten.nord", alpha.ip_addresses)
         await query_dns(connection_beta, "ono.nord", beta.ip_addresses)
 
-        # Set new meshmap removing nicknames
+        # Set new meshnet config removing nicknames
         api.reset_nickname(alpha.id)
         api.reset_nickname(beta.id)
-        await client_alpha.set_meshmap(api.get_meshmap(alpha.id, derp_servers=[]))
-        await client_beta.set_meshmap(api.get_meshmap(beta.id, derp_servers=[]))
+        await client_alpha.set_meshnet_config(
+            api.get_meshnet_config(alpha.id, derp_servers=[])
+        )
+        await client_beta.set_meshnet_config(
+            api.get_meshnet_config(beta.id, derp_servers=[])
+        )
 
         with pytest.raises(ProcessExecError):
             await query_dns(connection_alpha, "ono.nord")

--- a/nat-lab/tests/test_events.py
+++ b/nat-lab/tests/test_events.py
@@ -145,7 +145,7 @@ async def test_event_content_meshnet(
 
         api.remove(beta.id)
 
-        await client_alpha.set_meshmap(api.get_meshmap(alpha.id))
+        await client_alpha.set_meshnet_config(api.get_meshnet_config(alpha.id))
 
         with pytest.raises(asyncio.TimeoutError):
             await ping(connection_alpha, beta.ip_addresses[0], 5)
@@ -576,7 +576,7 @@ async def test_event_content_meshnet_node_upgrade_direct(
                 alpha,
                 alpha_setup_params.adapter_type,
                 alpha_setup_params.features,
-            ).run(api.get_meshmap(alpha.id))
+            ).run(api.get_meshnet_config(alpha.id))
         )
 
         async with Client(
@@ -584,7 +584,7 @@ async def test_event_content_meshnet_node_upgrade_direct(
             beta,
             beta_setup_params.adapter_type,
             beta_setup_params.features,
-        ).run(api.get_meshmap(beta.id)) as client_beta:
+        ).run(api.get_meshnet_config(beta.id)) as client_beta:
             await asyncio.gather(
                 client_alpha.wait_for_state_on_any_derp([State.Connected]),
                 client_beta.wait_for_state_on_any_derp([State.Connected]),
@@ -648,7 +648,7 @@ async def test_event_content_meshnet_node_upgrade_direct(
                 telio_features=features_with_endpoint_providers(
                     [EndpointProvider.STUN]
                 ),
-            ).run(api.get_meshmap(beta.id))
+            ).run(api.get_meshnet_config(beta.id))
         )
 
         await client_beta.wait_for_state_on_any_derp([State.Connected])

--- a/nat-lab/tests/test_lana.py
+++ b/nat-lab/tests/test_lana.py
@@ -75,9 +75,9 @@ DOCKER_CONE_GW_1_IPv4 = "10.0.254.1"
 DOCKER_CONE_GW_1_IPv6 = "2001:db8:85a4::1000:2541"
 
 DERP_SERVERS_STRS = [
-    f"{DERP_PRIMARY['ipv4']}:{DERP_PRIMARY['relay_port']}",
-    f"{DERP_SECONDARY['ipv4']}:{DERP_SECONDARY['relay_port']}",
-    f"{DERP_TERTIARY['ipv4']}:{DERP_TERTIARY['relay_port']}",
+    f"{DERP_PRIMARY.ipv4}:{DERP_PRIMARY.relay_port}",
+    f"{DERP_SECONDARY.ipv4}:{DERP_SECONDARY.relay_port}",
+    f"{DERP_TERTIARY.ipv4}:{DERP_TERTIARY.relay_port}",
 ]
 
 DEFAULT_WAITING_TIME = 5
@@ -267,7 +267,7 @@ async def start_alpha_beta_in_relay(
             alpha,
             telio_features=alpha_features,
             fingerprint=ALPHA_FINGERPRINT,
-        ).run(api.get_meshmap(alpha.id))
+        ).run(api.get_meshnet_config(alpha.id))
     )
 
     client_beta = telio.Client(
@@ -298,7 +298,9 @@ async def start_alpha_beta_in_relay(
             f'Relayed peer state change for "{losing_key[:4]}...{losing_key[-4:]}" to Connected will be reported'
         )
 
-        await exit_stack.enter_async_context(client_beta.run(api.get_meshmap(beta.id)))
+        await exit_stack.enter_async_context(
+            client_beta.run(api.get_meshnet_config(beta.id))
+        )
 
         await relayed_state_reported.wait()
 
@@ -383,7 +385,7 @@ async def run_default_scenario(
             gamma,
             telio_features=build_telio_features(),
             fingerprint=GAMMA_FINGERPRINT,
-        ).run(api.get_meshmap(gamma.id))
+        ).run(api.get_meshnet_config(gamma.id))
     )
 
     await asyncio.gather(
@@ -1910,7 +1912,7 @@ async def test_lana_with_second_node_joining_later_meshnet_id_can_change(
                 beta,
                 telio_features=build_telio_features(),
                 fingerprint=BETA_FINGERPRINT,
-            ).run(api.get_meshmap(beta.id))
+            ).run(api.get_meshnet_config(beta.id))
         )
 
         await client_beta.trigger_event_collection()
@@ -1938,11 +1940,11 @@ async def test_lana_with_second_node_joining_later_meshnet_id_can_change(
                 alpha,
                 telio_features=build_telio_features(),
                 fingerprint=ALPHA_FINGERPRINT,
-            ).run(api.get_meshmap(alpha.id))
+            ).run(api.get_meshnet_config(alpha.id))
         )
 
         beta.set_peer_firewall_settings(alpha.id, allow_incoming_connections=True)
-        await client_beta.set_meshmap(api.get_meshmap(beta.id))
+        await client_beta.set_meshnet_config(api.get_meshnet_config(beta.id))
 
         await asyncio.gather(
             client_alpha.wait_for_state_peer(
@@ -2006,7 +2008,7 @@ async def test_lana_same_meshnet_id_is_reported_after_a_restart(
             beta,
             telio_features=build_telio_features(),
             fingerprint=BETA_FINGERPRINT,
-        ).run(api.get_meshmap(beta.id)) as client_beta:
+        ).run(api.get_meshnet_config(beta.id)) as client_beta:
 
             await client_beta.trigger_event_collection()
             beta_events = await wait_for_event_dump(
@@ -2028,7 +2030,7 @@ async def test_lana_same_meshnet_id_is_reported_after_a_restart(
                 beta,
                 telio_features=build_telio_features(),
                 fingerprint=BETA_FINGERPRINT,
-            ).run(api.get_meshmap(beta.id))
+            ).run(api.get_meshnet_config(beta.id))
         )
 
         await client_beta.trigger_event_collection()
@@ -2066,7 +2068,7 @@ async def test_lana_initial_heartbeat_no_trigger(
                     initial_heartbeat_interval=initial_heartbeat_interval,
                 ),
                 fingerprint=ALPHA_FINGERPRINT,
-            ).run(api.get_meshmap(alpha.id))
+            ).run(api.get_meshnet_config(alpha.id))
         )
 
         if initial_heartbeat_interval == 5:

--- a/nat-lab/tests/test_mesh_api.py
+++ b/nat-lab/tests/test_mesh_api.py
@@ -2,6 +2,7 @@ import mesh_api
 import platform
 import pytest
 from mesh_api import Node, API
+from utils.bindings import Config, Peer, PeerBase
 
 if platform.machine() != "x86_64":
     import pure_wg as Key
@@ -30,32 +31,32 @@ class TestNode:
         node.nickname = "ff"
         node.endpoints = ["ee"]
 
-        expected = {
-            "identifier": "aa",
-            "public_key": "bb",
-            "hostname": "cc",
-            "ip_addresses": ["dd"],
-            "nickname": "ff",
-            "endpoints": ["ee"],
-            "is_local": False,
-            "allow_connections": False,
-            "allow_incoming_connections": False,
-            "allow_peer_send_files": False,
-        }
+        expected = Peer(
+            base=PeerBase(
+                identifier="aa",
+                public_key="bb",
+                hostname="cc",
+                ip_addresses=["dd"],
+                nickname="ff",
+            ),
+            is_local=False,
+            allow_incoming_connections=False,
+            allow_peer_send_files=False,
+            allow_multicast=False,
+            peer_allows_multicast=False,
+        )
         assert expected == node.to_peer_config_for_node(node)
 
         node = Node()
         node.is_local = True
-        assert node.to_peer_config_for_node(node)["is_local"]
+        assert node.to_peer_config_for_node(node).is_local
 
         node = Node()
-        node.allow_connections = True
-        assert node.to_peer_config_for_node(node)["allow_connections"]
 
         node = Node()
         node.set_peer_firewall_settings(node.id, True)
-        assert node.to_peer_config_for_node(node)["allow_incoming_connections"]
-        assert not node.to_peer_config_for_node(node)["allow_peer_send_files"]
+        assert node.to_peer_config_for_node(node).allow_incoming_connections
+        assert not node.to_peer_config_for_node(node).allow_peer_send_files
 
 
 class TestMeshApi:
@@ -77,13 +78,13 @@ class TestMeshApi:
 
         assert e.value.node_id == "bb"
 
-    def test_get_meshmap_missing_node(self) -> None:
+    def test_get_meshnet_config_missing_node(self) -> None:
         api = API()
         with pytest.raises(mesh_api.MissingNodeError) as e:
-            api.get_meshmap(node_id="aa")
+            api.get_meshnet_config(node_id="aa")
         assert e.value.node_id == "aa"
 
-    def test_get_meshmap(self) -> None:
+    def test_get_meshnet_config(self) -> None:
         api = API()
 
         sk_alpha, pk_alpha = Key.key_pair()
@@ -103,27 +104,30 @@ class TestMeshApi:
             name="beta", node_id="id-beta", private_key="sk-beta", public_key="pk-beta"
         )
 
-        meshmap = api.get_meshmap("id-alpha")
+        meshnet_config = api.get_meshnet_config("id-alpha")
 
-        expected = {
-            "identifier": "id-alpha",
-            "public_key": pk_alpha,
-            "hostname": "aaa",
-            "ip_addresses": ["bbb"],
-            "nickname": "fff",
-            "endpoints": ["ccc"],
-            "peers": [beta.to_peer_config_for_node(alpha)],
-            "derp_servers": mesh_api.DERP_SERVERS,
-        }
-        assert meshmap == expected
+        expected = Config(
+            this=PeerBase(
+                identifier="id-alpha",
+                public_key=pk_alpha,
+                hostname="aaa",
+                ip_addresses=["bbb"],
+                nickname="fff",
+            ),
+            peers=[beta.to_peer_config_for_node(alpha)],
+            derp_servers=mesh_api.DERP_SERVERS,
+            dns=None,
+        )
 
-    def test_get_meshmap_derp_servers(self):
+        assert meshnet_config == expected
+
+    def test_get_meshnet_config_derp_servers(self):
         api = API()
         api.register(name="name", node_id="id", private_key="sk", public_key="pk")
 
         derp_servers = [{"aaa": "bbb"}]
-        meshmap = api.get_meshmap("id", derp_servers=derp_servers)
-        assert meshmap["derp_servers"] == derp_servers
+        meshnet_config = api.get_meshnet_config("id", derp_servers=derp_servers)
+        assert meshnet_config.derp_servers == derp_servers
 
     def test_assign_ip_collision(self):
         api = API()

--- a/nat-lab/tests/test_mesh_exit_through_peer.py
+++ b/nat-lab/tests/test_mesh_exit_through_peer.py
@@ -262,12 +262,12 @@ async def test_ipv6_exit_node(
 
         client_alpha = await exit_stack.enter_async_context(
             telio.Client(connection_alpha, alpha, adapter_type).run(
-                api.get_meshmap(alpha.id)
+                api.get_meshnet_config(alpha.id)
             )
         )
 
         client_beta = await exit_stack.enter_async_context(
-            telio.Client(connection_beta, beta).run(api.get_meshmap(beta.id))
+            telio.Client(connection_beta, beta).run(api.get_meshnet_config(beta.id))
         )
 
         await asyncio.gather(

--- a/nat-lab/tests/test_mesh_firewall.py
+++ b/nat-lab/tests/test_mesh_firewall.py
@@ -290,10 +290,10 @@ async def test_blocking_incoming_connections_from_exit_node() -> None:
         # Block traffic both ways
 
         alpha.set_peer_firewall_settings(exit_node.id, allow_incoming_connections=False)
-        await client_alpha.set_meshmap(api.get_meshmap(alpha.id))
+        await client_alpha.set_meshnet_config(api.get_meshnet_config(alpha.id))
 
         exit_node.set_peer_firewall_settings(alpha.id, allow_incoming_connections=False)
-        await client_exit_node.set_meshmap(api.get_meshmap(exit_node.id))
+        await client_exit_node.set_meshnet_config(api.get_meshnet_config(exit_node.id))
 
         # Ping should fail both ways
         with pytest.raises(asyncio.TimeoutError):
@@ -305,10 +305,10 @@ async def test_blocking_incoming_connections_from_exit_node() -> None:
         # Allow traffic both ways
 
         alpha.set_peer_firewall_settings(exit_node.id, allow_incoming_connections=True)
-        await client_alpha.set_meshmap(api.get_meshmap(alpha.id))
+        await client_alpha.set_meshnet_config(api.get_meshnet_config(alpha.id))
 
         exit_node.set_peer_firewall_settings(alpha.id, allow_incoming_connections=True)
-        await client_exit_node.set_meshmap(api.get_meshmap(exit_node.id))
+        await client_exit_node.set_meshnet_config(api.get_meshnet_config(exit_node.id))
 
         # Ping should again work both ways
 
@@ -337,7 +337,7 @@ async def test_blocking_incoming_connections_from_exit_node() -> None:
         # Block traffic from exit node
 
         alpha.set_peer_firewall_settings(exit_node.id, allow_incoming_connections=False)
-        await client_alpha.set_meshmap(api.get_meshmap(alpha.id))
+        await client_alpha.set_meshnet_config(api.get_meshnet_config(alpha.id))
 
         # Ping should only work in one direction
 

--- a/nat-lab/tests/test_mesh_off.py
+++ b/nat-lab/tests/test_mesh_off.py
@@ -69,7 +69,7 @@ async def test_mesh_off(direct) -> None:
             beta.public_key, [State.Disconnected], [path_type]
         )
 
-        await client_alpha.set_meshmap(env.api.get_meshmap(alpha.id))
+        await client_alpha.set_meshnet_config(env.api.get_meshnet_config(alpha.id))
 
         asyncio.gather(
             client_alpha.wait_for_state_peer(
@@ -139,7 +139,7 @@ async def test_mesh_state_after_disconnecting_node() -> None:
             )
 
         await client_beta.simple_start()
-        await client_beta.set_meshmap(env.api.get_meshmap(beta.id))
+        await client_beta.set_meshnet_config(env.api.get_meshnet_config(beta.id))
 
         await client_alpha.wait_for_state_peer(
             beta.public_key, [State.Connected], [PathType.Direct]

--- a/nat-lab/tests/test_mesh_plus_vpn.py
+++ b/nat-lab/tests/test_mesh_plus_vpn.py
@@ -337,10 +337,10 @@ async def test_vpn_plus_mesh(
         ip = await stun.get(connection_alpha, config.STUN_SERVER)
         assert ip == wg_server["ipv4"], f"wrong public IP when connected to VPN {ip}"
 
-        await client_alpha.set_meshmap(api.get_meshmap(alpha.id))
+        await client_alpha.set_meshnet_config(api.get_meshnet_config(alpha.id))
 
         client_beta = await exit_stack.enter_async_context(
-            telio.Client(connection_beta, beta).run(api.get_meshmap(beta.id))
+            telio.Client(connection_beta, beta).run(api.get_meshnet_config(beta.id))
         )
 
         await asyncio.gather(

--- a/nat-lab/tests/test_mesh_remove_node.py
+++ b/nat-lab/tests/test_mesh_remove_node.py
@@ -132,8 +132,8 @@ async def test_mesh_remove_node(
 
         api.remove(gamma.id)
 
-        await client_alpha.set_meshmap(api.get_meshmap(alpha.id))
-        await client_beta.set_meshmap(api.get_meshmap(beta.id))
+        await client_alpha.set_meshnet_config(api.get_meshnet_config(alpha.id))
+        await client_beta.set_meshnet_config(api.get_meshnet_config(beta.id))
 
         await ping(connection_alpha, beta.ip_addresses[0])
         with pytest.raises(asyncio.TimeoutError):

--- a/nat-lab/tests/test_reconnections.py
+++ b/nat-lab/tests/test_reconnections.py
@@ -119,7 +119,7 @@ async def test_mesh_reconnect(
                 client_alpha.wait_for_event_on_any_derp([telio.State.Connected]),
             ),
         ) as event:
-            await client_alpha.set_meshmap(api.get_meshmap(alpha.id))
+            await client_alpha.set_meshnet_config(api.get_meshnet_config(alpha.id))
             await event
 
         await asyncio.gather(

--- a/nat-lab/tests/uniffi/libtelio_proxy.py
+++ b/nat-lab/tests/uniffi/libtelio_proxy.py
@@ -109,7 +109,7 @@ class LibtelioProxy:
     def disable_magic_dns(self):
         self.handle_remote_error(lambda r: r.disable_magic_dns())
 
-    def set_meshnet(self, cfg: str):
+    def set_meshnet(self, cfg: libtelio.Config):
         self.handle_remote_error(lambda r: r.set_meshnet(cfg))
 
     def set_meshnet_off(self):

--- a/nat-lab/tests/uniffi/libtelio_remote.py
+++ b/nat-lab/tests/uniffi/libtelio_remote.py
@@ -171,8 +171,7 @@ class LibtelioWrapper:
         self._libtelio.disable_magic_dns()
 
     @serialize_error
-    def set_meshnet(self, cfg: str):
-        cfg = libtelio.deserialize_meshnet_config(cfg)
+    def set_meshnet(self, cfg: libtelio.Config):
         self._libtelio.set_meshnet(cfg)
 
     @serialize_error

--- a/nat-lab/tests/utils/connection_util.py
+++ b/nat-lab/tests/utils/connection_util.py
@@ -389,7 +389,7 @@ def generate_connection_tracker_config(
             FiveTuple(
                 protocol="tcp",
                 src_ip=lan_addr,
-                dst_ip=str(config.DERP_FAKE.get("ipv4")),
+                dst_ip=str(config.DERP_FAKE.ipv4),
                 dst_port=8765,
             ),
         ),
@@ -399,7 +399,7 @@ def generate_connection_tracker_config(
             FiveTuple(
                 protocol="tcp",
                 src_ip=lan_addr,
-                dst_ip=str(config.DERP_PRIMARY.get("ipv4")),
+                dst_ip=str(config.DERP_PRIMARY.ipv4),
                 dst_port=8765,
             ),
         ),
@@ -409,7 +409,7 @@ def generate_connection_tracker_config(
             FiveTuple(
                 protocol="tcp",
                 src_ip=lan_addr,
-                dst_ip=str(config.DERP_SECONDARY.get("ipv4")),
+                dst_ip=str(config.DERP_SECONDARY.ipv4),
                 dst_port=8765,
             ),
         ),
@@ -419,7 +419,7 @@ def generate_connection_tracker_config(
             FiveTuple(
                 protocol="tcp",
                 src_ip=lan_addr,
-                dst_ip=str(config.DERP_TERTIARY.get("ipv4")),
+                dst_ip=str(config.DERP_TERTIARY.ipv4),
                 dst_port=8765,
             ),
         ),

--- a/nat-lab/tests/utils/network_switcher/network_switcher_mac.py
+++ b/nat-lab/tests/utils/network_switcher/network_switcher_mac.py
@@ -32,7 +32,7 @@ class NetworkSwitcherMac(NetworkSwitcher):
                 [
                     "route",
                     "add",
-                    str(derp.get("ipv4")) + "/32",
+                    str(derp.ipv4) + "/32",
                     LINUX_VM_PRIMARY_GATEWAY,
                 ],
             ).execute()
@@ -55,7 +55,7 @@ class NetworkSwitcherMac(NetworkSwitcher):
                 [
                     "route",
                     "add",
-                    str(derp.get("ipv4")) + "/32",
+                    str(derp.ipv4) + "/32",
                     LINUX_VM_SECONDARY_GATEWAY,
                 ],
             ).execute()
@@ -71,6 +71,6 @@ class NetworkSwitcherMac(NetworkSwitcher):
                 [
                     "route",
                     "delete",
-                    str(derp.get("ipv4")) + "/32",
+                    str(derp.ipv4) + "/32",
                 ],
             ).execute()


### PR DESCRIPTION
This is the second PR to start using types generated from UniFFI instead of defining new ones, where possible, in natlab. This PR deals with the meshnet config.

Some notes:
- The `(get|set)_meshmap` functions have been renamed to `(get|set)_meshnet_config`
- Strong types instead of dicts means that we can do things like `derp.ipv4` instead of `derp["ipv4"]`


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
