### PR TITLE
LLT-5683: Increase constrains in link state testcases

### DIFF
--- a/.unreleased/LLT-5683
+++ b/.unreleased/LLT-5683
@@ -1,1 +1,0 @@
-Increase constrains in link state testcases

--- a/.unreleased/LLT-5683
+++ b/.unreleased/LLT-5683
@@ -1,0 +1,1 @@
+Increase constrains in link state testcases

--- a/nat-lab/tests/telio.py
+++ b/nat-lab/tests/telio.py
@@ -130,10 +130,11 @@ class Runtime:
                 return
             await asyncio.sleep(0.1)
 
-    async def notify_link_state(self, public_key: str, states: List[LinkState]) -> None:
+    async def notify_link_state(self, public_key: str, state: LinkState) -> None:
+        """Wait until a link_state event matching the `state` for `public_key` is available."""
         while True:
             peer = self.get_peer_info(public_key)
-            if peer and peer.link_state in states:
+            if peer and peer.link_state == state:
                 return
             await asyncio.sleep(0.1)
 
@@ -165,11 +166,11 @@ class Runtime:
                 return
             await asyncio.sleep(0.1)
 
-    def get_link_state_events(self, public_key: str) -> List[Optional[LinkState]]:
+    def get_link_state_events(self, public_key: str) -> List[LinkState]:
         return [
             peer.link_state
             for peer in self._peer_state_events
-            if peer and peer.public_key == public_key
+            if peer and peer.public_key == public_key and peer.link_state is not None
         ]
 
     def get_peer_info(self, public_key: str) -> Optional[TelioNode]:
@@ -273,9 +274,10 @@ class Events:
     async def wait_for_link_state(
         self,
         public_key: str,
-        state: List[LinkState],
+        state: LinkState,
         timeout: Optional[float] = None,
     ) -> None:
+        """Wait until a link_state event matching the `state` for `public_key` is available."""
         await asyncio.wait_for(
             self._runtime.notify_link_state(public_key, state), timeout
         )
@@ -294,7 +296,7 @@ class Events:
             timeout,
         )
 
-    def get_link_state_events(self, public_key: str) -> List[Optional[LinkState]]:
+    def get_link_state_events(self, public_key: str) -> List[LinkState]:
         return self._runtime.get_link_state_events(public_key)
 
     async def wait_for_state_derp(
@@ -570,12 +572,13 @@ class Client:
     async def wait_for_link_state(
         self,
         public_key: str,
-        states: List[LinkState],
+        state: LinkState,
         timeout: Optional[float] = None,
     ) -> None:
+        """Wait until a link_state event matching the `state` for `public_key` is available."""
         await self.get_events().wait_for_link_state(
             public_key,
-            states,
+            state,
             timeout,
         )
 
@@ -601,7 +604,7 @@ class Client:
         )
         print(datetime.now(), f"[{self._node.name}]: got event {event_info}")
 
-    def get_link_state_events(self, public_key: str) -> List[Optional[LinkState]]:
+    def get_link_state_events(self, public_key: str) -> List[LinkState]:
         return self.get_events().get_link_state_events(public_key)
 
     async def wait_for_state_derp(

--- a/nat-lab/tests/telio.py
+++ b/nat-lab/tests/telio.py
@@ -130,6 +130,13 @@ class Runtime:
                 return
             await asyncio.sleep(0.1)
 
+    async def notify_link_state(self, public_key: str, states: List[LinkState]) -> None:
+        while True:
+            peer = self.get_peer_info(public_key)
+            if peer and peer.link_state in states:
+                return
+            await asyncio.sleep(0.1)
+
     async def notify_peer_event(
         self,
         public_key: str,
@@ -261,6 +268,16 @@ class Events:
                 public_key, state, paths, is_exit, is_vpn, link_state
             ),
             timeout,
+        )
+
+    async def wait_for_link_state(
+        self,
+        public_key: str,
+        state: List[LinkState],
+        timeout: Optional[float] = None,
+    ) -> None:
+        await asyncio.wait_for(
+            self._runtime.notify_link_state(public_key, state), timeout
         )
 
     async def wait_for_event_peer(
@@ -548,6 +565,18 @@ class Client:
             is_vpn,
             timeout,
             link_state,
+        )
+
+    async def wait_for_link_state(
+        self,
+        public_key: str,
+        states: List[LinkState],
+        timeout: Optional[float] = None,
+    ) -> None:
+        await self.get_events().wait_for_link_state(
+            public_key,
+            states,
+            timeout,
         )
 
     async def wait_for_event_peer(


### PR DESCRIPTION
Previously the link state testcase scenarios were structured like setup, do some interaction between peers, sleep for a while and check the reported link states. This approach did not consider the timings of the events.

Proposed solution consists in checking the state constantly during the scenario, not only at the end of it.



### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
