### PR TITLE
LLT-5535: Use generated events in natlab

### DIFF
--- a/nat-lab/tests/helpers.py
+++ b/nat-lab/tests/helpers.py
@@ -6,9 +6,17 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from itertools import product, zip_longest
 from mesh_api import Node, API, stop_tcpdump
-from telio import Client, AdapterType, State, PathType
+from telio import Client, AdapterType
 from typing import AsyncIterator, List, Tuple, Optional, Union
-from utils.bindings import default_features, Features, Server, Config
+from utils.bindings import (
+    default_features,
+    Features,
+    Server,
+    Config,
+    RelayState,
+    NodeState,
+    PathType,
+)
 from utils.connection import Connection
 from utils.connection_tracker import ConnectionTrackerConfig
 from utils.connection_util import (
@@ -332,7 +340,7 @@ async def setup_mesh_nodes(
     )
 
     await asyncio.gather(*[
-        client.wait_for_state_on_any_derp([State.Connected])
+        client.wait_for_state_on_any_derp([RelayState.CONNECTED])
         for client, instance in zip_longest(env.clients, instances)
         if instance.derp_servers != []
     ])
@@ -340,11 +348,11 @@ async def setup_mesh_nodes(
     connection_future = asyncio.gather(*[
         client.wait_for_state_peer(
             other_node.public_key,
-            [State.Connected],
+            [NodeState.CONNECTED],
             (
-                [PathType.Direct]
+                [PathType.DIRECT]
                 if instance.features.direct and other_instance.features.direct
-                else [PathType.Relay]
+                else [PathType.RELAY]
             ),
             timeout=90 if is_timeout_expected else None,
         )

--- a/nat-lab/tests/telio_test.py
+++ b/nat-lab/tests/telio_test.py
@@ -1,12 +1,13 @@
 import asyncio
 import copy
 import pytest
-from telio import State, Runtime, Events, PeerInfo, PathType, DerpServer
+from telio import Runtime, Events
 from utils.asyncio_util import run_async_contexts, run_async_context
+from utils.bindings import NodeState, RelayState, PathType, Server, telio_node, Event
 
 
-def create_derpserver_config(state: State) -> DerpServer:
-    return DerpServer(
+def create_derpserver_config(state: RelayState) -> Server:
+    return Server(
         region_code="test",
         name="test",
         hostname="test-01",
@@ -53,32 +54,40 @@ class TestRuntime:
         runtime.allowed_pub_keys = set(["AAA", "BBB"])
 
         runtime.set_peer(
-            PeerInfo(public_key="AAA", state=State.Connected, path=PathType.Relay)
+            telio_node(public_key="AAA", state=NodeState.CONNECTED, path=PathType.RELAY)
         )
 
         runtime.set_peer(
-            PeerInfo(public_key="BBB", state=State.Disconnected, path=PathType.Direct)
+            telio_node(
+                public_key="BBB", state=NodeState.DISCONNECTED, path=PathType.DIRECT
+            )
         )
 
-        await runtime.notify_peer_state("AAA", [State.Connected], [PathType.Relay])
-        await runtime.notify_peer_state("BBB", [State.Disconnected], [PathType.Direct])
+        await runtime.notify_peer_state("AAA", [NodeState.CONNECTED], [PathType.RELAY])
+        await runtime.notify_peer_state(
+            "BBB", [NodeState.DISCONNECTED], [PathType.DIRECT]
+        )
 
         # it should pass again
         await runtime.notify_peer_state(
-            "AAA", [State.Connected], [PathType.Relay, PathType.Direct]
+            "AAA", [NodeState.CONNECTED], [PathType.RELAY, PathType.DIRECT]
         )
 
         # it should fail (wrong state)
         with pytest.raises(asyncio.TimeoutError):
             await asyncio.wait_for(
-                runtime.notify_peer_state("BBB", [State.Connected], [PathType.Direct]),
+                runtime.notify_peer_state(
+                    "BBB", [NodeState.CONNECTED], [PathType.DIRECT]
+                ),
                 0.1,
             )
 
         # it should fail (wrong path)
         with pytest.raises(asyncio.TimeoutError):
             await asyncio.wait_for(
-                runtime.notify_peer_state("AAA", [State.Connected], [PathType.Direct]),
+                runtime.notify_peer_state(
+                    "AAA", [NodeState.CONNECTED], [PathType.DIRECT]
+                ),
                 0.1,
             )
 
@@ -89,41 +98,43 @@ class TestRuntime:
 
         # Start waiting for new event before it is being generated
         async with run_async_context(
-            runtime.notify_peer_event("AAA", [State.Connected], [PathType.Relay])
+            runtime.notify_peer_event("AAA", [NodeState.CONNECTED], [PathType.RELAY])
         ) as future:
             # wait for futures to be started
             await asyncio.sleep(0)
-            runtime.set_peer(PeerInfo(public_key="AAA", state=State.Connected))
+            runtime.set_peer(telio_node(public_key="AAA", state=NodeState.CONNECTED))
             await future
 
         with pytest.raises(asyncio.TimeoutError):
             await asyncio.wait_for(
-                runtime.notify_peer_event("AAA", [State.Connected], [PathType.Relay]),
+                runtime.notify_peer_event(
+                    "AAA", [NodeState.CONNECTED], [PathType.RELAY]
+                ),
                 0.1,
             )
 
     @pytest.mark.asyncio
     async def test_set_derp_state(self) -> None:
         runtime = Runtime()
-        runtime.set_derp(create_derpserver_config(State.Connected))
-        await runtime.notify_derp_state("1.1.1.1", [State.Connected])
+        runtime.set_derp(create_derpserver_config(RelayState.CONNECTED))
+        await runtime.notify_derp_state("1.1.1.1", [RelayState.CONNECTED])
 
         # it should pass again
         await runtime.notify_derp_state(
             "1.1.1.1",
-            [State.Disconnected, State.Connecting, State.Connected],
+            [RelayState.DISCONNECTED, RelayState.CONNECTING, RelayState.CONNECTED],
         )
 
         # it should fail (wrong state)
         with pytest.raises(asyncio.TimeoutError):
             await asyncio.wait_for(
-                runtime.notify_derp_state("1.1.1.1", [State.Disconnected]), 0.1
+                runtime.notify_derp_state("1.1.1.1", [RelayState.DISCONNECTED]), 0.1
             )
 
         # it should fail (wrong IP)
         with pytest.raises(asyncio.TimeoutError):
             await asyncio.wait_for(
-                runtime.notify_derp_state("1.1.1.2", [State.Connected]), 0.1
+                runtime.notify_derp_state("1.1.1.2", [RelayState.CONNECTED]), 0.1
             )
 
     @pytest.mark.asyncio
@@ -131,45 +142,57 @@ class TestRuntime:
         runtime = Runtime()
 
         async with run_async_context(
-            runtime.notify_derp_event("1.1.1.1", [State.Connected])
+            runtime.notify_derp_event("1.1.1.1", [RelayState.CONNECTED])
         ) as future:
             # wait for futures to be started
             await asyncio.sleep(0)
-            runtime.set_derp(create_derpserver_config(State.Connected))
+            runtime.set_derp(create_derpserver_config(RelayState.CONNECTED))
             await future
 
         with pytest.raises(asyncio.TimeoutError):
             await asyncio.wait_for(
-                runtime.notify_derp_event("1.1.1.1", [State.Connected]), 0.1
+                runtime.notify_derp_event("1.1.1.1", [RelayState.CONNECTED]), 0.1
             )
 
     @pytest.mark.asyncio
     async def test_handle_derp_event(self) -> None:
         runtime = Runtime()
 
-        assert await runtime.handle_output_line(
-            '{"type":"relay","body":{"region_code":"test","name":"test","hostname"'
-            + ':"test","ipv4":"1.1.1.1","relay_port":1111,"stun_port":1111,'
-            + '"stun_plaintext_port":1111,"public_key":"test","weight":1,'
-            + '"use_plain_text":true,"conn_state":"connected"}}'
+        server = Server(
+            region_code="test",
+            name="test",
+            hostname="test",
+            ipv4="1.1.1.1",
+            relay_port=1111,
+            stun_port=1111,
+            stun_plaintext_port=1111,
+            public_key="test",
+            weight=1,
+            use_plain_text=True,
+            conn_state=RelayState.CONNECTED,
         )
+        event = Event.RELAY(server)
+        runtime.handle_event(event)
 
-        await runtime.notify_derp_state("1.1.1.1", [State.Connected])
+        await runtime.notify_derp_state("1.1.1.1", [RelayState.CONNECTED])
 
     @pytest.mark.asyncio
     async def test_handle_node_event(self) -> None:
         runtime = Runtime()
         runtime.allowed_pub_keys = set(["AAA"])
 
-        assert await runtime.handle_output_line(
-            '{"type":"node","body":'
-            + '{"identifier":"tcli","public_key":"AAA","state":"connected","is_exit":true,'
-            + '"is_vpn":true,"ip_addresses":[],"allowed_ips":[],"endpoint":null,"hostname":null,'
-            + '"allow_incoming_connections":false,"allow_peer_send_files":false,"path":"relay"}}'
+        node = telio_node(
+            identifier="tcli",
+            public_key="AAA",
+            state=NodeState.CONNECTED,
+            is_exit=True,
+            is_vpn=True,
         )
+        event = Event.NODE(node)
+        runtime.handle_event(event)
 
         await runtime.notify_peer_state(
-            "AAA", [State.Connected], [PathType.Relay], is_exit=True, is_vpn=True
+            "AAA", [NodeState.CONNECTED], [PathType.RELAY], is_exit=True, is_vpn=True
         )
 
 
@@ -182,33 +205,37 @@ class TestEvents:
         runtime.allowed_pub_keys = set(["AAA", "BBB"])
 
         runtime.set_peer(
-            PeerInfo(public_key="AAA", state=State.Connected, path=PathType.Relay)
+            telio_node(public_key="AAA", state=NodeState.CONNECTED, path=PathType.RELAY)
         )
         runtime.set_peer(
-            PeerInfo(public_key="BBB", state=State.Disconnected, path=PathType.Direct)
+            telio_node(
+                public_key="BBB", state=NodeState.DISCONNECTED, path=PathType.DIRECT
+            )
         )
 
-        await events.wait_for_state_peer("AAA", [State.Connected], [PathType.Relay])
-        await events.wait_for_state_peer("BBB", [State.Disconnected], [PathType.Direct])
+        await events.wait_for_state_peer("AAA", [NodeState.CONNECTED], [PathType.RELAY])
+        await events.wait_for_state_peer(
+            "BBB", [NodeState.DISCONNECTED], [PathType.DIRECT]
+        )
 
         # it should pass again
         await events.wait_for_state_peer(
-            "AAA", [State.Connected], [PathType.Relay, PathType.Direct]
+            "AAA", [NodeState.CONNECTED], [PathType.RELAY, PathType.DIRECT]
         )
         await events.wait_for_state_peer(
-            "BBB", [State.Disconnected], [PathType.Relay, PathType.Direct]
+            "BBB", [NodeState.DISCONNECTED], [PathType.RELAY, PathType.DIRECT]
         )
 
         # it should fail (wrong state)
         with pytest.raises(asyncio.TimeoutError):
             await events.wait_for_state_peer(
-                "BBB", [State.Connected], [PathType.Direct], timeout=0.1
+                "BBB", [NodeState.CONNECTED], [PathType.DIRECT], timeout=0.1
             )
 
         # it should fail (wrong path)
         with pytest.raises(asyncio.TimeoutError):
             await events.wait_for_state_peer(
-                "AAA", [State.Connected], [PathType.Direct], timeout=0.1
+                "AAA", [NodeState.CONNECTED], [PathType.DIRECT], timeout=0.1
             )
 
     @pytest.mark.asyncio
@@ -217,36 +244,40 @@ class TestEvents:
         events = Events(runtime)
         runtime.allowed_pub_keys = set(["AAA", "BBB"])
 
-        runtime.set_peer(PeerInfo(public_key="AAA", state=State.Connected))
-        runtime.set_peer(PeerInfo(public_key="BBB", state=State.Connected))
+        runtime.set_peer(telio_node(public_key="AAA", state=NodeState.CONNECTED))
+        runtime.set_peer(telio_node(public_key="BBB", state=NodeState.CONNECTED))
 
-        await events.wait_for_state_peer("BBB", [State.Connected], [PathType.Relay])
-        await events.wait_for_state_peer("AAA", [State.Connected], [PathType.Relay])
+        await events.wait_for_state_peer("BBB", [NodeState.CONNECTED], [PathType.RELAY])
+        await events.wait_for_state_peer("AAA", [NodeState.CONNECTED], [PathType.RELAY])
 
-        runtime.set_peer(PeerInfo(public_key="AAA", state=State.Disconnected))
-        runtime.set_peer(PeerInfo(public_key="BBB", state=State.Disconnected))
+        runtime.set_peer(telio_node(public_key="AAA", state=NodeState.DISCONNECTED))
+        runtime.set_peer(telio_node(public_key="BBB", state=NodeState.DISCONNECTED))
 
-        await events.wait_for_state_peer("BBB", [State.Disconnected], [PathType.Relay])
-        await events.wait_for_state_peer("AAA", [State.Disconnected], [PathType.Relay])
+        await events.wait_for_state_peer(
+            "BBB", [NodeState.DISCONNECTED], [PathType.RELAY]
+        )
+        await events.wait_for_state_peer(
+            "AAA", [NodeState.DISCONNECTED], [PathType.RELAY]
+        )
 
         # It should pass again
         await events.wait_for_state_peer(
-            "BBB", [State.Disconnected], [PathType.Relay, PathType.Direct]
+            "BBB", [NodeState.DISCONNECTED], [PathType.RELAY, PathType.DIRECT]
         )
         await events.wait_for_state_peer(
-            "AAA", [State.Disconnected], [PathType.Relay, PathType.Direct]
+            "AAA", [NodeState.DISCONNECTED], [PathType.RELAY, PathType.DIRECT]
         )
 
         # it should fail (old state)
         with pytest.raises(asyncio.TimeoutError):
             await events.wait_for_state_peer(
-                "BBB", [State.Connected], [PathType.Relay], timeout=0.1
+                "BBB", [NodeState.CONNECTED], [PathType.RELAY], timeout=0.1
             )
 
         # it should fail (wrong path)
         with pytest.raises(asyncio.TimeoutError):
             await events.wait_for_state_peer(
-                "AAA", [State.Disconnected], [PathType.Direct], timeout=0.1
+                "AAA", [NodeState.DISCONNECTED], [PathType.DIRECT], timeout=0.1
             )
 
     @pytest.mark.asyncio
@@ -258,36 +289,38 @@ class TestEvents:
         # Start waiting for new event before it is being generated
         async with run_async_context(
             events.wait_for_event_peer(
-                "AAA", [State.Connected], [PathType.Relay], timeout=1
+                "AAA", [NodeState.CONNECTED], [PathType.RELAY], timeout=1
             )
         ) as future:
             # wait for futures to be started
             await asyncio.sleep(0)
 
-            runtime.set_peer(PeerInfo(public_key="BBB", state=State.Connected))
+            runtime.set_peer(telio_node(public_key="BBB", state=NodeState.CONNECTED))
             with pytest.raises(asyncio.TimeoutError):
                 await asyncio.wait_for(asyncio.shield(future), 0.1)
 
-            runtime.set_peer(PeerInfo(public_key="AAA", state=State.Disconnected))
+            runtime.set_peer(telio_node(public_key="AAA", state=NodeState.DISCONNECTED))
             with pytest.raises(asyncio.TimeoutError):
                 await asyncio.wait_for(asyncio.shield(future), 0.1)
 
-            runtime.set_peer(PeerInfo(public_key="AAA", state=State.Connecting))
+            runtime.set_peer(telio_node(public_key="AAA", state=NodeState.CONNECTING))
             with pytest.raises(asyncio.TimeoutError):
                 await asyncio.wait_for(asyncio.shield(future), 0.1)
 
             runtime.set_peer(
-                PeerInfo(public_key="AAA", state=State.Connected, path=PathType.Direct)
+                telio_node(
+                    public_key="AAA", state=NodeState.CONNECTED, path=PathType.DIRECT
+                )
             )
             with pytest.raises(asyncio.TimeoutError):
                 await asyncio.wait_for(asyncio.shield(future), 0.1)
 
-            runtime.set_peer(PeerInfo(public_key="AAA", state=State.Connected))
+            runtime.set_peer(telio_node(public_key="AAA", state=NodeState.CONNECTED))
             await future
 
         with pytest.raises(asyncio.TimeoutError):
             await events.wait_for_event_peer(
-                "AAA", [State.Connected], [PathType.Relay], timeout=0.1
+                "AAA", [NodeState.CONNECTED], [PathType.RELAY], timeout=0.1
             )
 
     @pytest.mark.asyncio
@@ -299,58 +332,70 @@ class TestEvents:
         # Start waiting for new event before it is being generated
         async with run_async_contexts([
             events.wait_for_event_peer(
-                "AAA", [State.Disconnected], [PathType.Relay], timeout=5
+                "AAA", [NodeState.DISCONNECTED], [PathType.RELAY], timeout=5
             ),
             events.wait_for_event_peer(
-                "AAA", [State.Connecting], [PathType.Relay], timeout=5
+                "AAA", [NodeState.CONNECTING], [PathType.RELAY], timeout=5
             ),
             events.wait_for_event_peer(
-                "AAA", [State.Connected], [PathType.Relay], timeout=5
+                "AAA", [NodeState.CONNECTED], [PathType.RELAY], timeout=5
             ),
             events.wait_for_event_peer(
-                "BBB", [State.Disconnected], [PathType.Direct], timeout=5
+                "BBB", [NodeState.DISCONNECTED], [PathType.DIRECT], timeout=5
             ),
             events.wait_for_event_peer(
-                "BBB", [State.Connecting], [PathType.Direct], timeout=5
+                "BBB", [NodeState.CONNECTING], [PathType.DIRECT], timeout=5
             ),
             events.wait_for_event_peer(
-                "BBB", [State.Connected], [PathType.Direct], timeout=5
+                "BBB", [NodeState.CONNECTED], [PathType.DIRECT], timeout=5
             ),
         ]) as futures:
             # wait for futures to be started
             await asyncio.sleep(0)
 
             runtime.set_peer(
-                PeerInfo(public_key="BBB", state=State.Connected, path=PathType.Relay)
+                telio_node(
+                    public_key="BBB", state=NodeState.CONNECTED, path=PathType.RELAY
+                )
             )
             runtime.set_peer(
-                PeerInfo(public_key="AAA", state=State.Connected, path=PathType.Direct)
+                telio_node(
+                    public_key="AAA", state=NodeState.CONNECTED, path=PathType.DIRECT
+                )
             )
             for future in futures:
                 with pytest.raises(asyncio.TimeoutError):
                     await asyncio.wait_for(asyncio.shield(future), 0.1)
 
             runtime.set_peer(
-                PeerInfo(
-                    public_key="AAA", state=State.Disconnected, path=PathType.Relay
+                telio_node(
+                    public_key="AAA", state=NodeState.DISCONNECTED, path=PathType.RELAY
                 )
             )
             runtime.set_peer(
-                PeerInfo(public_key="AAA", state=State.Connecting, path=PathType.Relay)
-            )
-            runtime.set_peer(
-                PeerInfo(public_key="AAA", state=State.Connected, path=PathType.Relay)
-            )
-            runtime.set_peer(
-                PeerInfo(
-                    public_key="BBB", state=State.Disconnected, path=PathType.Direct
+                telio_node(
+                    public_key="AAA", state=NodeState.CONNECTING, path=PathType.RELAY
                 )
             )
             runtime.set_peer(
-                PeerInfo(public_key="BBB", state=State.Connecting, path=PathType.Direct)
+                telio_node(
+                    public_key="AAA", state=NodeState.CONNECTED, path=PathType.RELAY
+                )
             )
             runtime.set_peer(
-                PeerInfo(public_key="BBB", state=State.Connected, path=PathType.Direct)
+                telio_node(
+                    public_key="BBB", state=NodeState.DISCONNECTED, path=PathType.DIRECT
+                )
+            )
+            runtime.set_peer(
+                telio_node(
+                    public_key="BBB", state=NodeState.CONNECTING, path=PathType.DIRECT
+                )
+            )
+            runtime.set_peer(
+                telio_node(
+                    public_key="BBB", state=NodeState.CONNECTED, path=PathType.DIRECT
+                )
             )
 
             for future in futures:
@@ -361,41 +406,45 @@ class TestEvents:
         runtime = Runtime()
         events = Events(runtime)
 
-        runtime.set_derp(create_derpserver_config(State.Connected))
-        await events.wait_for_state_derp("1.1.1.1", [State.Connected], timeout=0.1)
+        runtime.set_derp(create_derpserver_config(RelayState.CONNECTED))
+        await events.wait_for_state_derp("1.1.1.1", [RelayState.CONNECTED], timeout=0.1)
 
         # It should pass again
         await events.wait_for_state_derp(
             "1.1.1.1",
-            [State.Disconnected, State.Connecting, State.Connected],
+            [RelayState.DISCONNECTED, RelayState.CONNECTING, RelayState.CONNECTED],
             timeout=0.1,
         )
 
         # it should fail (wrong state)
         with pytest.raises(asyncio.TimeoutError):
             await events.wait_for_state_derp(
-                "1.1.1.1", [State.Disconnected], timeout=0.1
+                "1.1.1.1", [RelayState.DISCONNECTED], timeout=0.1
             )
 
         # it should fail (wrong IP)
         with pytest.raises(asyncio.TimeoutError):
-            await events.wait_for_state_derp("1.1.1.2", [State.Connected], timeout=0.1)
+            await events.wait_for_state_derp(
+                "1.1.1.2", [RelayState.CONNECTED], timeout=0.1
+            )
 
     @pytest.mark.asyncio
     async def test_derp_change_state(self) -> None:
         runtime = Runtime()
         events = Events(runtime)
 
-        runtime.set_derp(create_derpserver_config(State.Connected))
-        await events.wait_for_state_derp("1.1.1.1", [State.Connected], timeout=0.1)
+        runtime.set_derp(create_derpserver_config(RelayState.CONNECTED))
+        await events.wait_for_state_derp("1.1.1.1", [RelayState.CONNECTED], timeout=0.1)
 
-        runtime.set_derp(create_derpserver_config(State.Disconnected))
-        await events.wait_for_state_derp("1.1.1.1", [State.Disconnected], timeout=0.1)
+        runtime.set_derp(create_derpserver_config(RelayState.DISCONNECTED))
+        await events.wait_for_state_derp(
+            "1.1.1.1", [RelayState.DISCONNECTED], timeout=0.1
+        )
 
         # It should pass again
         await events.wait_for_state_derp(
             "1.1.1.1",
-            [State.Connected, State.Connecting, State.Disconnected],
+            [RelayState.CONNECTED, RelayState.CONNECTING, RelayState.DISCONNECTED],
             timeout=0.1,
         )
 
@@ -403,11 +452,11 @@ class TestEvents:
     async def test_derp_event(self) -> None:
         runtime = Runtime()
         events = Events(runtime)
-        test_derp_server = create_derpserver_config(State.Connected)
+        test_derp_server = create_derpserver_config(RelayState.CONNECTED)
 
         # Start waiting for new event before it is being generated
         async with run_async_context(
-            events.wait_for_event_derp("1.1.1.1", [State.Connected], timeout=1)
+            events.wait_for_event_derp("1.1.1.1", [RelayState.CONNECTED], timeout=1)
         ) as future:
             # wait for futures to be started
             await asyncio.sleep(0)
@@ -418,43 +467,45 @@ class TestEvents:
                 await asyncio.wait_for(asyncio.shield(future), 0.1)
 
             test_derp_server.ipv4 = "1.1.1.1"
-            test_derp_server.conn_state = State.Disconnected
+            test_derp_server.conn_state = RelayState.DISCONNECTED
             runtime.set_derp(copy.deepcopy(test_derp_server))
             with pytest.raises(asyncio.TimeoutError):
                 await asyncio.wait_for(asyncio.shield(future), 0.1)
 
-            test_derp_server.conn_state = State.Connecting
+            test_derp_server.conn_state = RelayState.CONNECTING
             runtime.set_derp(copy.deepcopy(test_derp_server))
             with pytest.raises(asyncio.TimeoutError):
                 await asyncio.wait_for(asyncio.shield(future), 0.1)
 
-            test_derp_server.conn_state = State.Connected
+            test_derp_server.conn_state = RelayState.CONNECTED
             runtime.set_derp(copy.deepcopy(test_derp_server))
             await future
 
         with pytest.raises(asyncio.TimeoutError):
-            await events.wait_for_event_derp("1.1.1.1", [State.Connected], timeout=0.1)
+            await events.wait_for_event_derp(
+                "1.1.1.1", [RelayState.CONNECTED], timeout=0.1
+            )
 
     @pytest.mark.asyncio
     async def test_derp_with_multiple_events(self) -> None:
         runtime = Runtime()
         events = Events(runtime)
-        test_derp_server = create_derpserver_config(State.Connected)
+        test_derp_server = create_derpserver_config(RelayState.CONNECTED)
         # Start waiting for new event before it is being generated
         async with run_async_contexts([
-            events.wait_for_event_derp("1.1.1.1", [State.Disconnected], 5),
-            events.wait_for_event_derp("1.1.1.1", [State.Connecting], 5),
-            events.wait_for_event_derp("1.1.1.1", [State.Connected], 5),
-            events.wait_for_event_derp("1.1.1.2", [State.Disconnected], 5),
-            events.wait_for_event_derp("1.1.1.2", [State.Connecting], 5),
-            events.wait_for_event_derp("1.1.1.2", [State.Connected], 5),
-            events.wait_for_event_derp("1.1.1.3", [State.Disconnected], 5),
+            events.wait_for_event_derp("1.1.1.1", [RelayState.DISCONNECTED], 5),
+            events.wait_for_event_derp("1.1.1.1", [RelayState.CONNECTING], 5),
+            events.wait_for_event_derp("1.1.1.1", [RelayState.CONNECTED], 5),
+            events.wait_for_event_derp("1.1.1.2", [RelayState.DISCONNECTED], 5),
+            events.wait_for_event_derp("1.1.1.2", [RelayState.CONNECTING], 5),
+            events.wait_for_event_derp("1.1.1.2", [RelayState.CONNECTED], 5),
+            events.wait_for_event_derp("1.1.1.3", [RelayState.DISCONNECTED], 5),
         ]) as futures:
             # wait for futures to be started
             await asyncio.sleep(0)
 
             test_derp_server.ipv4 = "1.1.1.3"
-            test_derp_server.conn_state = State.Connected
+            test_derp_server.conn_state = RelayState.CONNECTED
             runtime.set_derp(copy.deepcopy(test_derp_server))
 
             test_derp_server.ipv4 = "1.1.1.4"
@@ -465,23 +516,23 @@ class TestEvents:
                     await asyncio.wait_for(asyncio.shield(future), 0.1)
 
             test_derp_server.ipv4 = "1.1.1.1"
-            test_derp_server.conn_state = State.Disconnected
+            test_derp_server.conn_state = RelayState.DISCONNECTED
             runtime.set_derp(copy.deepcopy(test_derp_server))
-            test_derp_server.conn_state = State.Connecting
+            test_derp_server.conn_state = RelayState.CONNECTING
             runtime.set_derp(copy.deepcopy(test_derp_server))
-            test_derp_server.conn_state = State.Connected
+            test_derp_server.conn_state = RelayState.CONNECTED
             runtime.set_derp(copy.deepcopy(test_derp_server))
 
             test_derp_server.ipv4 = "1.1.1.2"
-            test_derp_server.conn_state = State.Disconnected
+            test_derp_server.conn_state = RelayState.DISCONNECTED
             runtime.set_derp(copy.deepcopy(test_derp_server))
-            test_derp_server.conn_state = State.Connecting
+            test_derp_server.conn_state = RelayState.CONNECTING
             runtime.set_derp(copy.deepcopy(test_derp_server))
-            test_derp_server.conn_state = State.Connected
+            test_derp_server.conn_state = RelayState.CONNECTED
             runtime.set_derp(copy.deepcopy(test_derp_server))
 
             test_derp_server.ipv4 = "1.1.1.3"
-            test_derp_server.conn_state = State.Disconnected
+            test_derp_server.conn_state = RelayState.DISCONNECTED
             runtime.set_derp(copy.deepcopy(test_derp_server))
 
             for future in futures:

--- a/nat-lab/tests/test_adapter.py
+++ b/nat-lab/tests/test_adapter.py
@@ -1,7 +1,8 @@
 import pytest
 from contextlib import AsyncExitStack
 from helpers import SetupParameters, setup_mesh_nodes, setup_connections
-from telio import AdapterType, ErrorEvent, ErrorCode, ErrorLevel
+from telio import AdapterType
+from utils.bindings import ErrorEvent, ErrorCode, ErrorLevel
 from utils.connection import TargetOS
 from utils.connection_util import ConnectionTag
 from utils.process import ProcessExecError
@@ -69,7 +70,7 @@ async def test_adapter_gone_event(alpha_setup_params: SetupParameters) -> None:
             raise RuntimeError("unsupported os")
 
         await client.wait_for_event_error(
-            ErrorEvent(ErrorLevel.Critical, ErrorCode.Unknown, "Interface gone")
+            ErrorEvent(ErrorLevel.CRITICAL, ErrorCode.UNKNOWN, "Interface gone")
         )
 
         client.allow_errors([

--- a/nat-lab/tests/test_batching.py
+++ b/nat-lab/tests/test_batching.py
@@ -6,7 +6,7 @@ from contextlib import AsyncExitStack
 from helpers import SetupParameters, setup_environment
 from itertools import zip_longest
 from scapy.layers.inet import TCP, UDP  # type: ignore
-from telio import State, AdapterType
+from telio import AdapterType
 from timeouts import TEST_BATCHING_TIMEOUT
 from typing import List, Tuple
 from utils.batching import (
@@ -20,6 +20,7 @@ from utils.bindings import (
     FeaturePersistentKeepalive,
     FeatureBatching,
     EndpointProvider,
+    RelayState,
 )
 from utils.connection import DockerConnection
 from utils.connection_util import DOCKER_GW_MAP, ConnectionTag, container_id
@@ -172,7 +173,7 @@ async def test_batching(
         )
 
         await asyncio.gather(*[
-            client.wait_for_state_on_any_derp([State.Connected])
+            client.wait_for_state_on_any_derp([RelayState.CONNECTED])
             for client, instance in zip_longest(env.clients, setup_params)
             if instance.derp_servers != []
         ])

--- a/nat-lab/tests/test_derp_connect.py
+++ b/nat-lab/tests/test_derp_connect.py
@@ -5,8 +5,8 @@ from config import DERP_PRIMARY, DERP_SECONDARY, DERP_TERTIARY, DERP_SERVERS
 from contextlib import AsyncExitStack
 from copy import deepcopy
 from helpers import SetupParameters, setup_mesh_nodes
-from telio import State
 from typing import List
+from utils.bindings import RelayState
 from utils.connection_util import ConnectionTag
 from utils.ping import ping
 
@@ -60,7 +60,7 @@ async def test_derp_reconnect_2clients(setup_params: List[SetupParameters]) -> N
 
         # Wait till connection is broken
         await beta_client.wait_for_state_derp(
-            DERP1_IP, [State.Disconnected, State.Connecting]
+            DERP1_IP, [RelayState.DISCONNECTED, RelayState.CONNECTING]
         )
 
         # ==============================================================
@@ -73,7 +73,7 @@ async def test_derp_reconnect_2clients(setup_params: List[SetupParameters]) -> N
         #   /           \
         # [ALPHA]     [BETA]
 
-        await beta_client.wait_for_state_derp(DERP2_IP, [State.Connected])
+        await beta_client.wait_for_state_derp(DERP2_IP, [RelayState.CONNECTED])
 
         # Ping peer to check if connection truly works
         await ping(alpha_connection, beta.ip_addresses[0])
@@ -146,10 +146,10 @@ async def test_derp_reconnect_3clients(setup_params: List[SetupParameters]) -> N
         )
 
         await beta_client.wait_for_state_derp(
-            DERP1_IP, [State.Disconnected, State.Connecting]
+            DERP1_IP, [RelayState.DISCONNECTED, RelayState.CONNECTING]
         )
         await gamma_client.wait_for_state_derp(
-            DERP1_IP, [State.Disconnected, State.Connecting]
+            DERP1_IP, [RelayState.DISCONNECTED, RelayState.CONNECTING]
         )
 
         # ==============================================================
@@ -166,9 +166,9 @@ async def test_derp_reconnect_3clients(setup_params: List[SetupParameters]) -> N
         # (* - connection to the escaped client, but DERP does not know):
 
         await asyncio.gather(
-            alpha_client.wait_for_state_derp(DERP1_IP, [State.Connected]),
-            beta_client.wait_for_state_derp(DERP2_IP, [State.Connected]),
-            gamma_client.wait_for_state_derp(DERP2_IP, [State.Connected]),
+            alpha_client.wait_for_state_derp(DERP1_IP, [RelayState.CONNECTED]),
+            beta_client.wait_for_state_derp(DERP2_IP, [RelayState.CONNECTED]),
+            gamma_client.wait_for_state_derp(DERP2_IP, [RelayState.CONNECTED]),
         )
 
         # ==============================================================
@@ -186,7 +186,7 @@ async def test_derp_reconnect_3clients(setup_params: List[SetupParameters]) -> N
             gamma_client.get_router().break_tcp_conn_to_host(DERP2_IP)
         )
         await gamma_client.wait_for_state_derp(
-            DERP2_IP, [State.Disconnected, State.Connecting]
+            DERP2_IP, [RelayState.DISCONNECTED, RelayState.CONNECTING]
         )
 
         # ==============================================================
@@ -202,9 +202,9 @@ async def test_derp_reconnect_3clients(setup_params: List[SetupParameters]) -> N
         # [ALPHA]    [BETA]     [GAMMA]
 
         await asyncio.gather(
-            alpha_client.wait_for_state_derp(DERP1_IP, [State.Connected]),
-            beta_client.wait_for_state_derp(DERP2_IP, [State.Connected]),
-            gamma_client.wait_for_state_derp(DERP3_IP, [State.Connected]),
+            alpha_client.wait_for_state_derp(DERP1_IP, [RelayState.CONNECTED]),
+            beta_client.wait_for_state_derp(DERP2_IP, [RelayState.CONNECTED]),
+            gamma_client.wait_for_state_derp(DERP3_IP, [RelayState.CONNECTED]),
         )
 
         # Ping ALPHA --> BETA
@@ -314,9 +314,9 @@ async def test_derp_restart(setup_params: List[SetupParameters]) -> None:
         os.system("docker restart nat-lab-derp-01-1")
 
         await asyncio.gather(
-            alpha_client.wait_for_state_derp(_DERP2_IP, [State.Connected]),
-            beta_client.wait_for_state_derp(_DERP2_IP, [State.Connected]),
-            gamma_client.wait_for_state_derp(_DERP3_IP, [State.Connected]),
+            alpha_client.wait_for_state_derp(_DERP2_IP, [RelayState.CONNECTED]),
+            beta_client.wait_for_state_derp(_DERP2_IP, [RelayState.CONNECTED]),
+            gamma_client.wait_for_state_derp(_DERP3_IP, [RelayState.CONNECTED]),
         )
 
         # Ping ALPHA --> BETA
@@ -345,9 +345,9 @@ async def test_derp_restart(setup_params: List[SetupParameters]) -> None:
         os.system("docker restart nat-lab-derp-02-1")
 
         await asyncio.gather(
-            alpha_client.wait_for_state_derp(_DERP1_IP, [State.Connected]),
-            beta_client.wait_for_state_derp(_DERP3_IP, [State.Connected]),
-            gamma_client.wait_for_state_derp(_DERP3_IP, [State.Connected]),
+            alpha_client.wait_for_state_derp(_DERP1_IP, [RelayState.CONNECTED]),
+            beta_client.wait_for_state_derp(_DERP3_IP, [RelayState.CONNECTED]),
+            gamma_client.wait_for_state_derp(_DERP3_IP, [RelayState.CONNECTED]),
         )
 
         # Ping ALPHA --> BETA
@@ -376,9 +376,9 @@ async def test_derp_restart(setup_params: List[SetupParameters]) -> None:
         os.system("docker restart nat-lab-derp-03-1")
 
         await asyncio.gather(
-            alpha_client.wait_for_state_derp(_DERP1_IP, [State.Connected]),
-            beta_client.wait_for_state_derp(_DERP2_IP, [State.Connected]),
-            gamma_client.wait_for_state_derp(_DERP2_IP, [State.Connected]),
+            alpha_client.wait_for_state_derp(_DERP1_IP, [RelayState.CONNECTED]),
+            beta_client.wait_for_state_derp(_DERP2_IP, [RelayState.CONNECTED]),
+            gamma_client.wait_for_state_derp(_DERP2_IP, [RelayState.CONNECTED]),
         )
 
         # Ping ALPHA --> BETA
@@ -437,7 +437,7 @@ async def test_derp_server_list_exhaustion(setup_params: List[SetupParameters]) 
             await beta_client.wait_for_every_derp_disconnection()
 
         # iptables rules are dropped already
-        await beta_client.wait_for_state_on_any_derp([State.Connected])
+        await beta_client.wait_for_state_on_any_derp([RelayState.CONNECTED])
 
         # Ping peer to check if connection truly works
         await ping(alpha_connection, beta.ip_addresses[0])

--- a/nat-lab/tests/test_downgrade.py
+++ b/nat-lab/tests/test_downgrade.py
@@ -2,13 +2,15 @@ import asyncio
 import pytest
 from contextlib import AsyncExitStack
 from helpers import setup_mesh_nodes, SetupParameters
-from telio import PathType, State, AdapterType
+from telio import AdapterType
 from typing import List, Tuple
 from utils.bindings import (
     default_features,
     FeatureLinkDetection,
     FeaturePersistentKeepalive,
     EndpointProvider,
+    PathType,
+    NodeState,
 )
 from utils.connection_util import ConnectionTag
 from utils.ping import ping
@@ -86,10 +88,10 @@ async def test_downgrade_using_link_detection(
         # Expect downgrade to relay
         await asyncio.gather(
             alpha_client.wait_for_state_peer(
-                beta.public_key, [State.Connected], [PathType.Relay], timeout=35
+                beta.public_key, [NodeState.CONNECTED], [PathType.RELAY], timeout=35
             ),
             beta_client.wait_for_state_peer(
-                alpha.public_key, [State.Connected], [PathType.Relay], timeout=35
+                alpha.public_key, [NodeState.CONNECTED], [PathType.RELAY], timeout=35
             ),
         )
 
@@ -148,10 +150,13 @@ async def test_downgrade_using_link_detection_with_silent_connection(
         with pytest.raises(asyncio.TimeoutError):
             await asyncio.gather(
                 alpha_client.wait_for_state_peer(
-                    beta.public_key, [State.Connected], [PathType.Relay], timeout=15
+                    beta.public_key, [NodeState.CONNECTED], [PathType.RELAY], timeout=15
                 ),
                 beta_client.wait_for_state_peer(
-                    alpha.public_key, [State.Connected], [PathType.Relay], timeout=15
+                    alpha.public_key,
+                    [NodeState.CONNECTED],
+                    [PathType.RELAY],
+                    timeout=15,
                 ),
             )
 
@@ -164,10 +169,10 @@ async def test_downgrade_using_link_detection_with_silent_connection(
         # Expect downgrade to relay
         await asyncio.gather(
             alpha_client.wait_for_state_peer(
-                beta.public_key, [State.Connected], [PathType.Relay], timeout=35
+                beta.public_key, [NodeState.CONNECTED], [PathType.RELAY], timeout=35
             ),
             beta_client.wait_for_state_peer(
-                alpha.public_key, [State.Connected], [PathType.Relay], timeout=35
+                alpha.public_key, [NodeState.CONNECTED], [PathType.RELAY], timeout=35
             ),
         )
 

--- a/nat-lab/tests/test_events_link_state.py
+++ b/nat-lab/tests/test_events_link_state.py
@@ -144,8 +144,8 @@ async def test_event_link_state_peers_idle_all_time(
         beta_events = client_alpha.get_link_state_events(beta.public_key)
 
         # 1 down when node is Connecting, 1 up when still Connecting and 1 up when node is Connected
-        assert alpha_events == [LinkState.Down, LinkState.Up, LinkState.Up]
-        assert beta_events == [LinkState.Down, LinkState.Up, LinkState.Up]
+        assert alpha_events == [LinkState.DOWN, LinkState.UP, LinkState.UP]
+        assert beta_events == [LinkState.DOWN, LinkState.UP, LinkState.UP]
 
 
 @pytest.mark.asyncio
@@ -171,8 +171,8 @@ async def test_event_link_state_peers_exchanging_data_for_a_long_time(
         beta_events = client_alpha.get_link_state_events(beta.public_key)
 
         # 1 down when node is Connecting, 1 up when still Connecting and 1 up when node is Connected
-        assert alpha_events == [LinkState.Down, LinkState.Up, LinkState.Up]
-        assert beta_events == [LinkState.Down, LinkState.Up, LinkState.Up]
+        assert alpha_events == [LinkState.DOWN, LinkState.UP, LinkState.UP]
+        assert beta_events == [LinkState.DOWN, LinkState.UP, LinkState.UP]
 
 
 @pytest.mark.asyncio
@@ -201,8 +201,8 @@ async def test_event_link_state_peers_exchanging_data_then_idling_then_resume(
         beta_events = client_alpha.get_link_state_events(beta.public_key)
 
         # 1 down when node is Connecting, 1 up when still Connecting and 1 up when node is Connected
-        assert alpha_events == [LinkState.Down, LinkState.Up, LinkState.Up]
-        assert beta_events == [LinkState.Down, LinkState.Up, LinkState.Up]
+        assert alpha_events == [LinkState.DOWN, LinkState.UP, LinkState.UP]
+        assert beta_events == [LinkState.DOWN, LinkState.UP, LinkState.UP]
 
 
 @pytest.mark.asyncio
@@ -233,13 +233,13 @@ async def test_event_link_state_peer_goes_offline(
         beta_events = client_alpha.get_link_state_events(beta.public_key)
 
         # 1 down when node is Connecting, 1 up when still Connecting and 1 up when node is Connected
-        assert alpha_events == [LinkState.Down, LinkState.Up, LinkState.Up]
+        assert alpha_events == [LinkState.DOWN, LinkState.UP, LinkState.UP]
         # beta will have 2 down events: 1 when is Connecting and 1 detected and 2 up when Connecting and Connected
         assert beta_events == [
-            LinkState.Down,
-            LinkState.Up,
-            LinkState.Up,
-            LinkState.Down,
+            LinkState.DOWN,
+            LinkState.UP,
+            LinkState.UP,
+            LinkState.DOWN,
         ]
 
 

--- a/nat-lab/tests/test_fire_connecting_event.py
+++ b/nat-lab/tests/test_fire_connecting_event.py
@@ -3,7 +3,8 @@ import pytest
 import timeouts
 from contextlib import AsyncExitStack
 from helpers import SetupParameters, setup_mesh_nodes
-from telio import AdapterType, State
+from telio import AdapterType
+from utils.bindings import NodeState
 from utils.connection_tracker import ConnectionLimits
 from utils.connection_util import generate_connection_tracker_config, ConnectionTag
 from utils.ping import ping
@@ -53,4 +54,4 @@ async def test_fire_connecting_event(
         with pytest.raises(asyncio.TimeoutError):
             await ping(connection_alpha, beta.ip_addresses[0], 15)
 
-        await client_alpha.wait_for_event_peer(beta.public_key, [State.Connecting])
+        await client_alpha.wait_for_event_peer(beta.public_key, [NodeState.CONNECTING])

--- a/nat-lab/tests/test_lana.py
+++ b/nat-lab/tests/test_lana.py
@@ -16,7 +16,6 @@ from config import (
 from contextlib import AsyncExitStack
 from helpers import connectivity_stack
 from mesh_api import API, Node
-from telio import PathType
 from typing import List, Optional
 from utils import testing, stun
 from utils.analytics import fetch_moose_events, DERP_BIT, WG_BIT, IPV4_BIT, IPV6_BIT
@@ -50,6 +49,9 @@ from utils.bindings import (
     FeatureEndpointProvidersOptimization,
     EndpointProvider,
     RttType,
+    PathType,
+    NodeState,
+    RelayState,
 )
 from utils.connection import Connection
 from utils.connection_tracker import ConnectionLimits
@@ -389,26 +391,26 @@ async def run_default_scenario(
     )
 
     await asyncio.gather(
-        client_alpha.wait_for_state_on_any_derp([telio.State.Connected]),
-        client_beta.wait_for_state_on_any_derp([telio.State.Connected]),
-        client_gamma.wait_for_state_on_any_derp([telio.State.Connected]),
+        client_alpha.wait_for_state_on_any_derp([RelayState.CONNECTED]),
+        client_beta.wait_for_state_on_any_derp([RelayState.CONNECTED]),
+        client_gamma.wait_for_state_on_any_derp([RelayState.CONNECTED]),
     )
     # Note: GAMMA is symmetric, so it will not connect to ALPHA or BETA in direct mode
     await asyncio.gather(
         client_alpha.wait_for_state_peer(
             beta.public_key,
-            [telio.State.Connected],
-            [PathType.Direct],
+            [NodeState.CONNECTED],
+            [PathType.DIRECT],
         ),
-        client_alpha.wait_for_state_peer(gamma.public_key, [telio.State.Connected]),
+        client_alpha.wait_for_state_peer(gamma.public_key, [NodeState.CONNECTED]),
         client_beta.wait_for_state_peer(
             alpha.public_key,
-            [telio.State.Connected],
-            [PathType.Direct],
+            [NodeState.CONNECTED],
+            [PathType.DIRECT],
         ),
-        client_beta.wait_for_state_peer(gamma.public_key, [telio.State.Connected]),
-        client_gamma.wait_for_state_peer(alpha.public_key, [telio.State.Connected]),
-        client_gamma.wait_for_state_peer(beta.public_key, [telio.State.Connected]),
+        client_beta.wait_for_state_peer(gamma.public_key, [NodeState.CONNECTED]),
+        client_gamma.wait_for_state_peer(alpha.public_key, [NodeState.CONNECTED]),
+        client_gamma.wait_for_state_peer(beta.public_key, [NodeState.CONNECTED]),
     )
 
     if alpha_has_vpn_connection:
@@ -1313,15 +1315,15 @@ async def test_lana_with_meshnet_exit_node(
         )
 
         await asyncio.gather(
-            client_alpha.wait_for_state_on_any_derp([telio.State.Connected]),
-            client_beta.wait_for_state_on_any_derp([telio.State.Connected]),
+            client_alpha.wait_for_state_on_any_derp([RelayState.CONNECTED]),
+            client_beta.wait_for_state_on_any_derp([RelayState.CONNECTED]),
         )
         await asyncio.gather(
             client_alpha.wait_for_state_peer(
-                beta.public_key, [telio.State.Connected], [PathType.Direct]
+                beta.public_key, [NodeState.CONNECTED], [PathType.DIRECT]
             ),
             client_beta.wait_for_state_peer(
-                alpha.public_key, [telio.State.Connected], [PathType.Direct]
+                alpha.public_key, [NodeState.CONNECTED], [PathType.DIRECT]
             ),
         )
 
@@ -1541,15 +1543,15 @@ async def test_lana_with_disconnected_node(
         )
 
         await asyncio.gather(
-            client_alpha.wait_for_state_on_any_derp([telio.State.Connected]),
-            client_beta.wait_for_state_on_any_derp([telio.State.Connected]),
+            client_alpha.wait_for_state_on_any_derp([RelayState.CONNECTED]),
+            client_beta.wait_for_state_on_any_derp([RelayState.CONNECTED]),
         )
         await asyncio.gather(
             client_alpha.wait_for_state_peer(
-                beta.public_key, [telio.State.Connected], [PathType.Direct]
+                beta.public_key, [NodeState.CONNECTED], [PathType.DIRECT]
             ),
             client_beta.wait_for_state_peer(
-                alpha.public_key, [telio.State.Connected], [PathType.Direct]
+                alpha.public_key, [NodeState.CONNECTED], [PathType.DIRECT]
             ),
         )
 
@@ -1948,10 +1950,10 @@ async def test_lana_with_second_node_joining_later_meshnet_id_can_change(
 
         await asyncio.gather(
             client_alpha.wait_for_state_peer(
-                beta.public_key, [telio.State.Connected], [PathType.Direct]
+                beta.public_key, [NodeState.CONNECTED], [PathType.DIRECT]
             ),
             client_beta.wait_for_state_peer(
-                alpha.public_key, [telio.State.Connected], [PathType.Direct]
+                alpha.public_key, [NodeState.CONNECTED], [PathType.DIRECT]
             ),
         )
 

--- a/nat-lab/tests/test_mesh_exit_through_peer.py
+++ b/nat-lab/tests/test_mesh_exit_through_peer.py
@@ -5,8 +5,9 @@ import telio
 from contextlib import AsyncExitStack
 from helpers import setup_mesh_nodes, SetupParameters
 from mesh_api import API
-from telio import State, AdapterType
+from telio import AdapterType
 from utils import testing, stun
+from utils.bindings import PathType, NodeState, RelayState
 from utils.connection_tracker import ConnectionLimits
 from utils.connection_util import (
     generate_connection_tracker_config,
@@ -153,17 +154,17 @@ async def test_mesh_exit_through_peer(
         disconnect_task = asyncio.create_task(
             client_alpha.wait_for_event_peer(
                 beta.public_key,
-                [State.Disconnected],
-                list(telio.PathType),
+                [NodeState.DISCONNECTED],
+                list(PathType),
                 is_exit=True,
             )
         )
-        # Using a list of all State variants except for Disconnect just in case new variants are added in the future.
-        all_other_states = list(State)
-        all_other_states.remove(State.Disconnected)
+        # Using a list of all NodeState variants except for Disconnect just in case new variants are added in the future.
+        all_other_states = list(NodeState)
+        all_other_states.remove(NodeState.DISCONNECTED)
         any_other_state_task = asyncio.create_task(
             client_alpha.wait_for_event_peer(
-                beta.public_key, all_other_states, list(telio.PathType)
+                beta.public_key, all_other_states, list(PathType)
             )
         )
         await client_alpha.set_mesh_off()
@@ -180,7 +181,7 @@ async def test_mesh_exit_through_peer(
         ), "disconnect from beta never happened after disabling meshnet"
         with pytest.raises(asyncio.TimeoutError):
             await client_alpha.wait_for_event_peer(
-                beta.public_key, list(State), list(telio.PathType), timeout=5
+                beta.public_key, list(NodeState), list(PathType), timeout=5
             )
 
 
@@ -271,12 +272,12 @@ async def test_ipv6_exit_node(
         )
 
         await asyncio.gather(
-            client_alpha.wait_for_state_on_any_derp([State.Connected]),
-            client_beta.wait_for_state_on_any_derp([State.Connected]),
+            client_alpha.wait_for_state_on_any_derp([RelayState.CONNECTED]),
+            client_beta.wait_for_state_on_any_derp([RelayState.CONNECTED]),
         )
         await asyncio.gather(
-            client_alpha.wait_for_state_peer(beta.public_key, [State.Connected]),
-            client_beta.wait_for_state_peer(alpha.public_key, [State.Connected]),
+            client_alpha.wait_for_state_peer(beta.public_key, [NodeState.CONNECTED]),
+            client_beta.wait_for_state_peer(alpha.public_key, [NodeState.CONNECTED]),
         )
 
         # Ping in-tunnel node with IPv6

--- a/nat-lab/tests/test_network_switch.py
+++ b/nat-lab/tests/test_network_switch.py
@@ -10,10 +10,16 @@ from helpers import (
     setup_mesh_nodes,
     SetupParameters,
 )
-from telio import AdapterType, PathType, State
+from telio import AdapterType
 from utils import stun
 from utils.asyncio_util import run_async_contexts
-from utils.bindings import features_with_endpoint_providers, EndpointProvider
+from utils.bindings import (
+    features_with_endpoint_providers,
+    EndpointProvider,
+    PathType,
+    NodeState,
+    RelayState,
+)
 from utils.connection import TargetOS
 from utils.connection_util import ConnectionTag
 from utils.ping import ping
@@ -295,16 +301,16 @@ async def test_mesh_network_switch_direct(
         await ping(alpha_connection, beta.ip_addresses[0])
 
         derp_connected_future = alpha_client.wait_for_event_on_any_derp(
-            [State.Connected]
+            [RelayState.CONNECTED]
         )
 
         # Beta doesn't change its endpoint, so WG roaming may be used by alpha node to restore
         # the connection, so no node event is logged in that case
         peers_connected_relay_future = beta_client.wait_for_event_peer(
-            alpha.public_key, [State.Connected], [PathType.Relay]
+            alpha.public_key, [NodeState.CONNECTED], [PathType.RELAY]
         )
         peers_connected_direct_future = beta_client.wait_for_event_peer(
-            alpha.public_key, [State.Connected], [PathType.Direct]
+            alpha.public_key, [NodeState.CONNECTED], [PathType.DIRECT]
         )
         async with run_async_contexts([
             derp_connected_future,

--- a/nat-lab/tests/test_node_state_flickering.py
+++ b/nat-lab/tests/test_node_state_flickering.py
@@ -4,8 +4,14 @@ import pytest
 import timeouts
 from contextlib import AsyncExitStack
 from helpers import SetupParameters, setup_mesh_nodes
-from telio import AdapterType, PathType, State
-from utils.bindings import features_with_endpoint_providers, EndpointProvider
+from telio import AdapterType
+from utils.bindings import (
+    features_with_endpoint_providers,
+    EndpointProvider,
+    PathType,
+    NodeState,
+    RelayState,
+)
 from utils.connection_tracker import ConnectionLimits
 from utils.connection_util import generate_connection_tracker_config, ConnectionTag
 
@@ -99,13 +105,13 @@ async def test_node_state_flickering_relay(
         with pytest.raises(asyncio.TimeoutError):
             await asyncio.gather(
                 client_alpha.wait_for_event_peer(
-                    beta.public_key, list(State), timeout=120
+                    beta.public_key, list(NodeState), timeout=120
                 ),
                 client_beta.wait_for_event_peer(
-                    alpha.public_key, list(State), timeout=120
+                    alpha.public_key, list(NodeState), timeout=120
                 ),
-                client_alpha.wait_for_event_on_any_derp(list(State), timeout=120),
-                client_beta.wait_for_event_on_any_derp(list(State), timeout=120),
+                client_alpha.wait_for_event_on_any_derp(list(RelayState), timeout=120),
+                client_beta.wait_for_event_on_any_derp(list(RelayState), timeout=120),
             )
 
 
@@ -174,16 +180,16 @@ async def test_node_state_flickering_direct(
             await asyncio.gather(
                 client_alpha.wait_for_event_peer(
                     beta.public_key,
-                    list(State),
+                    list(NodeState),
                     list(PathType),
                     timeout=120,
                 ),
                 client_beta.wait_for_event_peer(
                     alpha.public_key,
-                    list(State),
+                    list(NodeState),
                     list(PathType),
                     timeout=120,
                 ),
-                client_alpha.wait_for_event_on_any_derp(list(State), timeout=120),
-                client_beta.wait_for_event_on_any_derp(list(State), timeout=120),
+                client_alpha.wait_for_event_on_any_derp(list(RelayState), timeout=120),
+                client_beta.wait_for_event_on_any_derp(list(RelayState), timeout=120),
             )

--- a/nat-lab/tests/test_pinging.py
+++ b/nat-lab/tests/test_pinging.py
@@ -3,8 +3,7 @@ import pytest
 import telio
 from contextlib import AsyncExitStack
 from datetime import datetime
-from helpers import connectivity_stack, setup_mesh_nodes, SetupParameters
-from telio import PathType, State
+from helpers import setup_mesh_nodes, SetupParameters, connectivity_stack
 from typing import Tuple
 from utils.bindings import (
     Features,
@@ -12,6 +11,8 @@ from utils.bindings import (
     FeatureQoS,
     EndpointProvider,
     RttType,
+    PathType,
+    NodeState,
 )
 from utils.connection import Connection
 from utils.connection_tracker import ConnectionTracker, ConnectionLimits
@@ -189,13 +190,13 @@ async def test_session_keeper(
         await asyncio.gather(
             alpha_client.wait_for_state_peer(
                 beta.public_key,
-                [State.Connected],
-                [PathType.Direct],
+                [NodeState.CONNECTED],
+                [PathType.DIRECT],
             ),
             beta_client.wait_for_state_peer(
                 alpha.public_key,
-                [State.Connected],
-                [PathType.Direct],
+                [NodeState.CONNECTED],
+                [PathType.DIRECT],
             ),
             wait_for_conntracker(),
         )
@@ -286,11 +287,11 @@ async def test_qos(
         await asyncio.gather(
             alpha_client.wait_for_state_peer(
                 beta.public_key,
-                [State.Connected],
+                [NodeState.CONNECTED],
             ),
             beta_client.wait_for_state_peer(
                 alpha.public_key,
-                [State.Connected],
+                [NodeState.CONNECTED],
             ),
             wait_for_conntracker(),
         )

--- a/nat-lab/tests/test_proxy.py
+++ b/nat-lab/tests/test_proxy.py
@@ -2,8 +2,8 @@ import asyncio
 import pytest
 from contextlib import AsyncExitStack
 from helpers import SetupParameters, setup_mesh_nodes
-from telio import PeerInfo
 from typing import Optional
+from utils.bindings import TelioNode
 from utils.connection_util import ConnectionTag
 from utils.ping import ping
 
@@ -46,7 +46,7 @@ async def test_proxy_endpoint_map_update() -> None:
         )
 
 
-def node_port(peer_info: Optional[PeerInfo]) -> int:
+def node_port(peer_info: Optional[TelioNode]) -> int:
     assert peer_info
     endpoint = peer_info.endpoint
     assert endpoint

--- a/nat-lab/tests/test_reconnections.py
+++ b/nat-lab/tests/test_reconnections.py
@@ -4,6 +4,7 @@ import telio
 from contextlib import AsyncExitStack
 from helpers import setup_mesh_nodes, SetupParameters
 from utils import asyncio_util
+from utils.bindings import NodeState, RelayState
 from utils.connection_tracker import ConnectionLimits
 from utils.connection_util import generate_connection_tracker_config, ConnectionTag
 from utils.ping import ping
@@ -114,17 +115,17 @@ async def test_mesh_reconnect(
         async with asyncio_util.run_async_context(
             asyncio.gather(
                 client_alpha.wait_for_event_peer(
-                    beta.public_key, [telio.State.Connected]
+                    beta.public_key, [NodeState.CONNECTED]
                 ),
-                client_alpha.wait_for_event_on_any_derp([telio.State.Connected]),
+                client_alpha.wait_for_event_on_any_derp([RelayState.CONNECTED]),
             ),
         ) as event:
             await client_alpha.set_meshnet_config(api.get_meshnet_config(alpha.id))
             await event
 
         await asyncio.gather(
-            client_alpha.wait_for_state_peer(beta.public_key, [telio.State.Connected]),
-            client_beta.wait_for_state_peer(alpha.public_key, [telio.State.Connected]),
+            client_alpha.wait_for_state_peer(beta.public_key, [NodeState.CONNECTED]),
+            client_beta.wait_for_state_peer(alpha.public_key, [NodeState.CONNECTED]),
         )
 
         await ping(alpha_connection, beta.ip_addresses[0])

--- a/nat-lab/tests/test_telio_version_compatibility.py
+++ b/nat-lab/tests/test_telio_version_compatibility.py
@@ -14,6 +14,8 @@ from utils.bindings import (
     Config,
     Peer,
     Server,
+    RelayState,
+    NodeState,
 )
 from utils.connection_util import (
     ConnectionTag,
@@ -190,8 +192,8 @@ async def test_connect_different_telio_version_through_relay(
             shlex.quote(backport_config(api.get_meshnet_config(beta.id))),
         ])
 
-        await alpha_client.wait_for_state_on_any_derp([telio.State.Connected])
-        await alpha_client.wait_for_state_peer(beta.public_key, [telio.State.Connected])
+        await alpha_client.wait_for_state_on_any_derp([RelayState.CONNECTED])
+        await alpha_client.wait_for_state_peer(beta.public_key, [NodeState.CONNECTED])
 
         await ping(
             alpha_conn,

--- a/nat-lab/tests/test_upnp_connection.py
+++ b/nat-lab/tests/test_upnp_connection.py
@@ -2,9 +2,15 @@ import asyncio
 import pytest
 from contextlib import AsyncExitStack
 from helpers import SetupParameters, setup_mesh_nodes, setup_environment
-from telio import AdapterType, PathType, State
+from telio import AdapterType
 from utils.asyncio_util import run_async_context
-from utils.bindings import features_with_endpoint_providers, EndpointProvider
+from utils.bindings import (
+    features_with_endpoint_providers,
+    EndpointProvider,
+    PathType,
+    NodeState,
+    RelayState,
+)
 from utils.connection_util import ConnectionTag
 from utils.ping import ping
 from utils.router import new_router, IPStack
@@ -55,7 +61,9 @@ async def test_upnp_route_removed(
             await temp_exit_stack.enter_async_context(beta_gw_router.reset_upnpd())
             task = await temp_exit_stack.enter_async_context(
                 run_async_context(
-                    alpha_client.wait_for_event_peer(beta.public_key, [State.Connected])
+                    alpha_client.wait_for_event_peer(
+                        beta.public_key, [NodeState.CONNECTED]
+                    )
                 )
             )
             try:
@@ -70,10 +78,10 @@ async def test_upnp_route_removed(
 
         await asyncio.gather(
             alpha_client.wait_for_event_peer(
-                beta.public_key, [State.Connected], [PathType.Direct]
+                beta.public_key, [NodeState.CONNECTED], [PathType.DIRECT]
             ),
             beta_client.wait_for_event_peer(
-                alpha.public_key, [State.Connected], [PathType.Direct]
+                alpha.public_key, [NodeState.CONNECTED], [PathType.DIRECT]
             ),
         )
 
@@ -158,8 +166,8 @@ async def test_upnp_without_support(
         (alpha_conn_mgr, beta_conn_mgr) = env.connections
 
         await asyncio.gather(
-            alpha_client.wait_for_state_on_any_derp([State.Connected]),
-            beta_client.wait_for_state_on_any_derp([State.Connected]),
+            alpha_client.wait_for_state_on_any_derp([RelayState.CONNECTED]),
+            beta_client.wait_for_state_on_any_derp([RelayState.CONNECTED]),
         )
 
         # Giving time for upnp gateway search to start
@@ -167,14 +175,14 @@ async def test_upnp_without_support(
             await asyncio.gather(
                 alpha_client.wait_for_event_peer(
                     beta_node.public_key,
-                    [State.Connected],
-                    [PathType.Direct],
+                    [NodeState.CONNECTED],
+                    [PathType.DIRECT],
                     timeout=10,
                 ),
                 beta_client.wait_for_event_peer(
                     alpha_node.public_key,
-                    [State.Connected],
-                    [PathType.Direct],
+                    [NodeState.CONNECTED],
+                    [PathType.DIRECT],
                     timeout=10,
                 ),
             )

--- a/nat-lab/tests/uniffi/libtelio_proxy.py
+++ b/nat-lab/tests/uniffi/libtelio_proxy.py
@@ -73,7 +73,7 @@ class LibtelioProxy:
     def _create(self, features: libtelio.Features):
         self.handle_remote_error(lambda r: r.create(features))
 
-    def next_event(self):
+    def next_event(self) -> libtelio.Event:
         return self.handle_remote_error(lambda r: r.next_event())
 
     def stop(self):

--- a/nat-lab/tests/utils/bindings.py
+++ b/nat-lab/tests/utils/bindings.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple
+from typing import Optional, Tuple, List
 
 from uniffi.telio_bindings import *  # pylint: disable=wildcard-import, unused-wildcard-import  # isort: skip
 
@@ -50,3 +50,41 @@ def default_features(
     features.hide_ips = False
     features.dns.exit_dns = FeatureExitDns(auto_switch_dns_ips=True)
     return features
+
+
+def telio_node(  # pylint: disable=dangerous-default-value
+    identifier: str = "",
+    public_key: str = "",
+    state: NodeState = NodeState.DISCONNECTED,
+    hostname: Optional[str] = None,
+    nickname: Optional[str] = None,
+    is_exit: bool = False,
+    is_vpn: bool = False,
+    ip_addresses: List[str] = [],
+    allowed_ips: List[str] = [],
+    endpoint: Optional[str] = None,
+    path: PathType = PathType.RELAY,
+    allow_incoming_connections: bool = False,
+    allow_peer_send_files: bool = False,
+    link_state: Optional[LinkState] = None,
+    allow_multicast: bool = False,
+    peer_allows_multicast: bool = False,
+) -> TelioNode:
+    return TelioNode(
+        identifier=identifier,
+        public_key=public_key,
+        state=state,
+        hostname=hostname,
+        nickname=nickname,
+        is_exit=is_exit,
+        is_vpn=is_vpn,
+        ip_addresses=ip_addresses,
+        allowed_ips=allowed_ips,
+        endpoint=endpoint,
+        path=path,
+        allow_incoming_connections=allow_incoming_connections,
+        allow_peer_send_files=allow_peer_send_files,
+        link_state=link_state,
+        allow_multicast=allow_multicast,
+        peer_allows_multicast=peer_allows_multicast,
+    )


### PR DESCRIPTION
This is PR 3/4 to replace bespoke types in natlab with those in the generated python bindings. This PR deals with using strongly typed events, which brings with it the need to start using some related types from the bindings, making the PR a bit on the bigger side. Most of the changes should be conceptually quite simple with mostly changes like `State.Connected` -> `NodeState.CONNECTED` 


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
