### PR TITLE
Ability to override nordderper

### DIFF
--- a/nat-lab/Dockerfile
+++ b/nat-lab/Dockerfile
@@ -8,8 +8,10 @@ COPY --chmod=0755 bin/ /opt/bin/
 COPY --chmod=0755 data/custom_debs /opt/custom_debs
 
 # If custom deb is found, install it. This command doesn't fail if it doesn't find anything.
-# Useful for overriding prebaked binaries, such as nordderper.
-RUN find /opt/custom_debs -name "*.deb" -exec dpkg -i {} \;
+# Useful for overriding prebaked binaries, such as nordderper. /opt/custom_deb_install.log contains logs for each installation done
+RUN find /opt/custom_debs -name "*.deb" -exec sh -c \
+    'dpkg -i "$1" && echo "$(basename "$1") with sha256: [$(sha256sum "$1" | cut -d " " -f 1)] was installed or updated" | tee -a /opt/custom_deb_install.log' _ {} \;
+
 RUN \
     tar -xf /opt/tclis-3.6.tar && \
     mv tcli-3.6* /opt/bin/ && \

--- a/nat-lab/Dockerfile
+++ b/nat-lab/Dockerfile
@@ -5,6 +5,11 @@ FROM ${LIBTELIO_ENV_SEC_CONTAINER_REGISTRY}/low-level-hacks/vpn/client/libtelio-
 LABEL org.opencontainers.image.authors="info@nordsec.com"
 
 COPY --chmod=0755 bin/ /opt/bin/
+COPY --chmod=0755 data/custom_debs /opt/custom_debs
+
+# If custom deb is found, install it. This command doesn't fail if it doesn't find anything.
+# Useful for overriding prebaked binaries, such as nordderper.
+RUN find /opt/custom_debs -name "*.deb" -exec dpkg -i {} \;
 RUN \
     tar -xf /opt/tclis-3.6.tar && \
     mv tcli-3.6* /opt/bin/ && \

--- a/nat-lab/data/custom_debs/README
+++ b/nat-lab/data/custom_debs/README
@@ -1,0 +1,3 @@
+Dockerfile mounts this directory and installs all found *.deb files.
+This is useful when adding temporary binaries for testing or for overriding
+existing ones, for example - *nordderper*.


### PR DESCRIPTION
Ability to override nordderper(will be used to trigger natlab with custom nordderper via Nordderper repo).

This is a generic solution though but the primary target is to trigger the natlab from derper project with custom derper.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
