### PR TITLE
Fix magic DNS not working under PQ VPN

### DIFF
--- a/.unreleased/LLT-5710
+++ b/.unreleased/LLT-5710
@@ -1,0 +1,1 @@
+Fix magic DNS not working under the Post-Quantum VPN

--- a/nat-lab/tests/telio.py
+++ b/nat-lab/tests/telio.py
@@ -722,6 +722,12 @@ class Client:
             )
 
     async def enable_magic_dns(self, forward_servers: List[str]) -> None:
+        # Magic DNS required adapter port.
+        # For the reasoning behind this see `set_meshnet_config()`
+        configured = await self._configure_interface()
+        if configured and self._adapter_type == TelioAdapterType.LINUX_NATIVE_TUN:
+            await asyncio.sleep(2.0)
+
         await self.get_proxy().enable_magic_dns(forward_servers)
 
     async def disable_magic_dns(self) -> None:


### PR DESCRIPTION
### Problem
Magic DNS breaks when a PQ connection is established

### Solution
Magic DNS relies on the stable public key of the WG interface. When connecting to the PQ server the keys change and are rotated every few minutes. The fix is to notify the DNS about this change.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
