### PR TITLE
Detect long blocking tasks

### DIFF
--- a/crates/telio-utils/src/tokio.rs
+++ b/crates/telio-utils/src/tokio.rs
@@ -6,7 +6,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-const ALERT_DURATION: Duration = Duration::from_secs(60);
+const ALERT_DURATION: Duration = Duration::from_secs(10);
 const UNPARKED_THRESHOLD: Duration = Duration::from_secs(1);
 
 #[derive(PartialEq, Eq, Debug, Clone, Copy)]
@@ -19,7 +19,7 @@ enum ThreadStatus {
 
 /// ThreadTracker will track changes of state of tokio's threads.
 pub struct ThreadTracker {
-    statuses: FxHashMap<ThreadId, ThreadStatus>,
+    statuses: FxHashMap<ThreadId, (ThreadStatus, Instant)>,
     last_change: Instant,
 }
 
@@ -35,18 +35,35 @@ impl Default for ThreadTracker {
 impl ThreadTracker {
     fn set_status(&mut self, status: ThreadStatus) {
         let now = Instant::now();
-        let delta = now - self.last_change;
+        let tid = current().id();
+
         self.last_change = now;
-        if let Some(ThreadStatus::Unparked) = self.statuses.insert(current().id(), status) {
+        if let Some((ThreadStatus::Unparked, thread_last_status_change)) =
+            self.statuses.insert(tid, (status, now))
+        {
+            let delta = now - thread_last_status_change;
             if status == ThreadStatus::Parked && delta > UNPARKED_THRESHOLD {
-                let tid = std::thread::current().id();
                 telio_log_debug!("Thread {tid:?} was unparked for too long: {delta:?}");
             }
         }
     }
 
+    fn check_for_long_unparked_threads(&self) {
+        let now = Instant::now();
+        for (tid, (status, last_status_change)) in &self.statuses {
+            if *status == ThreadStatus::Unparked {
+                let delta = now - *last_status_change;
+                if delta > 2 * UNPARKED_THRESHOLD {
+                    telio_log_debug!("{tid:?} is unparked for {delta:?}");
+                }
+            }
+        }
+    }
+
     fn are_all_threads_parked(&self) -> bool {
-        self.statuses.values().all(|s| *s == ThreadStatus::Parked)
+        self.statuses
+            .values()
+            .all(|(s, _)| *s == ThreadStatus::Parked)
     }
 
     /// Tokio runtime callback
@@ -85,6 +102,7 @@ impl Monitor for Arc<parking_lot::Mutex<ThreadTracker>> {
                 let now = Instant::now();
                 let thread_tracker = self.lock();
                 let time_since_last_change = now - thread_tracker.last_change;
+                thread_tracker.check_for_long_unparked_threads();
                 if time_since_last_change > ALERT_DURATION
                     && thread_tracker.are_all_threads_parked()
                     && last_alert

--- a/src/ffi/logging.rs
+++ b/src/ffi/logging.rs
@@ -45,10 +45,11 @@ where
         mut writer: fmt::format::Writer<'_>,
         event: &tracing::Event<'_>,
     ) -> std::fmt::Result {
+        let tid = std::thread::current().id();
         let meta = event.metadata();
         write!(
             writer,
-            "{:?}:{} ",
+            "{tid:?} {:?}:{} ",
             meta.module_path().unwrap_or("<unknown module>"),
             meta.line().unwrap_or(0),
         )?;
@@ -193,19 +194,20 @@ mod test {
             ); // +4
         };
         let mpath = module_path!();
+        let tid = std::thread::current().id();
         let expected = [
             (
                 TelioLogLevel::Debug,
-                format!("{:?}:{} second message", mpath, start + 2),
+                format!("{tid:?} {:?}:{} second message", mpath, start + 2),
             ),
             (
                 TelioLogLevel::Info,
-                format!("{:?}:{} third\nmutiline\nmessage", mpath, start + 3),
+                format!("{tid:?} {:?}:{} third\nmutiline\nmessage", mpath, start + 3),
             ),
             (
                 TelioLogLevel::Warning,
                 format!(
-                    "{:?}:{} fourth message with info n=2 extra=\"extra info\"",
+                    "{tid:?} {:?}:{} fourth message with info n=2 extra=\"extra info\"",
                     mpath,
                     start + 4
                 ),

--- a/tests/logger.rs
+++ b/tests/logger.rs
@@ -13,7 +13,7 @@ mod test_module {
     #[test]
     fn test_logger() {
         // Line number of tracing::info! location
-        const INFO_LINE: u32 = 50;
+        const INFO_LINE: u32 = 51;
 
         let call_count = Arc::new(AtomicUsize::new(0));
 
@@ -27,9 +27,10 @@ mod test_module {
                 log_level: telio::ffi_types::TelioLogLevel,
                 payload: String,
             ) -> FfiResult<()> {
+                let tid = std::thread::current().id();
                 assert!(matches!(log_level, telio::ffi_types::TelioLogLevel::Info));
                 assert_eq!(
-                    format!(r#""logger::test_module":{INFO_LINE} test message"#),
+                    format!(r#"{tid:?} "logger::test_module":{INFO_LINE} test message"#),
                     payload
                 );
                 assert_eq!(0, self.call_count.fetch_add(1, Ordering::Relaxed));


### PR DESCRIPTION
### Problem
We suspect that tokio threads are blocked by some blocking operations.

### Solution
Print a log when some thread goes from unparked to parked after more than 1s - telio has no place where it expects to be doing work for that long without a break. To make it simpler to match with what was happening thread ID will also be printed in the logs.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
