### PR TITLE
[LLT-5635] Fix Teliod test

### DIFF
--- a/nat-lab/tests/test_teliod.py
+++ b/nat-lab/tests/test_teliod.py
@@ -1,4 +1,5 @@
 import asyncio
+import pytest
 from contextlib import AsyncExitStack
 from helpers import setup_connections
 from utils.connection_util import ConnectionTag
@@ -6,6 +7,7 @@ from utils.process.process import ProcessExecError
 
 TELIOD_EXEC_PATH = "/libtelio/dist/linux/release/x86_64/teliod"
 CONFIG_FILE_PATH = "/etc/teliod/config.json"
+SOCKET_FILE_PATH = "/run/teliod.sock"
 
 TELIOD_START_PARAMS = [
     TELIOD_EXEC_PATH,
@@ -16,6 +18,14 @@ TELIOD_START_PARAMS = [
 TELIOD_HELLO_WORLD_PARAMS = [TELIOD_EXEC_PATH, "hello-world", "TestName"]
 
 TELIOD_STOP_PARAMS = [TELIOD_EXEC_PATH, "stop"]
+
+
+async def is_teliod_running(connection):
+    try:
+        await connection.create_process(["test", "-e", SOCKET_FILE_PATH]).execute()
+        return True
+    except:
+        return False
 
 
 async def test_teliod() -> None:
@@ -30,56 +40,31 @@ async def test_teliod() -> None:
         )
 
         # Let the daemon start
-        await asyncio.sleep(1)
+        while not await is_teliod_running(connection):
+            await asyncio.sleep(0.1)
 
-        try:
-            await asyncio.wait_for(
-                connection.create_process(TELIOD_START_PARAMS).execute(),
-                1,
-            )
-            assert False
-        except ProcessExecError as err:
-            assert err.stderr == "Error: DaemonIsRunning"
+        with pytest.raises(ProcessExecError) as err:
+            await connection.create_process(TELIOD_START_PARAMS).execute()
+        assert err.value.stderr == "Error: DaemonIsRunning"
 
         # Run the hello-world command
         assert (
             "Command executed successfully"
             == (
-                await asyncio.wait_for(
-                    connection.create_process(TELIOD_HELLO_WORLD_PARAMS).execute(),
-                    1,
-                )
+                await connection.create_process(TELIOD_HELLO_WORLD_PARAMS).execute()
             ).get_stdout()
         )
 
         assert teliod_process.is_executing()
 
-        # Get Teliod PID
-        teliod_pid = (
-            await asyncio.wait_for(
-                connection.create_process(["pidof", "teliod"]).execute(),
-                1,
-            )
-        ).get_stdout()
-
-        print(f"Teliod PID: {teliod_pid}")
-
         # Send SIGTERM to the daemon
-        await asyncio.wait_for(
-            connection.create_process(["kill", f"{teliod_pid}"]).execute(),
-            1,
-        )
-
-        # Let the daemon stop
-        await asyncio.sleep(1)
+        await connection.create_process(
+            ["killall", "-w", "-s", "SIGTERM", "teliod"]
+        ).execute()
 
         assert not teliod_process.is_executing()
 
         # Run the hello-world command again - this time it should fail
-        try:
-            await asyncio.wait_for(
-                connection.create_process(TELIOD_HELLO_WORLD_PARAMS).execute(),
-                1,
-            )
-        except ProcessExecError as err:
-            assert err.stderr == "Error: DaemonIsNotRunning"
+        with pytest.raises(ProcessExecError) as err:
+            await connection.create_process(TELIOD_HELLO_WORLD_PARAMS).execute()
+        assert err.value.stderr == "Error: DaemonIsNotRunning"


### PR DESCRIPTION
### Problem
Teliod test is flaky

### Solution
Removes sleeps and timeouts, ensures that the socket is created before running the next Teliod instance, uses waiting killall instead of kill.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
