### PR TITLE
Add logs to make it clear when libtelio is fetching lana entries in uninitialized state

### DIFF
--- a/crates/telio-lana/src/lib.rs
+++ b/crates/telio-lana/src/lib.rs
@@ -3,6 +3,7 @@
 
 use std::sync::atomic::{AtomicBool, Ordering};
 
+use telio_utils::telio_log_debug;
 pub use telio_utils::{telio_log_error, telio_log_warn};
 
 #[cfg_attr(all(feature = "moose", not(docrs)), path = "event_log_moose.rs")]
@@ -146,8 +147,11 @@ pub fn init_moose(
 /// Fetches context string from moose
 pub fn fetch_context_string(path: String) -> Option<String> {
     if is_lana_initialized() {
-        moose::moose_libtelioapp_fetch_context_string(path)
+        let result = moose::moose_libtelioapp_fetch_context_string(path.clone());
+        telio_log_debug!("Lana is initialized, fetching '{path}' resulted in '{result:?}'");
+        result
     } else {
+        telio_log_debug!("Lana is not initialized");
         None
     }
 }

--- a/crates/telio-nurse/src/nurse.rs
+++ b/crates/telio-nurse/src/nurse.rs
@@ -369,7 +369,7 @@ impl State {
             })
         })
         .unwrap_or_else(|| {
-            telio_log_trace!("Could not find stored meshnet id by moose, generating a fresh one");
+            telio_log_info!("Could not find stored meshnet id by moose, generating a fresh one");
             Uuid::new_v4()
         })
     }


### PR DESCRIPTION
Sometimes test verifying that restarting libtelio results in the same meshnet ID fails. Those logs hopefully will help in tracking down the reason for those failures.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
