### PR TITLE
bump libtelio build to v2.4.12

### DIFF
--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -22,4 +22,4 @@ jobs:
     with:
       schedule: ${{ github.event_name == 'schedule' }}
       cancel-outdated-pipelines: ${{ github.ref_name != 'main' }}
-      triggered-ref: v2.4.11 # REMEMBER to also update in .gitlab-ci.yml
+      triggered-ref: v2.4.12 # REMEMBER to also update in .gitlab-ci.yml

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,4 +15,4 @@ libtelio-build-pipeline:
 
   trigger:
     project: $LIBTELIO_BUILD_PROJECT_PATH
-    branch: v2.4.11 # REMEMBER to also update in .github/workflows/gitlab.yml
+    branch: v2.4.12 # REMEMBER to also update in .github/workflows/gitlab.yml


### PR DESCRIPTION
### Problem
This error was found in one of the CI, possibly preventing libtelio from working correctly on windows
```
794 Oct 26 02:09  Error       Server                 3221227977 The server could not bind to the transport \Device
                                                                     \NetBT_Tcpip_{0E186230-9C20-2C05-1B58-9DF3FA403D1A
                                                                     } because another computer on the network has the 
                                                                     same name.  The server could not start.           
```

### Solution
Adding custom hostname to prevent collision


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
