### PR TITLE
Llt 5617 collect dns server logs

### DIFF
--- a/nat-lab/bin/dns-server
+++ b/nat-lab/bin/dns-server
@@ -1,5 +1,6 @@
 #!/bin/env python3
 
+import logging
 from twisted.internet import defer, reactor
 from twisted.names import dns, server
 
@@ -30,22 +31,23 @@ KNOWN = {
 
 class DNSResolver:
     def _reply(self, name, type, record):
-        print(f"Resolving name: {name} => {record}")
+        logging.info(f"Resolving name: {name} => {record}")
         if record is None:
             return [], [], []
         answer = dns.RRHeader(name=name, type=type, payload=record)
         return [answer], [], []
 
     def query(self, query, timeout=None):
-        print(f"query: {query}")
+        logging.info(f"query: {query}")
         record = KNOWN[query.type][query.name.name]
         return defer.succeed(self._reply(query.name.name, query.type, record))
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG, format='%(asctime)s %(levelname)-8s %(message)s', datefmt='%Y-%m-%d %H:%M:%S')
     factory = server.DNSServerFactory(clients=[DNSResolver()])
     protocol = dns.DNSDatagramProtocol(controller=factory)
     reactor.listenUDP(53, protocol, interface='::')
     reactor.listenTCP(53, factory, interface='::')
-    print(f"DNS server starting with known hostnames: {KNOWN}")
+    logging.info(f"DNS server starting with known hostnames: {KNOWN}")
     reactor.run()

--- a/nat-lab/bin/dns-server.sh
+++ b/nat-lab/bin/dns-server.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+/opt/bin/dns-server 2>&1 | tee /dns-server.log

--- a/nat-lab/docker-compose.yml
+++ b/nat-lab/docker-compose.yml
@@ -541,7 +541,7 @@ services:
   dns-server-1:
     hostname: dns-server-1
     image: nat-lab:base
-    entrypoint: /opt/bin/dns-server
+    entrypoint: /opt/bin/dns-server.sh
     environment:
       PYTHONUNBUFFERED: 1
     networks:
@@ -553,7 +553,7 @@ services:
   dns-server-2:
     hostname: dns-server-2
     image: nat-lab:base
-    entrypoint: /opt/bin/dns-server
+    entrypoint: /opt/bin/dns-server.sh
     environment:
       PYTHONUNBUFFERED: 1
     networks:

--- a/nat-lab/tests/conftest.py
+++ b/nat-lab/tests/conftest.py
@@ -250,16 +250,38 @@ def pytest_sessionfinish(session, exitstatus):
         return
 
     if not session.config.option.collectonly:
-        num_containers = 3
+        collect_nordderper_logs()
+        collect_dns_server_logs()
 
-        for i in range(1, num_containers + 1):
-            container_name = f"nat-lab-derp-{i:02d}-1"
-            destination_path = f"logs/derp_{i:02d}_relay.log"
 
-            docker_cp_command = f"docker cp {container_name}:/etc/nordderper/relay.log {destination_path}"
+def collect_nordderper_logs():
+    num_containers = 3
 
-            try:
-                subprocess.run(docker_cp_command, shell=True, check=True)
-                print(f"Log file copied successfully from {container_name}")
-            except subprocess.CalledProcessError:
-                print(f"Error copying log file from {container_name}")
+    for i in range(1, num_containers + 1):
+        container_name = f"nat-lab-derp-{i:02d}-1"
+        destination_path = f"logs/derp_{i:02d}_relay.log"
+
+        copy_file_from_container(
+            container_name, "/etc/nordderper/relay.log", destination_path
+        )
+
+
+def collect_dns_server_logs():
+    num_containers = 2
+
+    for i in range(1, num_containers + 1):
+        container_name = f"nat-lab-dns-server-{i}-1"
+        destination_path = f"logs/dns_server_{i}.log"
+
+        copy_file_from_container(container_name, "/dns-server.log", destination_path)
+
+
+def copy_file_from_container(container_name, src_path, dst_path):
+    docker_cp_command = f"docker cp {container_name}:{src_path} {dst_path}"
+    try:
+        subprocess.run(docker_cp_command, shell=True, check=True)
+        print(
+            f"Log file {src_path} copied successfully from {container_name} to {dst_path}"
+        )
+    except subprocess.CalledProcessError:
+        print(f"Error copying log file {src_path} from {container_name} to {dst_path}")

--- a/nat-lab/tests/conftest.py
+++ b/nat-lab/tests/conftest.py
@@ -245,6 +245,17 @@ def pytest_runtest_setup():
 
 
 # pylint: disable=unused-argument
+def pytest_runtest_call(item):
+    start_tcpdump([f"nat-lab-dns-server-{i}-1" for i in range(1, 3)])
+
+
+# pylint: disable=unused-argument
+def pytest_runtest_makereport(item, call):
+    if call.when == "call":
+        stop_tcpdump([f"nat-lab-dns-server-{i}-1" for i in range(1, 3)])
+
+
+# pylint: disable=unused-argument
 def pytest_sessionfinish(session, exitstatus):
     if os.environ.get("NATLAB_SAVE_LOGS") is None:
         return


### PR DESCRIPTION
### Problem
Logs from dns server (and tcpdump pcaps) are not collected from dns servers, but are needed for nat-lab investigation.

### Solution
Dns logs are now timestamped and are collected once per the run_local.py run. The pcaps are collected per test.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
