### PR TITLE
Reset exponential backoff on succesfull endpoint verification

### DIFF
--- a/crates/telio-traversal/src/connectivity_check/cross_ping_check.rs
+++ b/crates/telio-traversal/src/connectivity_check/cross_ping_check.rs
@@ -820,6 +820,10 @@ impl<E: Backoff> EndpointConnectivityCheckState<E> {
                         };
 
                         do_state_transition!(self, Event::Publish);
+
+                        // Reset exponential backoff on succesfull endpoint verification
+                        self.exponential_backoff.reset();
+
                         let wg_publish_event = WireGuardEndpointCandidateChangeEvent {
                             public_key: self.public_key,
                             remote_endpoint: (remote_endpoint, remote_endpoint_type),
@@ -1244,6 +1248,12 @@ mod tests {
             endpoint,
             last_rx_time_provider_mock.clone(),
         );
+
+        endpoint_connectivity_check_state
+            .exponential_backoff
+            .expect_reset()
+            .times(1)
+            .returning(|| ());
 
         let msg = PingerMsg::ping(WGPort(2), 1, 10_u64)
             .pong(


### PR DESCRIPTION
### Description
It is not guaranteed that `wg_controller` will use every published endpoint, which means, that existing [exponential backoff reset](https://github.com/NordSecurity/libtelio/blob/main/crates/telio-traversal/src/connectivity_check/cross_ping_check.rs#L758) may not occur. But in any case, if endpoint has passed the validation - we may reset exponential backoff already, as we know, that required information has flown succesfully between two meshnet nodes.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
