### PR TITLE
Move moose flush to spawn blocking

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -151,10 +151,8 @@ jobs:
           toolchain: 1.80.0
           override: true
           default: true
-      - uses: actions-rs/install@9da1d2adcfe5e7c16992e8242ca33a56b6d9b101
-        with:
-          crate: cargo-unused-features
-          version: 0.2.0
+      - name: Install cargo-unusued-features
+        run: cargo install --version 0.2.0 cargo-unused-features --locked
       - name: Run cargo-unused-features
         run: |
           for dir in ./crates/* ./clis/*; do

--- a/crates/telio-nurse/src/nurse.rs
+++ b/crates/telio-nurse/src/nurse.rs
@@ -13,6 +13,7 @@ use telio_utils::{
     telio_log_debug, telio_log_error, telio_log_info, telio_log_trace, telio_log_warn,
 };
 use telio_wg::uapi::AnalyticsEvent;
+use tokio::task::spawn_blocking;
 use uuid::Uuid;
 
 #[mockall_double::double]
@@ -345,9 +346,12 @@ impl State {
 
         self.handle_service_quality_event(&info, false).await;
 
-        telio_log_info!("Attempting to flush moose changes");
-        let r = lana!(flush_changes);
-        telio_log_info!("Flushing moose changes result: {:?}", r);
+        let _ = spawn_blocking(move || {
+            telio_log_info!("Attempting to flush moose changes");
+            let r = lana!(flush_changes);
+            telio_log_info!("Flushing moose changes result: {:?}", r);
+        })
+        .await;
     }
 
     fn meshnet_id() -> Uuid {


### PR DESCRIPTION
### Problem
In natlab tests, calls to `lana!(flush_changes)` took more than 1s. Since it's non-async, it blocks the thread on which current async task is running.

### Solution
To fix this, it's wrapped in `spawn_blocking` which moves it to a separate thread where tokio is expecting blocking to occur.

Also fixed the CI job for unused-features by locking in the dependency versions.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
