### PR TITLE
LLT-5547: Use generated adapter type

### DIFF
--- a/nat-lab/tests/conftest.py
+++ b/nat-lab/tests/conftest.py
@@ -6,7 +6,7 @@ from contextlib import AsyncExitStack
 from helpers import SetupParameters, setup_connections
 from interderp_cli import InterDerpClient
 from mesh_api import start_tcpdump, stop_tcpdump
-from telio import AdapterType
+from utils.bindings import TelioAdapterType
 from utils.connection import DockerConnection
 from utils.connection_util import ConnectionTag, LAN_ADDR_MAP
 from utils.router import IPStack
@@ -70,7 +70,7 @@ def pytest_make_parametrize_id(config, val):
         param_id = f"{param_id[1:]}"
     elif isinstance(val, (SetupParameters,)):
         short_conn_tag_name = val.connection_tag.name.removeprefix("DOCKER_")
-        param_id = f"{short_conn_tag_name}-{val.adapter_type.name}"
+        param_id = f"{short_conn_tag_name}-{val.adapter_type_override.name.replace('_', '') if val.adapter_type_override is not None else ''}"
         if (
             val.features.direct is not None
             and val.features.direct.providers is not None
@@ -84,8 +84,8 @@ def pytest_make_parametrize_id(config, val):
             )
     elif isinstance(val, (ConnectionTag,)):
         param_id = val.name.removeprefix("DOCKER_")
-    elif isinstance(val, (AdapterType,)):
-        param_id = val.name
+    elif isinstance(val, (TelioAdapterType,)):
+        param_id = val.name.replace("_", "")
     elif isinstance(val, IPStack):
         if val == IPStack.IPv4:
             param_id = "IPv4"

--- a/nat-lab/tests/test_adapter.py
+++ b/nat-lab/tests/test_adapter.py
@@ -1,8 +1,7 @@
 import pytest
 from contextlib import AsyncExitStack
 from helpers import SetupParameters, setup_mesh_nodes, setup_connections
-from telio import AdapterType
-from utils.bindings import ErrorEvent, ErrorCode, ErrorLevel
+from utils.bindings import ErrorEvent, ErrorCode, ErrorLevel, TelioAdapterType
 from utils.connection import TargetOS
 from utils.connection_util import ConnectionTag
 from utils.process import ProcessExecError
@@ -14,27 +13,27 @@ from utils.process import ProcessExecError
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                adapter_type=AdapterType.BoringTun,
+                adapter_type_override=TelioAdapterType.BORING_TUN,
             ),
         ),
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                adapter_type=AdapterType.LinuxNativeWg,
+                adapter_type_override=TelioAdapterType.LINUX_NATIVE_TUN,
             ),
             marks=[pytest.mark.linux_native],
         ),
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.WINDOWS_VM_1,
-                adapter_type=AdapterType.WindowsNativeWg,
+                adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
             ),
             marks=[pytest.mark.windows],
         ),
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.WINDOWS_VM_1,
-                adapter_type=AdapterType.WireguardGo,
+                adapter_type_override=TelioAdapterType.WIREGUARD_GO_TUN,
             ),
             marks=[pytest.mark.windows],
         ),
@@ -86,14 +85,14 @@ async def test_adapter_gone_event(alpha_setup_params: SetupParameters) -> None:
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.WINDOWS_VM_1,
-                adapter_type=AdapterType.WindowsNativeWg,
+                adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
             ),
             marks=[pytest.mark.windows],
         ),
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.WINDOWS_VM_1,
-                adapter_type=AdapterType.WireguardGo,
+                adapter_type_override=TelioAdapterType.WIREGUARD_GO_TUN,
             ),
             marks=[pytest.mark.windows],
         ),

--- a/nat-lab/tests/test_batching.py
+++ b/nat-lab/tests/test_batching.py
@@ -1,12 +1,10 @@
 import asyncio
 import pytest
 import random
-import telio
 from contextlib import AsyncExitStack
 from helpers import SetupParameters, setup_environment
 from itertools import zip_longest
 from scapy.layers.inet import TCP, UDP  # type: ignore
-from telio import AdapterType
 from timeouts import TEST_BATCHING_TIMEOUT
 from typing import List, Tuple
 from utils.batching import (
@@ -21,6 +19,7 @@ from utils.bindings import (
     FeatureBatching,
     EndpointProvider,
     RelayState,
+    TelioAdapterType,
 )
 from utils.connection import DockerConnection
 from utils.connection_util import DOCKER_GW_MAP, ConnectionTag, container_id
@@ -30,7 +29,7 @@ BATCHING_CAPTURE_TIME = 240  # Tied to TEST_BATCHING_TIMEOUT
 
 
 def _generate_setup_parameters(
-    conn_tag: ConnectionTag, adapter: telio.AdapterType, batching: bool
+    conn_tag: ConnectionTag, adapter: TelioAdapterType, batching: bool
 ) -> SetupParameters:
     features = features_with_endpoint_providers(
         [EndpointProvider.UPNP, EndpointProvider.LOCAL, EndpointProvider.STUN]
@@ -51,7 +50,7 @@ def _generate_setup_parameters(
 
     return SetupParameters(
         connection_tag=conn_tag,
-        adapter_type=adapter,
+        adapter_type_override=adapter,
         features=features,
     )
 
@@ -59,64 +58,64 @@ def _generate_setup_parameters(
 ALL_NODES = [
     (
         ConnectionTag.DOCKER_CONE_CLIENT_1,
-        AdapterType.LinuxNativeWg,
+        TelioAdapterType.LINUX_NATIVE_TUN,
     ),
     (
         ConnectionTag.DOCKER_CONE_CLIENT_2,
-        AdapterType.LinuxNativeWg,
+        TelioAdapterType.LINUX_NATIVE_TUN,
     ),
     (
         ConnectionTag.DOCKER_SYMMETRIC_CLIENT_1,
-        AdapterType.LinuxNativeWg,
+        TelioAdapterType.LINUX_NATIVE_TUN,
     ),
     (
         ConnectionTag.DOCKER_SYMMETRIC_CLIENT_2,
-        AdapterType.LinuxNativeWg,
+        TelioAdapterType.LINUX_NATIVE_TUN,
     ),
     (
         ConnectionTag.DOCKER_UPNP_CLIENT_1,
-        AdapterType.LinuxNativeWg,
+        TelioAdapterType.LINUX_NATIVE_TUN,
     ),
     (
         ConnectionTag.DOCKER_UPNP_CLIENT_2,
-        AdapterType.LinuxNativeWg,
+        TelioAdapterType.LINUX_NATIVE_TUN,
     ),
     (
         ConnectionTag.DOCKER_SHARED_CLIENT_1,
-        AdapterType.LinuxNativeWg,
+        TelioAdapterType.LINUX_NATIVE_TUN,
     ),
     (
         ConnectionTag.DOCKER_OPEN_INTERNET_CLIENT_1,
-        AdapterType.LinuxNativeWg,
+        TelioAdapterType.LINUX_NATIVE_TUN,
     ),
     (
         ConnectionTag.DOCKER_OPEN_INTERNET_CLIENT_2,
-        AdapterType.LinuxNativeWg,
+        TelioAdapterType.LINUX_NATIVE_TUN,
     ),
     (
         ConnectionTag.DOCKER_OPEN_INTERNET_CLIENT_DUAL_STACK,
-        AdapterType.LinuxNativeWg,
+        TelioAdapterType.LINUX_NATIVE_TUN,
     ),
     (
         ConnectionTag.DOCKER_UDP_BLOCK_CLIENT_1,
-        AdapterType.LinuxNativeWg,
+        TelioAdapterType.LINUX_NATIVE_TUN,
     ),
     (
         ConnectionTag.DOCKER_UDP_BLOCK_CLIENT_2,
-        AdapterType.LinuxNativeWg,
+        TelioAdapterType.LINUX_NATIVE_TUN,
     ),
     (
         ConnectionTag.DOCKER_INTERNAL_SYMMETRIC_CLIENT,
-        AdapterType.LinuxNativeWg,
+        TelioAdapterType.LINUX_NATIVE_TUN,
     ),
-    (ConnectionTag.DOCKER_FULLCONE_CLIENT_1, AdapterType.LinuxNativeWg),
-    (ConnectionTag.DOCKER_FULLCONE_CLIENT_2, AdapterType.LinuxNativeWg),
+    (ConnectionTag.DOCKER_FULLCONE_CLIENT_1, TelioAdapterType.LINUX_NATIVE_TUN),
+    (ConnectionTag.DOCKER_FULLCONE_CLIENT_2, TelioAdapterType.LINUX_NATIVE_TUN),
     (
         ConnectionTag.MAC_VM,
-        AdapterType.BoringTun,
+        TelioAdapterType.BORING_TUN,
     ),
-    (ConnectionTag.WINDOWS_VM_1, AdapterType.WindowsNativeWg),
-    (ConnectionTag.WINDOWS_VM_2, AdapterType.WireguardGo),
+    (ConnectionTag.WINDOWS_VM_1, TelioAdapterType.WINDOWS_NATIVE_TUN),
+    (ConnectionTag.WINDOWS_VM_2, TelioAdapterType.WIREGUARD_GO_TUN),
 ]
 # This test captures histograms of network activity to evaluate the effect of local batching in libtelio.
 # Since only local batching is implemented, no client-generated traffic should occur during the test.

--- a/nat-lab/tests/test_cleanup.py
+++ b/nat-lab/tests/test_cleanup.py
@@ -1,7 +1,7 @@
 import pytest
-import telio
 from contextlib import AsyncExitStack
 from helpers import SetupParameters, setup_environment
+from utils.bindings import TelioAdapterType
 from utils.connection_util import ConnectionTag, new_connection_raw
 from utils.vm.windows_vm_util import _get_network_interface_tunnel_keys
 
@@ -11,8 +11,8 @@ from utils.vm.windows_vm_util import _get_network_interface_tunnel_keys
 @pytest.mark.parametrize(
     "adapter_type, name",
     [
-        (telio.AdapterType.WireguardGo, "Wintun Userspace Tunnel"),
-        (telio.AdapterType.WindowsNativeWg, "WireGuard Tunnel"),
+        (TelioAdapterType.WIREGUARD_GO_TUN, "Wintun Userspace Tunnel"),
+        (TelioAdapterType.WINDOWS_NATIVE_TUN, "WireGuard Tunnel"),
     ],
 )
 async def test_get_network_interface_tunnel_keys(adapter_type, name) -> None:
@@ -27,11 +27,11 @@ async def test_get_network_interface_tunnel_keys(adapter_type, name) -> None:
                 [
                     SetupParameters(
                         connection_tag=ConnectionTag.WINDOWS_VM_1,
-                        adapter_type=adapter_type,
+                        adapter_type_override=adapter_type,
                     ),
                     SetupParameters(
                         connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2,
-                        adapter_type=telio.AdapterType.LinuxNativeWg,
+                        adapter_type_override=TelioAdapterType.LINUX_NATIVE_TUN,
                     ),
                 ],
             )

--- a/nat-lab/tests/test_connection_states.py
+++ b/nat-lab/tests/test_connection_states.py
@@ -1,7 +1,7 @@
 import pytest
-import telio
 from contextlib import AsyncExitStack
 from helpers import SetupParameters, setup_mesh_nodes
+from utils.bindings import TelioAdapterType
 from utils.connection_tracker import ConnectionLimits
 from utils.connection_util import generate_connection_tracker_config, ConnectionTag
 from utils.ping import ping
@@ -14,7 +14,7 @@ from utils.ping import ping
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                adapter_type=telio.AdapterType.BoringTun,
+                adapter_type_override=TelioAdapterType.BORING_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
                     derp_1_limits=ConnectionLimits(1, 1),
@@ -24,7 +24,7 @@ from utils.ping import ping
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                adapter_type=telio.AdapterType.LinuxNativeWg,
+                adapter_type_override=TelioAdapterType.LINUX_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
                     derp_1_limits=ConnectionLimits(1, 1),
@@ -35,7 +35,7 @@ from utils.ping import ping
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.WINDOWS_VM_1,
-                adapter_type=telio.AdapterType.WindowsNativeWg,
+                adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
                     derp_1_limits=ConnectionLimits(1, 1),
@@ -46,7 +46,7 @@ from utils.ping import ping
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.WINDOWS_VM_1,
-                adapter_type=telio.AdapterType.WireguardGo,
+                adapter_type_override=TelioAdapterType.WIREGUARD_GO_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
                     derp_1_limits=ConnectionLimits(1, 1),
@@ -57,7 +57,7 @@ from utils.ping import ping
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.MAC_VM,
-                adapter_type=telio.AdapterType.BoringTun,
+                adapter_type_override=TelioAdapterType.BORING_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.MAC_VM,
                     derp_1_limits=ConnectionLimits(1, 1),

--- a/nat-lab/tests/test_derp_connect.py
+++ b/nat-lab/tests/test_derp_connect.py
@@ -40,7 +40,6 @@ async def test_derp_reconnect_2clients(setup_params: List[SetupParameters]) -> N
         #  [GW1]     [GW2]
         #   /           \
         # [ALPHA]     [BETA]
-
         await ping(alpha_connection, beta.ip_addresses[0])
 
         # ==============================================================

--- a/nat-lab/tests/test_direct_connection.py
+++ b/nat-lab/tests/test_direct_connection.py
@@ -4,7 +4,6 @@ import config
 import itertools
 import pytest
 import re
-import telio
 import timeouts
 from config import DERP_SERVERS
 from contextlib import AsyncExitStack
@@ -21,6 +20,7 @@ from utils.bindings import (
     FeatureEndpointProvidersOptimization,
     EndpointProvider,
     PathType,
+    TelioAdapterType,
     NodeState,
     RelayState,
 )
@@ -60,7 +60,7 @@ def _generate_setup_parameter_pair(
     return [
         SetupParameters(
             connection_tag=conn_tag,
-            adapter_type=telio.AdapterType.BoringTun,
+            adapter_type_override=TelioAdapterType.BORING_TUN,
             features=features(endpoint_providers, batching),
             fingerprint=f"{conn_tag}",
         )
@@ -434,7 +434,7 @@ async def test_direct_working_paths_stun_ipv6() -> None:
     setup_params = [
         SetupParameters(
             connection_tag=conn_tag,
-            adapter_type=telio.AdapterType.BoringTun,
+            adapter_type_override=TelioAdapterType.BORING_TUN,
             features=features,
         )
         for conn_tag in [

--- a/nat-lab/tests/test_dns.py
+++ b/nat-lab/tests/test_dns.py
@@ -9,9 +9,8 @@ import timeouts
 from config import LIBTELIO_DNS_IPV4, LIBTELIO_DNS_IPV6
 from contextlib import AsyncExitStack
 from helpers import SetupParameters, setup_api, setup_environment, setup_mesh_nodes
-from telio import AdapterType
 from typing import List
-from utils.bindings import default_features, FeatureDns
+from utils.bindings import default_features, FeatureDns, TelioAdapterType
 from utils.connection_tracker import ConnectionLimits
 from utils.connection_util import ConnectionTag, generate_connection_tracker_config
 from utils.dns import query_dns, query_dns_port
@@ -444,7 +443,7 @@ async def test_dns_stability(alpha_ip_stack: IPStack) -> None:
                 SetupParameters(
                     connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
                     ip_stack=alpha_ip_stack,
-                    adapter_type=AdapterType.BoringTun,
+                    adapter_type_override=TelioAdapterType.BORING_TUN,
                     connection_tracker_config=generate_connection_tracker_config(
                         ConnectionTag.DOCKER_CONE_CLIENT_1,
                         derp_1_limits=ConnectionLimits(1, 1),

--- a/nat-lab/tests/test_dns_through_exit.py
+++ b/nat-lab/tests/test_dns_through_exit.py
@@ -1,10 +1,10 @@
 import asyncio
 import config
 import pytest
-import telio
 from contextlib import AsyncExitStack
 from helpers import setup_mesh_nodes, SetupParameters
 from typing import List, Tuple
+from utils.bindings import TelioAdapterType
 from utils.connection_tracker import ConnectionLimits
 from utils.connection_util import generate_connection_tracker_config, ConnectionTag
 from utils.dns import query_dns
@@ -55,7 +55,7 @@ from utils.router import IPStack
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                adapter_type=telio.AdapterType.BoringTun,
+                adapter_type_override=TelioAdapterType.BORING_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
                     derp_1_limits=ConnectionLimits(1, 1),
@@ -65,7 +65,7 @@ from utils.router import IPStack
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                adapter_type=telio.AdapterType.LinuxNativeWg,
+                adapter_type_override=TelioAdapterType.LINUX_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
                     derp_1_limits=ConnectionLimits(1, 1),
@@ -77,7 +77,7 @@ from utils.router import IPStack
         # pytest.param(
         #     SetupParameters(
         #         connection_tag=ConnectionTag.MAC_VM,
-        #         adapter_type=telio.AdapterType.BoringTun,
+        #         adapter_type_override=TelioAdapterType.BORING_TUN,
         #         connection_tracker_config=generate_connection_tracker_config(
         #             ConnectionTag.MAC_VM,
         #             derp_1_limits=ConnectionLimits(1, 1),

--- a/nat-lab/tests/test_downgrade.py
+++ b/nat-lab/tests/test_downgrade.py
@@ -2,7 +2,6 @@ import asyncio
 import pytest
 from contextlib import AsyncExitStack
 from helpers import setup_mesh_nodes, SetupParameters
-from telio import AdapterType
 from typing import List, Tuple
 from utils.bindings import (
     default_features,
@@ -10,6 +9,7 @@ from utils.bindings import (
     FeaturePersistentKeepalive,
     EndpointProvider,
     PathType,
+    TelioAdapterType,
     NodeState,
 )
 from utils.connection_util import ConnectionTag
@@ -17,7 +17,7 @@ from utils.ping import ping
 
 
 def _generate_setup_parameter_pair(
-    cfg: List[Tuple[ConnectionTag, AdapterType]],
+    cfg: List[Tuple[ConnectionTag, TelioAdapterType]],
 ) -> List[SetupParameters]:
     features = default_features(enable_link_detection=True, enable_direct=True)
     features.wireguard.persistent_keepalive = FeaturePersistentKeepalive(
@@ -31,7 +31,7 @@ def _generate_setup_parameter_pair(
     return [
         SetupParameters(
             connection_tag=tag,
-            adapter_type=adapter,
+            adapter_type_override=adapter,
             features=features,
         )
         for tag, adapter in cfg
@@ -44,8 +44,8 @@ def _generate_setup_parameter_pair(
     [
         pytest.param(
             _generate_setup_parameter_pair([
-                (ConnectionTag.DOCKER_CONE_CLIENT_1, AdapterType.BoringTun),
-                (ConnectionTag.DOCKER_CONE_CLIENT_2, AdapterType.BoringTun),
+                (ConnectionTag.DOCKER_CONE_CLIENT_1, TelioAdapterType.BORING_TUN),
+                (ConnectionTag.DOCKER_CONE_CLIENT_2, TelioAdapterType.BORING_TUN),
             ])
         )
     ],
@@ -106,8 +106,8 @@ async def test_downgrade_using_link_detection(
     [
         pytest.param(
             _generate_setup_parameter_pair([
-                (ConnectionTag.DOCKER_CONE_CLIENT_1, AdapterType.BoringTun),
-                (ConnectionTag.DOCKER_CONE_CLIENT_2, AdapterType.BoringTun),
+                (ConnectionTag.DOCKER_CONE_CLIENT_1, TelioAdapterType.BORING_TUN),
+                (ConnectionTag.DOCKER_CONE_CLIENT_2, TelioAdapterType.BORING_TUN),
             ])  # Disable enhanced detection via pinging to reduce the test duration
         )
     ],

--- a/nat-lab/tests/test_events.py
+++ b/nat-lab/tests/test_events.py
@@ -5,7 +5,7 @@ import timeouts
 from contextlib import AsyncExitStack
 from helpers import SetupParameters, setup_environment, setup_mesh_nodes, setup_api
 from mesh_api import API
-from telio import AdapterType, Client
+from telio import Client
 from utils import stun
 from utils.bindings import (
     features_with_endpoint_providers,
@@ -15,6 +15,7 @@ from utils.bindings import (
     NodeState,
     RelayState,
     telio_node,
+    TelioAdapterType,
 )
 from utils.connection_tracker import ConnectionLimits
 from utils.connection_util import (
@@ -68,7 +69,7 @@ def node_cmp(left: TelioNode, right: TelioNode):
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                adapter_type=AdapterType.BoringTun,
+                adapter_type_override=TelioAdapterType.BORING_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
                     derp_1_limits=ConnectionLimits(1, 1),
@@ -78,7 +79,7 @@ def node_cmp(left: TelioNode, right: TelioNode):
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                adapter_type=AdapterType.LinuxNativeWg,
+                adapter_type_override=TelioAdapterType.LINUX_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
                     derp_1_limits=ConnectionLimits(1, 1),
@@ -89,7 +90,7 @@ def node_cmp(left: TelioNode, right: TelioNode):
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.WINDOWS_VM_1,
-                adapter_type=AdapterType.WindowsNativeWg,
+                adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
                     derp_1_limits=ConnectionLimits(1, 1),
@@ -100,7 +101,7 @@ def node_cmp(left: TelioNode, right: TelioNode):
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.WINDOWS_VM_1,
-                adapter_type=AdapterType.WireguardGo,
+                adapter_type_override=TelioAdapterType.WIREGUARD_GO_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
                     derp_1_limits=ConnectionLimits(1, 1),
@@ -111,7 +112,7 @@ def node_cmp(left: TelioNode, right: TelioNode):
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.MAC_VM,
-                adapter_type=AdapterType.BoringTun,
+                adapter_type_override=TelioAdapterType.BORING_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.MAC_VM,
                     derp_1_limits=ConnectionLimits(1, 1),
@@ -223,7 +224,7 @@ async def test_event_content_meshnet(
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                adapter_type=AdapterType.BoringTun,
+                adapter_type_override=TelioAdapterType.BORING_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
                     vpn_1_limits=ConnectionLimits(1, 1),
@@ -236,7 +237,7 @@ async def test_event_content_meshnet(
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                adapter_type=AdapterType.LinuxNativeWg,
+                adapter_type_override=TelioAdapterType.LINUX_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
                     vpn_1_limits=ConnectionLimits(1, 1),
@@ -250,7 +251,7 @@ async def test_event_content_meshnet(
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.WINDOWS_VM_1,
-                adapter_type=AdapterType.WindowsNativeWg,
+                adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
                     vpn_1_limits=ConnectionLimits(1, 1),
@@ -266,7 +267,7 @@ async def test_event_content_meshnet(
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.WINDOWS_VM_1,
-                adapter_type=AdapterType.WireguardGo,
+                adapter_type_override=TelioAdapterType.WIREGUARD_GO_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
                     vpn_1_limits=ConnectionLimits(1, 1),
@@ -282,7 +283,7 @@ async def test_event_content_meshnet(
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.MAC_VM,
-                adapter_type=AdapterType.BoringTun,
+                adapter_type_override=TelioAdapterType.BORING_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.MAC_VM,
                     vpn_1_limits=ConnectionLimits(1, 1),
@@ -371,7 +372,7 @@ async def test_event_content_vpn_connection(
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                adapter_type=AdapterType.BoringTun,
+                adapter_type_override=TelioAdapterType.BORING_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
                     derp_1_limits=ConnectionLimits(1, 1),
@@ -381,7 +382,7 @@ async def test_event_content_vpn_connection(
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                adapter_type=AdapterType.LinuxNativeWg,
+                adapter_type_override=TelioAdapterType.LINUX_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
                     derp_1_limits=ConnectionLimits(1, 1),
@@ -392,7 +393,7 @@ async def test_event_content_vpn_connection(
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.WINDOWS_VM_1,
-                adapter_type=AdapterType.WindowsNativeWg,
+                adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
                     derp_1_limits=ConnectionLimits(1, 1),
@@ -403,7 +404,7 @@ async def test_event_content_vpn_connection(
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.WINDOWS_VM_1,
-                adapter_type=AdapterType.WireguardGo,
+                adapter_type_override=TelioAdapterType.WIREGUARD_GO_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
                     derp_1_limits=ConnectionLimits(1, 1),
@@ -414,7 +415,7 @@ async def test_event_content_vpn_connection(
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.MAC_VM,
-                adapter_type=AdapterType.BoringTun,
+                adapter_type_override=TelioAdapterType.BORING_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.MAC_VM,
                     derp_1_limits=ConnectionLimits(1, 1),
@@ -508,7 +509,7 @@ async def test_event_content_exit_through_peer(
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                adapter_type=AdapterType.BoringTun,
+                adapter_type_override=TelioAdapterType.BORING_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
                     derp_1_limits=ConnectionLimits(1, 1),
@@ -520,7 +521,7 @@ async def test_event_content_exit_through_peer(
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                adapter_type=AdapterType.LinuxNativeWg,
+                adapter_type_override=TelioAdapterType.LINUX_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
                     derp_1_limits=ConnectionLimits(1, 1),
@@ -533,7 +534,7 @@ async def test_event_content_exit_through_peer(
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.WINDOWS_VM_1,
-                adapter_type=AdapterType.WindowsNativeWg,
+                adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
                     derp_1_limits=ConnectionLimits(1, 1),
@@ -546,7 +547,7 @@ async def test_event_content_exit_through_peer(
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.WINDOWS_VM_1,
-                adapter_type=AdapterType.WireguardGo,
+                adapter_type_override=TelioAdapterType.WIREGUARD_GO_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
                     derp_1_limits=ConnectionLimits(1, 1),
@@ -559,7 +560,7 @@ async def test_event_content_exit_through_peer(
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.MAC_VM,
-                adapter_type=AdapterType.BoringTun,
+                adapter_type_override=TelioAdapterType.BORING_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.MAC_VM,
                     derp_1_limits=ConnectionLimits(1, 1),
@@ -621,7 +622,7 @@ async def test_event_content_meshnet_node_upgrade_direct(
             Client(
                 connection_alpha,
                 alpha,
-                alpha_setup_params.adapter_type,
+                alpha_setup_params.adapter_type_override,
                 alpha_setup_params.features,
             ).run(api.get_meshnet_config(alpha.id))
         )
@@ -629,7 +630,7 @@ async def test_event_content_meshnet_node_upgrade_direct(
         async with Client(
             connection_beta,
             beta,
-            beta_setup_params.adapter_type,
+            beta_setup_params.adapter_type_override,
             beta_setup_params.features,
         ).run(api.get_meshnet_config(beta.id)) as client_beta:
             await asyncio.gather(

--- a/nat-lab/tests/test_events_link_state.py
+++ b/nat-lab/tests/test_events_link_state.py
@@ -2,13 +2,14 @@ import asyncio
 import pytest
 from contextlib import AsyncExitStack
 from helpers import SetupParameters, setup_mesh_nodes
-from telio import AdapterType, LinkState
 from typing import List, Tuple
 from utils.bindings import (
     default_features,
     FeatureLinkDetection,
     FeatureWireguard,
     FeaturePersistentKeepalive,
+    LinkState,
+    TelioAdapterType,
 )
 from utils.connection_util import ConnectionTag
 from utils.ping import ping
@@ -23,7 +24,7 @@ def long_persistent_keepalive_periods() -> FeatureWireguard:
 
 
 def _generate_setup_parameter_pair(
-    cfg: List[Tuple[ConnectionTag, AdapterType]],
+    cfg: List[Tuple[ConnectionTag, TelioAdapterType]],
     enhaced_detection: bool,
 ) -> List[SetupParameters]:
     if enhaced_detection:
@@ -40,7 +41,7 @@ def _generate_setup_parameter_pair(
     return [
         SetupParameters(
             connection_tag=tag,
-            adapter_type=adapter,
+            adapter_type_override=adapter,
             features=features,
         )
         for tag, adapter in cfg
@@ -51,16 +52,16 @@ FEATURE_ENABLED_PARAMS = [
     # This scenario has been removed because it was causing flakyness due to LLT-5014.
     # Add it back when the issue is fixed.
     # pytest.param(
-    #     _generate_setup_paramete_pair([
-    #         (ConnectionTag.DOCKER_CONE_CLIENT_1, AdapterType.LinuxNativeWg),
-    #         (ConnectionTag.DOCKER_CONE_CLIENT_2, AdapterType.LinuxNativeWg),
+    #     _generate_setup_parameter_pair([
+    #         (ConnectionTag.DOCKER_CONE_CLIENT_1, TelioAdapterType.LINUX_NATIVE_TUN),
+    #         (ConnectionTag.DOCKER_CONE_CLIENT_2, TelioAdapterType.LINUX_NATIVE_TUN),
     #     ])
     # ),
     pytest.param(
         _generate_setup_parameter_pair(
             [
-                (ConnectionTag.DOCKER_CONE_CLIENT_1, AdapterType.LinuxNativeWg),
-                (ConnectionTag.DOCKER_CONE_CLIENT_2, AdapterType.BoringTun),
+                (ConnectionTag.DOCKER_CONE_CLIENT_1, TelioAdapterType.LINUX_NATIVE_TUN),
+                (ConnectionTag.DOCKER_CONE_CLIENT_2, TelioAdapterType.BORING_TUN),
             ],
             False,
         )
@@ -68,8 +69,8 @@ FEATURE_ENABLED_PARAMS = [
     pytest.param(
         _generate_setup_parameter_pair(
             [
-                (ConnectionTag.DOCKER_CONE_CLIENT_1, AdapterType.LinuxNativeWg),
-                (ConnectionTag.DOCKER_CONE_CLIENT_2, AdapterType.BoringTun),
+                (ConnectionTag.DOCKER_CONE_CLIENT_1, TelioAdapterType.LINUX_NATIVE_TUN),
+                (ConnectionTag.DOCKER_CONE_CLIENT_2, TelioAdapterType.BORING_TUN),
             ],
             True,
         )
@@ -77,8 +78,8 @@ FEATURE_ENABLED_PARAMS = [
     pytest.param(
         _generate_setup_parameter_pair(
             [
-                (ConnectionTag.DOCKER_CONE_CLIENT_1, AdapterType.BoringTun),
-                (ConnectionTag.DOCKER_CONE_CLIENT_2, AdapterType.BoringTun),
+                (ConnectionTag.DOCKER_CONE_CLIENT_1, TelioAdapterType.BORING_TUN),
+                (ConnectionTag.DOCKER_CONE_CLIENT_2, TelioAdapterType.BORING_TUN),
             ],
             False,
         )
@@ -86,8 +87,8 @@ FEATURE_ENABLED_PARAMS = [
     pytest.param(
         _generate_setup_parameter_pair(
             [
-                (ConnectionTag.DOCKER_CONE_CLIENT_1, AdapterType.BoringTun),
-                (ConnectionTag.DOCKER_CONE_CLIENT_2, AdapterType.BoringTun),
+                (ConnectionTag.DOCKER_CONE_CLIENT_1, TelioAdapterType.BORING_TUN),
+                (ConnectionTag.DOCKER_CONE_CLIENT_2, TelioAdapterType.BORING_TUN),
             ],
             True,
         )
@@ -95,8 +96,8 @@ FEATURE_ENABLED_PARAMS = [
     pytest.param(
         _generate_setup_parameter_pair(
             [
-                (ConnectionTag.WINDOWS_VM_1, AdapterType.WindowsNativeWg),
-                (ConnectionTag.DOCKER_CONE_CLIENT_1, AdapterType.BoringTun),
+                (ConnectionTag.WINDOWS_VM_1, TelioAdapterType.WINDOWS_NATIVE_TUN),
+                (ConnectionTag.DOCKER_CONE_CLIENT_1, TelioAdapterType.BORING_TUN),
             ],
             False,
         ),
@@ -105,8 +106,8 @@ FEATURE_ENABLED_PARAMS = [
     pytest.param(
         _generate_setup_parameter_pair(
             [
-                (ConnectionTag.WINDOWS_VM_1, AdapterType.WindowsNativeWg),
-                (ConnectionTag.DOCKER_CONE_CLIENT_1, AdapterType.BoringTun),
+                (ConnectionTag.WINDOWS_VM_1, TelioAdapterType.WINDOWS_NATIVE_TUN),
+                (ConnectionTag.DOCKER_CONE_CLIENT_1, TelioAdapterType.BORING_TUN),
             ],
             True,
         ),
@@ -118,11 +119,11 @@ FEATURE_DISABLED_PARAMS = [
     pytest.param([
         SetupParameters(
             connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-            adapter_type=AdapterType.BoringTun,
+            adapter_type_override=TelioAdapterType.BORING_TUN,
         ),
         SetupParameters(
             connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2,
-            adapter_type=AdapterType.BoringTun,
+            adapter_type_override=TelioAdapterType.BORING_TUN,
         ),
     ])
 ]

--- a/nat-lab/tests/test_fire_connecting_event.py
+++ b/nat-lab/tests/test_fire_connecting_event.py
@@ -3,8 +3,7 @@ import pytest
 import timeouts
 from contextlib import AsyncExitStack
 from helpers import SetupParameters, setup_mesh_nodes
-from telio import AdapterType
-from utils.bindings import NodeState
+from utils.bindings import NodeState, TelioAdapterType
 from utils.connection_tracker import ConnectionLimits
 from utils.connection_util import generate_connection_tracker_config, ConnectionTag
 from utils.ping import ping
@@ -18,7 +17,7 @@ from utils.ping import ping
     [
         SetupParameters(
             connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-            adapter_type=AdapterType.BoringTun,
+            adapter_type_override=TelioAdapterType.BORING_TUN,
             connection_tracker_config=generate_connection_tracker_config(
                 ConnectionTag.DOCKER_CONE_CLIENT_1, derp_1_limits=ConnectionLimits(1, 1)
             ),

--- a/nat-lab/tests/test_lana.py
+++ b/nat-lab/tests/test_lana.py
@@ -4,7 +4,6 @@ import asyncio
 import base64
 import pytest
 import subprocess
-import telio
 from config import (
     WG_SERVER,
     STUN_SERVER,
@@ -16,6 +15,7 @@ from config import (
 from contextlib import AsyncExitStack
 from helpers import connectivity_stack
 from mesh_api import API, Node
+from telio import Client
 from typing import List, Optional
 from utils import testing, stun
 from utils.analytics import fetch_moose_events, DERP_BIT, WG_BIT, IPV4_BIT, IPV6_BIT
@@ -262,9 +262,9 @@ async def start_alpha_beta_in_relay(
     connection_beta: Connection,
     alpha_features: Features,
     beta_features: Features,
-) -> tuple[telio.Client, telio.Client]:
+) -> tuple[Client, Client]:
     client_alpha = await exit_stack.enter_async_context(
-        telio.Client(
+        Client(
             connection_alpha,
             alpha,
             telio_features=alpha_features,
@@ -272,7 +272,7 @@ async def start_alpha_beta_in_relay(
         ).run(api.get_meshnet_config(alpha.id))
     )
 
-    client_beta = telio.Client(
+    client_beta = Client(
         connection_beta,
         beta,
         telio_features=beta_features,
@@ -382,7 +382,7 @@ async def run_default_scenario(
         build_telio_features(),
     )
     client_gamma = await exit_stack.enter_async_context(
-        telio.Client(
+        Client(
             connection_gamma,
             gamma,
             telio_features=build_telio_features(),
@@ -1908,7 +1908,7 @@ async def test_lana_with_second_node_joining_later_meshnet_id_can_change(
         await clean_container(connection_beta)
 
         client_beta = await exit_stack.enter_async_context(
-            telio.Client(
+            Client(
                 connection_beta,
                 beta,
                 telio_features=build_telio_features(),
@@ -1936,7 +1936,7 @@ async def test_lana_with_second_node_joining_later_meshnet_id_can_change(
 
         alpha.set_peer_firewall_settings(beta.id, allow_incoming_connections=True)
         client_alpha = await exit_stack.enter_async_context(
-            telio.Client(
+            Client(
                 connection_alpha,
                 alpha,
                 telio_features=build_telio_features(),
@@ -2004,7 +2004,7 @@ async def test_lana_same_meshnet_id_is_reported_after_a_restart(
         )
         await clean_container(connection_beta)
 
-        async with telio.Client(
+        async with Client(
             connection_beta,
             beta,
             telio_features=build_telio_features(),
@@ -2026,7 +2026,7 @@ async def test_lana_same_meshnet_id_is_reported_after_a_restart(
         )
 
         client_beta = await exit_stack.enter_async_context(
-            telio.Client(
+            Client(
                 connection_beta,
                 beta,
                 telio_features=build_telio_features(),
@@ -2062,7 +2062,7 @@ async def test_lana_initial_heartbeat_no_trigger(
         await clean_container(connection_alpha)
 
         await exit_stack.enter_async_context(
-            telio.Client(
+            Client(
                 connection_alpha,
                 alpha,
                 telio_features=build_telio_features(

--- a/nat-lab/tests/test_mesh_firewall.py
+++ b/nat-lab/tests/test_mesh_firewall.py
@@ -3,13 +3,13 @@
 import asyncio
 import config
 import pytest
-import telio
 from contextlib import AsyncExitStack
 from datetime import datetime
 from helpers import SetupParameters, setup_mesh_nodes, setup_api
 from mesh_api import Node
-from typing import Tuple
+from typing import Tuple, Optional
 from utils import testing, stun
+from utils.bindings import TelioAdapterType
 from utils.connection_tracker import (
     ConnectionLimits,
     ConnectionTrackerConfig,
@@ -40,12 +40,12 @@ def get_ips_and_stack(alpha: Node, beta: Node) -> Tuple[IPProto, str, str]:
 
 def _setup_params(
     connection_tag: ConnectionTag,
-    adapter_type: telio.AdapterType = telio.AdapterType.Default,
+    adapter_type_override: Optional[TelioAdapterType] = None,
     stun_limits: ConnectionLimits = ConnectionLimits(0, 0),
 ) -> SetupParameters:
     return SetupParameters(
         connection_tag=connection_tag,
-        adapter_type=adapter_type,
+        adapter_type_override=adapter_type_override,
         connection_tracker_config=generate_connection_tracker_config(
             connection_tag,
             derp_1_limits=ConnectionLimits(1, 1),
@@ -97,7 +97,7 @@ async def test_mesh_firewall_successful_passthrough(
             exit_stack,
             [
                 _setup_params(
-                    ConnectionTag.DOCKER_CONE_CLIENT_1, telio.AdapterType.BoringTun
+                    ConnectionTag.DOCKER_CONE_CLIENT_1, TelioAdapterType.BORING_TUN
                 ),
                 _setup_params(ConnectionTag.DOCKER_CONE_CLIENT_2),
             ],
@@ -200,7 +200,7 @@ async def test_mesh_firewall_reject_packet(
             exit_stack,
             [
                 _setup_params(
-                    ConnectionTag.DOCKER_CONE_CLIENT_1, telio.AdapterType.BoringTun
+                    ConnectionTag.DOCKER_CONE_CLIENT_1, TelioAdapterType.BORING_TUN
                 ),
                 _setup_params(ConnectionTag.DOCKER_CONE_CLIENT_2),
             ],
@@ -259,7 +259,7 @@ async def test_blocking_incoming_connections_from_exit_node() -> None:
             [
                 _setup_params(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
-                    telio.AdapterType.BoringTun,
+                    TelioAdapterType.BORING_TUN,
                     stun_limits=ConnectionLimits(1, 1),
                 ),
                 _setup_params(
@@ -427,7 +427,7 @@ async def test_mesh_firewall_file_share_port(
             exit_stack,
             [
                 _setup_params(
-                    ConnectionTag.DOCKER_CONE_CLIENT_1, telio.AdapterType.BoringTun
+                    ConnectionTag.DOCKER_CONE_CLIENT_1, TelioAdapterType.BORING_TUN
                 ),
                 _setup_params(ConnectionTag.DOCKER_CONE_CLIENT_2),
             ],
@@ -546,14 +546,14 @@ async def test_mesh_firewall_file_share_port(
 @pytest.mark.parametrize(
     "alpha_adapter_type, beta_adapter_type",
     [
-        (telio.AdapterType.BoringTun, telio.AdapterType.BoringTun),
-        (telio.AdapterType.BoringTun, telio.AdapterType.LinuxNativeWg),
-        (telio.AdapterType.LinuxNativeWg, telio.AdapterType.BoringTun),
+        (TelioAdapterType.BORING_TUN, TelioAdapterType.BORING_TUN),
+        (TelioAdapterType.BORING_TUN, TelioAdapterType.LINUX_NATIVE_TUN),
+        (TelioAdapterType.LINUX_NATIVE_TUN, TelioAdapterType.BORING_TUN),
     ],
 )
 async def test_mesh_firewall_tcp_stuck_in_last_ack_state_conn_kill_from_server_side(
-    alpha_adapter_type: telio.AdapterType,
-    beta_adapter_type: telio.AdapterType,
+    alpha_adapter_type: Optional[TelioAdapterType],
+    beta_adapter_type: Optional[TelioAdapterType],
     alpha_ip_stack: IPStack,
     beta_ip_stack: IPStack,
 ) -> None:
@@ -684,14 +684,14 @@ async def test_mesh_firewall_tcp_stuck_in_last_ack_state_conn_kill_from_server_s
 @pytest.mark.parametrize(
     "alpha_adapter_type, beta_adapter_type",
     [
-        (telio.AdapterType.BoringTun, telio.AdapterType.BoringTun),
-        (telio.AdapterType.BoringTun, telio.AdapterType.LinuxNativeWg),
-        (telio.AdapterType.LinuxNativeWg, telio.AdapterType.BoringTun),
+        (TelioAdapterType.BORING_TUN, TelioAdapterType.BORING_TUN),
+        (TelioAdapterType.BORING_TUN, TelioAdapterType.LINUX_NATIVE_TUN),
+        (TelioAdapterType.LINUX_NATIVE_TUN, TelioAdapterType.BORING_TUN),
     ],
 )
 async def test_mesh_firewall_tcp_stuck_in_last_ack_state_conn_kill_from_client_side(
-    alpha_adapter_type: telio.AdapterType,
-    beta_adapter_type: telio.AdapterType,
+    alpha_adapter_type: Optional[TelioAdapterType],
+    beta_adapter_type: Optional[TelioAdapterType],
     alpha_ip_stack: IPStack,
     beta_ip_stack: IPStack,
 ) -> None:

--- a/nat-lab/tests/test_mesh_off.py
+++ b/nat-lab/tests/test_mesh_off.py
@@ -1,10 +1,15 @@
 import asyncio
 import pytest
-import telio
 from contextlib import AsyncExitStack
 from helpers import SetupParameters, setup_mesh_nodes
 from timeouts import TEST_MESH_STATE_AFTER_DISCONNECTING_NODE_TIMEOUT
-from utils.bindings import default_features, EndpointProvider, PathType, NodeState
+from utils.bindings import (
+    default_features,
+    EndpointProvider,
+    PathType,
+    TelioAdapterType,
+    NodeState,
+)
 from utils.connection_util import ConnectionTag
 from utils.ping import ping
 
@@ -29,12 +34,12 @@ async def test_mesh_off(direct) -> None:
             [
                 SetupParameters(
                     connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                    adapter_type=telio.AdapterType.LinuxNativeWg,
+                    adapter_type_override=TelioAdapterType.LINUX_NATIVE_TUN,
                     features=features,
                 ),
                 SetupParameters(
                     connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2,
-                    adapter_type=telio.AdapterType.LinuxNativeWg,
+                    adapter_type_override=TelioAdapterType.LINUX_NATIVE_TUN,
                     features=features,
                 ),
             ],

--- a/nat-lab/tests/test_mesh_plus_vpn.py
+++ b/nat-lab/tests/test_mesh_plus_vpn.py
@@ -1,16 +1,16 @@
 import asyncio
 import config
 import pytest
-import telio
 import timeouts
 from contextlib import AsyncExitStack
 from helpers import SetupParameters, setup_mesh_nodes
 from mesh_api import API
-from telio import AdapterType
+from telio import Client
 from utils import stun
 from utils.bindings import (
     features_with_endpoint_providers,
     EndpointProvider,
+    TelioAdapterType,
     PathType,
     RelayState,
     NodeState,
@@ -32,7 +32,7 @@ from utils.ping import ping
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                adapter_type=telio.AdapterType.BoringTun,
+                adapter_type_override=TelioAdapterType.BORING_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
                     derp_1_limits=ConnectionLimits(1, 1),
@@ -43,7 +43,7 @@ from utils.ping import ping
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                adapter_type=telio.AdapterType.LinuxNativeWg,
+                adapter_type_override=TelioAdapterType.LINUX_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
                     derp_1_limits=ConnectionLimits(1, 1),
@@ -55,7 +55,7 @@ from utils.ping import ping
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.WINDOWS_VM_1,
-                adapter_type=telio.AdapterType.WindowsNativeWg,
+                adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
                     derp_1_limits=ConnectionLimits(1, 1),
@@ -67,7 +67,7 @@ from utils.ping import ping
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.WINDOWS_VM_1,
-                adapter_type=telio.AdapterType.WireguardGo,
+                adapter_type_override=TelioAdapterType.WIREGUARD_GO_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
                     derp_1_limits=ConnectionLimits(1, 1),
@@ -81,7 +81,7 @@ from utils.ping import ping
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.MAC_VM,
-                adapter_type=telio.AdapterType.BoringTun,
+                adapter_type_override=TelioAdapterType.BORING_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.MAC_VM,
                     derp_1_limits=ConnectionLimits(1, 1),
@@ -143,7 +143,7 @@ async def test_mesh_plus_vpn_one_peer(
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                adapter_type=telio.AdapterType.BoringTun,
+                adapter_type_override=TelioAdapterType.BORING_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
                     derp_1_limits=ConnectionLimits(1, 1),
@@ -154,7 +154,7 @@ async def test_mesh_plus_vpn_one_peer(
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                adapter_type=telio.AdapterType.LinuxNativeWg,
+                adapter_type_override=TelioAdapterType.LINUX_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
                     derp_1_limits=ConnectionLimits(1, 1),
@@ -166,7 +166,7 @@ async def test_mesh_plus_vpn_one_peer(
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.WINDOWS_VM_1,
-                adapter_type=telio.AdapterType.WindowsNativeWg,
+                adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
                     derp_1_limits=ConnectionLimits(1, 1),
@@ -178,7 +178,7 @@ async def test_mesh_plus_vpn_one_peer(
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.WINDOWS_VM_1,
-                adapter_type=telio.AdapterType.WireguardGo,
+                adapter_type_override=TelioAdapterType.WIREGUARD_GO_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
                     derp_1_limits=ConnectionLimits(1, 1),
@@ -192,7 +192,7 @@ async def test_mesh_plus_vpn_one_peer(
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.MAC_VM,
-                adapter_type=telio.AdapterType.BoringTun,
+                adapter_type_override=TelioAdapterType.BORING_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.MAC_VM,
                     derp_1_limits=ConnectionLimits(1, 1),
@@ -268,37 +268,39 @@ async def test_mesh_plus_vpn_both_peers(
     [
         pytest.param(
             ConnectionTag.DOCKER_CONE_CLIENT_1,
-            AdapterType.BoringTun,
+            TelioAdapterType.BORING_TUN,
             "10.0.254.1",
         ),
         pytest.param(
             ConnectionTag.DOCKER_CONE_CLIENT_1,
-            AdapterType.LinuxNativeWg,
+            TelioAdapterType.LINUX_NATIVE_TUN,
             "10.0.254.1",
             marks=pytest.mark.linux_native,
         ),
         pytest.param(
             ConnectionTag.WINDOWS_VM_1,
-            AdapterType.WindowsNativeWg,
+            TelioAdapterType.WINDOWS_NATIVE_TUN,
             "10.0.254.7",
             marks=pytest.mark.windows,
         ),
         pytest.param(
             ConnectionTag.WINDOWS_VM_1,
-            AdapterType.WireguardGo,
+            TelioAdapterType.WIREGUARD_GO_TUN,
             "10.0.254.7",
             marks=pytest.mark.windows,
         ),
         pytest.param(
             ConnectionTag.MAC_VM,
-            AdapterType.Default,
+            TelioAdapterType.BORING_TUN,
             "10.0.254.7",
             marks=pytest.mark.mac,
         ),
     ],
 )
 async def test_vpn_plus_mesh(
-    alpha_connection_tag: ConnectionTag, adapter_type: AdapterType, public_ip: str
+    alpha_connection_tag: ConnectionTag,
+    adapter_type: TelioAdapterType,
+    public_ip: str,
 ) -> None:
     async with AsyncExitStack() as exit_stack:
         api = API()
@@ -329,7 +331,7 @@ async def test_vpn_plus_mesh(
         assert ip == public_ip, f"wrong public IP before connecting to VPN {ip}"
 
         client_alpha = await exit_stack.enter_async_context(
-            telio.Client(connection_alpha, alpha, adapter_type).run()
+            Client(connection_alpha, alpha, adapter_type).run()
         )
 
         wg_server = config.WG_SERVER
@@ -346,7 +348,7 @@ async def test_vpn_plus_mesh(
         await client_alpha.set_meshnet_config(api.get_meshnet_config(alpha.id))
 
         client_beta = await exit_stack.enter_async_context(
-            telio.Client(connection_beta, beta).run(api.get_meshnet_config(beta.id))
+            Client(connection_beta, beta).run(api.get_meshnet_config(beta.id))
         )
 
         await asyncio.gather(
@@ -380,7 +382,7 @@ async def test_vpn_plus_mesh(
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                adapter_type=telio.AdapterType.BoringTun,
+                adapter_type_override=TelioAdapterType.BORING_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
                     derp_1_limits=ConnectionLimits(1, 1),
@@ -394,7 +396,7 @@ async def test_vpn_plus_mesh(
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                adapter_type=telio.AdapterType.LinuxNativeWg,
+                adapter_type_override=TelioAdapterType.LINUX_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
                     derp_1_limits=ConnectionLimits(1, 1),
@@ -411,7 +413,7 @@ async def test_vpn_plus_mesh(
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.WINDOWS_VM_1,
-                adapter_type=telio.AdapterType.WindowsNativeWg,
+                adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
                     derp_1_limits=ConnectionLimits(1, 1),
@@ -428,7 +430,7 @@ async def test_vpn_plus_mesh(
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.WINDOWS_VM_1,
-                adapter_type=telio.AdapterType.WireguardGo,
+                adapter_type_override=TelioAdapterType.WIREGUARD_GO_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
                     derp_1_limits=ConnectionLimits(1, 1),
@@ -445,7 +447,7 @@ async def test_vpn_plus_mesh(
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.MAC_VM,
-                adapter_type=telio.AdapterType.BoringTun,
+                adapter_type_override=TelioAdapterType.BORING_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.MAC_VM,
                     derp_1_limits=ConnectionLimits(1, 1),
@@ -542,7 +544,7 @@ async def test_vpn_plus_mesh_over_direct(
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                adapter_type=telio.AdapterType.BoringTun,
+                adapter_type_override=TelioAdapterType.BORING_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
                     derp_1_limits=ConnectionLimits(1, 1),
@@ -556,7 +558,7 @@ async def test_vpn_plus_mesh_over_direct(
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                adapter_type=telio.AdapterType.LinuxNativeWg,
+                adapter_type_override=TelioAdapterType.LINUX_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
                     derp_1_limits=ConnectionLimits(1, 1),
@@ -571,7 +573,7 @@ async def test_vpn_plus_mesh_over_direct(
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.WINDOWS_VM_1,
-                adapter_type=telio.AdapterType.WindowsNativeWg,
+                adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
                     derp_1_limits=ConnectionLimits(1, 1),
@@ -586,7 +588,7 @@ async def test_vpn_plus_mesh_over_direct(
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.WINDOWS_VM_1,
-                adapter_type=telio.AdapterType.WireguardGo,
+                adapter_type_override=TelioAdapterType.WIREGUARD_GO_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
                     derp_1_limits=ConnectionLimits(1, 1),
@@ -603,7 +605,7 @@ async def test_vpn_plus_mesh_over_direct(
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.MAC_VM,
-                adapter_type=telio.AdapterType.BoringTun,
+                adapter_type_override=TelioAdapterType.BORING_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.MAC_VM,
                     derp_1_limits=ConnectionLimits(1, 1),

--- a/nat-lab/tests/test_mesh_remove_node.py
+++ b/nat-lab/tests/test_mesh_remove_node.py
@@ -1,9 +1,9 @@
 import asyncio
 import pytest
-import telio
 from contextlib import AsyncExitStack
 from helpers import SetupParameters, setup_mesh_nodes
 from mesh_api import API
+from utils.bindings import TelioAdapterType
 from utils.connection_tracker import ConnectionLimits
 from utils.connection_util import generate_connection_tracker_config, ConnectionTag
 from utils.ping import ping
@@ -16,7 +16,7 @@ from utils.ping import ping
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                adapter_type=telio.AdapterType.BoringTun,
+                adapter_type_override=TelioAdapterType.BORING_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
                     derp_1_limits=ConnectionLimits(1, 1),
@@ -26,7 +26,7 @@ from utils.ping import ping
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                adapter_type=telio.AdapterType.LinuxNativeWg,
+                adapter_type_override=TelioAdapterType.LINUX_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
                     derp_1_limits=ConnectionLimits(1, 1),
@@ -37,7 +37,7 @@ from utils.ping import ping
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.WINDOWS_VM_1,
-                adapter_type=telio.AdapterType.WindowsNativeWg,
+                adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
                     derp_1_limits=ConnectionLimits(1, 1),
@@ -50,7 +50,7 @@ from utils.ping import ping
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.WINDOWS_VM_1,
-                adapter_type=telio.AdapterType.WireguardGo,
+                adapter_type_override=TelioAdapterType.WIREGUARD_GO_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
                     derp_1_limits=ConnectionLimits(1, 1),
@@ -61,7 +61,7 @@ from utils.ping import ping
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.MAC_VM,
-                adapter_type=telio.AdapterType.BoringTun,
+                adapter_type_override=TelioAdapterType.BORING_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.MAC_VM,
                     derp_1_limits=ConnectionLimits(1, 1),

--- a/nat-lab/tests/test_multicast_connection.py
+++ b/nat-lab/tests/test_multicast_connection.py
@@ -1,20 +1,19 @@
 import pytest
 from contextlib import AsyncExitStack
 from helpers import setup_mesh_nodes, SetupParameters
-from telio import AdapterType
 from typing import List, Tuple
-from utils.bindings import default_features
+from utils.bindings import default_features, TelioAdapterType
 from utils.connection_util import ConnectionTag, Connection, TargetOS
 from utils.multicast import MulticastClient, MulticastServer
 
 
 def generate_setup_parameter_pair(
-    cfg: List[Tuple[ConnectionTag, AdapterType]],
+    cfg: List[Tuple[ConnectionTag, TelioAdapterType]],
 ) -> List[SetupParameters]:
     return [
         SetupParameters(
             connection_tag=conn_tag,
-            adapter_type=adapter_type,
+            adapter_type_override=adapter_type,
             features=default_features(enable_multicast=True),
         )
         for conn_tag, adapter_type in cfg
@@ -24,44 +23,44 @@ def generate_setup_parameter_pair(
 MUILTICAST_TEST_PARAMS = [
     pytest.param(
         generate_setup_parameter_pair([
-            (ConnectionTag.DOCKER_FULLCONE_CLIENT_1, AdapterType.BoringTun),
-            (ConnectionTag.DOCKER_FULLCONE_CLIENT_2, AdapterType.BoringTun),
+            (ConnectionTag.DOCKER_FULLCONE_CLIENT_1, TelioAdapterType.BORING_TUN),
+            (ConnectionTag.DOCKER_FULLCONE_CLIENT_2, TelioAdapterType.BORING_TUN),
         ]),
         "ssdp",
     ),
     pytest.param(
         generate_setup_parameter_pair([
-            (ConnectionTag.DOCKER_SYMMETRIC_CLIENT_1, AdapterType.BoringTun),
-            (ConnectionTag.DOCKER_SYMMETRIC_CLIENT_2, AdapterType.BoringTun),
+            (ConnectionTag.DOCKER_SYMMETRIC_CLIENT_1, TelioAdapterType.BORING_TUN),
+            (ConnectionTag.DOCKER_SYMMETRIC_CLIENT_2, TelioAdapterType.BORING_TUN),
         ]),
         "mdns",
     ),
     pytest.param(
         generate_setup_parameter_pair([
-            (ConnectionTag.WINDOWS_VM_1, AdapterType.WireguardGo),
-            (ConnectionTag.DOCKER_CONE_CLIENT_1, AdapterType.BoringTun),
+            (ConnectionTag.WINDOWS_VM_1, TelioAdapterType.WIREGUARD_GO_TUN),
+            (ConnectionTag.DOCKER_CONE_CLIENT_1, TelioAdapterType.BORING_TUN),
         ]),
         "ssdp",
     ),
     pytest.param(
         generate_setup_parameter_pair([
-            (ConnectionTag.DOCKER_CONE_CLIENT_1, AdapterType.BoringTun),
-            (ConnectionTag.WINDOWS_VM_1, AdapterType.WindowsNativeWg),
+            (ConnectionTag.DOCKER_CONE_CLIENT_1, TelioAdapterType.BORING_TUN),
+            (ConnectionTag.WINDOWS_VM_1, TelioAdapterType.WINDOWS_NATIVE_TUN),
         ]),
         "mdns",
     ),
     pytest.param(
         generate_setup_parameter_pair([
-            (ConnectionTag.MAC_VM, AdapterType.BoringTun),
-            (ConnectionTag.DOCKER_CONE_CLIENT_1, AdapterType.BoringTun),
+            (ConnectionTag.MAC_VM, TelioAdapterType.BORING_TUN),
+            (ConnectionTag.DOCKER_CONE_CLIENT_1, TelioAdapterType.BORING_TUN),
         ]),
         "ssdp",
         marks=pytest.mark.mac,
     ),
     pytest.param(
         generate_setup_parameter_pair([
-            (ConnectionTag.DOCKER_CONE_CLIENT_1, AdapterType.BoringTun),
-            (ConnectionTag.MAC_VM, AdapterType.BoringTun),
+            (ConnectionTag.DOCKER_CONE_CLIENT_1, TelioAdapterType.BORING_TUN),
+            (ConnectionTag.MAC_VM, TelioAdapterType.BORING_TUN),
         ]),
         "mdns",
         marks=pytest.mark.mac,

--- a/nat-lab/tests/test_network_monitor.py
+++ b/nat-lab/tests/test_network_monitor.py
@@ -2,7 +2,7 @@ import asyncio
 import pytest
 from contextlib import AsyncExitStack
 from helpers import setup_mesh_nodes, SetupParameters
-from telio import AdapterType
+from utils.bindings import TelioAdapterType
 from utils.connection_util import ConnectionTag
 
 DEFAULT_WAITING_TIME = 2
@@ -15,20 +15,20 @@ DEFAULT_WAITING_TIME = 2
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.DOCKER_SHARED_CLIENT_1,
-                adapter_type=AdapterType.BoringTun,
+                adapter_type_override=TelioAdapterType.BORING_TUN,
             ),
         ),
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.WINDOWS_VM_1,
-                adapter_type=AdapterType.WireguardGo,
+                adapter_type_override=TelioAdapterType.WIREGUARD_GO_TUN,
             ),
             marks=[pytest.mark.windows],
         ),
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.MAC_VM,
-                adapter_type=AdapterType.BoringTun,
+                adapter_type_override=TelioAdapterType.BORING_TUN,
             ),
             marks=[
                 pytest.mark.mac,

--- a/nat-lab/tests/test_network_switch.py
+++ b/nat-lab/tests/test_network_switch.py
@@ -1,7 +1,6 @@
 import asyncio
 import config
 import pytest
-import telio
 import timeouts
 from contextlib import AsyncExitStack
 from helpers import (
@@ -10,13 +9,13 @@ from helpers import (
     setup_mesh_nodes,
     SetupParameters,
 )
-from telio import AdapterType
 from utils import stun
 from utils.asyncio_util import run_async_contexts
 from utils.bindings import (
     features_with_endpoint_providers,
     EndpointProvider,
     PathType,
+    TelioAdapterType,
     NodeState,
     RelayState,
 )
@@ -69,27 +68,27 @@ async def test_network_switcher(
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.DOCKER_SHARED_CLIENT_1,
-                adapter_type=telio.AdapterType.BoringTun,
+                adapter_type_override=TelioAdapterType.BORING_TUN,
             ),
         ),
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.DOCKER_SHARED_CLIENT_1,
-                adapter_type=telio.AdapterType.LinuxNativeWg,
+                adapter_type_override=TelioAdapterType.LINUX_NATIVE_TUN,
             ),
             marks=pytest.mark.linux_native,
         ),
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.WINDOWS_VM_1,
-                adapter_type=telio.AdapterType.WindowsNativeWg,
+                adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
             ),
             marks=pytest.mark.windows,
         ),
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.WINDOWS_VM_1,
-                adapter_type=telio.AdapterType.WireguardGo,
+                adapter_type_override=TelioAdapterType.WIREGUARD_GO_TUN,
             ),
             marks=[
                 pytest.mark.windows,
@@ -98,7 +97,7 @@ async def test_network_switcher(
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.MAC_VM,
-                adapter_type=telio.AdapterType.BoringTun,
+                adapter_type_override=TelioAdapterType.BORING_TUN,
             ),
             marks=[
                 pytest.mark.mac,
@@ -143,14 +142,14 @@ async def test_mesh_network_switch(
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.DOCKER_SHARED_CLIENT_1,
-                adapter_type=telio.AdapterType.BoringTun,
+                adapter_type_override=TelioAdapterType.BORING_TUN,
                 is_meshnet=False,
             ),
         ),
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.DOCKER_SHARED_CLIENT_1,
-                adapter_type=telio.AdapterType.LinuxNativeWg,
+                adapter_type_override=TelioAdapterType.LINUX_NATIVE_TUN,
                 is_meshnet=False,
             ),
             marks=pytest.mark.linux_native,
@@ -158,7 +157,7 @@ async def test_mesh_network_switch(
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.WINDOWS_VM_1,
-                adapter_type=telio.AdapterType.WindowsNativeWg,
+                adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
                 is_meshnet=False,
             ),
             marks=[pytest.mark.windows],
@@ -166,7 +165,7 @@ async def test_mesh_network_switch(
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.WINDOWS_VM_1,
-                adapter_type=telio.AdapterType.WireguardGo,
+                adapter_type_override=TelioAdapterType.WIREGUARD_GO_TUN,
                 is_meshnet=False,
             ),
             marks=[pytest.mark.windows],
@@ -174,7 +173,7 @@ async def test_mesh_network_switch(
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.MAC_VM,
-                adapter_type=telio.AdapterType.BoringTun,
+                adapter_type_override=TelioAdapterType.BORING_TUN,
                 is_meshnet=False,
             ),
             marks=[
@@ -229,7 +228,7 @@ async def test_vpn_network_switch(alpha_setup_params: SetupParameters) -> None:
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.DOCKER_SHARED_CLIENT_1,
-                adapter_type=telio.AdapterType.BoringTun,
+                adapter_type_override=TelioAdapterType.BORING_TUN,
                 features=features_with_endpoint_providers([EndpointProvider.STUN]),
             ),
             marks=[],
@@ -237,7 +236,7 @@ async def test_vpn_network_switch(alpha_setup_params: SetupParameters) -> None:
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.DOCKER_SHARED_CLIENT_1,
-                adapter_type=telio.AdapterType.LinuxNativeWg,
+                adapter_type_override=TelioAdapterType.LINUX_NATIVE_TUN,
                 features=features_with_endpoint_providers([EndpointProvider.STUN]),
             ),
             marks=pytest.mark.linux_native,
@@ -245,7 +244,7 @@ async def test_vpn_network_switch(alpha_setup_params: SetupParameters) -> None:
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.WINDOWS_VM_1,
-                adapter_type=telio.AdapterType.WindowsNativeWg,
+                adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
                 features=features_with_endpoint_providers([EndpointProvider.STUN]),
             ),
             marks=[
@@ -255,7 +254,7 @@ async def test_vpn_network_switch(alpha_setup_params: SetupParameters) -> None:
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.WINDOWS_VM_1,
-                adapter_type=telio.AdapterType.WireguardGo,
+                adapter_type_override=TelioAdapterType.WIREGUARD_GO_TUN,
                 features=features_with_endpoint_providers([EndpointProvider.STUN]),
             ),
             marks=pytest.mark.windows,
@@ -263,7 +262,7 @@ async def test_vpn_network_switch(alpha_setup_params: SetupParameters) -> None:
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.MAC_VM,
-                adapter_type=telio.AdapterType.BoringTun,
+                adapter_type_override=TelioAdapterType.BORING_TUN,
                 features=features_with_endpoint_providers([EndpointProvider.STUN]),
             ),
             marks=[
@@ -278,7 +277,7 @@ async def test_vpn_network_switch(alpha_setup_params: SetupParameters) -> None:
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2,
-                adapter_type=AdapterType.BoringTun,
+                adapter_type_override=TelioAdapterType.BORING_TUN,
                 features=features_with_endpoint_providers([EndpointProvider.STUN]),
             )
         )

--- a/nat-lab/tests/test_node_state_flickering.py
+++ b/nat-lab/tests/test_node_state_flickering.py
@@ -4,11 +4,11 @@ import pytest
 import timeouts
 from contextlib import AsyncExitStack
 from helpers import SetupParameters, setup_mesh_nodes
-from telio import AdapterType
 from utils.bindings import (
     features_with_endpoint_providers,
     EndpointProvider,
     PathType,
+    TelioAdapterType,
     NodeState,
     RelayState,
 )
@@ -25,7 +25,7 @@ from utils.connection_util import generate_connection_tracker_config, Connection
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                adapter_type=AdapterType.BoringTun,
+                adapter_type_override=TelioAdapterType.BORING_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
                     derp_1_limits=ConnectionLimits(1, 1),
@@ -35,7 +35,7 @@ from utils.connection_util import generate_connection_tracker_config, Connection
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                adapter_type=AdapterType.LinuxNativeWg,
+                adapter_type_override=TelioAdapterType.LINUX_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
                     derp_1_limits=ConnectionLimits(1, 1),
@@ -46,7 +46,7 @@ from utils.connection_util import generate_connection_tracker_config, Connection
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.WINDOWS_VM_1,
-                adapter_type=AdapterType.WindowsNativeWg,
+                adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
                     derp_1_limits=ConnectionLimits(1, 1),
@@ -57,7 +57,7 @@ from utils.connection_util import generate_connection_tracker_config, Connection
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.WINDOWS_VM_1,
-                adapter_type=AdapterType.WireguardGo,
+                adapter_type_override=TelioAdapterType.WIREGUARD_GO_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
                     derp_1_limits=ConnectionLimits(1, 1),
@@ -68,7 +68,7 @@ from utils.connection_util import generate_connection_tracker_config, Connection
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.MAC_VM,
-                adapter_type=AdapterType.BoringTun,
+                adapter_type_override=TelioAdapterType.BORING_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.MAC_VM,
                     derp_1_limits=ConnectionLimits(1, 1),
@@ -116,10 +116,10 @@ async def test_node_state_flickering_relay(
 
 
 CFG = [
-    (AdapterType.WindowsNativeWg, [pytest.mark.windows]),
-    (AdapterType.WireguardGo, [pytest.mark.windows]),
-    (AdapterType.BoringTun, []),
-    (AdapterType.LinuxNativeWg, []),
+    (TelioAdapterType.WINDOWS_NATIVE_TUN, [pytest.mark.windows]),
+    (TelioAdapterType.WIREGUARD_GO_TUN, [pytest.mark.windows]),
+    (TelioAdapterType.BORING_TUN, []),
+    (TelioAdapterType.LINUX_NATIVE_TUN, []),
 ]
 
 
@@ -133,20 +133,20 @@ CFG = [
     ],
 )
 async def test_node_state_flickering_direct(
-    alpha_adapter_type: AdapterType,
-    beta_adapter_type: AdapterType,
+    alpha_adapter_type: TelioAdapterType,
+    beta_adapter_type: TelioAdapterType,
 ) -> None:
     async with AsyncExitStack() as exit_stack:
         alpha_conn_tag = (
             ConnectionTag.WINDOWS_VM_1
             if alpha_adapter_type
-            in [AdapterType.WindowsNativeWg, AdapterType.WireguardGo]
+            in [TelioAdapterType.WINDOWS_NATIVE_TUN, TelioAdapterType.WIREGUARD_GO_TUN]
             else ConnectionTag.DOCKER_CONE_CLIENT_1
         )
         beta_conn_tag = (
             ConnectionTag.WINDOWS_VM_2
             if beta_adapter_type
-            in [AdapterType.WindowsNativeWg, AdapterType.WireguardGo]
+            in [TelioAdapterType.WINDOWS_NATIVE_TUN, TelioAdapterType.WIREGUARD_GO_TUN]
             else ConnectionTag.DOCKER_CONE_CLIENT_2
         )
 
@@ -155,7 +155,7 @@ async def test_node_state_flickering_direct(
             [
                 SetupParameters(
                     connection_tag=alpha_conn_tag,
-                    adapter_type=alpha_adapter_type,
+                    adapter_type_override=alpha_adapter_type,
                     features=features_with_endpoint_providers([
                         EndpointProvider.STUN,
                         EndpointProvider.LOCAL,
@@ -164,7 +164,7 @@ async def test_node_state_flickering_direct(
                 ),
                 SetupParameters(
                     connection_tag=beta_conn_tag,
-                    adapter_type=beta_adapter_type,
+                    adapter_type_override=beta_adapter_type,
                     features=features_with_endpoint_providers([
                         EndpointProvider.STUN,
                         EndpointProvider.LOCAL,

--- a/nat-lab/tests/test_pinging.py
+++ b/nat-lab/tests/test_pinging.py
@@ -1,6 +1,5 @@
 import asyncio
 import pytest
-import telio
 from contextlib import AsyncExitStack
 from datetime import datetime
 from helpers import setup_mesh_nodes, SetupParameters, connectivity_stack
@@ -12,6 +11,7 @@ from utils.bindings import (
     EndpointProvider,
     RttType,
     PathType,
+    TelioAdapterType,
     NodeState,
 )
 from utils.connection import Connection
@@ -102,7 +102,7 @@ def nurse_features() -> Features:
     [
         pytest.param(
             SetupParameters(
-                adapter_type=telio.AdapterType.BoringTun,
+                adapter_type_override=TelioAdapterType.BORING_TUN,
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
@@ -113,7 +113,7 @@ def nurse_features() -> Features:
         ),
         pytest.param(
             SetupParameters(
-                adapter_type=telio.AdapterType.LinuxNativeWg,
+                adapter_type_override=TelioAdapterType.LINUX_NATIVE_TUN,
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
@@ -134,7 +134,7 @@ def nurse_features() -> Features:
     [
         pytest.param(
             SetupParameters(
-                adapter_type=telio.AdapterType.BoringTun,
+                adapter_type_override=TelioAdapterType.BORING_TUN,
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_2,
@@ -208,7 +208,7 @@ async def test_session_keeper(
     [
         pytest.param(
             SetupParameters(
-                adapter_type=telio.AdapterType.BoringTun,
+                adapter_type_override=TelioAdapterType.BORING_TUN,
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
@@ -220,7 +220,7 @@ async def test_session_keeper(
         ),
         pytest.param(
             SetupParameters(
-                adapter_type=telio.AdapterType.LinuxNativeWg,
+                adapter_type_override=TelioAdapterType.LINUX_NATIVE_TUN,
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
@@ -241,7 +241,7 @@ async def test_session_keeper(
     [
         pytest.param(
             SetupParameters(
-                adapter_type=telio.AdapterType.BoringTun,
+                adapter_type_override=TelioAdapterType.BORING_TUN,
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_2,

--- a/nat-lab/tests/test_pmtu.py
+++ b/nat-lab/tests/test_pmtu.py
@@ -2,9 +2,13 @@ import config
 import pytest
 from contextlib import AsyncExitStack
 from helpers import SetupParameters, setup_environment, setup_connections
-from telio import AdapterType
 from utils import stun
-from utils.bindings import default_features, Features, FeaturePmtuDiscovery
+from utils.bindings import (
+    default_features,
+    Features,
+    FeaturePmtuDiscovery,
+    TelioAdapterType,
+)
 from utils.connection_util import (
     ConnectionTag,
     generate_connection_tracker_config,
@@ -159,7 +163,7 @@ async def test_pmtu_without_nexthop(setup_params: SetupParameters) -> None:
     [
         pytest.param(
             SetupParameters(
-                adapter_type=AdapterType.BoringTun,
+                adapter_type_override=TelioAdapterType.BORING_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
                     vpn_1_limits=ConnectionLimits(1, 1),
@@ -172,7 +176,7 @@ async def test_pmtu_without_nexthop(setup_params: SetupParameters) -> None:
         ),
         pytest.param(
             SetupParameters(
-                adapter_type=AdapterType.LinuxNativeWg,
+                adapter_type_override=TelioAdapterType.LINUX_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
                     vpn_1_limits=ConnectionLimits(1, 1),

--- a/nat-lab/tests/test_pq.py
+++ b/nat-lab/tests/test_pq.py
@@ -2,8 +2,9 @@ import config
 import pytest
 from contextlib import AsyncExitStack
 from helpers import SetupParameters, setup_environment
-from telio import AdapterType, Client
+from telio import Client
 from utils import stun
+from utils.bindings import TelioAdapterType
 from utils.connection import Connection
 from utils.connection_tracker import ConnectionLimits
 from utils.connection_util import (
@@ -50,7 +51,7 @@ async def inspect_preshared_key(nlx_conn: Connection) -> str:
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                adapter_type=AdapterType.BoringTun,
+                adapter_type_override=TelioAdapterType.BORING_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
                     stun_limits=ConnectionLimits(1, 1),
@@ -63,7 +64,7 @@ async def inspect_preshared_key(nlx_conn: Connection) -> str:
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                adapter_type=AdapterType.LinuxNativeWg,
+                adapter_type_override=TelioAdapterType.LINUX_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
                     stun_limits=ConnectionLimits(1, 1),
@@ -77,7 +78,7 @@ async def inspect_preshared_key(nlx_conn: Connection) -> str:
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.WINDOWS_VM_1,
-                adapter_type=AdapterType.WindowsNativeWg,
+                adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
                     stun_limits=ConnectionLimits(1, 1),
@@ -93,7 +94,7 @@ async def inspect_preshared_key(nlx_conn: Connection) -> str:
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.WINDOWS_VM_1,
-                adapter_type=AdapterType.WireguardGo,
+                adapter_type_override=TelioAdapterType.WIREGUARD_GO_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
                     stun_limits=ConnectionLimits(1, 1),
@@ -109,7 +110,7 @@ async def inspect_preshared_key(nlx_conn: Connection) -> str:
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.MAC_VM,
-                adapter_type=AdapterType.BoringTun,
+                adapter_type_override=TelioAdapterType.BORING_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.MAC_VM,
                     stun_limits=ConnectionLimits(1, 1),
@@ -149,7 +150,7 @@ async def test_pq_vpn_connection(
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                adapter_type=AdapterType.BoringTun,
+                adapter_type_override=TelioAdapterType.BORING_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
                     stun_limits=ConnectionLimits(1, 1),
@@ -162,7 +163,7 @@ async def test_pq_vpn_connection(
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                adapter_type=AdapterType.LinuxNativeWg,
+                adapter_type_override=TelioAdapterType.LINUX_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
                     stun_limits=ConnectionLimits(1, 1),
@@ -176,7 +177,7 @@ async def test_pq_vpn_connection(
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.WINDOWS_VM_1,
-                adapter_type=AdapterType.WindowsNativeWg,
+                adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
                     stun_limits=ConnectionLimits(1, 1),
@@ -192,7 +193,7 @@ async def test_pq_vpn_connection(
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.WINDOWS_VM_1,
-                adapter_type=AdapterType.WireguardGo,
+                adapter_type_override=TelioAdapterType.WIREGUARD_GO_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
                     stun_limits=ConnectionLimits(1, 1),
@@ -208,7 +209,7 @@ async def test_pq_vpn_connection(
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.MAC_VM,
-                adapter_type=AdapterType.BoringTun,
+                adapter_type_override=TelioAdapterType.BORING_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.MAC_VM,
                     stun_limits=ConnectionLimits(1, 1),

--- a/nat-lab/tests/test_reconnections.py
+++ b/nat-lab/tests/test_reconnections.py
@@ -1,10 +1,9 @@
 import asyncio
 import pytest
-import telio
 from contextlib import AsyncExitStack
 from helpers import setup_mesh_nodes, SetupParameters
 from utils import asyncio_util
-from utils.bindings import NodeState, RelayState
+from utils.bindings import NodeState, RelayState, TelioAdapterType
 from utils.connection_tracker import ConnectionLimits
 from utils.connection_util import generate_connection_tracker_config, ConnectionTag
 from utils.ping import ping
@@ -17,7 +16,7 @@ from utils.ping import ping
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                adapter_type=telio.AdapterType.BoringTun,
+                adapter_type_override=TelioAdapterType.BORING_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
                     derp_1_limits=ConnectionLimits(1, 2),
@@ -27,7 +26,7 @@ from utils.ping import ping
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                adapter_type=telio.AdapterType.LinuxNativeWg,
+                adapter_type_override=TelioAdapterType.LINUX_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
                     derp_1_limits=ConnectionLimits(1, 2),
@@ -38,7 +37,7 @@ from utils.ping import ping
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.WINDOWS_VM_1,
-                adapter_type=telio.AdapterType.WindowsNativeWg,
+                adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
                     derp_1_limits=ConnectionLimits(1, 2),
@@ -51,7 +50,7 @@ from utils.ping import ping
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.WINDOWS_VM_1,
-                adapter_type=telio.AdapterType.WireguardGo,
+                adapter_type_override=TelioAdapterType.WIREGUARD_GO_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
                     derp_1_limits=ConnectionLimits(1, 2),
@@ -64,7 +63,7 @@ from utils.ping import ping
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.MAC_VM,
-                adapter_type=telio.AdapterType.BoringTun,
+                adapter_type_override=TelioAdapterType.BORING_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.MAC_VM,
                     derp_1_limits=ConnectionLimits(1, 2),

--- a/nat-lab/tests/test_telio_version_compatibility.py
+++ b/nat-lab/tests/test_telio_version_compatibility.py
@@ -2,10 +2,10 @@ import asyncio
 import json
 import pytest
 import shlex
-import telio
 from config import DERP_SERVERS
 from contextlib import AsyncExitStack
 from mesh_api import API
+from telio import Client
 from typing import Any, List, Dict
 from utils import testing
 from utils.bindings import (
@@ -14,6 +14,7 @@ from utils.bindings import (
     Config,
     Peer,
     Server,
+    TelioAdapterType,
     RelayState,
     NodeState,
 )
@@ -34,7 +35,7 @@ UHP_conn_client_types = [
         STUN_PROVIDER,
         ConnectionTag.DOCKER_CONE_CLIENT_1,
         ConnectionTag.DOCKER_CONE_CLIENT_2,
-        telio.AdapterType.BoringTun,
+        TelioAdapterType.BORING_TUN,
     ),
 ]
 
@@ -154,7 +155,7 @@ async def test_connect_different_telio_version_through_relay(
         )
 
         alpha_client = await exit_stack.enter_async_context(
-            telio.Client(
+            Client(
                 alpha_conn,
                 alpha,
                 adapter_type,

--- a/nat-lab/tests/test_upnp_connection.py
+++ b/nat-lab/tests/test_upnp_connection.py
@@ -2,13 +2,13 @@ import asyncio
 import pytest
 from contextlib import AsyncExitStack
 from helpers import SetupParameters, setup_mesh_nodes, setup_environment
-from telio import AdapterType
 from utils.asyncio_util import run_async_context
 from utils.bindings import (
     features_with_endpoint_providers,
     EndpointProvider,
     PathType,
     NodeState,
+    TelioAdapterType,
     RelayState,
 )
 from utils.connection_util import ConnectionTag
@@ -22,7 +22,7 @@ from utils.router import new_router, IPStack
     [
         SetupParameters(
             connection_tag=ConnectionTag.DOCKER_UPNP_CLIENT_1,
-            adapter_type=AdapterType.BoringTun,
+            adapter_type_override=TelioAdapterType.BORING_TUN,
             features=features_with_endpoint_providers([EndpointProvider.UPNP]),
         ),
     ],
@@ -32,7 +32,7 @@ from utils.router import new_router, IPStack
     [
         SetupParameters(
             connection_tag=ConnectionTag.DOCKER_UPNP_CLIENT_2,
-            adapter_type=AdapterType.BoringTun,
+            adapter_type_override=TelioAdapterType.BORING_TUN,
             features=features_with_endpoint_providers([EndpointProvider.UPNP]),
         ),
     ],
@@ -104,14 +104,14 @@ async def test_upnp_route_removed(
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                adapter_type=AdapterType.BoringTun,
+                adapter_type_override=TelioAdapterType.BORING_TUN,
                 features=features_with_endpoint_providers([EndpointProvider.UPNP]),
             ),
         ),
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                adapter_type=AdapterType.LinuxNativeWg,
+                adapter_type_override=TelioAdapterType.LINUX_NATIVE_TUN,
                 features=features_with_endpoint_providers([EndpointProvider.UPNP]),
             ),
             marks=pytest.mark.linux_native,
@@ -119,7 +119,7 @@ async def test_upnp_route_removed(
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.WINDOWS_VM_1,
-                adapter_type=AdapterType.WindowsNativeWg,
+                adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
                 features=features_with_endpoint_providers([EndpointProvider.UPNP]),
             ),
             marks=pytest.mark.windows,
@@ -127,7 +127,7 @@ async def test_upnp_route_removed(
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.WINDOWS_VM_1,
-                adapter_type=AdapterType.WireguardGo,
+                adapter_type_override=TelioAdapterType.WIREGUARD_GO_TUN,
                 features=features_with_endpoint_providers([EndpointProvider.UPNP]),
             ),
             marks=pytest.mark.windows,
@@ -135,7 +135,7 @@ async def test_upnp_route_removed(
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.MAC_VM,
-                adapter_type=AdapterType.BoringTun,
+                adapter_type_override=TelioAdapterType.BORING_TUN,
                 features=features_with_endpoint_providers([EndpointProvider.UPNP]),
             ),
             marks=pytest.mark.mac,
@@ -148,7 +148,7 @@ async def test_upnp_route_removed(
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2,
-                adapter_type=AdapterType.BoringTun,
+                adapter_type_override=TelioAdapterType.BORING_TUN,
                 features=features_with_endpoint_providers([EndpointProvider.UPNP]),
             )
         )

--- a/nat-lab/tests/test_vpn.py
+++ b/nat-lab/tests/test_vpn.py
@@ -4,10 +4,15 @@ import copy
 import pytest
 from contextlib import AsyncExitStack
 from helpers import SetupParameters, setup_environment, setup_connections
-from telio import AdapterType, Client, generate_public_key, generate_secret_key
+from telio import Client
 from typing import Optional
 from utils import testing, stun
-from utils.bindings import default_features
+from utils.bindings import (
+    default_features,
+    TelioAdapterType,
+    generate_secret_key,
+    generate_public_key,
+)
 from utils.connection import Connection
 from utils.connection_tracker import (
     ConnectionLimits,
@@ -70,7 +75,7 @@ class VpnConfig:
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                adapter_type=AdapterType.BoringTun,
+                adapter_type_override=TelioAdapterType.BORING_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
                     stun_limits=ConnectionLimits(1, 1),
@@ -82,7 +87,7 @@ class VpnConfig:
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                adapter_type=AdapterType.LinuxNativeWg,
+                adapter_type_override=TelioAdapterType.LINUX_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
                     stun_limits=ConnectionLimits(1, 1),
@@ -95,7 +100,7 @@ class VpnConfig:
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.WINDOWS_VM_1,
-                adapter_type=AdapterType.WindowsNativeWg,
+                adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
                     stun_limits=ConnectionLimits(1, 1),
@@ -110,7 +115,7 @@ class VpnConfig:
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.WINDOWS_VM_1,
-                adapter_type=AdapterType.WireguardGo,
+                adapter_type_override=TelioAdapterType.WIREGUARD_GO_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
                     stun_limits=ConnectionLimits(1, 1),
@@ -125,7 +130,7 @@ class VpnConfig:
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.MAC_VM,
-                adapter_type=AdapterType.BoringTun,
+                adapter_type_override=TelioAdapterType.BORING_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.MAC_VM,
                     stun_limits=ConnectionLimits(1, 1),
@@ -228,7 +233,7 @@ async def test_vpn_connection(
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                adapter_type=AdapterType.BoringTun,
+                adapter_type_override=TelioAdapterType.BORING_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
                     vpn_1_limits=ConnectionLimits(1, 1),
@@ -242,7 +247,7 @@ async def test_vpn_connection(
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                adapter_type=AdapterType.LinuxNativeWg,
+                adapter_type_override=TelioAdapterType.LINUX_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
                     vpn_1_limits=ConnectionLimits(1, 1),
@@ -257,7 +262,7 @@ async def test_vpn_connection(
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.WINDOWS_VM_1,
-                adapter_type=AdapterType.WindowsNativeWg,
+                adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
                     vpn_1_limits=ConnectionLimits(1, 1),
@@ -274,7 +279,7 @@ async def test_vpn_connection(
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.WINDOWS_VM_1,
-                adapter_type=AdapterType.WireguardGo,
+                adapter_type_override=TelioAdapterType.WIREGUARD_GO_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
                     vpn_1_limits=ConnectionLimits(1, 1),
@@ -291,7 +296,7 @@ async def test_vpn_connection(
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.MAC_VM,
-                adapter_type=AdapterType.BoringTun,
+                adapter_type_override=TelioAdapterType.BORING_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.MAC_VM,
                     vpn_1_limits=ConnectionLimits(1, 1),
@@ -354,7 +359,7 @@ async def test_vpn_reconnect(
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                adapter_type=AdapterType.BoringTun,
+                adapter_type_override=TelioAdapterType.BORING_TUN,
                 ip_stack=IPStack.IPv4,
                 features=default_features(enable_firewall_connection_reset=True),
             )
@@ -363,7 +368,7 @@ async def test_vpn_reconnect(
         # pytest.param(
         #     SetupParameters(
         #         connection_tag=ConnectionTag.DOCKER_OPEN_INTERNET_CLIENT_DUAL_STACK,
-        #         adapter_type=AdapterType.BoringTun,
+        #         adapter_type_override=TelioAdapterType.BORING_TUN,
         #         ip_stack=IPStack.IPv6,
         #         features=default_features(enable_firewall_connection_reset=True),
         #     )
@@ -493,7 +498,7 @@ async def test_kill_external_tcp_conn_on_vpn_reconnect(
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                adapter_type=AdapterType.BoringTun,
+                adapter_type_override=TelioAdapterType.BORING_TUN,
                 ip_stack=IPStack.IPv4,
                 features=default_features(enable_firewall_connection_reset=True),
             )
@@ -502,7 +507,7 @@ async def test_kill_external_tcp_conn_on_vpn_reconnect(
         # pytest.param(
         #     SetupParameters(
         #         connection_tag=ConnectionTag.DOCKER_OPEN_INTERNET_CLIENT_DUAL_STACK,
-        #         adapter_type=AdapterType.BoringTun,
+        #         adapter_type_override=TelioAdapterType.BORING_TUN,
         #         ip_stack=IPStack.IPv6,
         #         features=default_features(enable_firewall_connection_reset=True),
         #     )
@@ -588,7 +593,7 @@ async def test_kill_external_udp_conn_on_vpn_reconnect(
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                adapter_type=AdapterType.BoringTun,
+                adapter_type_override=TelioAdapterType.BORING_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
                     stun_limits=ConnectionLimits(1, 1),
@@ -601,7 +606,7 @@ async def test_kill_external_udp_conn_on_vpn_reconnect(
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                adapter_type=AdapterType.LinuxNativeWg,
+                adapter_type_override=TelioAdapterType.LINUX_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
                     stun_limits=ConnectionLimits(1, 1),
@@ -615,7 +620,7 @@ async def test_kill_external_udp_conn_on_vpn_reconnect(
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.WINDOWS_VM_1,
-                adapter_type=AdapterType.WindowsNativeWg,
+                adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
                     stun_limits=ConnectionLimits(1, 1),
@@ -631,7 +636,7 @@ async def test_kill_external_udp_conn_on_vpn_reconnect(
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.WINDOWS_VM_1,
-                adapter_type=AdapterType.WireguardGo,
+                adapter_type_override=TelioAdapterType.WIREGUARD_GO_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
                     stun_limits=ConnectionLimits(1, 1),
@@ -647,7 +652,7 @@ async def test_kill_external_udp_conn_on_vpn_reconnect(
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.MAC_VM,
-                adapter_type=AdapterType.BoringTun,
+                adapter_type_override=TelioAdapterType.BORING_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.MAC_VM,
                     stun_limits=ConnectionLimits(1, 1),

--- a/nat-lab/tests/test_wg_adapter.py
+++ b/nat-lab/tests/test_wg_adapter.py
@@ -1,7 +1,7 @@
 import pytest
 from contextlib import AsyncExitStack
 from helpers import SetupParameters, setup_environment
-from telio import AdapterType
+from utils.bindings import TelioAdapterType
 from utils.connection_util import ConnectionTag, new_connection_by_tag
 from utils.process import ProcessExecError
 
@@ -26,7 +26,7 @@ async def test_wg_adapter_cleanup(conn_tag: ConnectionTag):
                     [
                         SetupParameters(
                             connection_tag=conn_tag,
-                            adapter_type=AdapterType.WireguardGo,
+                            adapter_type_override=TelioAdapterType.WIREGUARD_GO_TUN,
                         )
                     ],
                 )
@@ -61,7 +61,7 @@ async def test_wg_adapter_cleanup(conn_tag: ConnectionTag):
                 [
                     SetupParameters(
                         connection_tag=conn_tag,
-                        adapter_type=AdapterType.WireguardGo,
+                        adapter_type_override=TelioAdapterType.WIREGUARD_GO_TUN,
                     )
                 ],
             )


### PR DESCRIPTION
This is the final PR migrating from bespoke types in natlab to types from generated python bindings. This PR consists of almost only changing from the old `AdapterType` (defined in `telio.py`)  to `TelioAdapterType` which is in the generated bindings. 

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
