### PR TITLE
[LLT-5574] Fix rustls-platform-verifer init procedure for Android

### DIFF
--- a/.unreleased/LLT-5574
+++ b/.unreleased/LLT-5574
@@ -1,0 +1,1 @@
+Fix rustls-platform-verifer init procedure for Android


### PR DESCRIPTION
### Problem
The rustls-platform-verifer init procedure crashes on the Android app

### Solution
It turns out that JVM passes one more argument to this function thus the signature is incorrect


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
