### PR TITLE
Fix broken (unexpected 'name()' call) wg_controller tests

### DIFF
--- a/src/device/wg_controller.rs
+++ b/src/device/wg_controller.rs
@@ -1649,6 +1649,7 @@ mod tests {
                 .expect_trigger_endpoint_candidates_discovery()
                 .returning(|_| Ok(()));
             stun_ep_provider.expect_pause().returning(|| ());
+            stun_ep_provider.expect_name().returning(|| "stun");
             stun_ep_provider
         }
 


### PR DESCRIPTION
### Problem
Some of the tests in wg_controrller started to fail on main. After local reproduction, it turns out that `EndpointProvider::name()` was called on a mock instance without any expectation set for that function.

The snippet that requires `expect_name` is this: https://github.com/NordSecurity/libtelio/blob/main/src/device/wg_controller.rs#L198-L206

### Solution
Add `expect_name` call.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
