### PR TITLE
Fix direct connection wait

### DIFF
--- a/nat-lab/tests/telio.py
+++ b/nat-lab/tests/telio.py
@@ -531,6 +531,9 @@ class Client:
         is_vpn: bool = False,
         timeout: Optional[float] = None,
     ) -> None:
+        event_info = f"peer({public_key}) with states({states}), paths({paths}), is_exit={is_exit}, is_vpn={is_vpn}"
+
+        print(datetime.now(), f"[{self._node.name}]: wait for event {event_info}")
         await self.get_events().wait_for_event_peer(
             public_key,
             states,
@@ -539,6 +542,7 @@ class Client:
             is_vpn,
             timeout,
         )
+        print(datetime.now(), f"[{self._node.name}]: got event {event_info}")
 
     def get_link_state_events(self, public_key: str) -> List[Optional[LinkState]]:
         return self.get_events().get_link_state_events(public_key)


### PR DESCRIPTION
### Problem
Direct connection test fails, as some nodes can report direct events, before we fully downgrade to relayed connections

### Solution
Because python futures are eagerly executed, we should not collect
events for two different steps at the same time.

Moved relay and direct event gathering after a change in network
configurations, and only after each step is confirmed

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
