### PR TITLE
Temporary logs in the dns library to track down nat-lab failure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1692,7 +1692,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 [[package]]
 name = "hickory-proto"
 version = "0.24.0"
-source = "git+https://github.com/NordSecurity/trust-dns.git?tag=v3.0.0#f3583ef082b448e808a492d034a2e30cda53dcdb"
+source = "git+https://github.com/NordSecurity/trust-dns.git?rev=8489dfa83f5cba0a6a77b3306560a00fd5421df7#8489dfa83f5cba0a6a77b3306560a00fd5421df7"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -1716,7 +1716,7 @@ dependencies = [
 [[package]]
 name = "hickory-resolver"
 version = "0.24.0"
-source = "git+https://github.com/NordSecurity/trust-dns.git?tag=v3.0.0#f3583ef082b448e808a492d034a2e30cda53dcdb"
+source = "git+https://github.com/NordSecurity/trust-dns.git?rev=8489dfa83f5cba0a6a77b3306560a00fd5421df7#8489dfa83f5cba0a6a77b3306560a00fd5421df7"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1737,7 +1737,7 @@ dependencies = [
 [[package]]
 name = "hickory-server"
 version = "0.24.0"
-source = "git+https://github.com/NordSecurity/trust-dns.git?tag=v3.0.0#f3583ef082b448e808a492d034a2e30cda53dcdb"
+source = "git+https://github.com/NordSecurity/trust-dns.git?rev=8489dfa83f5cba0a6a77b3306560a00fd5421df7#8489dfa83f5cba0a6a77b3306560a00fd5421df7"
 dependencies = [
  "async-trait",
  "bytes",

--- a/crates/telio-dns/Cargo.toml
+++ b/crates/telio-dns/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 rand = { default-features = false, version = "0.8" }
-hickory-server = { git = "https://github.com/NordSecurity/trust-dns.git", tag = "v3.0.0", features = ["hickory-resolver"], default-features = false }
+hickory-server = { git = "https://github.com/NordSecurity/trust-dns.git", rev = "8489dfa83f5cba0a6a77b3306560a00fd5421df7", features = ["hickory-resolver"], default-features = false }
 async-trait.workspace = true
 base64.workspace = true
 boringtun.workspace = true


### PR DESCRIPTION
### Problem
test_dns* test sometimes fail with a nslookup timeout. It looks as if the dns forwarder sometimes taking a lot of time to resolve the queries.

### Solution
This adds more (temporary) logs to the underlying dns library


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
