### PR TITLE
[LLT-5725] avoid opening and closing log file on every log line

### DIFF
--- a/nat-lab/tests/uniffi/libtelio_proxy.py
+++ b/nat-lab/tests/uniffi/libtelio_proxy.py
@@ -168,3 +168,7 @@ class LibtelioProxy:
         return libtelio.NatType(
             self._handle_remote_error(lambda r: r.get_nat(ip, port))
         )
+
+    @move_to_async_thread
+    def flush_logs(self) -> None:
+        self._handle_remote_error(lambda r: r.flush_logs())

--- a/nat-lab/tests/uniffi/libtelio_remote.py
+++ b/nat-lab/tests/uniffi/libtelio_remote.py
@@ -3,8 +3,8 @@ import os
 import Pyro5.api  # type: ignore
 import Pyro5.server  # type: ignore
 import sys
-import time
 import telio_bindings as libtelio  # type: ignore # pylint: disable=import-error
+import time
 from serialization import (  # type: ignore # pylint: disable=import-error
     init_serialization,
 )
@@ -52,53 +52,36 @@ class TelioEventCbImpl(libtelio.TelioEventCb):
 
 
 class TelioLoggerCbImpl(libtelio.TelioLoggerCb):
-    def __init__(self):
+    def __init__(self, logfile):
         self.lock = Lock()
-        try:
-            os.remove(TCLI_LOG)
-        except FileNotFoundError:
-            pass
+        self.logfile = logfile
 
     def _do_log(self, log_level, payload):
-        open_ts = None
-        write_ts = None
-        start_ts = time.time();
+        start_ts = time.time()
         with self.lock:
             lock_acquired_ts = time.time()
-            with open(TCLI_LOG, "a", encoding="utf-8") as logfile:
-                try:
-                    open_ts = time.time()
-                    logfile.write(f"{datetime.datetime.now()} {log_level} {payload}\n")
-                    write_ts = time.time()
-                except IOError as e:
-                    logfile.write(
-                        f"{datetime.datetime.now()} Failed to write logline due to error {str(e)}\n"
-                    )
-            closed_ts = time.time()
+            self.logfile.write(f"{datetime.datetime.now()} {log_level} {payload}\n")
         end_ts = time.time()
-        return (start_ts, lock_acquired_ts, open_ts, write_ts, closed_ts, end_ts)
-
+        return (start_ts, lock_acquired_ts, end_ts)
 
     def log(self, log_level, payload):
-        (start_ts, lock_acquired_ts, open_ts, write_ts, closed_ts, end_ts) = self._do_log(log_level, payload)
+        (start_ts, lock_acquired_ts, end_ts) = self._do_log(log_level, payload)
         if end_ts - start_ts > 0.5:
-            self._do_log(log_level, f"Dumping log line took too long: {start_ts} {lock_acquired_ts} {open_ts} {write_ts} {closed_ts} {end_ts}")
+            self._do_log(
+                log_level,
+                f"Dumping log line took too long: {start_ts} {lock_acquired_ts} {end_ts}",
+            )
 
 
 @Pyro5.api.expose
 @Pyro5.server.behavior(instance_mode="single")
 class LibtelioWrapper:
-    def __init__(self, daemon):
-        try:
-            os.remove(REMOTE_LOG)
-        except:
-            pass
-
+    def __init__(self, daemon, logfile):
         self._daemon = daemon
 
         self._libtelio = None
         self._event_cb = TelioEventCbImpl()
-        self._logger_cb = TelioLoggerCbImpl()
+        self._logger_cb = TelioLoggerCbImpl(logfile)
         libtelio.set_global_logger(libtelio.TelioLogLevel.DEBUG, self._logger_cb)
 
     def shutdown(self):
@@ -192,23 +175,35 @@ class LibtelioWrapper:
     def get_nat(self, ip: str, port: int) -> libtelio.NatType:
         return self._libtelio.get_nat(ip, port)
 
+    @serialize_error
+    def flush_logs(self):
+        self._logger_cb.logfile.flush()
+
 
 def main():
     object_name = sys.argv[1]
     container_ip = sys.argv[2]
     port = int(sys.argv[3])
 
+    # Cleanup old log files if any exists
     try:
-        daemon = Pyro5.server.Daemon(host=container_ip, port=port)
-        _, port = daemon.sock.getsockname()
-        print(f"libtelio-port:{port}")
-        sys.stdout.flush()
+        os.remove(TCLI_LOG)
+        os.remove(REMOTE_LOG)
+    except FileNotFoundError:
+        pass
 
-        wrapper = LibtelioWrapper(daemon)
-        daemon.register(wrapper, objectId=object_name)
+    try:
+        with open(TCLI_LOG, "a", encoding="utf-8") as logfile:
+            daemon = Pyro5.server.Daemon(host=container_ip, port=port)
+            _, port = daemon.sock.getsockname()
+            print(f"libtelio-port:{port}")
+            sys.stdout.flush()
 
-        daemon.requestLoop()
-        daemon.close()
+            wrapper = LibtelioWrapper(daemon, logfile)
+            daemon.register(wrapper, objectId=object_name)
+
+            daemon.requestLoop()
+            daemon.close()
     except Exception as e:  # pylint: disable=broad-exception-caught
         print(f"libtelio_remote error: {e}")
         raise e


### PR DESCRIPTION
### Problem
`libtelio_remote.py` when consuming logs via callback would open and close log file on every single log line, which is really innefficient. This PR reuses the same open file handle for the duration of `libtelio_remote.py` process itself.



### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
