### PR TITLE
Retarget libtelio from trigger gitlab action to reusable workflow

### DIFF
--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -13,22 +13,13 @@ permissions: {}
 
 jobs:
   trigger-gitlab-pipeline:
-    runs-on: [self-hosted, gitlab]
-    if: |
-      github.event_name == 'schedule' ||
-      github.event_name == 'push' ||
-      (
-        github.event_name == 'pull_request_target' &&
-        github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name &&
-        github.event.label.name == 'run tests'
-      )
-    steps:
-      - uses: NordSecurity/trigger-gitlab-pipeline@940714dbb5c77428fb13ecdb3a94cf929adfb65e # v2.0.0
-        with:
-          ci-api-v4-url: ${{ secrets.CI_API_V4_URL }}
-          access-token: ${{ secrets.GITLAB_API_TOKEN }}
-          trigger-token: ${{ secrets.TOKEN }}
-          project-id: ${{ secrets.PROJECT_ID }}
-          schedule: ${{ github.event_name == 'schedule' }}
-          cancel-outdated-pipelines: ${{ github.ref_name != 'main' }}
-          triggered-ref: v2.4.11 # REMEMBER to also update in .gitlab-ci.yml
+    uses: NordSecurity/trigger-gitlab-pipeline/.github/workflows/trigger-gitlab-pipeline.yml@272b0b859016b5c0ff2c3b7d70799270b0a047fb
+    secrets:
+      ci-api-v4-url: ${{ secrets.CI_API_V4_URL }}
+      access-token: ${{ secrets.GITLAB_API_TOKEN }}
+      trigger-token: ${{ secrets.TOKEN }}
+      project-id: ${{ secrets.PROJECT_ID }}
+    with:
+      schedule: ${{ github.event_name == 'schedule' }}
+      cancel-outdated-pipelines: ${{ github.ref_name != 'main' }}
+      triggered-ref: v2.4.11 # REMEMBER to also update in .gitlab-ci.yml


### PR DESCRIPTION
### Problem
So it turns out, that current implementation of label based variant for controlling whether workflows are being run or not for 3rd-party contributors is not good enough. Abusing it still requires maintainer action, but really non-obvious one. For this reason, a reusable workflow has been implemented, which will be pinned in github settings to be the only one allowed to run on the private runner. The workflow is already implemented and merged, hence this PR, which migrates from github actions (which you cannot pin) to workflow (which you can pin). 


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
