### PR TITLE
Introduce Pause/Unpause for CPC

### DIFF
--- a/crates/telio-traversal/src/endpoint_state.rs
+++ b/crates/telio-traversal/src/endpoint_state.rs
@@ -7,6 +7,7 @@ pub enum EndpointState {
     EndpointGathering,
     Ping,
     Published,
+    Paused,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -51,7 +52,9 @@ impl EndpointStateMachine {
             (EndpointState::Published, Event::EndpointGone) => {
                 self.state = EndpointState::Disconnected(event);
             }
-
+            (EndpointState::Paused, _) => {
+                // just ignore the event. The state is paused, meaning nothing to do
+            }
             (_, event) => {
                 telio_log_warn!("Invalid state transition {:?} -> {:?}", &self.state, event);
             }
@@ -60,6 +63,10 @@ impl EndpointStateMachine {
 
     pub fn get(&self) -> EndpointState {
         self.state
+    }
+
+    pub fn new(state: EndpointState) -> EndpointStateMachine {
+        EndpointStateMachine { state }
     }
 }
 
@@ -72,13 +79,6 @@ impl PartialEq<EndpointState> for EndpointStateMachine {
 impl fmt::Display for EndpointStateMachine {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:?}", self.state)
-    }
-}
-
-#[cfg(test)]
-impl EndpointStateMachine {
-    pub fn new(state: EndpointState) -> EndpointStateMachine {
-        EndpointStateMachine { state }
     }
 }
 


### PR DESCRIPTION
Cross Ping Checker constantly pinged peers via endpoint providers even though it's not necessary once all direct connections are established. The pausing has an effect only on active pinging, the remaining CPC logic is left as-is as confirmed to be good via green natlab.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
