### PR TITLE
LLT-5554: Add MQTT notification center support to `teliod`

### DIFF
--- a/.unreleased/LLT-5554
+++ b/.unreleased/LLT-5554
@@ -1,0 +1,1 @@
+Add Mqtt / Notification Center support in teliod

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -299,7 +299,7 @@ version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb8867f378f33f78a811a8eb9bf108ad99430d7aad43315dd9319c827ef6247"
 dependencies = [
- "http",
+ "http 0.2.12",
  "log",
  "url",
  "wildmatch",
@@ -348,6 +348,12 @@ name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "basic-toml"
@@ -1408,6 +1414,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1607,7 +1624,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.12",
  "indexmap 2.5.0",
  "slab",
  "tokio",
@@ -1801,13 +1818,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http 1.1.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -1840,8 +1891,8 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
- "http-body",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -1854,17 +1905,73 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
- "http",
- "hyper",
- "rustls",
+ "http 0.2.12",
+ "hyper 0.14.30",
+ "rustls 0.21.12",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
+dependencies = [
+ "futures-util",
+ "http 1.1.0",
+ "hyper 1.4.1",
+ "hyper-util",
+ "rustls 0.23.14",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.0",
+ "tower-service",
+ "webpki-roots 0.26.6",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41296eb09f183ac68eec06e03cdbea2e759633d4067b2f6552fc2e009bcad08b"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "hyper 1.4.1",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1912,8 +2019,8 @@ dependencies = [
  "attohttpc",
  "bytes",
  "futures",
- "http",
- "hyper",
+ "http 0.2.12",
+ "hyper 0.14.30",
  "log",
  "rand",
  "tokio",
@@ -3047,6 +3154,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
+name = "quinn"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c7c5fdde3cdae7203427dc4f0a68fe0ed09833edc525a03456b153b79828684"
+dependencies = [
+ "bytes",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash 2.0.0",
+ "rustls 0.23.14",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fadfaed2cd7f389d0161bb73eeb07b7b78f8691047a6f3e73caaeae55310a4a6"
+dependencies = [
+ "bytes",
+ "rand",
+ "ring",
+ "rustc-hash 2.0.0",
+ "rustls 0.23.14",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fe68c2e9e1a1234e218683dbdf9f9dfcb094113c5ac2b938dfcb9bab4c4140b"
+dependencies = [
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3197,10 +3352,10 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
- "http-body",
- "hyper",
- "hyper-rustls",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.30",
+ "hyper-rustls 0.24.2",
  "ipnet",
  "js-sys",
  "log",
@@ -3208,22 +3363,64 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
- "rustls-pemfile",
+ "rustls 0.21.12",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "system-configuration 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 0.25.4",
  "winreg",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f713147fbe92361e52392c73b8c9e48c04c6625bce969ef54dc901e58e042a7b"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-rustls 0.27.3",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls 0.23.14",
+ "rustls-pemfile 2.2.0",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 1.0.1",
+ "tokio",
+ "tokio-rustls 0.26.0",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots 0.26.6",
+ "windows-registry",
 ]
 
 [[package]]
@@ -3265,6 +3462,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "rumqttc"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1568e15fab2d546f940ed3a21f48bbbd1c494c90c99c4481339364a497f94a9"
+dependencies = [
+ "bytes",
+ "flume",
+ "futures-util",
+ "log",
+ "rustls-native-certs 0.7.3",
+ "rustls-pemfile 2.2.0",
+ "rustls-webpki 0.102.8",
+ "thiserror",
+ "tokio",
+ "tokio-rustls 0.25.0",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3275,6 +3490,12 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
 
 [[package]]
 name = "rustc_version"
@@ -3306,8 +3527,36 @@ checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
  "ring",
- "rustls-webpki",
+ "rustls-webpki 0.101.7",
  "sct",
+]
+
+[[package]]
+name = "rustls"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "415d9944693cb90382053259f89fbb077ea730ad7273047ec63b19bc9b160ba8"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.8",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -3317,7 +3566,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
+ "schannel",
+ "security-framework 2.11.1",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 2.2.0",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 2.11.1",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcaf18a4f2be7326cd874a5fa579fae794320a0f388d365dca7e480e55f83f8a"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 2.2.0",
+ "rustls-pki-types",
  "schannel",
  "security-framework 2.11.1",
 ]
@@ -3332,6 +3607,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e696e35370c65c9c541198af4543ccd580cf17fc25d8e05c5a242b202488c55"
+
+[[package]]
 name = "rustls-platform-verifier"
 version = "0.1.0"
 source = "git+https://github.com/tomaszklak/rustls-platform-verifier.git?rev=2db68dd17d76eadb062176b913040341b99ef4f3#2db68dd17d76eadb062176b913040341b99ef4f3"
@@ -3341,12 +3631,12 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls",
- "rustls-native-certs",
- "rustls-webpki",
+ "rustls 0.21.12",
+ "rustls-native-certs 0.6.3",
+ "rustls-webpki 0.101.7",
  "security-framework 2.9.2",
  "security-framework-sys 2.9.1",
- "webpki-roots",
+ "webpki-roots 0.25.4",
  "winapi",
 ]
 
@@ -3357,6 +3647,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
  "untrusted",
 ]
 
@@ -3855,6 +4156,9 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spinning"
@@ -4003,6 +4307,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "sysinfo"
 version = "0.30.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4086,7 +4399,7 @@ dependencies = [
  "parking_lot",
  "rand",
  "regex",
- "reqwest",
+ "reqwest 0.11.27",
  "rustyline",
  "serde",
  "serde_json",
@@ -4246,7 +4559,7 @@ dependencies = [
  "proptest",
  "proptest-derive",
  "rand",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "sn_fake_clock",
  "telio-crypto",
  "telio-utils",
@@ -4449,7 +4762,7 @@ dependencies = [
  "generic-array",
  "hex",
  "httparse",
- "hyper",
+ "hyper 0.14.30",
  "libc",
  "mockall_double",
  "ntest",
@@ -4457,7 +4770,7 @@ dependencies = [
  "rand",
  "rand_core",
  "rstest",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "rustls-platform-verifier",
  "serde",
  "smart-default",
@@ -4473,12 +4786,12 @@ dependencies = [
  "telio-utils",
  "thiserror",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "tokio-stream",
  "tokio-util",
  "tracing",
  "url",
- "webpki-roots",
+ "webpki-roots 0.25.4",
 ]
 
 [[package]]
@@ -4562,7 +4875,7 @@ dependencies = [
  "enum-map",
  "env_logger",
  "futures",
- "http",
+ "http 0.2.12",
  "httparse",
  "if-addrs",
  "igd",
@@ -4609,7 +4922,7 @@ dependencies = [
  "proptest-derive",
  "rand",
  "regex",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "serde",
  "smart-default",
  "sn_fake_clock",
@@ -4667,10 +4980,15 @@ dependencies = [
 name = "teliod"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "clap 3.2.25",
  "futures",
  "interprocess 2.2.1",
  "nix 0.28.0",
+ "regex",
+ "reqwest 0.12.8",
+ "rumqttc",
+ "rustls-native-certs 0.8.0",
  "serde",
  "serde_json",
  "signal-hook",
@@ -4678,9 +4996,11 @@ dependencies = [
  "telio",
  "thiserror",
  "tokio",
+ "tokio-rustls 0.25.0",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]
@@ -4858,7 +5178,29 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls",
+ "rustls 0.21.12",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls 0.22.4",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+dependencies = [
+ "rustls 0.23.14",
+ "rustls-pki-types",
  "tokio",
 ]
 
@@ -5244,6 +5586,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
 dependencies = [
  "getrandom",
+ "serde",
 ]
 
 [[package]]
@@ -5388,6 +5731,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
+name = "webpki-roots"
+version = "0.26.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841c67bff177718f1d4dfefde8d8f0e78f9b6589319ba88312f567fc5841a958"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "weedle2"
 version = "4.0.0"
 source = "git+https://github.com/NordSecurity/uniffi-rs.git?tag=v0.3.1+v0.25.0#1a5dc527165589456c3d7233107917e065192b03"
@@ -5502,7 +5854,7 @@ checksum = "4698e52ed2d08f8658ab0c39512a7c00ee5fe2688c65f8c0a4f06750d729f2a6"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-result",
+ "windows-result 0.1.2",
  "windows-targets 0.52.6",
 ]
 
@@ -5529,11 +5881,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-registry"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+dependencies = [
+ "windows-result 0.2.0",
+ "windows-strings",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
 dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result 0.2.0",
  "windows-targets 0.52.6",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4993,6 +4993,7 @@ dependencies = [
  "serde_json",
  "signal-hook",
  "signal-hook-tokio",
+ "smart-default",
  "telio",
  "thiserror",
  "tokio",

--- a/clis/teliod/Cargo.toml
+++ b/clis/teliod/Cargo.toml
@@ -24,3 +24,10 @@ signal-hook = "0.3.17"
 signal-hook-tokio = { version = "0.3.1", features = ["futures-v0_3"]}
 futures.workspace = true
 thiserror.workspace = true
+regex.workspace = true
+reqwest = { version = "0.12.8", default-features = false, features = ["json", "rustls-tls"] }
+uuid = { workspace = true, features = ["serde"] }
+rumqttc = "0.24.0"
+tokio-rustls = "0.25.0" # This version needs to be the same as the one used by the rumqttc
+rustls-native-certs = "0.8"
+anyhow.workspace = true

--- a/clis/teliod/Cargo.toml
+++ b/clis/teliod/Cargo.toml
@@ -31,3 +31,4 @@ rumqttc = "0.24.0"
 tokio-rustls = "0.25.0" # This version needs to be the same as the one used by the rumqttc
 rustls-native-certs = "0.8"
 anyhow.workspace = true
+smart-default = "0.7.1"

--- a/clis/teliod/Cargo.toml
+++ b/clis/teliod/Cargo.toml
@@ -16,7 +16,7 @@ tracing-subscriber.workspace = true
 # Tokio support is needed, because the daemon runs on the async runtime.
 interprocess = { version = "2.2.1", features = ["tokio"] }
 
-nix = "0.28.0"
+nix = { version = "0.28.0", features = ["signal"] }
 
 telio = { path = "../.." }
 tokio.workspace = true

--- a/clis/teliod/README.md
+++ b/clis/teliod/README.md
@@ -6,7 +6,7 @@ For typical Linux environment it might be built using simply:
 
 For OpenWRT you might need a bit more complex command, including your router architecture and the fact the OpenWRT is MUSLE-based, for example:
 
-```CARGO_TARGET_ARMV7_UNKNOWN_LINUX_MUSLEABIHF_LINKER=rust-lld CC=/path/to/arm-linux-gnueabi-gcc cargo build -0 teliod --target armv7-unknown-linux-musleabihf```
+```CARGO_TARGET_ARMV7_UNKNOWN_LINUX_MUSLEABIHF_LINKER=rust-lld CC=/path/to/arm-linux-gnueabi-gcc cargo build --package teliod --target armv7-unknown-linux-musleabihf```
 
 You may need to download some sufficient MUSLE toolchains from `musle.cc`.
 

--- a/clis/teliod/example_teliod_config.json
+++ b/clis/teliod/example_teliod_config.json
@@ -1,4 +1,6 @@
 {
     "log_level": "trace",
-    "log_file_path": "example_log_file.log"
+    "log_file_path": "example_log_file.log",
+    "authentication_token": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "app_user_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
 }

--- a/clis/teliod/example_teliod_config.json
+++ b/clis/teliod/example_teliod_config.json
@@ -2,5 +2,5 @@
     "log_level": "trace",
     "log_file_path": "example_log_file.log",
     "authentication_token": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-    "app_user_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    "app_user_uid": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
 }

--- a/clis/teliod/src/comms.rs
+++ b/clis/teliod/src/comms.rs
@@ -58,6 +58,7 @@ impl DaemonSocket {
         let _ = fs::remove_file(ipc_socket_path);
         let socket = ListenerOptions::new()
             .name(ipc_socket_path.to_fs_name::<FilesystemUdSocket>()?)
+            .reclaim_name(true)
             .create_tokio()?;
 
         Ok(Self { socket })

--- a/clis/teliod/src/config.rs
+++ b/clis/teliod/src/config.rs
@@ -1,0 +1,123 @@
+use std::{num::NonZeroU64, path::PathBuf, str::FromStr};
+
+use serde::{de, Deserialize, Deserializer};
+use smart_default::SmartDefault;
+use tracing::level_filters::LevelFilter;
+use uuid::Uuid;
+
+#[derive(Clone, Copy, Debug, SmartDefault)]
+#[repr(transparent)]
+pub struct Percentage(u8);
+
+impl std::ops::Mul<std::time::Duration> for Percentage {
+    type Output = std::time::Duration;
+
+    fn mul(self, rhs: std::time::Duration) -> Self::Output {
+        (self.0 as u32 * rhs) / 100
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, SmartDefault)]
+pub struct MqttConfig {
+    /// Starting backoff time for mqtt retry, has to be at least one. (in seconds)
+    #[default(backoff_initial_default())]
+    #[serde(default = "backoff_initial_default")]
+    pub backoff_initial: NonZeroU64,
+    /// Maximum backoff time for the mqtt retry. Has to be greater than the initial value. (in seconds)
+    #[default(backoff_maximal_default())]
+    #[serde(default = "backoff_maximal_default")]
+    pub backoff_maximal: NonZeroU64,
+
+    /// Percentage of the expiry period after which new mqtt token will be requested
+    #[default(reconnect_after_expiry_default())]
+    #[serde(deserialize_with = "deserialize_percent")]
+    #[serde(default = "reconnect_after_expiry_default")]
+    pub reconnect_after_expiry: Percentage,
+
+    /// Path to a mqtt pem certificate to be used when connecting to Notification Center
+    #[serde(default)]
+    pub certificate_file_path: Option<PathBuf>,
+}
+
+fn backoff_initial_default() -> NonZeroU64 {
+    #[allow(unwrap_check)]
+    NonZeroU64::new(1).unwrap()
+}
+
+fn backoff_maximal_default() -> NonZeroU64 {
+    #[allow(unwrap_check)]
+    NonZeroU64::new(300).unwrap()
+}
+
+fn reconnect_after_expiry_default() -> Percentage {
+    Percentage(90)
+}
+
+#[derive(Deserialize, Debug)]
+pub struct TeliodDaemonConfig {
+    #[serde(deserialize_with = "deserialize_log_level")]
+    pub log_level: LevelFilter,
+    pub log_file_path: String,
+
+    pub app_user_uid: Uuid,
+
+    #[serde(deserialize_with = "deserialize_authentication_token")]
+    pub authentication_token: String,
+
+    /// Path to a http pem certificate to be used when connecting to CoreApi
+    pub http_certificate_file_path: Option<PathBuf>,
+
+    #[serde(default)]
+    pub mqtt: MqttConfig,
+}
+
+fn deserialize_percent<'de, D>(deserializer: D) -> Result<Percentage, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value: u8 = de::Deserialize::deserialize(deserializer)?;
+    if value > 100 {
+        return Err(de::Error::custom(
+            "Percentage value can only be in range from 0 to 100 inclusive",
+        ));
+    }
+    Ok(Percentage(value))
+}
+
+fn deserialize_log_level<'de, D>(deserializer: D) -> Result<LevelFilter, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Deserialize::deserialize(deserializer).and_then(|s: String| {
+        LevelFilter::from_str(&s).map_err(|_| {
+            de::Error::unknown_variant(&s, &["error", "warn", "info", "debug", "trace", "off"])
+        })
+    })
+}
+
+fn deserialize_authentication_token<'de, D: Deserializer<'de>>(
+    deserializer: D,
+) -> Result<String, D::Error> {
+    let raw_string: String = de::Deserialize::deserialize(deserializer)?;
+    let re = regex::Regex::new("[0-9a-f]{64}").map_err(de::Error::custom)?;
+    if re.is_match(&raw_string) {
+        Ok(raw_string)
+    } else {
+        Err(de::Error::custom("Incorrect authentication token"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    #[test]
+    fn percentage_times_duration() {
+        let input = Duration::from_secs(86400);
+        let expected = Duration::from_secs(77760);
+        let percentage = Percentage(90);
+        assert_eq!(expected, percentage * input);
+    }
+}

--- a/clis/teliod/src/main.rs
+++ b/clis/teliod/src/main.rs
@@ -3,15 +3,17 @@
 use clap::Parser;
 use nix::libc::{SIGHUP, SIGINT, SIGQUIT, SIGTERM};
 use signal_hook_tokio::Signals;
+use smart_default::SmartDefault;
 use std::{
     fs::{self, File},
+    num::NonZeroU64,
     path::PathBuf,
     str::FromStr,
     sync::Arc,
 };
 use thiserror::Error as ThisError;
 use tokio::task::JoinError;
-use tracing::{error, info, level_filters::LevelFilter, warn};
+use tracing::{debug, error, info, level_filters::LevelFilter, warn};
 use uuid::Uuid;
 
 mod comms;
@@ -26,7 +28,55 @@ use serde_json::error::Error as SerdeJsonError;
 
 use futures::stream::StreamExt;
 
-#[derive(Deserialize)]
+#[derive(Clone, Copy, Debug, SmartDefault)]
+#[repr(transparent)]
+struct Percentage(u8);
+
+impl std::ops::Mul<std::time::Duration> for Percentage {
+    type Output = std::time::Duration;
+
+    fn mul(self, rhs: std::time::Duration) -> Self::Output {
+        (self.0 as u32 * rhs) / 100
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, SmartDefault)]
+struct MqttConfig {
+    /// Starting backoff time for mqtt retry, has to be at least one. (in seconds)
+    #[default(backoff_initial_default())]
+    #[serde(default = "backoff_initial_default")]
+    backoff_initial: NonZeroU64,
+    /// Maximum backoff time for the mqtt retry. Has to be greater than the initial value. (in seconds)
+    #[default(backoff_maximal_default())]
+    #[serde(default = "backoff_maximal_default")]
+    backoff_maximal: NonZeroU64,
+
+    /// Percentage of the expiry period after which new mqtt token will be requested
+    #[default(reconnect_after_expiry_default())]
+    #[serde(deserialize_with = "deserialize_percent")]
+    #[serde(default = "reconnect_after_expiry_default")]
+    reconnect_after_expiry: Percentage,
+
+    /// Path to a mqtt pem certificate to be used when connecting to Notification Center
+    #[serde(default)]
+    certificate_file_path: Option<PathBuf>,
+}
+
+fn backoff_initial_default() -> NonZeroU64 {
+    #[allow(unwrap_check)]
+    NonZeroU64::new(1).unwrap()
+}
+
+fn backoff_maximal_default() -> NonZeroU64 {
+    #[allow(unwrap_check)]
+    NonZeroU64::new(300).unwrap()
+}
+
+fn reconnect_after_expiry_default() -> Percentage {
+    Percentage(90)
+}
+
+#[derive(Deserialize, Debug)]
 struct TeliodDaemonConfig {
     #[serde(deserialize_with = "deserialize_log_level")]
     log_level: LevelFilter,
@@ -39,8 +89,22 @@ struct TeliodDaemonConfig {
 
     /// Path to a http pem certificate to be used when connecting to CoreApi
     http_certificate_file_path: Option<PathBuf>,
-    /// Path to a mqtt pem certificate to be used when connecting to Notification Center
-    mqtt_certificate_file_path: Option<PathBuf>,
+
+    #[serde(default)]
+    mqtt: MqttConfig,
+}
+
+fn deserialize_percent<'de, D>(deserializer: D) -> Result<Percentage, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value: u8 = de::Deserialize::deserialize(deserializer)?;
+    if value > 100 {
+        return Err(de::Error::custom(
+            "Percentage value can only be in range from 0 to 100 inclusive",
+        ));
+    }
+    Ok(Percentage(value))
 }
 
 fn deserialize_log_level<'de, D>(deserializer: D) -> Result<LevelFilter, D::Error>
@@ -178,6 +242,8 @@ async fn daemon_event_loop(config: TeliodDaemonConfig) -> Result<(), TeliodError
         .with_level(true)
         .init();
 
+    debug!("started with config: {config:?}");
+
     let socket = DaemonSocket::new(&DaemonSocket::get_ipc_socket_path()?)?;
     let cmd_listener = CommandListener { socket };
 
@@ -240,5 +306,20 @@ async fn daemon_event_loop(config: TeliodDaemonConfig) -> Result<(), TeliodError
         result
     } else {
         join_result.map_err(|err| err.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    #[test]
+    fn percentage_times_duration() {
+        let input = Duration::from_secs(86400);
+        let expected = Duration::from_secs(77760);
+        let percentage = Percentage(90);
+        assert_eq!(expected, percentage * input);
     }
 }

--- a/clis/teliod/src/main.rs
+++ b/clis/teliod/src/main.rs
@@ -2,6 +2,7 @@
 
 use clap::Parser;
 use nix::libc::{SIGHUP, SIGINT, SIGQUIT, SIGTERM};
+use nix::sys::signal::Signal;
 use signal_hook_tokio::Signals;
 use smart_default::SmartDefault;
 use std::{
@@ -284,7 +285,7 @@ async fn daemon_event_loop(config: TeliodDaemonConfig) -> Result<(), TeliodError
             signal = signals.next() => {
                 match signal {
                     Some(s @ SIGHUP | s @ SIGTERM | s @ SIGINT | s @ SIGQUIT) => {
-                        info!("Received signal {s}, exiting");
+                        info!("Received signal {:?}, exiting", Signal::try_from(s));
                         break Ok(());
                     }
                     Some(s) => {

--- a/clis/teliod/src/main.rs
+++ b/clis/teliod/src/main.rs
@@ -1,135 +1,28 @@
 //! Main and implementation of config and commands for Teliod - simple telio daemon for Linux and OpenWRT
 
 use clap::Parser;
+use config::TeliodDaemonConfig;
+use futures::stream::StreamExt;
 use nix::libc::{SIGHUP, SIGINT, SIGQUIT, SIGTERM};
 use nix::sys::signal::Signal;
+use serde::{Deserialize, Serialize};
+use serde_json::error::Error as SerdeJsonError;
 use signal_hook_tokio::Signals;
-use smart_default::SmartDefault;
 use std::{
     fs::{self, File},
-    num::NonZeroU64,
-    path::PathBuf,
-    str::FromStr,
     sync::Arc,
 };
 use thiserror::Error as ThisError;
 use tokio::task::JoinError;
-use tracing::{debug, error, info, level_filters::LevelFilter, warn};
-use uuid::Uuid;
-
-mod comms;
-mod nc;
-
-use crate::{comms::DaemonSocket, nc::NotificationCenter};
+use tracing::{debug, error, info, warn};
 
 use telio::{device::Device, telio_model::features::Features, telio_utils::select};
 
-use serde::{de, Deserialize, Deserializer, Serialize};
-use serde_json::error::Error as SerdeJsonError;
+mod comms;
+mod config;
+mod nc;
 
-use futures::stream::StreamExt;
-
-#[derive(Clone, Copy, Debug, SmartDefault)]
-#[repr(transparent)]
-struct Percentage(u8);
-
-impl std::ops::Mul<std::time::Duration> for Percentage {
-    type Output = std::time::Duration;
-
-    fn mul(self, rhs: std::time::Duration) -> Self::Output {
-        (self.0 as u32 * rhs) / 100
-    }
-}
-
-#[derive(Clone, Debug, Deserialize, SmartDefault)]
-struct MqttConfig {
-    /// Starting backoff time for mqtt retry, has to be at least one. (in seconds)
-    #[default(backoff_initial_default())]
-    #[serde(default = "backoff_initial_default")]
-    backoff_initial: NonZeroU64,
-    /// Maximum backoff time for the mqtt retry. Has to be greater than the initial value. (in seconds)
-    #[default(backoff_maximal_default())]
-    #[serde(default = "backoff_maximal_default")]
-    backoff_maximal: NonZeroU64,
-
-    /// Percentage of the expiry period after which new mqtt token will be requested
-    #[default(reconnect_after_expiry_default())]
-    #[serde(deserialize_with = "deserialize_percent")]
-    #[serde(default = "reconnect_after_expiry_default")]
-    reconnect_after_expiry: Percentage,
-
-    /// Path to a mqtt pem certificate to be used when connecting to Notification Center
-    #[serde(default)]
-    certificate_file_path: Option<PathBuf>,
-}
-
-fn backoff_initial_default() -> NonZeroU64 {
-    #[allow(unwrap_check)]
-    NonZeroU64::new(1).unwrap()
-}
-
-fn backoff_maximal_default() -> NonZeroU64 {
-    #[allow(unwrap_check)]
-    NonZeroU64::new(300).unwrap()
-}
-
-fn reconnect_after_expiry_default() -> Percentage {
-    Percentage(90)
-}
-
-#[derive(Deserialize, Debug)]
-struct TeliodDaemonConfig {
-    #[serde(deserialize_with = "deserialize_log_level")]
-    log_level: LevelFilter,
-    log_file_path: String,
-
-    app_user_uid: Uuid,
-
-    #[serde(deserialize_with = "deserialize_authentication_token")]
-    authentication_token: String,
-
-    /// Path to a http pem certificate to be used when connecting to CoreApi
-    http_certificate_file_path: Option<PathBuf>,
-
-    #[serde(default)]
-    mqtt: MqttConfig,
-}
-
-fn deserialize_percent<'de, D>(deserializer: D) -> Result<Percentage, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let value: u8 = de::Deserialize::deserialize(deserializer)?;
-    if value > 100 {
-        return Err(de::Error::custom(
-            "Percentage value can only be in range from 0 to 100 inclusive",
-        ));
-    }
-    Ok(Percentage(value))
-}
-
-fn deserialize_log_level<'de, D>(deserializer: D) -> Result<LevelFilter, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    Deserialize::deserialize(deserializer).and_then(|s: String| {
-        LevelFilter::from_str(&s).map_err(|_| {
-            de::Error::unknown_variant(&s, &["error", "warn", "info", "debug", "trace", "off"])
-        })
-    })
-}
-
-fn deserialize_authentication_token<'de, D: Deserializer<'de>>(
-    deserializer: D,
-) -> Result<String, D::Error> {
-    let raw_string: String = de::Deserialize::deserialize(deserializer)?;
-    let re = regex::Regex::new("[0-9a-f]{64}").map_err(de::Error::custom)?;
-    if re.is_match(&raw_string) {
-        Ok(raw_string)
-    } else {
-        Err(de::Error::custom("Incorrect authentication token"))
-    }
-}
+use crate::{comms::DaemonSocket, nc::NotificationCenter};
 
 #[derive(Parser, Debug)]
 #[clap()]
@@ -307,20 +200,5 @@ async fn daemon_event_loop(config: TeliodDaemonConfig) -> Result<(), TeliodError
         result
     } else {
         join_result.map_err(|err| err.into())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::time::Duration;
-
-    use super::*;
-
-    #[test]
-    fn percentage_times_duration() {
-        let input = Duration::from_secs(86400);
-        let expected = Duration::from_secs(77760);
-        let percentage = Percentage(90);
-        assert_eq!(expected, percentage * input);
     }
 }

--- a/clis/teliod/src/nc.rs
+++ b/clis/teliod/src/nc.rs
@@ -1,0 +1,350 @@
+use anyhow::ensure;
+use reqwest::{Client, StatusCode, Url};
+use rumqttc::{
+    AsyncClient, ConnAck, ConnectReturnCode, Event, EventLoop, Incoming, MqttOptions, Packet,
+    Publish, QoS, TlsConfiguration, Transport,
+};
+use serde::{Deserialize, Serialize};
+use std::{sync::Arc, time::Duration};
+use telio::telio_utils::Hidden;
+use tokio::{
+    select,
+    sync::Mutex,
+    time::{error::Elapsed, timeout, Instant},
+};
+use tokio_rustls::rustls::ClientConfig;
+use tracing::{debug, error, info};
+use uuid::Uuid;
+
+use self::outgoing::{Acknowledgement, DeliveryConfirmation};
+
+const TOKENS_URL: &'static str = "https://api.nordvpn.com/v1/notifications/tokens";
+const USERNAME: &'static str = "token";
+const ROUTER_PLATFORM_ID: u64 = 900;
+const MQTT_CONNECTION_TIMEOUT: Duration = Duration::from_secs(30);
+
+const TOPIC_SUBSCRIBE: &'static str = "meshnet";
+const TOPIC_DELIVERED: &'static str = "delivered";
+const TOPIC_ACKNOWLEDGED: &'static str = "ack";
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("Failed to get send http request for token: {0}")]
+    TokenHttpError(#[from] reqwest::Error),
+    #[error("Failed to get token: {0}")]
+    TokenError(String),
+    #[error("Malformed notification center json response: {0}")]
+    MalformedNotificationCenterJsonResponse(#[from] serde_json::Error),
+    #[error("Mqtt broker rejected connection: {0:?}")]
+    MqttConnectionRejected(ConnectReturnCode),
+    #[error("Unexpected mqtt event before connection established: {0:?}")]
+    MqttUnexpectedEventBeforeConnection(Event),
+    #[error("Mqtt connection timeout")]
+    MqttConnectionTimeout,
+    #[error("Mqtt connection error: {0}")]
+    MqttConnectionError(rumqttc::ConnectionError),
+}
+
+type Callback = Arc<dyn Fn(&[Uuid]) + Send + Sync>;
+
+pub struct NotificationCenter {
+    callbacks: Arc<Mutex<Vec<Callback>>>,
+}
+
+impl NotificationCenter {
+    pub async fn new(
+        authentication_token: &str,
+        app_user_uid: Uuid,
+        callbacks: Vec<Callback>,
+    ) -> Result<Self, Error> {
+        let callbacks = Arc::new(Mutex::new(callbacks));
+        let nc_config = request_nc_config(authentication_token, app_user_uid).await?;
+
+        dbg!(&nc_config);
+
+        start_mqtt(nc_config, app_user_uid, callbacks.clone()).await?;
+
+        Ok(Self { callbacks })
+    }
+
+    pub async fn add_callback(&self, callback: Callback) {
+        let mut callbacks = self.callbacks.lock().await;
+        callbacks.push(callback);
+    }
+}
+
+async fn start_mqtt(
+    nc_config: NotificationCenterConfig,
+    app_user_uid: Uuid,
+    callbacks: Arc<Mutex<Vec<Callback>>>,
+) -> Result<(), Error> {
+    let (client, mut eventloop, expires_at) = connect_to_mqtt(nc_config, app_user_uid).await?;
+
+    client
+        .subscribe(TOPIC_SUBSCRIBE, QoS::AtLeastOnce)
+        .await
+        .unwrap();
+
+    tokio::spawn(async move {
+        loop {
+            select! {
+                _ = tokio::time::sleep_until(expires_at) => {
+
+                },
+                event = eventloop.poll() => {
+                    match event {
+                        Ok(Event::Incoming(Packet::Publish(p))) => {
+                            if let Err(e) = handle_incoming_publish(&client, p, &callbacks).await {
+                                error!("Failed to handle incomming publish: {e}");
+                            }
+                        }
+                        Ok(Event::Incoming(p)) => {
+                            info!("mqtt incomming: {p:?}");
+                        }
+                        Ok(Event::Outgoing(p)) => info!("mqtt outgoing: {p:?}"),
+                        Err(e) => {
+                            error!("mqtt event loop error: {e}");
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    });
+
+    Ok(())
+}
+
+async fn connect_to_mqtt(
+    nc_config: NotificationCenterConfig,
+    app_user_uid: Uuid,
+) -> Result<(AsyncClient, EventLoop, Instant), Error> {
+    let mut mqttoptions = MqttOptions::new(
+        app_user_uid.to_string(),
+        nc_config.endpoint.host().unwrap().to_string(),
+        nc_config.endpoint.port().unwrap(),
+    );
+    mqttoptions.set_credentials(nc_config.username.clone(), &*nc_config.password);
+    mqttoptions.set_keep_alive(Duration::from_secs(30));
+    mqttoptions.set_clean_session(true);
+
+    // Use rustls-native-certs to load root certificates from the operating system.
+    let mut root_cert_store = tokio_rustls::rustls::RootCertStore::empty();
+    root_cert_store.add_parsable_certificates(
+        rustls_native_certs::load_native_certs().expect("could not load platform certs"),
+    );
+
+    let client_config = Arc::new(
+        ClientConfig::builder()
+            .with_root_certificates(root_cert_store)
+            .with_no_client_auth(),
+    );
+
+    mqttoptions.set_transport(Transport::tls_with_config(TlsConfiguration::Rustls(
+        client_config,
+    )));
+
+    let (client, eventloop) = AsyncClient::new(mqttoptions, 10);
+    let eventloop = wait_for_connection(eventloop, MQTT_CONNECTION_TIMEOUT).await?;
+    info!("Mqtt connection established");
+    let start = Instant::now();
+    let expires_in = Duration::from_secs(nc_config.expires_in);
+    let expires_at = start + expires_in;
+    Ok((client, eventloop, expires_at))
+}
+
+async fn handle_incoming_publish(
+    client: &AsyncClient,
+    p: Publish,
+    callbacks: &Arc<Mutex<Vec<Callback>>>,
+) -> Result<(), anyhow::Error> {
+    let text = std::str::from_utf8(&*p.payload)?;
+    let notification: incoming::Notification = serde_json::from_str(&text)?;
+    debug!("mqtt incomming publish: {p:?}: {text:?}");
+
+    ensure!(
+        !notification.is_acked(),
+        "received {:?} which is already acked",
+        notification.message_id()
+    );
+
+    send_delivery_confirmation(client, notification.message_id()).await?;
+    send_acknowledgement(client, notification.message_id()).await?;
+
+    let callbacks: Vec<Callback> = (*callbacks.lock().await).clone();
+
+    callbacks
+        .into_iter()
+        .for_each(|c| c(&notification.message.data.event.attributes.affected_machines));
+
+    Ok(())
+}
+
+async fn send_delivery_confirmation(
+    client: &AsyncClient,
+    message_id: MessageID,
+) -> Result<(), anyhow::Error> {
+    let payload = DeliveryConfirmation { message_id };
+    let payload = serde_json::to_string(&payload)?;
+
+    client
+        .publish_bytes(TOPIC_DELIVERED, QoS::AtLeastOnce, false, payload.into())
+        .await?;
+
+    Ok(())
+}
+
+async fn send_acknowledgement(
+    client: &AsyncClient,
+    message_id: MessageID,
+) -> Result<(), anyhow::Error> {
+    let payload = Acknowledgement {
+        message_id,
+        track_type: outgoing::TrackType::Processed,
+        action_slug: None,
+    };
+
+    let payload = serde_json::to_string(&payload)?;
+
+    client
+        .publish_bytes(TOPIC_ACKNOWLEDGED, QoS::AtLeastOnce, false, payload.into())
+        .await?;
+
+    Ok(())
+}
+
+async fn request_nc_config(
+    authentication_token: &str,
+    app_user_uid: Uuid,
+) -> Result<NotificationCenterConfig, Error> {
+    let client = Client::new();
+
+    let data = TokenHttpRequestData {
+        app_user_uid: app_user_uid.to_string(),
+        platform_id: ROUTER_PLATFORM_ID,
+    };
+    let resp = client
+        .post(TOKENS_URL)
+        .basic_auth(USERNAME, Some(authentication_token))
+        .json(&data)
+        .send()
+        .await?;
+    let status = resp.status();
+    let text = resp.text().await?;
+    if status != StatusCode::CREATED {
+        return Err(Error::TokenError(text));
+    }
+
+    let resp: NotificationCenterConfig = serde_json::from_str(&text)?;
+    Ok(resp)
+}
+
+async fn wait_for_connection(mut event_loop: EventLoop, t: Duration) -> Result<EventLoop, Error> {
+    match timeout(t, event_loop.poll()).await {
+        Ok(Ok(Event::Incoming(Packet::ConnAck(ConnAck { code, .. })))) => {
+            if code == ConnectReturnCode::Success {
+                Ok(event_loop)
+            } else {
+                Err(Error::MqttConnectionRejected(code))
+            }
+        }
+        Ok(Ok(unexpected_event)) => {
+            Err(Error::MqttUnexpectedEventBeforeConnection(unexpected_event))
+        }
+        Err(Elapsed { .. }) => Err(Error::MqttConnectionTimeout),
+        Ok(Err(err)) => Err(Error::MqttConnectionError(err)),
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct TokenHttpRequestData {
+    app_user_uid: String,
+    platform_id: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct NotificationCenterConfig {
+    endpoint: Url,
+    username: String,
+    password: Hidden<String>,
+    expires_in: u64,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[repr(transparent)]
+pub struct MessageID(Uuid);
+
+mod incoming {
+    use super::*;
+
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct Notification {
+        pub message: Message,
+    }
+
+    impl Notification {
+        pub fn message_id(&self) -> MessageID {
+            self.message.data.metadata.message_id
+        }
+        pub fn is_acked(&self) -> bool {
+            self.message.data.metadata.acked
+        }
+    }
+
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct Message {
+        pub data: Data,
+    }
+
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct Data {
+        pub event: Event,
+        metadata: Metadata,
+    }
+
+    #[derive(Debug, Serialize, Deserialize)]
+    struct Metadata {
+        acked: bool,
+        created_at: u64,
+        message_id: MessageID,
+        target_uid: String,
+    }
+
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct Event {
+        #[serde(rename = "type")]
+        type_: String,
+        pub attributes: Attributes,
+    }
+
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct Attributes {
+        pub affected_machines: Vec<Uuid>,
+    }
+}
+
+mod outgoing {
+    use super::*;
+
+    #[derive(Debug, Serialize, Deserialize)]
+    #[serde(rename_all = "UPPERCASE")]
+    pub enum TrackType {
+        Opened,
+        Clicked,
+        Cleared,
+        Disabled,
+        Processed,
+    }
+
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct DeliveryConfirmation {
+        pub message_id: MessageID,
+    }
+
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct Acknowledgement {
+        pub message_id: MessageID,
+        pub track_type: TrackType,
+        pub action_slug: Option<String>,
+    }
+}

--- a/clis/teliod/src/nc.rs
+++ b/clis/teliod/src/nc.rs
@@ -24,7 +24,7 @@ use tokio_rustls::rustls::{
 use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
-use crate::MqttConfig;
+use crate::config::MqttConfig;
 
 use self::outgoing::{Acknowledgement, DeliveryConfirmation};
 

--- a/nat-lab/data/teliod/config.json
+++ b/nat-lab/data/teliod/config.json
@@ -1,4 +1,6 @@
 {
     "log_level": "trace",
-    "log_file_path": "teliod_natlab.log"
+    "log_file_path": "teliod_natlab.log",
+    "authentication_token": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "app_user_uid": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
 }


### PR DESCRIPTION
### Problem
Teliod needs to be notified about meshnet changes which means it has to have a connection to Notification Center.

### Solution
Implement Notification Center connection using rumqttc. After #853 is merged, the placeholder callback(s) will be replaced by triggering of meshmap update.

Integration tests will be done once core api support is added to nat-lab.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
