### PR TITLE
[LLT-5565] teliod status reporting

### DIFF
--- a/clis/teliod/.gitignore
+++ b/clis/teliod/.gitignore
@@ -1,0 +1,3 @@
+*.log
+*config.json
+!example_teliod_config.json

--- a/clis/teliod/README.md
+++ b/clis/teliod/README.md
@@ -28,4 +28,4 @@ There is a command for running the daemon:
    - `interface_name` - Name of tunnel interface to connect to. Note that for macOS the name has to be in form `tun#` where `#` can be any integer number
 
 And following cli commands:
- - `teliod hello-world <NAME>` - simple command for testing purposes, logs "Hello NAME!", used to ensure daemon proper startup, should be erased in the future and replaced by some more serious one
+ - `teliod get-status` - returns the status of teliod and a peer list

--- a/clis/teliod/src/command_listener.rs
+++ b/clis/teliod/src/command_listener.rs
@@ -1,0 +1,209 @@
+use crate::{
+    comms::DaemonConnection, daemon::TelioTaskCmd, ClientCmd, DaemonSocket, TelioStatusReport,
+    TeliodError,
+};
+use serde::{Deserialize, Serialize};
+use telio::telio_task::io::chan;
+use tokio::sync::oneshot;
+use tracing::{error, info};
+
+/// Command response type used to communicate between `telio runner -> daemon -> client`
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+pub enum CommandResponse {
+    Ok,
+    StatusReport(TelioStatusReport),
+    Err(String),
+}
+
+impl CommandResponse {
+    pub fn serialize(&self) -> String {
+        serde_json::to_string(self).unwrap_or("Err serializing".to_string())
+    }
+
+    pub fn deserialize(input: &str) -> Result<CommandResponse, TeliodError> {
+        serde_json::from_str::<CommandResponse>(input)
+            .map_err(|e| TeliodError::InvalidResponse(format!("{}", e)))
+    }
+}
+
+pub struct CommandListener {
+    socket: DaemonSocket,
+    /// Channel to send commands to telio task
+    telio_task_tx: chan::Tx<TelioTaskCmd>,
+}
+
+impl CommandListener {
+    pub fn new(socket: DaemonSocket, telio_task_tx: chan::Tx<TelioTaskCmd>) -> CommandListener {
+        CommandListener {
+            socket,
+            telio_task_tx,
+        }
+    }
+
+    async fn process_command(
+        &mut self,
+        command: &ClientCmd,
+        connection: &mut DaemonConnection,
+    ) -> Result<(), TeliodError> {
+        match command {
+            ClientCmd::GetStatus => {
+                info!("Reporting telio status");
+                let (response_tx, response_rx) = oneshot::channel();
+                #[allow(mpsc_blocking_send)]
+                self.telio_task_tx
+                    .send(TelioTaskCmd::GetStatus(response_tx))
+                    .await
+                    .map_err(|e| {
+                        error!("Error sending command: {}", e);
+                        TeliodError::CommandFailed(ClientCmd::GetStatus)
+                    })?;
+                // wait for a response from telio runner
+                if let Ok(report) = response_rx.await {
+                    // send the response to teliod client
+                    connection
+                        .respond(CommandResponse::StatusReport(report).serialize())
+                        .await?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub async fn handle_client_connection(&mut self) -> Result<ClientCmd, TeliodError> {
+        let mut connection = self.socket.accept().await?;
+        let command_str = connection.read_command().await?;
+
+        if let Ok(command) = serde_json::from_str::<ClientCmd>(&command_str) {
+            self.process_command(&command, &mut connection).await?;
+            Ok(command)
+        } else {
+            error!("Received invalid command from client: {}", command_str);
+            connection
+                .respond(
+                    CommandResponse::Err(format!("Invalid command: {}", command_str)).serialize(),
+                )
+                .await?;
+            Err(TeliodError::InvalidCommand(command_str))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{ClientCmd, CommandResponse, DaemonSocket};
+    use std::{
+        path::Path,
+        time::{SystemTime, UNIX_EPOCH},
+    };
+    use tokio::{
+        io::{AsyncReadExt, AsyncWriteExt},
+        net::UnixStream,
+        sync::mpsc,
+        task,
+    };
+
+    const TEST_SOCKET_PATH: &str = "test_socket";
+
+    // Create a "random" socket path for the test, since tests run in parallel they can deadlock
+    fn make_socket_path() -> String {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .subsec_nanos();
+        format!("{}_{}", TEST_SOCKET_PATH, nanos)
+    }
+
+    // Helper to create a fake command listener
+    fn make_command_listener(path: &str) -> CommandListener {
+        let (tx, mut task_rx) = mpsc::channel(1);
+
+        // spawn a fake telio task
+        task::spawn(async move {
+            match task_rx.recv().await.unwrap() {
+                TelioTaskCmd::GetStatus(response_tx_channel) => {
+                    let status_report = TelioStatusReport::default();
+                    response_tx_channel.send(status_report).unwrap();
+                }
+                _ => (),
+            }
+        });
+
+        let socket = DaemonSocket::new(Path::new(path)).unwrap();
+
+        CommandListener::new(socket, tx)
+    }
+
+    // Simulate client sending command and waiting for response
+    async fn client_send_command(path: &str, cmd: &str) -> std::io::Result<CommandResponse> {
+        let mut client_stream = UnixStream::connect(&Path::new(path)).await?;
+        client_stream.write(format!("{}\n", cmd).as_bytes()).await?;
+
+        let mut data = vec![0; 1024];
+        let size = client_stream.read(&mut data).await?;
+        let response = String::from_utf8(data[..size].to_vec()).unwrap();
+        Ok(CommandResponse::deserialize(response.trim()).unwrap())
+    }
+
+    // Broken client, closes connection without waiting for response
+    async fn broken_client_send_command(path: &str, cmd: &str) -> std::io::Result<()> {
+        let mut client_stream = UnixStream::connect(&Path::new(path)).await?;
+        client_stream.write(format!("{}\n", cmd).as_bytes()).await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_command_response_serialization() {
+        let response = CommandResponse::Ok;
+        assert_eq!(response.serialize(), "\"Ok\"");
+
+        let error_response = CommandResponse::Err("Test error".to_string());
+        assert_eq!(error_response.serialize(), "{\"Err\":\"Test error\"}");
+    }
+
+    #[tokio::test]
+    async fn test_command_valid() {
+        let path = make_socket_path();
+        let mut listener = make_command_listener(&path);
+
+        let command = serde_json::to_string(&ClientCmd::GetStatus).unwrap();
+        let (cmd, response) = tokio::join!(
+            listener.handle_client_connection(),
+            client_send_command(&path, &command)
+        );
+        assert_eq!(cmd.unwrap(), ClientCmd::GetStatus);
+        assert_eq!(
+            response.unwrap(),
+            CommandResponse::StatusReport(TelioStatusReport::default())
+        );
+    }
+
+    #[tokio::test]
+    async fn test_command_invalid() {
+        let path = make_socket_path();
+        let mut listener = make_command_listener(&path);
+
+        let command = "garbage";
+        let (cmd, _) = tokio::join!(
+            listener.handle_client_connection(),
+            client_send_command(&path, &command)
+        );
+
+        assert!(matches!(cmd, Err(TeliodError::InvalidCommand(_))));
+    }
+
+    #[tokio::test]
+    async fn test_command_broken() {
+        let path = make_socket_path();
+        let mut listener = make_command_listener(&path);
+
+        let command = "garbage";
+        let (cmd, _) = tokio::join!(
+            listener.handle_client_connection(),
+            broken_client_send_command(&path, &command)
+        );
+
+        assert!(matches!(cmd, Err(TeliodError::Io(_))));
+    }
+}

--- a/clis/teliod/src/daemon.rs
+++ b/clis/teliod/src/daemon.rs
@@ -1,0 +1,230 @@
+use futures::stream::StreamExt;
+use nix::libc::{SIGHUP, SIGINT, SIGQUIT, SIGTERM};
+use nix::sys::signal::Signal;
+use signal_hook_tokio::Signals;
+use std::{fs, sync::Arc};
+use telio::{
+    crypto::SecretKey,
+    device::{Device, DeviceConfig, Error as DeviceError},
+    telio_model::{config::Config as MeshMap, features::Features},
+    telio_utils::select,
+    telio_wg::AdapterType,
+};
+use tokio::{sync::mpsc, sync::oneshot, time::Duration};
+use tracing::{debug, error, info, trace};
+
+use crate::core_api::{get_meshmap as get_meshmap_from_server, init_with_api};
+use crate::{
+    command_listener::CommandListener, comms::DaemonSocket, config::DeviceIdentity,
+    config::TeliodDaemonConfig, nc::NotificationCenter, TelioStatusReport, TeliodError,
+};
+
+#[derive(Debug)]
+pub enum TelioTaskCmd {
+    // Command to set the downloaded meshmap to telio instance
+    UpdateMeshmap(MeshMap),
+    // Get telio status
+    GetStatus(oneshot::Sender<TelioStatusReport>),
+    // Break the receive loop to quit the daemon and exit gracefully
+    Quit,
+}
+
+const EMPTY_TOKEN: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+// From async context Telio needs to be run in separate task
+fn telio_task(
+    node_identity: Arc<DeviceIdentity>,
+    auth_token: Arc<String>,
+    mut rx_channel: mpsc::Receiver<TelioTaskCmd>,
+    tx_channel: mpsc::Sender<TelioTaskCmd>,
+    interface_name: &str,
+) -> Result<(), TeliodError> {
+    debug!("Initializing telio device");
+    let mut telio = Device::new(
+        Features::default(),
+        // TODO: replace this with some real event handling
+        move |event| info!("Incoming event: {:?}", event),
+        None,
+    )?;
+
+    // TODO: This is temporary to be removed later on when we have proper integration
+    // tests with core API. This is to not look for tokens in a test environment
+    // right now as the values are dummy and program will not run as it expects
+    // real tokens.
+    if !auth_token.as_str().eq("") {
+        start_telio(&mut telio, node_identity.private_key, interface_name)?;
+        task_retrieve_meshmap(node_identity, auth_token, tx_channel);
+
+        while let Some(cmd) = rx_channel.blocking_recv() {
+            info!("Got command {:?}", cmd);
+            match cmd {
+                TelioTaskCmd::UpdateMeshmap(map) => {
+                    if let Err(e) = telio.set_config(&Some(map)) {
+                        error!("Unable to set meshmap due to {e}");
+                    }
+                }
+                TelioTaskCmd::GetStatus(response_tx_channel) => {
+                    let status_report = TelioStatusReport {
+                        is_running: telio.is_running(),
+                        nodes: telio.external_nodes()?,
+                    };
+                    debug!("Telio status: {:#?}", status_report);
+                    if response_tx_channel.send(status_report).is_err() {
+                        error!("Telio task failed sending status report")
+                    }
+                }
+                TelioTaskCmd::Quit => {
+                    telio.stop();
+                    break;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn task_retrieve_meshmap(
+    device_identity: Arc<DeviceIdentity>,
+    auth_token: Arc<String>,
+    tx: mpsc::Sender<TelioTaskCmd>,
+) {
+    tokio::spawn(async move {
+        let result = get_meshmap_from_server(device_identity, auth_token).await;
+        match result {
+            Ok(meshmap) => {
+                trace!("Meshmap {:#?}", meshmap);
+                #[allow(mpsc_blocking_send)]
+                if let Err(e) = tx.send(TelioTaskCmd::UpdateMeshmap(meshmap)).await {
+                    error!("Unable to send meshmap due to {e}");
+                }
+            }
+            Err(e) => error!("Getting meshmap failed due to {e}"),
+        }
+    });
+}
+
+fn start_telio(
+    telio: &mut Device,
+    private_key: SecretKey,
+    interface_name: &str,
+) -> Result<(), DeviceError> {
+    telio.start(&DeviceConfig {
+        private_key,
+        name: Some(interface_name.to_owned()),
+        adapter: AdapterType::BoringTun,
+        ..Default::default()
+    })?;
+
+    debug!("started telio with {:?}...", AdapterType::BoringTun,);
+    Ok(())
+}
+
+pub async fn daemon_event_loop(config: TeliodDaemonConfig) -> Result<(), TeliodError> {
+    let (non_blocking_writer, _tracing_worker_guard) =
+        tracing_appender::non_blocking(fs::File::create(&config.log_file_path)?);
+    tracing_subscriber::fmt()
+        .with_max_level(config.log_level)
+        .with_writer(non_blocking_writer)
+        .with_ansi(false)
+        .with_line_number(true)
+        .with_level(true)
+        .init();
+
+    debug!("started with config: {config:?}");
+
+    let socket = DaemonSocket::new(&DaemonSocket::get_ipc_socket_path()?)?;
+
+    let nc = NotificationCenter::new(&config).await?;
+
+    // Tx is unused here, but this channel can be used to communicate with the
+    // telio task
+    let (tx, rx) = mpsc::channel(10);
+    let mut cmd_listener = CommandListener::new(socket, tx.clone());
+
+    // TODO: This if condition and ::default call is temporary to be removed later
+    // on when we have proper integration tests with core API.
+    // This is to not look for tokens in a test environment right now as the values
+    // are dummy and program will not run as it expects real tokens.
+    let mut identity = DeviceIdentity::default();
+    if !config.authentication_token.eq(EMPTY_TOKEN) {
+        identity = init_with_api(&config.authentication_token, &config.interface_name).await?;
+    }
+    let tx_clone = tx.clone();
+
+    let token_ptr = Arc::new(config.authentication_token);
+    let token_clone = token_ptr.clone();
+
+    let identity_ptr = Arc::new(identity);
+    let identity_clone = identity_ptr.clone();
+
+    let mut telio_task_handle = tokio::task::spawn_blocking(move || {
+        telio_task(
+            identity_clone,
+            token_clone,
+            rx,
+            tx_clone,
+            &config.interface_name,
+        )
+    });
+
+    let tx_clone = tx.clone();
+    nc.add_callback(Arc::new(move |_am| {
+        task_retrieve_meshmap(identity_ptr.clone(), token_ptr.clone(), tx_clone.clone());
+    }))
+    .await;
+
+    let mut signals = Signals::new([SIGHUP, SIGTERM, SIGINT, SIGQUIT])?;
+
+    info!("Entering event loop");
+    eprintln!("Daemon started");
+
+    loop {
+        select! {
+            // Check if telio_task completes and exit if it fails
+            join_result = &mut telio_task_handle => {
+                match join_result {
+                    Ok(Ok(_)) => {
+                        info!("Telio task thread completed normally");
+                    }
+                    Ok(Err(err)) => {
+                        error!("Telio task failed with error: {:?}", err);
+                        break Err(err);
+                    }
+                    Err(err) => {
+                        error!("Failed to join telio task: {:?}", err);
+                        break Err(err.into());
+                    }
+                }
+            },
+            // Handle commands from the client side
+            result = cmd_listener.handle_client_connection() => {
+                match result {
+                    Ok(command) => {
+                        info!("Client command {:?} executed succesfully", command);
+                    }
+                    Err(err) => {
+                        break Err(err);
+                    }
+                }
+            },
+            // Handle interrupt signals for clean shutdown
+            signal = signals.next() => {
+                match signal {
+                    Some(s @ SIGHUP | s @ SIGTERM | s @ SIGINT | s @ SIGQUIT) => {
+                        info!("Received signal {:?}, exiting", Signal::try_from(s));
+                        if let Err(e) = tx.send_timeout(TelioTaskCmd::Quit, Duration::from_secs(2)).await {
+                            error!("Unable to send QUIT due to {e}");
+                        };
+                        break Ok(());
+                    }
+                    Some(s) => {
+                        info!("Received unexpected signal {s:?}, ignoring");
+                    }
+                    None => {
+                        break Err(TeliodError::BrokenSignalStream);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/clis/teliod/src/main.rs
+++ b/clis/teliod/src/main.rs
@@ -1,45 +1,40 @@
 //! Main and implementation of config and commands for Teliod - simple telio daemon for Linux and OpenWRT
 
 use clap::Parser;
+use command_listener::CommandResponse;
 use config::TeliodDaemonConfig;
-use futures::stream::StreamExt;
-use nix::libc::{SIGHUP, SIGINT, SIGQUIT, SIGTERM};
-use nix::sys::signal::Signal;
 use serde::{Deserialize, Serialize};
 use serde_json::error::Error as SerdeJsonError;
-use signal_hook_tokio::Signals;
-use std::time::Duration;
-use std::{
-    fs::{self, File},
-    sync::Arc,
-};
+use std::fs::File;
 use telio::{
-    crypto::SecretKey,
-    device::{Device, DeviceConfig, Error as DeviceError},
-    telio_model::{config::Config as MeshMap, features::Features},
-    telio_utils::select,
-    telio_wg::AdapterType,
+    device::Error as DeviceError,
+    telio_model::{config::Config as MeshMap, mesh::Node},
 };
 use thiserror::Error as ThisError;
-use tokio::{sync::mpsc, task::JoinError};
-use tracing::{debug, error, info, trace, warn};
+use tokio::{
+    task::JoinError,
+    time::{timeout, Duration},
+};
+use tracing::{debug, error};
 
+mod command_listener;
 mod comms;
 mod config;
 mod core_api;
+mod daemon;
 mod nc;
 
-use crate::core_api::{get_meshmap as get_meshmap_from_server, init_with_api, Error as ApiError};
-use crate::{comms::DaemonSocket, config::DeviceIdentity, nc::NotificationCenter};
+use crate::core_api::Error as ApiError;
+use crate::{comms::DaemonSocket, config::DeviceIdentity};
 
-#[derive(Parser, Debug)]
+const TIMEOUT_SEC: u64 = 1;
+
+#[derive(Parser, Debug, PartialEq)]
 #[clap()]
 #[derive(Serialize, Deserialize)]
 enum ClientCmd {
-    #[clap(
-        about = "Forces daemon to add a log, added for testing, to be removed when the daemon will be more mature"
-    )]
-    HelloWorld { name: String },
+    #[clap(about = "Retrieve the status report")]
+    GetStatus,
 }
 
 #[derive(Parser, Debug)]
@@ -55,6 +50,8 @@ enum Cmd {
 pub enum TelioTaskCmd {
     // Command to set the downloaded meshmap to telio instance
     UpdateMeshmap(MeshMap),
+    // Get telio status
+    GetStatus,
     // Break the recieve loop to quit the daemon and exit gracefully
     Quit,
 }
@@ -65,6 +62,10 @@ enum TeliodError {
     Io(#[from] std::io::Error),
     #[error("Invalid command received: {0}")]
     InvalidCommand(String),
+    #[error("Invalid response received: {0}")]
+    InvalidResponse(String),
+    #[error("Client failed to receive response in {TIMEOUT_SEC}")]
+    ClientTimeoutError,
     #[error("Broken signal stream")]
     BrokenSignalStream,
     #[error(transparent)]
@@ -85,6 +86,14 @@ enum TeliodError {
     DeviceError(#[from] DeviceError),
 }
 
+/// Libtelio and meshnet status report
+#[derive(Debug, Serialize, Deserialize, PartialEq, Default)]
+pub struct TelioStatusReport {
+    pub is_running: bool,
+    /// List of meshnet peers
+    pub nodes: Vec<Node>,
+}
+
 #[tokio::main]
 #[allow(large_futures)]
 async fn main() -> Result<(), TeliodError> {
@@ -100,228 +109,36 @@ async fn main() -> Result<(), TeliodError> {
                     debug!("Overriding token from env");
                     config.authentication_token = t;
                 }
-                daemon_event_loop(config).await
+                daemon::daemon_event_loop(config).await
             }
         }
         Cmd::Client(cmd) => {
             let socket_path = DaemonSocket::get_ipc_socket_path()?;
             if socket_path.exists() {
-                let response =
-                    DaemonSocket::send_command(&socket_path, &serde_json::to_string(&cmd)?).await?;
+                let response = timeout(
+                    Duration::from_secs(TIMEOUT_SEC),
+                    DaemonSocket::send_command(&socket_path, &serde_json::to_string(&cmd)?),
+                )
+                .await
+                .map_err(|_| TeliodError::ClientTimeoutError)?;
 
-                if response.as_str() == "OK" {
-                    println!("Command executed successfully");
-                    Ok(())
-                } else {
-                    Err(TeliodError::CommandFailed(cmd))
+                match CommandResponse::deserialize(&response?)? {
+                    CommandResponse::Ok => {
+                        println!("Command executed successfully");
+                        Ok(())
+                    }
+                    CommandResponse::StatusReport(status) => {
+                        println!("{:#?}", status);
+                        Ok(())
+                    }
+                    CommandResponse::Err(e) => {
+                        println!("Command executed failed: {}", e);
+                        Err(TeliodError::CommandFailed(cmd))
+                    }
                 }
             } else {
                 Err(TeliodError::DaemonIsNotRunning)
             }
         }
-    }
-}
-
-struct CommandListener {
-    socket: DaemonSocket,
-}
-
-impl CommandListener {
-    async fn get_command(&self) -> Result<ClientCmd, TeliodError> {
-        let mut connection = self.socket.accept().await?;
-        let command_str = connection.read_command().await?;
-
-        if let Ok(cmd) = serde_json::from_str::<ClientCmd>(&command_str) {
-            connection.respond("OK".to_owned()).await?;
-            Ok(cmd)
-        } else {
-            connection.respond("ERR".to_owned()).await?;
-            Err(TeliodError::InvalidCommand(command_str))
-        }
-    }
-}
-
-// From async context Telio needs to be run in separate task
-fn telio_task(
-    node_identity: Arc<DeviceIdentity>,
-    auth_token: Arc<String>,
-    mut rx_channel: mpsc::Receiver<TelioTaskCmd>,
-    tx_channel: mpsc::Sender<TelioTaskCmd>,
-    interface_name: &str,
-) -> Result<(), TeliodError> {
-    debug!("Initializing telio device");
-    let mut telio = Device::new(
-        Features::default(),
-        // TODO: replace this with some real event handling
-        move |event| info!("Incoming event: {:?}", event),
-        None,
-    )?;
-
-    // TODO: This is temporary to be removed later on when we have proper integration
-    // tests with core API. This is to not look for tokens in a test environment
-    // right now as the values are dummy and program will not run as it expects
-    // real tokens.
-    if !auth_token.as_str().eq("") {
-        start_telio(&mut telio, node_identity.private_key, &interface_name)?;
-        task_retrieve_meshmap(node_identity, auth_token, tx_channel);
-
-        while let Some(cmd) = rx_channel.blocking_recv() {
-            info!("Got command {:?}", cmd);
-            match cmd {
-                TelioTaskCmd::UpdateMeshmap(map) => {
-                    if let Err(e) = telio.set_config(&Some(map)) {
-                        error!("Unable to set meshmap due to {e}");
-                    }
-                }
-                TelioTaskCmd::Quit => {
-                    telio.stop();
-                    break;
-                }
-            }
-        }
-    }
-    Ok(())
-}
-
-fn task_retrieve_meshmap(
-    device_identity: Arc<DeviceIdentity>,
-    auth_token: Arc<String>,
-    tx: mpsc::Sender<TelioTaskCmd>,
-) {
-    tokio::spawn(async move {
-        let result = get_meshmap_from_server(device_identity, auth_token).await;
-        match result {
-            Ok(meshmap) => {
-                trace!("Meshmap {:#?}", meshmap);
-                #[allow(mpsc_blocking_send)]
-                if let Err(e) = tx.send(TelioTaskCmd::UpdateMeshmap(meshmap)).await {
-                    error!("Unable to send meshmap due to {e}");
-                }
-            }
-            Err(e) => error!("Getting meshmap failed due to {e}"),
-        }
-    });
-}
-
-fn start_telio(
-    telio: &mut Device,
-    private_key: SecretKey,
-    interface_name: &str,
-) -> Result<(), DeviceError> {
-    telio.start(&DeviceConfig {
-        private_key,
-        name: Some(interface_name.to_owned()),
-        adapter: AdapterType::BoringTun,
-        ..Default::default()
-    })?;
-
-    debug!("started telio with {:?}...", AdapterType::BoringTun,);
-    Ok(())
-}
-
-async fn daemon_event_loop(config: TeliodDaemonConfig) -> Result<(), TeliodError> {
-    let (non_blocking_writer, _tracing_worker_guard) =
-        tracing_appender::non_blocking(fs::File::create(&config.log_file_path)?);
-    tracing_subscriber::fmt()
-        .with_max_level(config.log_level)
-        .with_writer(non_blocking_writer)
-        .with_ansi(false)
-        .with_line_number(true)
-        .with_level(true)
-        .init();
-
-    debug!("started with config: {config:?}");
-
-    let socket = DaemonSocket::new(&DaemonSocket::get_ipc_socket_path()?)?;
-    let cmd_listener = CommandListener { socket };
-
-    let nc = NotificationCenter::new(&config).await?;
-
-    // Tx is unused here, but this channel can be used to communicate with the
-    // telio task
-    let (tx, rx) = mpsc::channel(10);
-
-    // TODO: This if condition and ::default call is temporary to be removed later
-    // on when we have proper integration tests with core API.
-    // This is to not look for tokens in a test environment right now as the values
-    // are dummy and program will not run as it expects real tokens.
-    let mut identity = DeviceIdentity::default();
-    if !config
-        .authentication_token
-        .eq("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
-    {
-        identity = init_with_api(&config.authentication_token, &config.interface_name).await?;
-    }
-    let tx_clone = tx.clone();
-
-    let token_ptr = Arc::new(config.authentication_token);
-    let token_clone = token_ptr.clone();
-
-    let identity_ptr = Arc::new(identity);
-    let identity_clone = identity_ptr.clone();
-
-    let telio_task_handle = tokio::task::spawn_blocking(move || {
-        telio_task(
-            identity_clone,
-            token_clone,
-            rx,
-            tx_clone,
-            &config.interface_name,
-        )
-    });
-
-    let tx_clone = tx.clone();
-    nc.add_callback(Arc::new(move |_am| {
-        task_retrieve_meshmap(identity_ptr.clone(), token_ptr.clone(), tx_clone.clone());
-    }))
-    .await;
-
-    let mut signals = Signals::new([SIGHUP, SIGTERM, SIGINT, SIGQUIT])?;
-
-    info!("Entering event loop");
-
-    let result = loop {
-        select! {
-            maybe_cmd = cmd_listener.get_command() => {
-                match maybe_cmd {
-                    Ok(ClientCmd::HelloWorld{name}) => {
-                        info!("Hello {}", name);
-                    }
-                    Err(TeliodError::InvalidCommand(cmd)) => {
-                        warn!("Received invalid command from client: {}", cmd);
-                    }
-                    Err(error) => {
-                        break Err(error);
-                    }
-                }
-            },
-            signal = signals.next() => {
-                match signal {
-                    Some(s @ SIGHUP | s @ SIGTERM | s @ SIGINT | s @ SIGQUIT) => {
-                        info!("Received signal {:?}, exiting", Signal::try_from(s));
-                        if let Err(e) = tx.send_timeout(TelioTaskCmd::Quit, Duration::from_secs(2)).await {
-                            error!("Unable to send QUIT due to {e}");
-                        };
-                        break Ok(());
-                    }
-                    Some(s) => {
-                        info!("Received unexpected signal {s:?}, ignoring");
-                    }
-                    None => {
-                        break Err(TeliodError::BrokenSignalStream);
-                    }
-                }
-            }
-        }
-    };
-
-    // Wait until Telio task ends
-    // TODO: When it will be doing something some channel with commands etc. might be needed
-    let join_result = telio_task_handle.await?;
-
-    if result.is_err() {
-        result
-    } else {
-        join_result.map_err(|err| err.into())
     }
 }

--- a/crates/telio-model/src/mesh.rs
+++ b/crates/telio-model/src/mesh.rs
@@ -13,7 +13,7 @@ pub use ipnet::IpNet;
 pub use std::net::{Ipv4Addr, SocketAddr};
 
 /// Description of a Node
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Deserialize, Serialize)]
 pub struct Node {
     /// An identifier for a node
     /// Makes it possible to distinguish different nodes in the presence of key reuse

--- a/nat-lab/tests/test_teliod.py
+++ b/nat-lab/tests/test_teliod.py
@@ -16,7 +16,7 @@ TELIOD_START_PARAMS = [
     CONFIG_FILE_PATH,
 ]
 
-TELIOD_HELLO_WORLD_PARAMS = [TELIOD_EXEC_PATH, "hello-world", "TestName"]
+TELIOD_STATUS_PARAMS = [TELIOD_EXEC_PATH, "get-status"]
 
 TELIOD_STOP_PARAMS = [TELIOD_EXEC_PATH, "stop"]
 
@@ -48,11 +48,11 @@ async def test_teliod() -> None:
             await connection.create_process(TELIOD_START_PARAMS).execute()
         assert err.value.stderr == "Error: DaemonIsRunning"
 
-        # Run the hello-world command
+        # Run the get-status command
         assert (
-            "Command executed successfully"
-            == (
-                await connection.create_process(TELIOD_HELLO_WORLD_PARAMS).execute()
+            "TelioStatusReport"
+            in (
+                await connection.create_process(TELIOD_STATUS_PARAMS).execute()
             ).get_stdout()
         )
 
@@ -68,5 +68,5 @@ async def test_teliod() -> None:
 
         # Run the hello-world command again - this time it should fail
         with pytest.raises(ProcessExecError) as err:
-            await connection.create_process(TELIOD_HELLO_WORLD_PARAMS).execute()
+            await connection.create_process(TELIOD_STATUS_PARAMS).execute()
         assert err.value.stderr == "Error: DaemonIsNotRunning"


### PR DESCRIPTION
### Problem
`teliod` is envisioned as rather headless daemon, which is expected to operate in places where there are no direct human interaction. But in some cases one may need to retrieve current state of meshnet, online/offline status of nodes etc.

### Solution
This PR adds a channel for returning results as `CommandResponse` back from `telio_task` that processes`TelioTaskCmd`s, and a `CommandListener` that handles commands from the client and passes it back the `CommandResponse` result.

Additionally this PR:
- Refactor `daemon_event_loop()` to exit sooner in case `telio_task()` fails with an error.
- Move error type definitions to `error.rs`
- Move daemon specific code to `daemon.rs`


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
