### PR TITLE
[LLT-5604] Notifications token support in CoreApi

### DIFF
--- a/nat-lab/bin/core-api.py
+++ b/nat-lab/bin/core-api.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python3
-
+import base64
 import json
 import paho.mqtt.client as mqtt  # type: ignore # pylint: disable=import-error
 import ssl
@@ -25,10 +25,26 @@ DERP_SERVER = {
 
 CERTIFICATE_PATH = "/etc/ssl/server_certificate/server.pem"
 
+MQTT_BROKER_HOST = "mqtt.nordvpn.com"
+MQTT_BROKER_PORT = 8883
+
+# Below credentials are intended only for testing purposes in nat-lab environment.
+CORE_API_CREDENTIALS = {
+    "username": "token",
+    "password": "48e9ef50178a68a716e38a9f9cd251e8be35e79a5c5f91464e92920425caa3d9",
+}
+MQTT_CREDENTIALS = {
+    "username": "mqtt_broker",
+    "password": "9-A'.:vUM3FPTCABorsK}J4mM}/3898_",
+}
+
 
 class CoreApiErrorCode(Enum):
     MACHINE_ALREADY_EXISTS = 101117
     MACHINE_NOT_FOUND = 101102
+    INVALID_CREDENTIALS = 100104
+    AUTHORIZATION_HEADER_NOT_PROVIDED = 100105
+    AUTHORIZATION_HEADER_INVALID = 100106
 
 
 @dataclass
@@ -105,6 +121,7 @@ class CoreApiHandler(BaseHTTPRequestHandler):
     def __init__(self, request, client_address, server: CoreServer):
         self.server: CoreServer
         self.machines_path = "/v1/meshnet/machines"
+        self.notifications_path = "/v1/notifications/tokens"
         super().__init__(request, client_address, server)
 
     def _set_headers(
@@ -124,16 +141,89 @@ class CoreApiHandler(BaseHTTPRequestHandler):
         error_response = {"errors": {"code": error_code.value, "message": message}}
         self._write_response(error_response, status_code)
 
+    def validate_authorization_header(self, authorization_header, authorization_type):
+        if not authorization_header:
+            self._send_error_response(
+                CoreApiErrorCode.AUTHORIZATION_HEADER_NOT_PROVIDED,
+                "Authorization header not provided",
+                HTTPStatus.BAD_REQUEST,
+            )
+            return False
+        if not authorization_header.startswith(f"{authorization_type} "):
+            self._send_error_response(
+                CoreApiErrorCode.AUTHORIZATION_HEADER_INVALID,
+                "Invalid authorization header",
+                HTTPStatus.BAD_REQUEST,
+            )
+            return False
+        return True
+
+    def validate_bearer_token(self):
+        auth_header = self.headers.get("Authorization")
+        self.validate_authorization_header(auth_header, "Bearer")
+        # Ignore "None" type warning as validation done in self.validate_authorization_header
+        auth = auth_header.split(" ")[1]  # type: ignore[union-attr]
+        username, token = auth.split(":", 1)
+        if (
+            username != CORE_API_CREDENTIALS["username"]
+            or token != CORE_API_CREDENTIALS["password"]
+        ):
+            self._send_error_response(
+                CoreApiErrorCode.INVALID_CREDENTIALS,
+                "Invalid credentials",
+                status_code=HTTPStatus.UNAUTHORIZED,
+            )
+            return False
+        return True
+
+    def validate_basic_authorization(self):
+        auth_header = self.headers.get("Authorization")
+        if not self.validate_authorization_header(auth_header, "Basic"):
+            return False
+        # Ignore "None" type warning as validation done in self.validate_authorization_header
+        encoded_auth = auth_header.split(" ")[1]  # type: ignore[union-attr]
+        decoded_auth = base64.b64decode(encoded_auth).decode("utf-8")
+        username, token = decoded_auth.split(":", 1)
+
+        if (
+            CORE_API_CREDENTIALS["username"] == username
+            and CORE_API_CREDENTIALS["password"] == token
+        ):
+            return True
+
+        self._send_error_response(
+            CoreApiErrorCode.INVALID_CREDENTIALS,
+            "Invalid credentials",
+            status_code=HTTPStatus.UNAUTHORIZED,
+        )
+        return False
+
+    @staticmethod
+    def requires_basic_authentication(func):
+        def wrapper(self, *args, **kwargs):
+            if not self.validate_basic_authorization():
+                return None
+            return func(self, *args, **kwargs)
+
+        return wrapper
+
+    @staticmethod
+    def requires_bearer_token(func):
+        def wrapper(self, *args, **kwargs):
+            if not self.validate_bearer_token():
+                return None
+            return func(self, *args, **kwargs)
+
+        return wrapper
+
     def do_GET(self):
-        if self.path == "/":
+        if self.path == "/v1/health":
             self.handle_root_path()
         elif self.path == self.machines_path:
             self.handle_get_machines()
         elif self.path.split("/")[-1] == "map":
             machine_id = self.path.split("/")[-2]
             self.handle_get_machine_map(machine_id)
-        elif self.path == "/v1/health":
-            self.handle_root_path()
 
     def do_HEAD(self):
         self._set_headers()
@@ -147,6 +237,8 @@ class CoreApiHandler(BaseHTTPRequestHandler):
     def do_POST(self):
         if self.path == self.machines_path:
             self.handle_register_machine()
+        elif self.path == self.notifications_path:
+            self.handle_get_notifications_token()
         else:
             print(f"unsupported endpoint '{self.path}'")
 
@@ -158,6 +250,7 @@ class CoreApiHandler(BaseHTTPRequestHandler):
     def handle_root_path(self):
         self._set_headers()
 
+    @requires_bearer_token
     def handle_register_machine(self):
         content_length = int(self.headers["Content-Length"])
         post_data = self.rfile.read(content_length)
@@ -202,6 +295,7 @@ class CoreApiHandler(BaseHTTPRequestHandler):
 
         return node
 
+    @requires_bearer_token
     def handle_machines_delete(self):
         uid = self.path.removeprefix(self.machines_path)[1:]
 
@@ -214,6 +308,7 @@ class CoreApiHandler(BaseHTTPRequestHandler):
                 HTTPStatus.NOT_FOUND,
             )
 
+    @requires_bearer_token
     def handle_patch_machine(self, machine_id):
         machine = self.server.get_machines().get(machine_id)
         if not machine:
@@ -239,12 +334,14 @@ class CoreApiHandler(BaseHTTPRequestHandler):
             resp = json.dumps(asdict(machine))
             self.wfile.write(resp.encode("utf-8"))
 
+    @requires_bearer_token
     def handle_get_machines(self):
         machines = self.server.get_machines()
         self._write_response(
             [asdict(machine) for machine in machines.values()] if machines else []
         )
 
+    @requires_bearer_token
     def handle_get_machine_map(self, machine_id):
         machine = self.server.get_machines().get(machine_id)
         if not machine:
@@ -274,6 +371,20 @@ class CoreApiHandler(BaseHTTPRequestHandler):
             "dns": {"domains": [], "hosts": {}},
             "derp_servers": [DERP_SERVER],
         }
+
+    @requires_basic_authentication
+    def handle_get_notifications_token(self):
+        content_length = int(self.headers["Content-Length"])
+        post_data = self.rfile.read(content_length)
+        print(f"The POST data: {post_data.decode()}")
+        json.loads(post_data)
+        response = {
+            "endpoint": f"tcps://{MQTT_BROKER_HOST}:{MQTT_BROKER_PORT}",
+            "username": MQTT_CREDENTIALS["username"],
+            "password": MQTT_CREDENTIALS["password"],
+            "expires_in": 60,
+        }
+        self._write_response(response)
 
 
 def run(mqttc, port=443):
@@ -317,7 +428,11 @@ def main():
         tls_version=ssl.PROTOCOL_TLSv1_2,
         cert_reqs=ssl.CERT_REQUIRED,
     )
-    mqttc.connect("mqtt.nordvpn.com", port=8883, keepalive=60)
+    mqttc.username_pw_set(
+        username=MQTT_CREDENTIALS["username"],
+        password=MQTT_CREDENTIALS["password"],
+    )
+    mqttc.connect(host=MQTT_BROKER_HOST, port=MQTT_BROKER_PORT, keepalive=60)
 
     mqttc.loop_start()
 

--- a/nat-lab/bin/mqtt-listener.py
+++ b/nat-lab/bin/mqtt-listener.py
@@ -1,0 +1,53 @@
+#!/usr/bin/python3
+import argparse
+import paho.mqtt.client as mqtt
+import ssl
+import sys
+
+CERTIFICATE_PATH = "/etc/ssl/server_certificate/server.pem"
+
+
+def on_message(_client, _userdata, message):
+    print(f"{message.payload.decode()}")
+    sys.exit(0)
+
+
+def main(mqtt_broker_host, mqtt_broker_port, mqtt_broker_user, mqtt_broker_password):
+
+    mqttc = mqtt.Client(
+        mqtt.CallbackAPIVersion.VERSION2, client_id="receiver", protocol=mqtt.MQTTv311
+    )
+
+    mqttc.on_message = on_message
+
+    mqttc.username_pw_set(
+        username=mqtt_broker_user,
+        password=mqtt_broker_password,
+    )
+    mqttc.tls_set(
+        ca_certs=CERTIFICATE_PATH,
+        certfile=CERTIFICATE_PATH,
+        keyfile=CERTIFICATE_PATH,
+        tls_version=ssl.PROTOCOL_TLSv1_2,
+        cert_reqs=ssl.CERT_REQUIRED,
+    )
+    mqttc.connect(mqtt_broker_host, port=mqtt_broker_port, keepalive=1)
+    mqttc.subscribe("meshnet", qos=0)
+    mqttc.loop_forever()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="MQTT Client")
+
+    parser.add_argument("mqtt_broker_host", type=str, help="MQTT broker host")
+    parser.add_argument("mqtt_broker_port", type=int, help="MQTT broker port")
+    parser.add_argument("mqtt_broker_user", type=str, help="MQTT broker user")
+    parser.add_argument("mqtt_broker_password", type=str, help="MQTT broker password")
+
+    args = parser.parse_args()
+    main(
+        args.mqtt_broker_host,
+        args.mqtt_broker_port,
+        args.mqtt_broker_user,
+        args.mqtt_broker_password,
+    )

--- a/nat-lab/data/core_api/rumqttd.toml
+++ b/nat-lab/data/core_api/rumqttd.toml
@@ -20,3 +20,6 @@ next_connection_delay_ms = 10
     max_payload_size = 20480
     max_inflight_count = 100
     max_inflight_size = 1024
+    [v4.2.connections.auth]
+    # Below credentials are intended only for testing purposes in nat-lab environment.
+    mqtt_broker = "9-A'.:vUM3FPTCABorsK}J4mM}/3898_"

--- a/nat-lab/docker-compose.yml
+++ b/nat-lab/docker-compose.yml
@@ -91,6 +91,7 @@ services:
       - "derp-03:10.0.10.3"
       - "derp-00:10.0.10.245"
       - "pmtu-probe:10.0.80.84"
+      - "mqtt.nordvpn.com:10.0.80.85"
       - "api.nordvpn.com:10.0.80.86"
     volumes:
       - ../:/libtelio

--- a/nat-lab/tests/helpers.py
+++ b/nat-lab/tests/helpers.py
@@ -437,7 +437,13 @@ async def ping_between_all_nodes(env: Environment) -> None:
 
 
 async def send_https_request(
-    connection, endpoint, method, ca_cert_path, data=None, expect_response=True
+    connection,
+    endpoint,
+    method,
+    ca_cert_path,
+    data=None,
+    authorization_header=None,
+    expect_response=True,
 ):
     curl_command = [
         "curl",
@@ -452,6 +458,11 @@ async def send_https_request(
 
     if data:
         curl_command.extend(["-d", data])
+
+    if authorization_header:
+        curl_command.extend(["-H", f"Authorization: {authorization_header}"])
+
+    print(f"Curl command: {curl_command}")
 
     process = await connection.create_process(curl_command).execute()
     response = process.get_stdout()


### PR DESCRIPTION
### Problem
In the ESP32 mesh network (meshnet) integration tests within the nat-lab environment, the v1/notifications/token endpoint must be supported by the nat-lab CoreApi to provide essential connection details for the MQTT message broker. This endpoint requires Basic authentication for access control, while all other CoreApi endpoints use Bearer token authentication.

### Solution
1) Implement `v1/notifications/token` Endpoint: Add the `v1/notifications/token` endpoint to provide connection details for the MQTT broker, based on the specifications outlined in the `v1/notifications/token` documentation.
2) Enable Basic Authentication for `v1/notifications/token`: Add Basic authentication support for the `v1/notifications/token` endpoint. Additionally, create and add test user accounts to validate authentication.
3) Add Bearer Token Authentication for Other Endpoints: For all endpoints except `v1/notifications/token`, add Bearer token authentication support. Generate a set of reusable tokens for testing purposes.
4) Configure MQTT Broker Credentials: Set up two credentials for the MQTT broker: one for CoreApi access and another for a subscriber, which will be returned by the `v1/notifications/token` endpoint.
5) Update Existing Tests for Authentication: Modify the existing tests to incorporate either Bearer token or Basic authentication as appropriate.
6) Relocate MQTT Listener for Testing Compatibility: Move the MQTT listener from `test_notification_center.py` to run within the cone-client to facilitate proper notification center testing. Since the data from `v1/notifications/token ` includes a broker domain name that the test execution host cannot resolve, this adjustment allows cone-client (with necessary Docker setup) to handle resolution.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
