### PR TITLE
LLT-5785-batcher-argument-constraints

### DIFF
--- a/.unreleased/LLT-5785
+++ b/.unreleased/LLT-5785
@@ -1,0 +1,1 @@
+Add batcher constraints


### PR DESCRIPTION
### Problem
Batcher had no checks against interval and threshold. This allows for API misuse, for example setting too much of a threshold(so the action would be always batched) or too short interval(so it would always fire).


### Solution
This PR adds some checks and unit tests, also refactored existing tests to reduce boilerplate.

It can be proved that half the interval threshold is enough and this PR adds a check that it should not be higher than that. Description in the code.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
