### PR TITLE
[LLT-5674] Collect interderpcli logs in case of process failure

### DIFF
--- a/nat-lab/tests/conftest.py
+++ b/nat-lab/tests/conftest.py
@@ -116,9 +116,10 @@ async def setup_check_interderp():
                 DERP_SERVER_2_ADDR,
                 DERP_SERVER_1_SECRET_KEY,
                 DERP_SERVER_2_SECRET_KEY,
+                1,
             )
             await derp_test_12.execute()
-            await derp_test_12.save_logs(1)
+            await derp_test_12.save_logs()
 
             derp_test_23 = InterDerpClient(
                 connection,
@@ -126,9 +127,10 @@ async def setup_check_interderp():
                 DERP_SERVER_3_ADDR,
                 DERP_SERVER_1_SECRET_KEY,
                 DERP_SERVER_2_SECRET_KEY,
+                2,
             )
             await derp_test_23.execute()
-            await derp_test_23.save_logs(2)
+            await derp_test_23.save_logs()
 
             derp_test_31 = InterDerpClient(
                 connection,
@@ -136,9 +138,10 @@ async def setup_check_interderp():
                 DERP_SERVER_1_ADDR,
                 DERP_SERVER_1_SECRET_KEY,
                 DERP_SERVER_2_SECRET_KEY,
+                3,
             )
             await derp_test_31.execute()
-            await derp_test_31.save_logs(3)
+            await derp_test_31.save_logs()
             stop_tcpdump([connection.container_name()])
 
 


### PR DESCRIPTION
### Problem
When interderpcli failed to execute there is only INTERNALERROR exception of the process printed out to the execution trace which not helps to identify the actual root cause.

### Solution
In case of exception raised during execution of interderpcli process save_logs method can be called to save interderpcli.log content.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
