### PR TITLE
add process exec error handling in natlab precondtions

### DIFF
--- a/nat-lab/tests/conftest.py
+++ b/nat-lab/tests/conftest.py
@@ -9,6 +9,7 @@ from mesh_api import start_tcpdump, stop_tcpdump
 from utils.bindings import TelioAdapterType
 from utils.connection import DockerConnection
 from utils.connection_util import ConnectionTag, LAN_ADDR_MAP, new_connection_raw
+from utils.process import ProcessExecError
 from utils.router import IPStack
 from utils.vm import windows_vm_util, mac_vm_util
 
@@ -150,6 +151,8 @@ async def perform_setup_checks() -> bool:
                 break
             except asyncio.TimeoutError:
                 print(f"{target}() timeout, retrying...")
+            except ProcessExecError as e:
+                print(f"{target}() process exec error {e}, retrying...")
             retries -= 1
         else:
             return False


### PR DESCRIPTION
### Problem
When running natlab precondition checks, we are not retrying if we get process error.

### Solution
Retry precondition check when we get process error.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
