### PR TITLE
Spawn event callback calling task loop on a separate thread

### DIFF
--- a/crates/telio-wg/src/wg.rs
+++ b/crates/telio-wg/src/wg.rs
@@ -707,13 +707,17 @@ impl State {
             }
         });
 
+        let event = Event {
+            state,
+            link_state,
+            peer,
+            old_peer,
+        };
+
+        telio_log_debug!("Sending new event {event:?}");
+
         self.event
-            .send(Box::new(Event {
-                state,
-                link_state,
-                peer,
-                old_peer,
-            }))
+            .send(Box::new(event))
             .await
             .map_err(|_| Error::InternalError("Failed to send node event"))
     }


### PR DESCRIPTION
### Problem
Analysis of `test_event_link_state_peer_goes_offline` failure suggests that event generation happened in rust code but was not visible on the python side.

### Solution
To make sure that nothing is blocking events processing, new separate thread is started only for that purpose. To 
to make sure that the event was indeed generated, new debug log is added.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
