### PR TITLE
Fix rustls crash on TLS connection

### DIFF
--- a/.unreleased/LLT-5770
+++ b/.unreleased/LLT-5770
@@ -1,0 +1,1 @@
+Fix rustls crash on derp TLS connection

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1947,7 +1947,7 @@ dependencies = [
  "http 1.1.0",
  "hyper 1.4.1",
  "hyper-util",
- "rustls 0.23.14",
+ "rustls 0.23.16",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.0",
@@ -3164,7 +3164,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.0.0",
- "rustls 0.23.14",
+ "rustls 0.23.16",
  "socket2",
  "thiserror",
  "tokio",
@@ -3181,7 +3181,7 @@ dependencies = [
  "rand",
  "ring",
  "rustc-hash 2.0.0",
- "rustls 0.23.14",
+ "rustls 0.23.16",
  "slab",
  "thiserror",
  "tinyvec",
@@ -3405,7 +3405,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.14",
+ "rustls 0.23.16",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "serde",
@@ -3547,9 +3547,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.14"
+version = "0.23.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "415d9944693cb90382053259f89fbb077ea730ad7273047ec63b19bc9b160ba8"
+checksum = "eee87ff5d9b36712a58574e12e9f0ea80f915a5b0ac518d322b24a465617925e"
 dependencies = [
  "once_cell",
  "ring",
@@ -3605,9 +3605,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e696e35370c65c9c541198af4543ccd580cf17fc25d8e05c5a242b202488c55"
+checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
 
 [[package]]
 name = "rustls-platform-verifier"
@@ -3620,7 +3620,7 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.14",
+ "rustls 0.23.16",
  "rustls-native-certs 0.7.3",
  "rustls-platform-verifier-android",
  "rustls-webpki 0.102.8",
@@ -4430,6 +4430,7 @@ dependencies = [
  "rand",
  "regex",
  "rstest",
+ "rustls 0.23.16",
  "rustls-platform-verifier",
  "serde",
  "serde_json",
@@ -5176,7 +5177,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls 0.23.14",
+ "rustls 0.23.16",
  "rustls-pki-types",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ modifier.workspace = true
 num_cpus.workspace = true
 parking_lot.workspace = true
 regex.workspace = true
+rustls.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 rand.workspace = true
@@ -150,6 +151,7 @@ rand = "0.8"
 regex = "1.5.5"
 rstest = "0.11.0"
 rustc-hash = "1"
+rustls = { version = "0.23.16", default-features = false, features = ["ring", "std"] }
 rustls-platform-verifier = "0.3.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
### Problem
rustls crashes when the default crypto provider is not defined

### Solution
Use one of the rustls crate features (`ring`) to define the default crypto provider.
According to https://docs.rs/rustls/latest/rustls/index.html#crate-features defining `ring` feature and NOT defining `custom-provider` is enough to implicitly use the ring provider without the need to install it manually.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
