### PR TITLE
Better tracking of meshnet ID in nat-lab

### DIFF
--- a/crates/telio-nurse/src/nurse.rs
+++ b/crates/telio-nurse/src/nurse.rs
@@ -132,6 +132,7 @@ impl State {
         ipv6_enabled: bool,
     ) -> Self {
         let meshnet_id = Self::meshnet_id();
+        telio_log_debug!("Meshnet ID: {meshnet_id}");
 
         // Analytics channel
         let analytics_channel = Chan::default();
@@ -359,9 +360,9 @@ impl State {
             "application.libtelioapp.config.current_state.internal_meshnet.fp",
         ))
         .map(|fp| {
-            Uuid::parse_str(&fp).unwrap_or_else(|_| {
+            Uuid::parse_str(&fp).unwrap_or_else(|e| {
                 telio_log_error!(
-                    "Failed to parse moose meshnet id ({:?}), generating a new one",
+                    "Failed to parse moose meshnet id ({:?}), generating a new one: {e}",
                     fp
                 );
                 Uuid::new_v4()

--- a/nat-lab/tests/telio.py
+++ b/nat-lab/tests/telio.py
@@ -897,18 +897,7 @@ class Client:
         return await self._get_log_without_flush()
 
     async def _get_log_without_flush(self) -> str:
-        """
-        This function retrieves telio logs without flushing them. It may be needed to do that
-        if log retrieval is requested after process has already exited. In such a case there is
-        nothing to flush and attempting to do so will cause errors.
-        """
-        process = (
-            self._connection.create_process(["type", "tcli.log"])
-            if self._connection.target_os == TargetOS.Windows
-            else self._connection.create_process(["cat", "./tcli.log"])
-        )
-        await process.execute()
-        return process.get_stdout()
+        return await get_log_without_flush(self._connection)
 
     async def get_system_log(self) -> Optional[str]:
         """
@@ -1161,3 +1150,18 @@ class Client:
                     f" {container_name}:{file_path} {core_dump_destination}"
                 )
                 os.system(cmd)
+
+
+async def get_log_without_flush(connection) -> str:
+    """
+    This function retrieves telio logs without flushing them. It may be needed to do that
+    if log retrieval is requested after process has already exited. In such a case there is
+    nothing to flush and attempting to do so will cause errors.
+    """
+    process = (
+        connection.create_process(["type", "tcli.log"])
+        if connection.target_os == TargetOS.Windows
+        else connection.create_process(["cat", "./tcli.log"])
+    )
+    await process.execute()
+    return process.get_stdout()

--- a/src/device.rs
+++ b/src/device.rs
@@ -1151,11 +1151,16 @@ impl Runtime {
                     collection_trigger_channel: collection_trigger_ch.clone(),
                     qos_trigger_channel: qos_trigger_ch.clone(),
                 };
+                let nurse_config = NurseConfig::new(nurse_features);
+                telio_log_debug!(
+                    "Nurse config heartbeat fp: {}",
+                    nurse_config.heartbeat_config.fingerprint
+                );
 
                 Some(Arc::new(
                     Nurse::start_with(
                         config.private_key.public(),
-                        NurseConfig::new(nurse_features),
+                        nurse_config,
                         nurse_io,
                         aggregator.clone(),
                         features.ipv6,


### PR DESCRIPTION
### Problem
`test_lana_same_meshnet_id_is_reported_after_a_restart` fails with a different meshnet id after the restart:

```
[2024-10-25 19:30:02] FAILED tests/test_lana.py::test_lana_same_meshnet_id_is_reported_after_a_restart[IPv4-IPv4v6] - AssertionError: assert '628c9cbb-8627-40ad-9b6c-518596d836a9' == 'd3dc4ef2-125d-43a6-b9d7-786f2879269b'
[2024-10-25 19:30:02]   
[2024-10-25 19:30:02]   - d3dc4ef2-125d-43a6-b9d7-786f2879269b
[2024-10-25 19:30:02]   + 628c9cbb-8627-40ad-9b6c-518596d836a9
```

### Solution

1. Additional logs are added to track values of the meshnet id at startup.
2. Additional logs are added to track device fingerprint at startup (it is modified by test in `maybe_write_device_fingerprint_to_moose_db`
3. Both logs and event database are saved after the client is shutdown but before it is restarted


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
