### PR TITLE
Fix possible PQ methods hang condition

### DIFF
--- a/.unreleased/LLT-5660
+++ b/.unreleased/LLT-5660
@@ -1,0 +1,1 @@
+Fix possible PQ fetch_keys()/rekey() method hanging

--- a/crates/telio-pq/src/lib.rs
+++ b/crates/telio-pq/src/lib.rs
@@ -37,6 +37,9 @@ pub enum Error {
     /// Generic unrecoverable error
     #[error("Generic: {0}")]
     Generic(String),
+    /// Socket recv() call timeout
+    #[error("Timeout on recv()")]
+    Timeout,
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -54,8 +57,8 @@ impl From<&str> for Error {
 }
 
 impl From<tokio::time::error::Elapsed> for Error {
-    fn from(value: tokio::time::error::Elapsed) -> Self {
-        Self::Io(io::Error::new(io::ErrorKind::TimedOut, value))
+    fn from(_: tokio::time::error::Elapsed) -> Self {
+        Self::Timeout
     }
 }
 


### PR DESCRIPTION
### Problem
On UDP packet drop PQ methods can hang on `recv()` call

### Solution
Introduce a timeout for UDP socket `recv()` calls and handle the error


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
