### PR TITLE
add tcpdump wrapper

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -82,7 +82,7 @@ jobs:
             command: fmt
             args: -- --check --color always
   python-format-black:
-      runs-on: ubuntu-22.04
+      runs-on: ubuntu-24.04
       steps:
         - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
         - uses: extractions/setup-just@dd310ad5a97d8e7b41793f8ef055398d51ad4de6 # v2.0.0
@@ -90,7 +90,7 @@ jobs:
             just-version: 1.37.0
         - run: just black
   python-format-isort:
-      runs-on: ubuntu-22.04
+      runs-on: ubuntu-24.04
       steps:
         - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
         - run: pip3 install --no-deps -r requirements.txt
@@ -98,7 +98,7 @@ jobs:
         - run: isort --check-only --diff .
           working-directory: nat-lab
   python-format-autoflake:
-      runs-on: ubuntu-22.04
+      runs-on: ubuntu-24.04
       steps:
         - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
         - run: pip3 install --no-deps -r requirements.txt
@@ -107,7 +107,7 @@ jobs:
           working-directory: nat-lab
   python-lint:
       needs: uniffi-bindings
-      runs-on: ubuntu-22.04
+      runs-on: ubuntu-24.04
       steps:
         - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
         - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
@@ -121,7 +121,7 @@ jobs:
         - run: just pylint
   natlab-typecheck:
       needs: uniffi-bindings
-      runs-on: ubuntu-22.04
+      runs-on: ubuntu-24.04
       steps:
         - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
         - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ tcli.log
 /nat-lab/3rd-party/netfilter-full-cone-nat
 /nat-lab/tests/uniffi/telio_bindings.py
 /nat-lab/tests/uniffi/libtelio.so
+/nat-lab/tests/uniffi/telio.dll
 /nat-lab/logs
 /nat-lab/coredumps
 /src/telio.py

--- a/Justfile
+++ b/Justfile
@@ -65,7 +65,7 @@ black fix="false":
     fi
 
 pylint:
-    docker run --rm -t -v$(pwd):/code 'ubuntu:22.04' sh -c "apt-get update && apt-get -y install python3-pip && cd code && pip3 install --no-deps -r requirements.txt && pipenv install --system && cd nat-lab && pipenv install --system && pylint -f colorized . --ignore telio_bindings.py"
+    docker run --rm -t -v$(pwd):/code 'ubuntu:24.04' sh -c "apt-get update && apt-get -y install python3-pip && cd code && pip3 install --no-deps -r requirements.txt && pipenv install --system && cd nat-lab && pipenv install --system && pylint -f colorized . --ignore telio_bindings.py"
 
 # Start a dev web cgi server, for local teliod cgi development
 web:

--- a/nat-lab/bin/cleanup_natlab_processes
+++ b/nat-lab/bin/cleanup_natlab_processes
@@ -4,12 +4,16 @@ echo "Executing natlab process cleanup script"
 
 for pid in $(ps -e -o pid=); do
     # Skip non-testing processes
-    if ! grep --null-data --text KILL_ID /proc/${pid}/environ; then
+    if ! grep --null-data --text "KILL_ID" /proc/${pid}/environ; then
+        continue
+    fi
+
+    if grep --null-data --text "DO_NOT_KILL" /proc/${pid}/environ; then
         continue
     fi
 
     # KILL
-    cmd=$(tr -d '\000' < /proc/${pid}/cmdline || echo "N/A")
+    cmd=$(tr -d '\000' </proc/${pid}/cmdline || echo "N/A")
     echo "$(date) Cleaning up process: ${pid} ${cmd}"
     kill "${pid}" || echo "Kill command failed with $?, perhaps processs already exited?"
 done

--- a/nat-lab/bin/derp-server
+++ b/nat-lab/bin/derp-server
@@ -2,6 +2,10 @@
 
 set -e
 
+# Backup IP tables
+iptables-save -f iptables_backup
+ip6tables-save -f ip6tables_backup
+
 /usr/bin/nordderper &
 
 sleep infinity

--- a/nat-lab/bin/dns-server.sh
+++ b/nat-lab/bin/dns-server.sh
@@ -1,2 +1,7 @@
 #!/bin/sh
+
+# Backup IP tables
+iptables-save -f iptables_backup
+ip6tables-save -f ip6tables_backup
+
 /opt/bin/dns-server 2>&1 | tee /dns-server.log

--- a/nat-lab/docker-compose.yml
+++ b/nat-lab/docker-compose.yml
@@ -424,6 +424,8 @@ services:
       - net.netfilter.nf_conntrack_tcp_timeout_fin_wait=15
     cap_drop:
       - ALL
+    cap_add:
+      - NET_ADMIN
     security_opt:
       - no-new-privileges:true
     networks:
@@ -550,6 +552,10 @@ services:
     hostname: dns-server-1
     image: nat-lab:base
     entrypoint: /opt/bin/dns-server.sh
+    cap_drop:
+      - ALL
+    cap_add:
+      - NET_ADMIN
     environment:
       PYTHONUNBUFFERED: 1
     networks:
@@ -562,6 +568,10 @@ services:
     hostname: dns-server-2
     image: nat-lab:base
     entrypoint: /opt/bin/dns-server.sh
+    cap_drop:
+      - ALL
+    cap_add:
+      - NET_ADMIN
     environment:
       PYTHONUNBUFFERED: 1
     networks:

--- a/nat-lab/tests/config.py
+++ b/nat-lab/tests/config.py
@@ -46,6 +46,8 @@ STUN_BINARY_PATH_MAC = "/var/root/stunserver/stunclient"
 IPERF_BINARY_MAC = "/var/root/iperf3/iperf3"
 IPERF_BINARY_WINDOWS = "C:/workspace/iperf3/iperf3.exe".replace("/", "\\")
 
+WINDUMP_BINARY_WINDOWS = "C:/workspace/WinDump.exe".replace("/", "\\")
+
 # JIRA issue: LLT-1664
 # The directories between host and Docker container are shared via
 # Docker volumes. Mounting `libtelio/dist` is a nogo, since when host

--- a/nat-lab/tests/conftest.py
+++ b/nat-lab/tests/conftest.py
@@ -360,9 +360,6 @@ async def perform_pretest_cleanups():
 
 
 async def _copy_vm_binaries(tag: ConnectionTag):
-    is_ci = os.environ.get("CUSTOM_ENV_GITLAB_CI") is not None and os.environ.get(
-        "CUSTOM_ENV_GITLAB_CI"
-    )
     if tag in [ConnectionTag.WINDOWS_VM_1, ConnectionTag.WINDOWS_VM_2]:
         try:
             print(f"copying for {tag}")
@@ -371,7 +368,7 @@ async def _copy_vm_binaries(tag: ConnectionTag):
             ):
                 pass
         except OSError as e:
-            if is_ci:
+            if os.environ.get("GITLAB_CI"):
                 raise e
             print(e)
     elif tag is ConnectionTag.MAC_VM:
@@ -381,7 +378,7 @@ async def _copy_vm_binaries(tag: ConnectionTag):
             ):
                 pass
         except OSError as e:
-            if is_ci:
+            if os.environ.get("GITLAB_CI"):
                 raise e
             print(e)
 
@@ -446,10 +443,6 @@ async def _save_macos_logs(conn, suffix):
 
 
 async def collect_kernel_logs(items, suffix):
-    is_ci = os.environ.get("CUSTOM_ENV_GITLAB_CI") is not None and os.environ.get(
-        "CUSTOM_ENV_GITLAB_CI"
-    )
-
     log_dir = "logs"
     os.makedirs(log_dir, exist_ok=True)
 
@@ -462,7 +455,7 @@ async def collect_kernel_logs(items, suffix):
                 async with mac_vm_util.new_connection() as conn:
                     await _save_macos_logs(conn, suffix)
             except OSError as e:
-                if is_ci:
+                if os.environ.get("GITLAB_CI"):
                     raise e
 
 

--- a/nat-lab/tests/conftest.py
+++ b/nat-lab/tests/conftest.py
@@ -56,13 +56,11 @@ def _cancel_all_tasks(loop: asyncio.AbstractEventLoop):
         if task.cancelled():
             continue
         if task.exception() is not None:
-            loop.call_exception_handler(
-                {
-                    "message": "unhandled exception during asyncio.run() shutdown",
-                    "exception": task.exception(),
-                    "task": task,
-                }
-            )
+            loop.call_exception_handler({
+                "message": "unhandled exception during asyncio.run() shutdown",
+                "exception": task.exception(),
+                "task": task,
+            })
 
 
 @pytest.fixture(scope="function")
@@ -135,25 +133,21 @@ def setup_ephemeral_ports(request):
     connection_tags = set()
 
     # Setup for all Docker clients
-    connection_tags.update(
-        [
-            tag
-            for tag in ConnectionTag.__members__.values()
-            if tag.name.startswith("DOCKER_") and "CLIENT" in tag.name
-        ]
-    )
+    connection_tags.update([
+        tag
+        for tag in ConnectionTag.__members__.values()
+        if tag.name.startswith("DOCKER_") and "CLIENT" in tag.name
+    ])
 
     # Handle test name (params) to search for VM tags
     test_name = request.node.name
     if "_VM_" in test_name:
         # Extract all connection tags from test name
-        connection_tags.update(
-            [
-                ConnectionTag[param]
-                for param in test_name.split("[")[1].split("]")[0].split("-")
-                if param in ConnectionTag.__members__
-            ]
-        )
+        connection_tags.update([
+            ConnectionTag[param]
+            for param in test_name.split("[")[1].split("]")[0].split("-")
+            if param in ConnectionTag.__members__
+        ])
 
     # Handle test markers to search for VMs tags
     for mark in request.node.own_markers:
@@ -179,9 +173,7 @@ def pytest_make_parametrize_id(config, val):
         param_id = f"{param_id[1:]}"
     elif isinstance(val, (SetupParameters,)):
         short_conn_tag_name = val.connection_tag.name.removeprefix("DOCKER_")
-        param_id = (
-            f"{short_conn_tag_name}-{val.adapter_type_override.name.replace('_', '') if val.adapter_type_override is not None else ''}"
-        )
+        param_id = f"{short_conn_tag_name}-{val.adapter_type_override.name.replace('_', '') if val.adapter_type_override is not None else ''}"
         if (
             val.features.direct is not None
             and val.features.direct.providers is not None

--- a/nat-lab/tests/mesh_api.py
+++ b/nat-lab/tests/mesh_api.py
@@ -44,8 +44,6 @@ GREEK_ALPHABET = [
     "omega",
 ]
 
-PCAP_FILE_PATH = "/dump.pcap"
-
 
 class NodeError(Exception):
     node_id: str

--- a/nat-lab/tests/utils/connection/connection.py
+++ b/nat-lab/tests/utils/connection/connection.py
@@ -17,7 +17,9 @@ class Connection(ABC):
         self._target_os = target_os
 
     @abstractmethod
-    def create_process(self, command: List[str], kill_id=None) -> "Process":
+    def create_process(
+        self, command: List[str], kill_id=None, term_type=None
+    ) -> "Process":
         pass
 
     @property

--- a/nat-lab/tests/utils/connection/docker_connection.py
+++ b/nat-lab/tests/utils/connection/docker_connection.py
@@ -41,7 +41,9 @@ class DockerConnection(Connection):
 
         await to_thread(aux)
 
-    def create_process(self, command: List[str], kill_id=None) -> "Process":
+    def create_process(
+        self, command: List[str], kill_id=None, term_type=None
+    ) -> "Process":
         process = DockerProcess(
             self._container, self.container_name(), command, kill_id
         )

--- a/nat-lab/tests/utils/connection/docker_connection.py
+++ b/nat-lab/tests/utils/connection/docker_connection.py
@@ -42,7 +42,9 @@ class DockerConnection(Connection):
         await to_thread(aux)
 
     def create_process(self, command: List[str], kill_id=None) -> "Process":
-        process = DockerProcess(self._container, command, kill_id)
+        process = DockerProcess(
+            self._container, self.container_name(), command, kill_id
+        )
         print(
             datetime.now(),
             "Executing",

--- a/nat-lab/tests/utils/connection/ssh_connection.py
+++ b/nat-lab/tests/utils/connection/ssh_connection.py
@@ -9,10 +9,17 @@ from utils.process import Process, SshProcess
 
 class SshConnection(Connection):
     _connection: asyncssh.SSHClientConnection
+    _vm_name: str
     _target_os: TargetOS
 
-    def __init__(self, connection: asyncssh.SSHClientConnection, target_os: TargetOS):
+    def __init__(
+        self,
+        connection: asyncssh.SSHClientConnection,
+        vm_name: str,
+        target_os: TargetOS,
+    ):
         super().__init__(target_os)
+        self._vm_name = vm_name
         self._connection = connection
         self._target_os = target_os
 
@@ -25,7 +32,7 @@ class SshConnection(Connection):
         else:
             assert False, f"not supported target_os '{self._target_os}'"
 
-        return SshProcess(self._connection, command, escape_argument)
+        return SshProcess(self._connection, self._vm_name, command, escape_argument)
 
     async def get_ip_address(self) -> tuple[str, str]:
         ip = self._connection._host  # pylint: disable=protected-access

--- a/nat-lab/tests/utils/connection/ssh_connection.py
+++ b/nat-lab/tests/utils/connection/ssh_connection.py
@@ -23,7 +23,9 @@ class SshConnection(Connection):
         self._connection = connection
         self._target_os = target_os
 
-    def create_process(self, command: List[str], kill_id=None) -> "Process":
+    def create_process(
+        self, command: List[str], kill_id=None, term_type=None
+    ) -> "Process":
         print(datetime.now(), "Executing", command, "on", self.target_os)
         if self._target_os == TargetOS.Windows:
             escape_argument = cmd_exe_escape.escape_argument
@@ -32,7 +34,9 @@ class SshConnection(Connection):
         else:
             assert False, f"not supported target_os '{self._target_os}'"
 
-        return SshProcess(self._connection, self._vm_name, command, escape_argument)
+        return SshProcess(
+            self._connection, self._vm_name, command, escape_argument, term_type
+        )
 
     async def get_ip_address(self) -> tuple[str, str]:
         ip = self._connection._host  # pylint: disable=protected-access

--- a/nat-lab/tests/utils/connection_util.py
+++ b/nat-lab/tests/utils/connection_util.py
@@ -55,6 +55,11 @@ class ConnectionTag(Enum):
     DOCKER_VPN_2 = auto()
     DOCKER_NLX_1 = auto()
     DOCKER_INTERNAL_SYMMETRIC_GW = auto()
+    DOCKER_DERP_1 = auto()
+    DOCKER_DERP_2 = auto()
+    DOCKER_DERP_3 = auto()
+    DOCKER_DNS_SERVER_1 = auto()
+    DOCKER_DNS_SERVER_2 = auto()
 
 
 DOCKER_SERVICE_IDS: Dict[ConnectionTag, str] = {
@@ -91,6 +96,11 @@ DOCKER_SERVICE_IDS: Dict[ConnectionTag, str] = {
     ConnectionTag.DOCKER_VPN_1: "vpn-01",
     ConnectionTag.DOCKER_VPN_2: "vpn-02",
     ConnectionTag.DOCKER_INTERNAL_SYMMETRIC_GW: "internal-symmetric-gw-01",
+    ConnectionTag.DOCKER_DERP_1: "derp-01",
+    ConnectionTag.DOCKER_DERP_2: "derp-02",
+    ConnectionTag.DOCKER_DERP_3: "derp-03",
+    ConnectionTag.DOCKER_DNS_SERVER_1: "dns-server-01",
+    ConnectionTag.DOCKER_DNS_SERVER_2: "dns-server-02",
 }
 
 

--- a/nat-lab/tests/utils/connection_util.py
+++ b/nat-lab/tests/utils/connection_util.py
@@ -99,8 +99,8 @@ DOCKER_SERVICE_IDS: Dict[ConnectionTag, str] = {
     ConnectionTag.DOCKER_DERP_1: "derp-01",
     ConnectionTag.DOCKER_DERP_2: "derp-02",
     ConnectionTag.DOCKER_DERP_3: "derp-03",
-    ConnectionTag.DOCKER_DNS_SERVER_1: "dns-server-01",
-    ConnectionTag.DOCKER_DNS_SERVER_2: "dns-server-02",
+    ConnectionTag.DOCKER_DNS_SERVER_1: "dns-server-1",
+    ConnectionTag.DOCKER_DNS_SERVER_2: "dns-server-2",
 }
 
 

--- a/nat-lab/tests/utils/process/process.py
+++ b/nat-lab/tests/utils/process/process.py
@@ -7,21 +7,28 @@ StreamCallback = Callable[[str], Awaitable[Any]]
 
 class ProcessExecError(Exception):
     returncode: int
+    remote_name: str
     cmd: List[str]
     stdout: str
     stderr: str
 
     def __init__(
-        self, returncode: int, cmd: List[str], stdout: str, stderr: str
+        self,
+        returncode: int,
+        remote_name: str,
+        cmd: List[str],
+        stdout: str,
+        stderr: str,
     ) -> None:
         self.returncode = returncode
+        self.remote_name = remote_name
         self.cmd = cmd
         self.stdout = stdout
         self.stderr = stderr
 
     def print(self) -> None:
         print(
-            f"Executed command {self.cmd} exited with ret code '{self.returncode}'. STDOUT: '{self.stdout}'. STDERR: '{self.stderr}'"
+            f"Executed command {self.cmd} on {self.remote_name} exited with ret code '{self.returncode}'. STDOUT: '{self.stdout}'. STDERR: '{self.stderr}'"
         )
 
 
@@ -31,7 +38,7 @@ class Process(ABC):
         self,
         stdout_callback: Optional[StreamCallback] = None,
         stderr_callback: Optional[StreamCallback] = None,
-        privileged=False,
+        privileged: bool = False,
     ) -> "Process":
         pass
 
@@ -41,6 +48,7 @@ class Process(ABC):
         self,
         stdout_callback: Optional[StreamCallback] = None,
         stderr_callback: Optional[StreamCallback] = None,
+        privileged: bool = False,
     ) -> AsyncIterator["Process"]:
         yield self
 

--- a/nat-lab/tests/utils/process/ssh_process.py
+++ b/nat-lab/tests/utils/process/ssh_process.py
@@ -17,6 +17,7 @@ class SshProcess(Process):
     _stdin: Optional[asyncssh.SSHWriter]
     _process: Optional[asyncssh.SSHClientProcess]
     _running: bool
+    _term_type: Optional[str]
 
     def __init__(
         self,
@@ -24,6 +25,7 @@ class SshProcess(Process):
         vm_name: str,
         command: List[str],
         escape_argument: Callable[[str], str],
+        term_type: Optional[str] = None,
     ) -> None:
         self._ssh_connection = ssh_connection
         self._vm_name = vm_name
@@ -36,6 +38,7 @@ class SshProcess(Process):
         self._escape_argument = escape_argument
         self._process = None
         self._running = False
+        self._term_type = term_type
 
     async def execute(
         self,
@@ -48,7 +51,9 @@ class SshProcess(Process):
         escaped = [self._escape_argument(arg) for arg in self._command]
         command_str = " ".join(escaped)
 
-        self._process = await self._ssh_connection.create_process(command_str)
+        self._process = await self._ssh_connection.create_process(
+            command_str, term_type=self._term_type
+        )
         self._running = True
         self._stdin = self._process.stdin
         self._stdin_ready.set()

--- a/nat-lab/tests/utils/tcpdump.py
+++ b/nat-lab/tests/utils/tcpdump.py
@@ -1,8 +1,10 @@
+import os
 from config import WINDUMP_BINARY_WINDOWS
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, AsyncExitStack
 from typing import AsyncIterator, Optional, List
 from utils.connection import TargetOS, Connection
 from utils.process import Process
+from utils.testing import get_current_test_log_path
 
 PCAP_FILE_PATH = "/dump.pcap"
 
@@ -19,19 +21,21 @@ class TcpDump:
     def __init__(
         self,
         connection: Connection,
-        interface: Optional[str],
-        output_file: Optional[str],
         filters: List[str],
+        interface: str = "any",
+        output_file: str = PCAP_FILE_PATH,
         verbose: bool = False,
     ) -> None:
         self.connection = connection
-        self.interface = interface or "any"
-        self.output_file = output_file or PCAP_FILE_PATH
+        self.interface = interface
+        self.output_file = output_file
         self.process = self.connection.create_process(
             [
                 self.get_tcpdump_binary(connection.target_os),
-                f"-i {self.interface}",
-                f"-w {self.output_file}",
+                "-i",
+                self.interface,
+                "-w",
+                self.output_file,
             ]
             + filters
         )
@@ -67,12 +71,48 @@ class TcpDump:
 
     async def execute(self) -> None:
         try:
-            await self.process.execute(self.on_stdout, self.on_stderr)
+            await self.process.execute(self.on_stdout, self.on_stderr, True)
         except Exception as e:
             print(f"Error executing tcpdump: {e}")
             raise
 
     @asynccontextmanager
     async def run(self) -> AsyncIterator["TcpDump"]:
-        async with self.process.run(self.on_stdout, self.on_stderr):
+        async with self.process.run(self.on_stdout, self.on_stderr, True):
             yield self
+
+
+def find_unique_path_for_tcpdump(log_dir, guest_name):
+    candidate_path = f"{log_dir}/{guest_name}.pcap"
+    counter = 1
+    # NOTE: counter starting from '1' means that the file will either have no suffix or
+    # will have a suffix starting from '2'. This is to make it clear that it's not the
+    # first log for that guest/client.
+    while os.path.isfile(candidate_path):
+        counter += 1
+        candidate_path = f"./{log_dir}/{guest_name}-{counter}.pcap"
+    return candidate_path
+
+
+@asynccontextmanager
+async def make_tcpdump(
+    connection_list: list[Connection],
+    download: bool = True,
+    store_in: Optional[str] = None,
+):
+    async with AsyncExitStack() as exit_stack:
+        for conn in connection_list:
+            await exit_stack.enter_async_context(
+                TcpDump(conn, ["-U"], verbose=True).run()
+            )
+        try:
+            yield
+        finally:
+            if download:
+                log_dir = get_current_test_log_path()
+                os.makedirs(log_dir, exist_ok=True)
+                for conn in connection_list:
+                    path = find_unique_path_for_tcpdump(
+                        store_in if store_in else log_dir, conn.target_name()
+                    )
+                    await conn.download(PCAP_FILE_PATH, path)

--- a/nat-lab/tests/utils/tcpdump.py
+++ b/nat-lab/tests/utils/tcpdump.py
@@ -1,0 +1,78 @@
+from config import WINDUMP_BINARY_WINDOWS
+from contextlib import asynccontextmanager
+from typing import AsyncIterator, Optional, List
+from utils.connection import TargetOS, Connection
+from utils.process import Process
+
+PCAP_FILE_PATH = "/dump.pcap"
+
+
+class TcpDump:
+    interface: str
+    connection: Connection
+    process: Process
+    verbose: bool
+    stdout: str
+    stderr: str
+    output_file: str
+
+    def __init__(
+        self,
+        connection: Connection,
+        interface: Optional[str],
+        output_file: Optional[str],
+        filters: List[str],
+        verbose: bool = False,
+    ) -> None:
+        self.connection = connection
+        self.interface = interface or "any"
+        self.output_file = output_file or PCAP_FILE_PATH
+        self.process = self.connection.create_process(
+            [
+                self.get_tcpdump_binary(connection.target_os),
+                f"-i {self.interface}",
+                f"-w {self.output_file}",
+            ]
+            + filters
+        )
+        self.verbose = verbose
+        self.stdout = ""
+        self.stderr = ""
+
+    @staticmethod
+    def get_tcpdump_binary(target_os: TargetOS) -> str:
+        if target_os in [TargetOS.Linux, TargetOS.Mac]:
+            return "tcpdump"
+
+        if target_os == TargetOS.Windows:
+            return WINDUMP_BINARY_WINDOWS
+
+        raise ValueError(f"target_os not supported {target_os}")
+
+    def get_stdout(self) -> str:
+        return self.stdout
+
+    def get_stderr(self) -> str:
+        return self.stderr
+
+    async def on_stdout(self, output: str) -> None:
+        self.stdout += output
+        if self.verbose:
+            print(f"TCPDUMP: {output}")
+
+    async def on_stderr(self, output: str) -> None:
+        self.stderr += output
+        if self.verbose:
+            print(f"TCPDUMP ERROR: {output}")
+
+    async def execute(self) -> None:
+        try:
+            await self.process.execute(self.on_stdout, self.on_stderr)
+        except Exception as e:
+            print(f"Error executing tcpdump: {e}")
+            raise
+
+    @asynccontextmanager
+    async def run(self) -> AsyncIterator["TcpDump"]:
+        async with self.process.run(self.on_stdout, self.on_stderr):
+            yield self

--- a/nat-lab/tests/utils/vm/mac_vm_util.py
+++ b/nat-lab/tests/utils/vm/mac_vm_util.py
@@ -44,7 +44,7 @@ async def new_connection(
         known_hosts=None,
         options=ssh_options,
     ) as ssh_connection:
-        connection = SshConnection(ssh_connection, TargetOS.Mac)
+        connection = SshConnection(ssh_connection, "Mac", TargetOS.Mac)
 
         if copy_binaries:
             await _copy_binaries(ssh_connection, connection)

--- a/nat-lab/tests/utils/vm/windows_vm_util.py
+++ b/nat-lab/tests/utils/vm/windows_vm_util.py
@@ -6,6 +6,7 @@ from config import (
     LIBTELIO_BINARY_PATH_WINDOWS_VM,
     UNIFFI_PATH_WINDOWS_VM,
     WINDOWS_1_VM_IP,
+    WINDOWS_2_VM_IP,
 )
 from contextlib import asynccontextmanager
 from datetime import datetime
@@ -16,6 +17,11 @@ from utils.process import ProcessExecError
 VM_TCLI_DIR = LIBTELIO_BINARY_PATH_WINDOWS_VM
 VM_UNIFFI_DIR = UNIFFI_PATH_WINDOWS_VM
 VM_SYSTEM32 = "C:\\Windows\\System32"
+
+NAME = {
+    WINDOWS_1_VM_IP: "Windows-1",
+    WINDOWS_2_VM_IP: "Windows-2",
+}
 
 
 @asynccontextmanager
@@ -46,7 +52,7 @@ async def new_connection(
         known_hosts=None,
         options=ssh_options,
     ) as ssh_connection:
-        connection = SshConnection(ssh_connection, TargetOS.Windows)
+        connection = SshConnection(ssh_connection, NAME[ip], TargetOS.Windows)
 
         keys = await _get_network_interface_tunnel_keys(connection)
         for key in keys:


### PR DESCRIPTION
### Description
- add multi-OS tcpdump wrapper
- add `DO_NOT_KILL` prefix to process kill_id, so it won't be killed during cleanup before each test
- make dns-server pcaps session wide
- unify `GITLAB_CI` usage between code, previously was `GITLAB_CI` and `CUSTOM_ENV_GITLAB_CI`
- add Connection name to Process, so errors would be more clear


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
