### PR TITLE
Update macOS clippy runner and remove actions-rs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,13 +22,13 @@ jobs:
         include:
           - arch: x86_64
             target_os: macos
-            runner: macos-12
+            runner: macos-13
           - arch: aarch64
             target_os: macos
-            runner: macos-12
+            runner: macos-14
           - arch: aarch64
             target_os: ios
-            runner: macos-12
+            runner: macos-13
           - arch: x86_64
             target_os: windows
             runner: windows-2022
@@ -47,7 +47,7 @@ jobs:
         uses: egor-tensin/vs-shell@9a932a62d05192eae18ca370155cf877eecc2202 # v2.1
         if: ${{ matrix.target_os == 'windows' }}
       - name: install python3-requests
-        run: pip3 install requests==2.32.3
+        run: pip3 install requests==2.32.3 --break-system-packages
       - name: Build libtelio
         run: python3 ci/build_libtelio.py build ${{ matrix.target_os }} ${{ matrix.arch }} --msvc
       - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -48,17 +48,10 @@ jobs:
             command: clippy
             args: --target "x86_64-pc-windows-gnu" --lib --color always -- --deny warnings --allow unknown-lints -W clippy::expect_used -W clippy::panic -W clippy::unwrap_used
   clippy-mac:
-      runs-on: macos-12
+      runs-on: macos-13
       steps:
         - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
-        - uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.6
-          with:
-            target: x86_64-apple-darwin
-            components: clippy
-        - uses: actions-rs/cargo@ae10961054e4aa8b4aa7dffede299aaf087aa33b # v1.0.3
-          with:
-            command: clippy
-            args: --target "x86_64-apple-darwin" --lib --color always -- --deny warnings --allow unknown-lints -W clippy::expect_used -W clippy::panic -W clippy::unwrap_used
+        - run: cargo clippy --verbose --target "x86_64-apple-darwin" --lib --color always -- --deny warnings --allow unknown-lints -W clippy::expect_used -W clippy::panic -W clippy::unwrap_used
   deny:
       runs-on: ubuntu-22.04
       steps:


### PR DESCRIPTION
### Problem
macOS clippy workflow is [occasionally failing](https://github.com/NordSecurity/libtelio/actions/runs/11365707093/job/31614492082?pr=868) with `(signal: 6, SIGABRT: process abort signal)`.
MacOS-12 runners are [deprecated by GitHub](https://github.com/actions/runner-images/issues/10721) and will be removed.
`actions-rs` Rust GitHub actions are [unmaintained and archived](https://github.com/actions-rs).

### Solution
Update the macOS workflow runners to `macos-13` for `x86_64` targets and `macos-14` for `aarch64`.
Remove `actions-rs` dependency for macOS clippy workflow, as the GitHub Runners already come with all the Rust [tools preinstalled](https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md#rust-tools).


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
