### PR TITLE
[LLT-5479] Use new win native wg adapter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6129,13 +6129,13 @@ dependencies = [
 [[package]]
 name = "wireguard-nt"
 version = "1.0.0"
-source = "git+https://github.com/NordSecurity/wireguard-nt-rust-wrapper?tag=v1.0.4#e2f2c1fe6ca27a4de6da7886be308fb2ffbb8c34"
+source = "git+https://github.com/NordSecurity/wireguard-nt-rust-wrapper?tag=v1.0.5#8ec27423762f110ed4aa243e4b0bd8f7fe599834"
 dependencies = [
  "bitflags 1.3.2",
  "ipnet",
  "libloading",
- "log",
  "rand",
+ "tracing",
  "widestring 0.4.3",
  "winapi",
  "wireguard-uapi",

--- a/crates/telio-wg/Cargo.toml
+++ b/crates/telio-wg/Cargo.toml
@@ -56,7 +56,7 @@ cc.workspace = true
 sha2.workspace = true
 winapi = { workspace = true, features = ["nldef"] }
 
-wireguard-nt = { git = "https://github.com/NordSecurity/wireguard-nt-rust-wrapper", tag = "v1.0.4" }
+wireguard-nt = { git = "https://github.com/NordSecurity/wireguard-nt-rust-wrapper", tag = "v1.0.5" }
 
 wg-go-rust-wrapper = { path = "../../wireguard-go-rust-wrapper" }
 


### PR DESCRIPTION
NOTE: This is a temporary version, when https://github.com/NordSecurity/wireguard-nt-rust-wrapper/pull/5 will be merged it will be updated

### Problem
Current version of our wireguard-nt-rust-wrapper uses `log` crate which is incompatible with our `tracing` log. This can be fixed using adapter on the Telio side (as we did in ..), but changing logging crate to `tracing` here seems to be simpler and nicer. Another problem is lack of the last OS error in some of the errors returned.

### Solution
Move wireguard-nt-rust-wrapper to a new version, which uses `tracing` log, and returns errors with last OS error included


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
