### PR TITLE
Update libtelio build ref to v2.4.10

### DIFF
--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -31,4 +31,4 @@ jobs:
           project-id: ${{ secrets.PROJECT_ID }}
           schedule: ${{ github.event_name == 'schedule' }}
           cancel-outdated-pipelines: ${{ github.ref_name != 'main' }}
-          triggered-ref: v2.4.9 # REMEMBER to also update in .gitlab-ci.yml
+          triggered-ref: v2.4.10 # REMEMBER to also update in .gitlab-ci.yml

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,4 +15,4 @@ libtelio-build-pipeline:
 
   trigger:
     project: $LIBTELIO_BUILD_PROJECT_PATH
-    branch: v2.4.9 # REMEMBER to also update in .github/workflows/gitlab.yml
+    branch: v2.4.10 # REMEMBER to also update in .github/workflows/gitlab.yml

--- a/nat-lab/tests/config.py
+++ b/nat-lab/tests/config.py
@@ -41,9 +41,9 @@ STUNV6_SERVER = "2001:db8:85a4::deed:6"
 STUN_BINARY_PATH_WINDOWS = "C:/workspace/stunserver/release/stunclient.exe".replace(
     "/", "\\"
 )
-STUN_BINARY_PATH_MAC = "/var/root/stunserver/stunclient"
+STUN_BINARY_PATH_MAC = "/usr/local/bin/stunclient"
 
-IPERF_BINARY_MAC = "/var/root/iperf3/iperf3"
+IPERF_BINARY_MAC = "/usr/local/bin/iperf3"
 IPERF_BINARY_WINDOWS = "C:/workspace/iperf3/iperf3.exe".replace("/", "\\")
 
 # JIRA issue: LLT-1664


### PR DESCRIPTION
### Problem
Old VM dependencies, missing windump for windows VM

### Solution
Updated VM dependencies, added windump


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
