### PR TITLE
Handle ConnectionRefusedError gracefully

### DIFF
--- a/nat-lab/tests/test_wg_adapter.py
+++ b/nat-lab/tests/test_wg_adapter.py
@@ -44,6 +44,8 @@ async def test_wg_adapter_cleanup(conn_tag: ConnectionTag):
             ).execute()
     except ProcessExecError:
         pass
+    except ConnectionRefusedError as e:
+        print(datetime.now(), f"First libtelio failed with {e}")
 
     # Check if libtelio left hanging wintun adapter, might now always happen, so we just leave test
     async with new_connection_by_tag(conn_tag) as conn:


### PR DESCRIPTION
When we kill the python process and immediately after exit the scope, it's possible that the cleanup of objects created in the scope races with the 'death' of the libtelio_remote.py. If the remote dies fast enough it can generate connection refused error on our side.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
