### PR TITLE
Make STUN and UPnP providers optimization enabled by default

### DIFF
--- a/.unreleased/LLT-4963
+++ b/.unreleased/LLT-4963
@@ -1,0 +1,1 @@
+Make STUN and UPnP providers optimization enabled by default

--- a/crates/telio-model/src/features.rs
+++ b/crates/telio-model/src/features.rs
@@ -233,6 +233,7 @@ pub struct FeatureDirect {
     #[default(Some(Default::default()))]
     pub skip_unresponsive_peers: Option<FeatureSkipUnresponsivePeers>,
     /// Parameters to optimize battery lifetime
+    #[default(Some(Default::default()))]
     pub endpoint_providers_optimization: Option<FeatureEndpointProvidersOptimization>,
 }
 


### PR DESCRIPTION
I runned some tests with optimization enabled/disabled to measure the relay to direct recovery time.

The scenario used for tests:
- Node A and B are directly connected
- Cut the connection and expect downgrade to relay
- Undo the cut and wait for path upgrade to direct

Times measured between relay event to the direct event showed that the recover process is faster with the optimization enabled.

For STUN is with 3-4 seconds faster.
For UPNP is with 10 seconds faster.

Nevertheless this is a battery lifetime improvement feature and we want to push apps to use it leaving them the option to disable it if needed.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
