### PR TITLE
Fix reset connections firewall feature panic on MacOS

### DIFF
--- a/.unreleased/LLT-5653
+++ b/.unreleased/LLT-5653
@@ -1,0 +1,1 @@
+Fix reset connections feature panic on MacOS

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,7 +447,7 @@ dependencies = [
 [[package]]
 name = "boringtun"
 version = "0.6.0"
-source = "git+https://github.com/NordSecurity/boringtun.git?tag=v1.2.6#ae0c7a7c9510c882c30633f4024833d89c885ae0"
+source = "git+https://github.com/NordSecurity/boringtun.git?tag=v1.2.7#5f8a8c38e6e4b0d801535d3411c4286672eb2215"
 dependencies = [
  "aead",
  "base64 0.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,7 +174,7 @@ windows = { version = "0.56", features = [
     "Win32_NetworkManagement_IpHelper",
 ] }
 
-boringtun = { git = "https://github.com/NordSecurity/boringtun.git", tag = "v1.2.6", features = ["device"] }
+boringtun = { git = "https://github.com/NordSecurity/boringtun.git", tag = "v1.2.7", features = ["device"] }
 x25519-dalek = { version = "2.0.1", features = ["reusable_secrets", "static_secrets"] }
 
 

--- a/nat-lab/tests/test_vpn.py
+++ b/nat-lab/tests/test_vpn.py
@@ -498,6 +498,15 @@ async def test_kill_external_tcp_conn_on_vpn_reconnect(
                 features=default_features(enable_firewall_connection_reset=True),
             )
         ),
+        pytest.param(
+            SetupParameters(
+                connection_tag=ConnectionTag.MAC_VM,
+                adapter_type=AdapterType.BoringTun,
+                ip_stack=IPStack.IPv4,
+                features=default_features(enable_firewall_connection_reset=True),
+            ),
+            marks=pytest.mark.mac,
+        ),
         # TODO(msz): IPv6 public server, it doesn't work with the current VPN implementation
         # pytest.param(
         #     SetupParameters(
@@ -545,7 +554,7 @@ async def test_kill_external_udp_conn_on_vpn_reconnect(
         sender_start_event = asyncio.Event()
 
         output_notifier.notify_output(
-            "2000 port [udp/*] succeeded!",
+            "[udp/*] succeeded!",
             sender_start_event,
         )
 


### PR DESCRIPTION
### Problem
The feature panics on MacOS.
It is caused by the fact that borintun writes more bytes to the tunnel than the packet size and we implement `io::Write::write()` for the tunnel sink. Down the road, we use its `io::Write::write_all()` implementation which panics if the returned number of bytes is larger than the buffer size.

### Solution
Override the default implementation of the `io::Write::write_all()` to mitigate the panic.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
