### PR TITLE
Reduce the number of parallel linkers started by build_libtelio.py

### DIFF
--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -22,4 +22,4 @@ jobs:
     with:
       schedule: ${{ github.event_name == 'schedule' }}
       cancel-outdated-pipelines: ${{ github.ref_name != 'main' }}
-      triggered-ref: v2.4.12 # REMEMBER to also update in .gitlab-ci.yml
+      triggered-ref: v2.4.13 # REMEMBER to also update in .gitlab-ci.yml

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,4 +15,4 @@ libtelio-build-pipeline:
 
   trigger:
     project: $LIBTELIO_BUILD_PROJECT_PATH
-    branch: v2.4.12 # REMEMBER to also update in .github/workflows/gitlab.yml
+    branch: v2.4.13 # REMEMBER to also update in .github/workflows/gitlab.yml

--- a/nat-lab/run_local.py
+++ b/nat-lab/run_local.py
@@ -85,6 +85,10 @@ def main() -> int:
         print("\u001b[33m")
         print("|=======================================================|")
         print("| WARNING! Running builds requires atleast 16GBs of RAM |")
+        print("|                                                       |")
+        print(
+            "| or set env variable \033[1mNATLAB_REDUCE_PARALLEL_LINKERS=1\033[0m\u001b[33m  |"
+        )
         print("|=======================================================|")
         print("\u001b[0m")
         try:
@@ -105,6 +109,12 @@ def main() -> int:
             )
             print(
                 "| ERROR! be due to lack of RAM. Build requires atleast 16GBs of RAM |"
+            )
+            print(
+                "|                                                                   |"
+            )
+            print(
+                "|       or set env variable \033[1mNATLAB_REDUCE_PARALLEL_LINKERS=1\033[0m\u001b[31m        |"
             )
             print(
                 "|===================================================================|"


### PR DESCRIPTION
The set of packages that are built at the same time is split into two groups. One containing only `teliod` and the other containing the rest. This way the peak memory usage drops from ~12 gigs down to less than 8 (this might increase the compilation duration, or not - your mileage may vary).

To enable this new behaviour set the environment variable `NATLAB_REDUCE_PARALLEL_LINKERS=1`.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
