### PR TITLE
Add missing subdomain www.google.com in nat-lab's dns

### DIFF
--- a/nat-lab/bin/dns-server
+++ b/nat-lab/bin/dns-server
@@ -6,10 +6,12 @@ from twisted.names import dns, server
 KNOWN = {
     dns.AAAA: {
         b"google.com": dns.Record_AAAA(address="2a00:1450:400e:80c::200e"),
+        b"www.google.com": dns.Record_AAAA(address="2a00:1450:400e:80c::200e"),
         b"error-with-noerror-return-code.com": None,
     },
     dns.A: {
         b"google.com": dns.Record_A(address="142.250.179.206"),
+        b"www.google.com": dns.Record_A(address="142.250.179.206"),
         b"error-with-noerror-return-code.com": None,
     },
     dns.CNAME: {


### PR DESCRIPTION
### Problem
Request to subdomain `www.google.com` are being made but the dns is lacking an entry for it.

### Solution
Add new entry for `www.google.com`.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
