### PR TITLE
Revert "Update libtelio build ref to v2.4.10"

### DIFF
--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -31,4 +31,4 @@ jobs:
           project-id: ${{ secrets.PROJECT_ID }}
           schedule: ${{ github.event_name == 'schedule' }}
           cancel-outdated-pipelines: ${{ github.ref_name != 'main' }}
-          triggered-ref: v2.4.10 # REMEMBER to also update in .gitlab-ci.yml
+          triggered-ref: v2.4.9 # REMEMBER to also update in .gitlab-ci.yml

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -155,7 +155,7 @@ jobs:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       - uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.6
         with:
-          toolchain: 1.79.0
+          toolchain: 1.80.0
           override: true
           default: true
       - uses: actions-rs/install@9da1d2adcfe5e7c16992e8242ca33a56b6d9b101

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,4 +15,4 @@ libtelio-build-pipeline:
 
   trigger:
     project: $LIBTELIO_BUILD_PROJECT_PATH
-    branch: v2.4.10 # REMEMBER to also update in .github/workflows/gitlab.yml
+    branch: v2.4.9 # REMEMBER to also update in .github/workflows/gitlab.yml

--- a/nat-lab/tests/config.py
+++ b/nat-lab/tests/config.py
@@ -41,9 +41,9 @@ STUNV6_SERVER = "2001:db8:85a4::deed:6"
 STUN_BINARY_PATH_WINDOWS = "C:/workspace/stunserver/release/stunclient.exe".replace(
     "/", "\\"
 )
-STUN_BINARY_PATH_MAC = "/usr/local/bin/stunclient"
+STUN_BINARY_PATH_MAC = "/var/root/stunserver/stunclient"
 
-IPERF_BINARY_MAC = "/usr/local/bin/iperf3"
+IPERF_BINARY_MAC = "/var/root/iperf3/iperf3"
 IPERF_BINARY_WINDOWS = "C:/workspace/iperf3/iperf3.exe".replace("/", "\\")
 
 # JIRA issue: LLT-1664


### PR DESCRIPTION
Reverts NordSecurity/libtelio#878

Windows VM sometimes hang during `vagrant up` -> therefore the revert, since the issue is resolved

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
