### PR TITLE
Update libtelio-build reference

### DIFF
--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -31,4 +31,4 @@ jobs:
           project-id: ${{ secrets.PROJECT_ID }}
           schedule: ${{ github.event_name == 'schedule' }}
           cancel-outdated-pipelines: ${{ github.ref_name != 'main' }}
-          triggered-ref: v2.4.7 # REMEMBER to also update in .gitlab-ci.yml
+          triggered-ref: v2.4.8 # REMEMBER to also update in .gitlab-ci.yml

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,4 +15,4 @@ libtelio-build-pipeline:
 
   trigger:
     project: $LIBTELIO_BUILD_PROJECT_PATH
-    branch: v2.4.7 # REMEMBER to also update in .github/workflows/gitlab.yml
+    branch: v2.4.8 # REMEMBER to also update in .github/workflows/gitlab.yml


### PR DESCRIPTION
### Problem
Upgrade libtelio-build reference to allow manually triggering job to upload xcframeworks.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
