### PR TITLE
Call logging callback on a separate thread

### DIFF
--- a/.unreleased/async-logs
+++ b/.unreleased/async-logs
@@ -1,0 +1,1 @@
+Logging callback is now called only from a dedicated thread

--- a/src/device.rs
+++ b/src/device.rs
@@ -99,7 +99,7 @@ pub use wg::{
 #[cfg(test)]
 use wg::tests::AdapterExpectation;
 
-use crate::logging::LOG_CENSOR;
+use crate::logging::{logs_dropped_until_now, LOG_CENSOR};
 
 #[derive(Debug, TError)]
 pub enum Error {
@@ -2422,7 +2422,7 @@ impl TaskRuntime for Runtime {
             },
 
             _ = self.polling_interval.tick() => {
-                telio_log_debug!("WG consolidation triggered by tick event");
+                telio_log_debug!("WG consolidation triggered by tick event, total logs dropped: {}", logs_dropped_until_now());
                 wg_controller::consolidate_wg_state(&self.requested_state, &self.entities, &self.features)
                     .boxed()
                     .await

--- a/src/device.rs
+++ b/src/device.rs
@@ -99,7 +99,7 @@ pub use wg::{
 #[cfg(test)]
 use wg::tests::AdapterExpectation;
 
-use crate::logging::{logs_dropped_until_now, LOG_CENSOR};
+use crate::logging::{logs_dropped_since_last_checked, logs_dropped_until_now, LOG_CENSOR};
 
 #[derive(Debug, TError)]
 pub enum Error {
@@ -2423,6 +2423,10 @@ impl TaskRuntime for Runtime {
 
             _ = self.polling_interval.tick() => {
                 telio_log_debug!("WG consolidation triggered by tick event, total logs dropped: {}", logs_dropped_until_now());
+                let dropped = logs_dropped_since_last_checked();
+                if dropped > 0 {
+                    telio_log_warn!("New logs dropped: {dropped}");
+                }
                 wg_controller::consolidate_wg_state(&self.requested_state, &self.entities, &self.features)
                     .boxed()
                     .await

--- a/src/ffi/logging.rs
+++ b/src/ffi/logging.rs
@@ -1,13 +1,16 @@
 use std::{
     io::{self, ErrorKind},
     str::from_utf8,
-    sync::{Arc, Mutex},
+    sync::{
+        atomic::AtomicUsize,
+        mpsc::{sync_channel, RecvError, SyncSender},
+        Mutex,
+    },
+    thread::Builder,
 };
 
-use telio_utils::log_censor::LogCensor;
-
 use once_cell::sync::Lazy;
-
+use telio_utils::log_censor::LogCensor;
 use tracing::{level_filters::LevelFilter, Subscriber};
 use tracing_subscriber::{
     fmt::{self, FormatEvent, FormatFields, MakeWriter},
@@ -17,18 +20,28 @@ use tracing_subscriber::{
 
 use crate::{TelioLogLevel, TelioLoggerCb};
 
+const LOG_BUFFER: usize = 1024;
+pub const START_ASYNC_LOGGER_MSG: &str = "Starting async logger thread";
+
+static DROPPED_LOGS: AtomicUsize = AtomicUsize::new(0);
+
+pub fn logs_dropped_until_now() -> usize {
+    DROPPED_LOGS.load(std::sync::atomic::Ordering::Relaxed)
+}
+
 /// Build a tracing subscriber for use in ffi
 pub fn build_subscriber(
     log_level: crate::TelioLogLevel,
     logger: Box<dyn TelioLoggerCb>,
 ) -> impl Subscriber {
+    let log_sender = start_async_logger(logger, LOG_BUFFER);
     tracing_subscriber::registry()
         .with(LevelFilter::from_level(log_level.into()))
         .with(
             fmt::layer()
                 .event_format(TelioEventFmt)
                 .with_ansi(false)
-                .with_writer(FfiCallback::new(logger)),
+                .with_writer(FfiCallback::new(log_sender)),
         )
 }
 
@@ -61,14 +74,18 @@ where
 }
 
 pub struct FfiCallback {
-    callback: Arc<dyn TelioLoggerCb>,
+    log_sender: SyncSender<LogMessage>,
 }
 
 impl FfiCallback {
-    fn new(logger: Box<dyn TelioLoggerCb>) -> Self {
-        Self {
-            callback: logger.into(),
-        }
+    fn new(log_sender: SyncSender<LogMessage>) -> Self {
+        Self { log_sender }
+    }
+}
+
+impl Drop for FfiCallback {
+    fn drop(&mut self) {
+        let _ = self.log_sender.try_send(LogMessage::Quit);
     }
 }
 
@@ -81,14 +98,14 @@ impl<'a> MakeWriter<'a> for FfiCallback {
 
     fn make_writer_for(&self, meta: &tracing::Metadata<'_>) -> Self::Writer {
         FfiCallbackWriter {
-            cb: self.callback.clone(),
+            log_sender: self.log_sender.clone(),
             level: (*meta.level()).into(),
         }
     }
 }
 
 pub struct FfiCallbackWriter {
-    cb: Arc<dyn TelioLoggerCb>,
+    log_sender: SyncSender<LogMessage>,
     level: TelioLogLevel,
 }
 
@@ -110,9 +127,17 @@ impl io::Write for FfiCallbackWriter {
         if let Some(filtered_msg) = filter_log_message(msg) {
             let filtered_msg = LOG_CENSOR.censor_logs(filtered_msg);
 
-            self.cb
-                .log(self.level, filtered_msg)
-                .map_err(io::Error::other)?;
+            // There are only 2 reasons why try_send should fail:
+            // - no more space in a buffer because we are not processing logs fast enough
+            // - the receiving thread has already stopped
+            // In both cases there is nothing to do when it happens.
+            if self
+                .log_sender
+                .try_send(LogMessage::Message(self.level, filtered_msg))
+                .is_err()
+            {
+                DROPPED_LOGS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            }
         }
 
         Ok(buf.len())
@@ -164,6 +189,45 @@ fn filter_log_message(msg: String) -> Option<String> {
     None
 }
 
+enum LogMessage {
+    Message(TelioLogLevel, String),
+    Quit,
+}
+
+fn start_async_logger(cb: Box<dyn TelioLoggerCb>, buffer_size: usize) -> SyncSender<LogMessage> {
+    let (sender, receiver) = sync_channel::<LogMessage>(buffer_size);
+    let handle = Builder::new()
+        .name("libtelio-logger".to_owned())
+        .spawn(move || {
+            let _ = cb.log(TelioLogLevel::Debug, START_ASYNC_LOGGER_MSG.to_owned());
+            loop {
+                match receiver.recv() {
+                    Ok(LogMessage::Message(level, msg)) => {
+                        let _ = cb.log(level, msg);
+                    }
+                    Ok(LogMessage::Quit) => {
+                        let _ = cb.log(
+                            TelioLogLevel::Debug,
+                            "Async channel explicitly closed".to_owned(),
+                        );
+                        return;
+                    }
+                    Err(RecvError) => {
+                        let _ = cb.log(
+                            TelioLogLevel::Debug,
+                            "Async channel implicitly closed".to_owned(),
+                        );
+                        return;
+                    }
+                }
+            }
+        });
+    if let Err(e) = handle {
+        eprintln!("Failed to start logging thread: {e:?}");
+    }
+    sender
+}
+
 #[cfg(test)]
 mod test {
 
@@ -181,6 +245,11 @@ mod test {
 
     #[test]
     fn test_trace_via_telio_cb() {
+        const EXPECTED_SIZE: usize = 5;
+
+        let log = Log::default();
+        let logs = log.0.clone();
+
         let start = line!() + 1;
         let act = || {
             trace!("first message"); // +1
@@ -195,7 +264,8 @@ mod test {
         };
         let mpath = module_path!();
         let tid = std::thread::current().id();
-        let expected = [
+        let expected: [_; EXPECTED_SIZE] = [
+            (TelioLogLevel::Debug, START_ASYNC_LOGGER_MSG.to_owned()),
             (
                 TelioLogLevel::Debug,
                 format!("{tid:?} {:?}:{} second message", mpath, start + 2),
@@ -212,15 +282,22 @@ mod test {
                     start + 4
                 ),
             ),
+            (
+                TelioLogLevel::Debug,
+                "Async channel explicitly closed".to_owned(),
+            ),
         ];
-        let logs = Log::default();
-        let subscriber = build_subscriber(TelioLogLevel::Debug, Box::new(logs.clone()));
+
+        let subscriber = build_subscriber(TelioLogLevel::Debug, Box::new(log));
 
         tracing::subscriber::with_default(subscriber, act);
 
-        let actual = logs.0.lock().unwrap().clone();
-
-        assert_eq!(&expected[..], &actual[..])
+        // Need to wait for the async thread to process above logs
+        while logs.lock().unwrap().len() < EXPECTED_SIZE {
+            println!("collected logs count: {}", logs.lock().unwrap().len());
+        }
+        let actual = logs.lock().unwrap().clone();
+        assert_eq!(&expected[..], &actual[..]);
     }
 
     #[derive(Default, Clone, Debug)]

--- a/tests/logger.rs
+++ b/tests/logger.rs
@@ -1,25 +1,32 @@
 use telio;
 
 mod test_module {
-    use std::sync::{
-        atomic::{AtomicUsize, Ordering},
-        Arc,
+    use std::{
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        },
+        thread::ThreadId,
     };
 
-    use telio::ffi_types::{FfiResult, TelioLoggerCb};
+    use telio::{
+        ffi_types::{FfiResult, TelioLoggerCb},
+        logging::START_ASYNC_LOGGER_MSG,
+    };
 
     use super::*;
 
     #[test]
     fn test_logger() {
         // Line number of tracing::info! location
-        const INFO_LINE: u32 = 51;
+        const INFO_LINE: u32 = 66;
 
         let call_count = Arc::new(AtomicUsize::new(0));
 
         #[derive(Debug)]
         struct TestLogger {
             call_count: Arc<AtomicUsize>,
+            log_caller_tid: ThreadId,
         }
         impl TelioLoggerCb for TestLogger {
             fn log(
@@ -27,10 +34,17 @@ mod test_module {
                 log_level: telio::ffi_types::TelioLogLevel,
                 payload: String,
             ) -> FfiResult<()> {
+                if payload == START_ASYNC_LOGGER_MSG {
+                    return Ok(());
+                }
                 let tid = std::thread::current().id();
+                assert_ne!(self.log_caller_tid, tid);
                 assert!(matches!(log_level, telio::ffi_types::TelioLogLevel::Info));
                 assert_eq!(
-                    format!(r#"{tid:?} "logger::test_module":{INFO_LINE} test message"#),
+                    format!(
+                        r#"{:?} "logger::test_module":{INFO_LINE} test message"#,
+                        self.log_caller_tid
+                    ),
                     payload
                 );
                 assert_eq!(0, self.call_count.fetch_add(1, Ordering::Relaxed));
@@ -40,6 +54,7 @@ mod test_module {
 
         let logger = TestLogger {
             call_count: call_count.clone(),
+            log_caller_tid: std::thread::current().id(),
         };
 
         let tracing_subscriber = telio::ffi::logging::build_subscriber(
@@ -49,7 +64,7 @@ mod test_module {
         tracing::subscriber::set_global_default(tracing_subscriber).unwrap();
 
         tracing::info!("test message");
-        assert_eq!(1, call_count.load(Ordering::Relaxed));
+        while call_count.load(Ordering::Relaxed) < 1 {}
         tracing::debug!("this will be ignored since it's below info");
     }
 }


### PR DESCRIPTION
To avoid blocking callers, when logging is slow, the call to the logging callback is moved to the separate therad. Now, logging anything only causes non blocking try_send that will fail if there is no more space in the queue of not yet processed log messages.

To have some visibility into how this system performs, count of dropped logs is printed along side one of the periodic logs of libtelio.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
