### PR TITLE
Add warning to run_local.py script

### DIFF
--- a/nat-lab/run_local.py
+++ b/nat-lab/run_local.py
@@ -82,13 +82,35 @@ def main() -> int:
         verify_setup_correctness()
 
     if not args.nobuild:
-        run_build_command("linux", args)
-        # Run windows tests on WinVM
-        if args.windows:
-            run_build_command("windows", args)
-        # Run nat-lab natively on macOS (TODO: Add windows support)
-        if args.o == "darwin":
-            run_build_command("darwin", args)
+        print("\u001b[33m")
+        print("|=======================================================|")
+        print("| WARNING! Running builds requires atleast 16GBs of RAM |")
+        print("|=======================================================|")
+        print("\u001b[0m")
+        try:
+            run_build_command("linux", args)
+            # Run windows tests on WinVM
+            if args.windows:
+                run_build_command("windows", args)
+            # Run nat-lab natively on macOS (TODO: Add windows support)
+            if args.o == "darwin":
+                run_build_command("darwin", args)
+        except subprocess.CalledProcessError:
+            print("\u001b[31m")
+            print(
+                "|===================================================================|"
+            )
+            print(
+                "| ERROR! If build failed by getting SIGKILL, it might               |"
+            )
+            print(
+                "| ERROR! be due to lack of RAM. Build requires atleast 16GBs of RAM |"
+            )
+            print(
+                "|===================================================================|"
+            )
+            print("\u001b[0m")
+            raise
 
     if not args.notypecheck:
         run_command(["mypy", "."])


### PR DESCRIPTION
### Problem
Running natlab locally with run_local.py and building libtelio from it, requires atleast 16GBs of RAM. Which would fail if it was run from within `default` natlab VM, which has only 4GBs of RAM.

### Solution
Adding a warning, so people won't get confused why this is happening.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
