### PR TITLE
[LLT-5681] Enable stack canary

### DIFF
--- a/.unreleased/LLT-5681
+++ b/.unreleased/LLT-5681
@@ -1,0 +1,1 @@
+Enable stack canary on non-Windows platforms

--- a/build.rs
+++ b/build.rs
@@ -32,6 +32,7 @@ fn build() -> Result<cc::Build> {
         // https://github.com/msys2/MINGW-packages/issues/5868
     } else {
         build.flag("-D_FORTIFY_SOURCE=2");
+        build.flag("-fstack-protector-strong");
     }
     Ok(build)
 }


### PR DESCRIPTION
### Problem
Android binaries do not pass `checksec` stack canary scan.

### Solution
Add the required compilation flag.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests