### PR TITLE
add tcpdump for interderp check

### DIFF
--- a/nat-lab/tests/interderp_cli.py
+++ b/nat-lab/tests/interderp_cli.py
@@ -1,7 +1,7 @@
 import os
 from utils.connection import Connection, TargetOS
 from utils.connection_util import get_libtelio_binary_path
-from utils.process import Process
+from utils.process import Process, ProcessExecError
 
 
 class InterDerpClient:
@@ -34,9 +34,12 @@ class InterDerpClient:
         self._connection = connection
 
     async def execute(self) -> None:
+        async def on_output(output: str) -> None:
+            print(f"interderpcli_{self._instance_id}: {output}")
+
         try:
-            await self._process.execute()
-        except Exception as e:
+            await self._process.execute(on_output, on_output)
+        except ProcessExecError as e:
             print(f"Interderpcli process execution failed: {e}")
             await self.save_logs()
             raise

--- a/nat-lab/tests/mesh_api.py
+++ b/nat-lab/tests/mesh_api.py
@@ -371,7 +371,7 @@ class API:
         )
 
         for node in node_list:
-            start_tcpdump(server_config["container"])
+            start_tcpdump([server_config["container"]])
             if "type" in server_config and server_config["type"] == "nordlynx":
                 priv_key = server_config["private_key"]
                 commands = [
@@ -444,17 +444,17 @@ class API:
         return tuple(list(self.nodes.values())[current_node_list_len:])
 
 
-def start_tcpdump(container_name):
+def start_tcpdump(container_names: List[str]):
     if os.environ.get("NATLAB_SAVE_LOGS") is None:
         return
-    # First make sure that no leftover processes/files will interfere
-    cmd = f"docker exec --privileged {container_name} killall tcpdump"
-    os.system(cmd)
-    cmd = f"docker exec --privileged {container_name} rm {PCAP_FILE_PATH}"
-    os.system(cmd)
-
-    cmd = f"docker exec -d --privileged {container_name} tcpdump -i any -U -w {PCAP_FILE_PATH}"
-    os.system(cmd)
+    for container_name in container_names:
+        # First make sure that no leftover processes/files will interfere
+        cmd = f"docker exec --privileged {container_name} killall tcpdump"
+        os.system(cmd)
+        cmd = f"docker exec --privileged {container_name} rm {PCAP_FILE_PATH}"
+        os.system(cmd)
+        cmd = f"docker exec -d --privileged {container_name} tcpdump -i any -U -w {PCAP_FILE_PATH}"
+        os.system(cmd)
 
 
 def stop_tcpdump(container_names):

--- a/nat-lab/tests/telio.py
+++ b/nat-lab/tests/telio.py
@@ -351,7 +351,7 @@ class Client:
         self, meshnet_config: Optional[Config] = None
     ) -> AsyncIterator["Client"]:
         if isinstance(self._connection, DockerConnection):
-            start_tcpdump(self._connection.container_name())
+            start_tcpdump([self._connection.container_name()])
             await self.clear_core_dumps()
 
         async def on_stdout(stdout: str) -> None:


### PR DESCRIPTION
### Problem
interderp check fails and we don't know really know why

### Solution
- print interderp logs
- catch tcpdump dumps for derp servers


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
