### PR TITLE
Tag each ping in nat lab with random payload

### DIFF
--- a/nat-lab/tests/utils/connection/connection.py
+++ b/nat-lab/tests/utils/connection/connection.py
@@ -17,7 +17,7 @@ class Connection(ABC):
         self._target_os = target_os
 
     @abstractmethod
-    def create_process(self, command: List[str]) -> "Process":
+    def create_process(self, command: List[str], kill_id=None) -> "Process":
         pass
 
     @property

--- a/nat-lab/tests/utils/connection/docker_connection.py
+++ b/nat-lab/tests/utils/connection/docker_connection.py
@@ -33,8 +33,8 @@ class DockerConnection(Connection):
     def target_name(self) -> str:
         return self.container_name()
 
-    def create_process(self, command: List[str]) -> "Process":
-        process = DockerProcess(self._container, command)
+    def create_process(self, command: List[str], kill_id=None) -> "Process":
+        process = DockerProcess(self._container, command, kill_id)
         print(
             datetime.now(),
             "Executing",

--- a/nat-lab/tests/utils/connection/ssh_connection.py
+++ b/nat-lab/tests/utils/connection/ssh_connection.py
@@ -16,7 +16,7 @@ class SshConnection(Connection):
         self._connection = connection
         self._target_os = target_os
 
-    def create_process(self, command: List[str]) -> "Process":
+    def create_process(self, command: List[str], kill_id=None) -> "Process":
         print(datetime.now(), "Executing", command, "on", self.target_os)
         if self._target_os == TargetOS.Windows:
             escape_argument = cmd_exe_escape.escape_argument

--- a/nat-lab/tests/utils/ping.py
+++ b/nat-lab/tests/utils/ping.py
@@ -34,17 +34,20 @@ class Ping:
         self._ip = ip
         self._connection = connection
         self._ip_proto = testing.unpack_optional(get_ip_address_type(ip))
+        kill_id = secrets.token_hex(8).upper()
 
         if connection.target_os == TargetOS.Windows:
             self._process = connection.create_process(
                 ["ping", ("-4" if self._ip_proto == IPProto.IPv4 else "-6"), "-t", ip]
             )
         elif connection.target_os == TargetOS.Mac:
-            self._process = connection.create_process(
-                [("ping" if self._ip_proto == IPProto.IPv4 else "ping6"), ip]
-            )
+            self._process = connection.create_process([
+                ("ping" if self._ip_proto == IPProto.IPv4 else "ping6"),
+                "-p",
+                kill_id,
+                ip,
+            ])
         else:
-            kill_id = secrets.token_hex(8).upper()
             self._process = connection.create_process(
                 [
                     "ping",

--- a/nat-lab/tests/utils/ping.py
+++ b/nat-lab/tests/utils/ping.py
@@ -1,5 +1,6 @@
 import asyncio
 import re
+import secrets
 from contextlib import asynccontextmanager
 from ipaddress import ip_address
 from typing import AsyncIterator, Optional
@@ -43,8 +44,16 @@ class Ping:
                 [("ping" if self._ip_proto == IPProto.IPv4 else "ping6"), ip]
             )
         else:
+            kill_id = secrets.token_hex(8).upper()
             self._process = connection.create_process(
-                ["ping", ("-4" if self._ip_proto == IPProto.IPv4 else "-6"), ip]
+                [
+                    "ping",
+                    ("-4" if self._ip_proto == IPProto.IPv4 else "-6"),
+                    "-p",
+                    kill_id,
+                    ip,
+                ],
+                kill_id,
             )
         self._next_ping_event = asyncio.Event()
 

--- a/nat-lab/tests/utils/process/docker_process.py
+++ b/nat-lab/tests/utils/process/docker_process.py
@@ -1,6 +1,5 @@
 import asyncio
-import random
-import string
+import secrets
 import subprocess
 import sys
 from .process import Process, ProcessExecError, StreamCallback
@@ -26,7 +25,9 @@ class DockerProcess(Process):
         str  # Private ID added to find the process easily when it needs to be killed
     )
 
-    def __init__(self, container: DockerContainer, command: List[str]) -> None:
+    def __init__(
+        self, container: DockerContainer, command: List[str], kill_id=None
+    ) -> None:
         self._container = container
         self._command = command
         self._stdout = ""
@@ -35,9 +36,7 @@ class DockerProcess(Process):
         self._is_done = asyncio.Event()
         self._stream = None
         self._execute = None
-        self._kill_id = "".join(
-            random.choices(string.ascii_uppercase + string.digits, k=12)
-        )
+        self._kill_id = kill_id if kill_id else secrets.token_hex(8).upper()
 
     async def execute(
         self,


### PR DESCRIPTION
### Problem
It's not always easy to map from the ping packet in the pcap to the test log.

### Solution
Tag each ping packet sent from tests with a random bytes to make it easy to map back from pcap to test log. In case of the docker connections, `KILL_ID` is used as the random string.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
