### PR TITLE
Add ping argument information

### DIFF
--- a/nat-lab/tests/utils/ping.py
+++ b/nat-lab/tests/utils/ping.py
@@ -16,7 +16,10 @@ async def ping(
     connection: Connection, ip: str, timeout: Optional[float] = None
 ) -> None:
     async with Ping(connection, ip).run() as ping_process:
-        await ping_process.wait_for_any_ping(timeout)
+        await asyncio.create_task(
+            ping_process.wait_for_any_ping(timeout),
+            name=f"ping({connection}, {ip}, {timeout})",
+        )
 
 
 class Ping:


### PR DESCRIPTION
### Problem
Then test times out due to global timeout, and ping is the failure reason, it's may be unclear what was not reached

### Solution
Attempt to add this information as task name.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
