### PR TITLE
Fix bad adapter type in natlab

### DIFF
--- a/nat-lab/tests/test_vpn.py
+++ b/nat-lab/tests/test_vpn.py
@@ -506,7 +506,7 @@ async def test_kill_external_tcp_conn_on_vpn_reconnect(
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.MAC_VM,
-                adapter_type=AdapterType.BoringTun,
+                adapter_type_override=TelioAdapterType.BORING_TUN,
                 ip_stack=IPStack.IPv4,
                 features=default_features(enable_firewall_connection_reset=True),
             ),


### PR DESCRIPTION
The old AdapterType was removed in favor of the generated TelioAdapterType, but between the last commit on that migration PR being pushed and the pipeline being green so it could be merged, another PR added a new test relying on the old AdapterType. because of that, the PRs were incompatible but had no code conflicts, and got the repo into a bad state


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
