### PR TITLE
Increase network monitor broadcast channel capacity

### DIFF
--- a/crates/telio-network-monitors/src/monitor.rs
+++ b/crates/telio-network-monitors/src/monitor.rs
@@ -8,7 +8,7 @@ use std::io;
 use telio_utils::{telio_log_debug, telio_log_warn};
 use tokio::{sync::broadcast::Sender, task::JoinHandle};
 /// Sender to notify if there is a change in OS interface order
-pub static PATH_CHANGE_BROADCAST: Lazy<Sender<()>> = Lazy::new(|| Sender::new(2));
+pub static PATH_CHANGE_BROADCAST: Lazy<Sender<()>> = Lazy::new(|| Sender::new(10));
 /// Vector containing all local interfaces
 pub static LOCAL_ADDRS_CACHE: Mutex<Vec<if_addrs::Interface>> = Mutex::new(Vec::new());
 #[cfg(all(


### PR DESCRIPTION
### Problem
Network monitor keeps reporting errors that the broadcast channel lagged and thus events are being missed.

### Solution
Since the channel's capacity was only 2, increased it to 10.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
