### PR TITLE
Move sync blocking code to thread

### DIFF
--- a/nat-lab/tests/test_vpn.py
+++ b/nat-lab/tests/test_vpn.py
@@ -506,7 +506,7 @@ async def test_kill_external_tcp_conn_on_vpn_reconnect(
         pytest.param(
             SetupParameters(
                 connection_tag=ConnectionTag.MAC_VM,
-                adapter_type=AdapterType.BoringTun,
+                adapter_type_override=TelioAdapterType.BORING_TUN,
                 ip_stack=IPStack.IPv4,
                 features=default_features(enable_firewall_connection_reset=True),
             ),


### PR DESCRIPTION
### Problem
Some libtelio code is synchronous blocking, which might block main thread.

### Solution
Wrap all libtelio_proxy functions with asyncio.to_thread so those calls wouldn’t block async threads.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
