### PR TITLE
Lower session keeper and DNS logging verbocity

### DIFF
--- a/src/device/wg_controller.rs
+++ b/src/device/wg_controller.rs
@@ -398,7 +398,7 @@ async fn consolidate_wg_peers<
                     telio_log_warn!("Peer {:?} has no ip address", key);
                 }
             }
-            (None, _) => telio_log_warn!("The session keeper is missing!"),
+            (None, _) => telio_log_debug!("The session keeper is missing!"),
             _ => (),
         }
 
@@ -455,7 +455,7 @@ async fn consolidate_wg_peers<
                 }
             }
             (Some(_), _, _) => (),
-            (None, _, _) => telio_log_warn!("The session keeper is missing!"),
+            (None, _, _) => telio_log_debug!("The session keeper is missing!"),
         }
 
         let is_actual_peer_proxying = is_peer_proxying(actual_peer, &proxy_endpoints);


### PR DESCRIPTION
### Problem
Session keeper is constantly spamming logs when VPN is connected. Lower the verbosity to Debug, which is normally not enabled in prod.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
