### PR TITLE
LLT-5677: print api nodes on setup

### DIFF
--- a/nat-lab/tests/helpers.py
+++ b/nat-lab/tests/helpers.py
@@ -119,6 +119,11 @@ def setup_api(node_params: List[Tuple[bool, IPStack]]) -> Tuple[API, List[Node]]
     for node, other_node in product(nodes, repeat=2):
         if node != other_node:
             node.set_peer_firewall_settings(other_node.id, True, True)
+
+    print("Nodes in API:")
+    for node in api.nodes.values():
+        print(node)
+
     return api, nodes
 
 

--- a/nat-lab/tests/mesh_api.py
+++ b/nat-lab/tests/mesh_api.py
@@ -1,3 +1,4 @@
+import json
 import os
 import platform
 import pprint
@@ -93,6 +94,9 @@ class FirewallRule:
         self.allow_incoming_connections = allow_incoming_connections
         self.allow_peer_send_files = allow_peer_send_files
 
+    def __str__(self):
+        return pprint.pformat(vars(self))
+
 
 class Node:
     name: str
@@ -186,7 +190,17 @@ class Node:
 
     # Pretty and informational string for debug messages, e.g. assert false, f"{node}"
     def __str__(self):
-        return pprint.pformat(vars(self))
+        node_dict = vars(self).copy()
+        node_dict["firewall_rules"] = {
+            key: rule.to_dict() if hasattr(rule, "to_dict") else str(rule)
+            for key, rule in self.firewall_rules.items()
+        }
+        node_dict["ip_stack"] = (
+            self.ip_stack.to_dict()
+            if hasattr(self.ip_stack, "to_dict")
+            else str(self.ip_stack)
+        )
+        return json.dumps(node_dict, indent=4, sort_keys=True, ensure_ascii=False)
 
 
 class API:


### PR DESCRIPTION
### Problem
it feels like sometimes mesh_api gives wrong or empty values, therefore further actions in test fails

### Solution
for debugging purposes print out api/node in natlab when setup is done


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
