### PR TITLE
Add more debug logs to link detection

### DIFF
--- a/crates/telio-wg/src/wg.rs
+++ b/crates/telio-wg/src/wg.rs
@@ -126,7 +126,7 @@ pub const KEEPALIVE_PACKET_SIZE: u64 = 32;
 /// Default wireguard keepalive duration
 pub const WG_KEEPALIVE: Duration = Duration::from_secs(10);
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 /// A structure to hold the bytes and timestamps for received and transmitted data.
 pub struct BytesAndTimestamps {
     /// Number of received bytes.
@@ -198,8 +198,21 @@ impl BytesAndTimestamps {
 
     /// Checks if the link is up based on the round-trip time (RTT) and WireGuard keepalive interval.
     pub fn is_link_up(&self, rtt: Duration) -> bool {
+        telio_log_debug!(
+            "is_link_up. rtt={:?} self.rx_ts={:?} self.tx_ts={:?}",
+            rtt,
+            self.rx_ts,
+            self.tx_ts
+        );
         match (self.rx_ts, self.tx_ts) {
-            (Some(rx_ts), Some(tx_ts)) => tx_ts <= rx_ts || rx_ts.elapsed() < WG_KEEPALIVE + rtt,
+            (Some(rx_ts), Some(tx_ts)) => {
+                telio_log_debug!(
+                    "is_link_up:: rx_ts.elapsed: {:?}, rx_ts.elapsed() < WG_KEEPALIVE + rtt: {}",
+                    rx_ts.elapsed(),
+                    rx_ts.elapsed() < WG_KEEPALIVE + rtt
+                );
+                tx_ts <= rx_ts || rx_ts.elapsed() < WG_KEEPALIVE + rtt
+            }
             _ => false,
         }
     }


### PR DESCRIPTION
Link detection had very little logs and now seems to fail on one of the cases. Having more logs is crucial in observing what is happening.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
