### PR TITLE
Fix link detection fluctuations

### DIFF
--- a/.unreleased/LLT-5675
+++ b/.unreleased/LLT-5675
@@ -1,0 +1,1 @@
+Fix link detection fluctuation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4639,6 +4639,7 @@ dependencies = [
  "pretty_assertions",
  "proptest",
  "rand",
+ "rstest",
  "serde",
  "serde_json",
  "sha2",

--- a/crates/telio-wg/Cargo.toml
+++ b/crates/telio-wg/Cargo.toml
@@ -41,6 +41,7 @@ itertools.workspace = true
 mockall.workspace = true
 ntest.workspace = true
 pretty_assertions.workspace = true
+rstest.workspace = true
 tokio = { workspace = true, features = ["test-util"] }
 
 telio-firewall.workspace = true


### PR DESCRIPTION
At some point the logic in is_link_up has been changed and it no longer used the WG_KEEPALIVE and RTT.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
