### PR TITLE
Conntracker skip all events from sync_connection

### DIFF
--- a/nat-lab/tests/utils/connection_tracker.py
+++ b/nat-lab/tests/utils/connection_tracker.py
@@ -150,10 +150,11 @@ class ConnectionTracker:
             if connection is FiveTuple():
                 continue
 
-            if not self._sync_event.is_set():
-                if self._sync_connection.partial_eq(connection):
+            if self._sync_connection.partial_eq(connection):
+                if not self._sync_event.is_set():
                     self._sync_event.set()
-                    continue
+                # always skip events from sync_connection
+                continue
 
             # skip if we are only interested in new events
             if not self._process_update_events and event.event_type != EventType.NEW:


### PR DESCRIPTION
### Problem
Sometimes sync events get counted towards ICMP events and some tests fail.

### Solution
Don't count any ICMP events from 127.0.0.2


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
