### PR TITLE
[LLT-5771] update telio dns test to rely on conntrack instead of tcpdump

### DIFF
--- a/nat-lab/tests/test_connection_states.py
+++ b/nat-lab/tests/test_connection_states.py
@@ -2,7 +2,6 @@ import pytest
 from contextlib import AsyncExitStack
 from helpers import SetupParameters, setup_mesh_nodes
 from utils.bindings import TelioAdapterType
-from utils.connection_tracker import ConnectionLimits
 from utils.connection_util import generate_connection_tracker_config, ConnectionTag
 from utils.ping import ping
 
@@ -17,7 +16,7 @@ from utils.ping import ping
                 adapter_type_override=TelioAdapterType.NEP_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
-                    derp_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
                 ),
             )
         ),
@@ -27,7 +26,7 @@ from utils.ping import ping
                 adapter_type_override=TelioAdapterType.LINUX_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
-                    derp_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
                 ),
             ),
             marks=pytest.mark.linux_native,
@@ -38,7 +37,7 @@ from utils.ping import ping
                 adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
-                    derp_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
                 ),
             ),
             marks=pytest.mark.windows,
@@ -49,7 +48,7 @@ from utils.ping import ping
                 adapter_type_override=TelioAdapterType.WIREGUARD_GO_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
-                    derp_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
                 ),
             ),
             marks=pytest.mark.windows,
@@ -60,7 +59,7 @@ from utils.ping import ping
                 adapter_type_override=TelioAdapterType.NEP_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.MAC_VM,
-                    derp_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
                 ),
             ),
             marks=pytest.mark.mac,
@@ -75,7 +74,7 @@ from utils.ping import ping
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_2,
-                    derp_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
                 ),
             )
         )

--- a/nat-lab/tests/test_dns.py
+++ b/nat-lab/tests/test_dns.py
@@ -325,7 +325,7 @@ async def test_vpn_dns(alpha_ip_stack: IPStack) -> None:
             "www.microsoft.com",
             ["canonical name"],
             dns_server_address,
-            "-q=CNAME",
+            ["-q=CNAME"],
         )
 
         # Turn off the module and see if it worked

--- a/nat-lab/tests/test_dns_through_exit.py
+++ b/nat-lab/tests/test_dns_through_exit.py
@@ -5,7 +5,6 @@ from contextlib import AsyncExitStack
 from helpers import setup_mesh_nodes, SetupParameters
 from typing import List, Tuple
 from utils.bindings import TelioAdapterType
-from utils.connection_tracker import ConnectionLimits
 from utils.connection_util import generate_connection_tracker_config, ConnectionTag
 from utils.dns import query_dns
 from utils.router import IPStack
@@ -58,7 +57,7 @@ from utils.router import IPStack
                 adapter_type_override=TelioAdapterType.NEP_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
-                    derp_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
                 ),
             ),
         ),
@@ -68,7 +67,7 @@ from utils.router import IPStack
                 adapter_type_override=TelioAdapterType.LINUX_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
-                    derp_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
                 ),
             ),
             marks=pytest.mark.linux_native,
@@ -80,7 +79,7 @@ from utils.router import IPStack
         #         adapter_type_override=TelioAdapterType.NEP_TUN,
         #         connection_tracker_config=generate_connection_tracker_config(
         #             ConnectionTag.MAC_VM,
-        #             derp_1_limits=ConnectionLimits(1, 1),
+        #             derp_1_limits=(1, 1),
         #         ),
         #     ),
         #     marks=pytest.mark.mac,
@@ -95,7 +94,7 @@ from utils.router import IPStack
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_2,
-                    derp_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
                 ),
             )
         )

--- a/nat-lab/tests/test_dns_through_exit.py
+++ b/nat-lab/tests/test_dns_through_exit.py
@@ -169,7 +169,7 @@ async def test_dns_through_exit(
             "google.com",
             dns_server=dns_server_address_local,
             expected_output=["Name:.*google.com.*Address"],
-            options="-timeout=5",
+            options=["-timeout=5"],
         )
         await client_alpha.disconnect_from_exit_node(exit_node.public_key)
 

--- a/nat-lab/tests/test_events.py
+++ b/nat-lab/tests/test_events.py
@@ -17,7 +17,6 @@ from utils.bindings import (
     telio_node,
     TelioAdapterType,
 )
-from utils.connection_tracker import ConnectionLimits
 from utils.connection_util import (
     generate_connection_tracker_config,
     ConnectionTag,
@@ -72,7 +71,7 @@ def node_cmp(left: TelioNode, right: TelioNode):
                 adapter_type_override=TelioAdapterType.NEP_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
-                    derp_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
                 ),
             )
         ),
@@ -82,7 +81,7 @@ def node_cmp(left: TelioNode, right: TelioNode):
                 adapter_type_override=TelioAdapterType.LINUX_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
-                    derp_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
                 ),
             ),
             marks=pytest.mark.linux_native,
@@ -93,7 +92,7 @@ def node_cmp(left: TelioNode, right: TelioNode):
                 adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
-                    derp_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
                 ),
             ),
             marks=pytest.mark.windows,
@@ -104,7 +103,7 @@ def node_cmp(left: TelioNode, right: TelioNode):
                 adapter_type_override=TelioAdapterType.WIREGUARD_GO_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
-                    derp_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
                 ),
             ),
             marks=pytest.mark.windows,
@@ -115,7 +114,7 @@ def node_cmp(left: TelioNode, right: TelioNode):
                 adapter_type_override=TelioAdapterType.NEP_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.MAC_VM,
-                    derp_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
                 ),
             ),
             marks=pytest.mark.mac,
@@ -130,7 +129,7 @@ def node_cmp(left: TelioNode, right: TelioNode):
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_2,
-                    derp_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
                 ),
             )
         )
@@ -227,8 +226,8 @@ async def test_event_content_meshnet(
                 adapter_type_override=TelioAdapterType.NEP_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
-                    vpn_1_limits=ConnectionLimits(1, 1),
-                    stun_limits=ConnectionLimits(1, 2),
+                    vpn_1_limits=(1, 1),
+                    stun_limits=(1, 2),
                 ),
                 is_meshnet=False,
             ),
@@ -240,8 +239,8 @@ async def test_event_content_meshnet(
                 adapter_type_override=TelioAdapterType.LINUX_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
-                    vpn_1_limits=ConnectionLimits(1, 1),
-                    stun_limits=ConnectionLimits(1, 2),
+                    vpn_1_limits=(1, 1),
+                    stun_limits=(1, 2),
                 ),
                 is_meshnet=False,
             ),
@@ -254,8 +253,8 @@ async def test_event_content_meshnet(
                 adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
-                    vpn_1_limits=ConnectionLimits(1, 1),
-                    stun_limits=ConnectionLimits(1, 2),
+                    vpn_1_limits=(1, 1),
+                    stun_limits=(1, 2),
                 ),
                 is_meshnet=False,
             ),
@@ -270,8 +269,8 @@ async def test_event_content_meshnet(
                 adapter_type_override=TelioAdapterType.WIREGUARD_GO_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
-                    vpn_1_limits=ConnectionLimits(1, 1),
-                    stun_limits=ConnectionLimits(1, 2),
+                    vpn_1_limits=(1, 1),
+                    stun_limits=(1, 2),
                 ),
                 is_meshnet=False,
             ),
@@ -286,8 +285,8 @@ async def test_event_content_meshnet(
                 adapter_type_override=TelioAdapterType.NEP_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.MAC_VM,
-                    vpn_1_limits=ConnectionLimits(1, 1),
-                    stun_limits=ConnectionLimits(1, 2),
+                    vpn_1_limits=(1, 1),
+                    stun_limits=(1, 2),
                 ),
                 is_meshnet=False,
             ),
@@ -375,7 +374,7 @@ async def test_event_content_vpn_connection(
                 adapter_type_override=TelioAdapterType.NEP_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
-                    derp_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
                 ),
             )
         ),
@@ -385,7 +384,7 @@ async def test_event_content_vpn_connection(
                 adapter_type_override=TelioAdapterType.LINUX_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
-                    derp_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
                 ),
             ),
             marks=pytest.mark.linux_native,
@@ -396,7 +395,7 @@ async def test_event_content_vpn_connection(
                 adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
-                    derp_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
                 ),
             ),
             marks=pytest.mark.windows,
@@ -407,7 +406,7 @@ async def test_event_content_vpn_connection(
                 adapter_type_override=TelioAdapterType.WIREGUARD_GO_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
-                    derp_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
                 ),
             ),
             marks=pytest.mark.windows,
@@ -418,7 +417,7 @@ async def test_event_content_vpn_connection(
                 adapter_type_override=TelioAdapterType.NEP_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.MAC_VM,
-                    derp_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
                 ),
             ),
             marks=pytest.mark.mac,
@@ -433,8 +432,8 @@ async def test_event_content_vpn_connection(
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_2,
-                    derp_1_limits=ConnectionLimits(1, 1),
-                    stun_limits=ConnectionLimits(1, 2),
+                    derp_1_limits=(1, 1),
+                    stun_limits=(1, 2),
                 ),
             )
         )
@@ -512,7 +511,7 @@ async def test_event_content_exit_through_peer(
                 adapter_type_override=TelioAdapterType.NEP_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
-                    derp_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
                 ),
                 features=features_with_endpoint_providers([EndpointProvider.STUN]),
             ),
@@ -524,7 +523,7 @@ async def test_event_content_exit_through_peer(
                 adapter_type_override=TelioAdapterType.LINUX_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
-                    derp_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
                 ),
                 features=features_with_endpoint_providers([EndpointProvider.STUN]),
             ),
@@ -537,7 +536,7 @@ async def test_event_content_exit_through_peer(
                 adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
-                    derp_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
                 ),
                 features=features_with_endpoint_providers([EndpointProvider.STUN]),
             ),
@@ -550,7 +549,7 @@ async def test_event_content_exit_through_peer(
                 adapter_type_override=TelioAdapterType.WIREGUARD_GO_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
-                    derp_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
                 ),
                 features=features_with_endpoint_providers([EndpointProvider.STUN]),
             ),
@@ -563,7 +562,7 @@ async def test_event_content_exit_through_peer(
                 adapter_type_override=TelioAdapterType.NEP_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.MAC_VM,
-                    derp_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
                 ),
                 features=features_with_endpoint_providers([EndpointProvider.STUN]),
             ),
@@ -580,7 +579,7 @@ async def test_event_content_exit_through_peer(
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_2,
-                    derp_1_limits=ConnectionLimits(1, 2),
+                    derp_1_limits=(1, 2),
                 ),
             ),
             "10.0.254.2",
@@ -755,5 +754,5 @@ async def test_event_content_meshnet_node_upgrade_direct(
             alpha_node_state.endpoint and alpha_public_ip in alpha_node_state.endpoint
         )
 
-        assert await alpha_conn_tracker.get_out_of_limits() is None
-        assert await beta_conn_tracker.get_out_of_limits() is None
+        assert await alpha_conn_tracker.find_conntracker_violations() is None
+        assert await beta_conn_tracker.find_conntracker_violations() is None

--- a/nat-lab/tests/test_fire_connecting_event.py
+++ b/nat-lab/tests/test_fire_connecting_event.py
@@ -4,7 +4,6 @@ import timeouts
 from contextlib import AsyncExitStack
 from helpers import SetupParameters, setup_mesh_nodes
 from utils.bindings import NodeState, TelioAdapterType
-from utils.connection_tracker import ConnectionLimits
 from utils.connection_util import generate_connection_tracker_config, ConnectionTag
 from utils.ping import ping
 
@@ -19,7 +18,7 @@ from utils.ping import ping
             connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
             adapter_type_override=TelioAdapterType.NEP_TUN,
             connection_tracker_config=generate_connection_tracker_config(
-                ConnectionTag.DOCKER_CONE_CLIENT_1, derp_1_limits=ConnectionLimits(1, 1)
+                ConnectionTag.DOCKER_CONE_CLIENT_1, derp_1_limits=(1, 1)
             ),
         )
     ],
@@ -30,7 +29,7 @@ from utils.ping import ping
         SetupParameters(
             connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2,
             connection_tracker_config=generate_connection_tracker_config(
-                ConnectionTag.DOCKER_CONE_CLIENT_2, derp_1_limits=ConnectionLimits(1, 1)
+                ConnectionTag.DOCKER_CONE_CLIENT_2, derp_1_limits=(1, 1)
             ),
         )
     ],

--- a/nat-lab/tests/test_lana.py
+++ b/nat-lab/tests/test_lana.py
@@ -62,7 +62,6 @@ from utils.bindings import (
     RelayState,
 )
 from utils.connection import Connection
-from utils.connection_tracker import ConnectionLimits
 from utils.connection_util import (
     generate_connection_tracker_config,
     ConnectionTag,
@@ -348,8 +347,8 @@ async def run_default_scenario(
             ConnectionTag.DOCKER_CONE_CLIENT_1,
             generate_connection_tracker_config(
                 ConnectionTag.DOCKER_CONE_CLIENT_1,
-                derp_1_limits=ConnectionLimits(1, 1),
-                vpn_1_limits=ConnectionLimits(1 if alpha_has_vpn_connection else 0, 1),
+                derp_1_limits=(1, 1),
+                vpn_1_limits=(1 if alpha_has_vpn_connection else 0, 1),
             ),
         )
     )
@@ -358,8 +357,8 @@ async def run_default_scenario(
             ConnectionTag.DOCKER_CONE_CLIENT_2,
             generate_connection_tracker_config(
                 ConnectionTag.DOCKER_CONE_CLIENT_2,
-                derp_1_limits=ConnectionLimits(1, 1),
-                vpn_1_limits=ConnectionLimits(1 if beta_has_vpn_connection else 0, 1),
+                derp_1_limits=(1, 1),
+                vpn_1_limits=(1 if beta_has_vpn_connection else 0, 1),
             ),
         )
     )
@@ -368,8 +367,8 @@ async def run_default_scenario(
             ConnectionTag.DOCKER_SYMMETRIC_CLIENT_1,
             generate_connection_tracker_config(
                 ConnectionTag.DOCKER_SYMMETRIC_CLIENT_1,
-                derp_1_limits=ConnectionLimits(1, 1),
-                vpn_1_limits=ConnectionLimits(1 if gamma_has_vpn_connection else 0, 1),
+                derp_1_limits=(1, 1),
+                vpn_1_limits=(1 if gamma_has_vpn_connection else 0, 1),
             ),
         )
     )
@@ -477,9 +476,9 @@ async def run_default_scenario(
     )
     assert gamma_events
 
-    assert await alpha_conn_tracker.get_out_of_limits() is None
-    assert await beta_conn_tracker.get_out_of_limits() is None
-    assert await gamma_conn_tracker.get_out_of_limits() is None
+    assert await alpha_conn_tracker.find_conntracker_violations() is None
+    assert await beta_conn_tracker.find_conntracker_violations() is None
+    assert await gamma_conn_tracker.find_conntracker_violations() is None
 
     (alpha_expected_states, beta_expected_states, gamma_expected_states) = (
         [
@@ -1288,7 +1287,7 @@ async def test_lana_with_meshnet_exit_node(
                 ConnectionTag.DOCKER_CONE_CLIENT_1,
                 generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
-                    derp_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
                 ),
             )
         )
@@ -1297,19 +1296,11 @@ async def test_lana_with_meshnet_exit_node(
                 ConnectionTag.DOCKER_OPEN_INTERNET_CLIENT_DUAL_STACK,
                 generate_connection_tracker_config(
                     ConnectionTag.DOCKER_OPEN_INTERNET_CLIENT_DUAL_STACK,
-                    derp_1_limits=ConnectionLimits(1, 1),
-                    stun6_limits=(
-                        ConnectionLimits(1, 1)
-                        if is_stun6_needed
-                        else ConnectionLimits(0, 0)
-                    ),
-                    stun_limits=(
-                        ConnectionLimits(1, 1)
-                        if not is_stun6_needed
-                        else ConnectionLimits(0, 0)
-                    ),
-                    ping_limits=ConnectionLimits(None, None),
-                    ping6_limits=ConnectionLimits(None, None),
+                    derp_1_limits=(1, 1),
+                    stun6_limits=((1, 1) if is_stun6_needed else (0, 0)),
+                    stun_limits=((1, 1) if not is_stun6_needed else (0, 0)),
+                    ping_limits=(None, None),
+                    ping6_limits=(None, None),
                 ),
             )
         )
@@ -1491,8 +1482,8 @@ async def test_lana_with_meshnet_exit_node(
         # Validate all nodes have the same meshnet id
         assert alpha_events[0].fp == beta_events[0].fp
 
-        assert await alpha_conn_tracker.get_out_of_limits() is None
-        assert await beta_conn_tracker.get_out_of_limits() is None
+        assert await alpha_conn_tracker.find_conntracker_violations() is None
+        assert await beta_conn_tracker.find_conntracker_violations() is None
 
         # LLT-5532: To be cleaned up...
         client_alpha.allow_errors(
@@ -1519,9 +1510,9 @@ async def test_lana_with_disconnected_node(
                 ConnectionTag.DOCKER_CONE_CLIENT_1,
                 generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
-                    derp_1_limits=ConnectionLimits(1, 1),
-                    ping_limits=ConnectionLimits(None, None),
-                    ping6_limits=ConnectionLimits(None, None),
+                    derp_1_limits=(1, 1),
+                    ping_limits=(None, None),
+                    ping6_limits=(None, None),
                 ),
             )
         )
@@ -1530,9 +1521,9 @@ async def test_lana_with_disconnected_node(
                 ConnectionTag.DOCKER_CONE_CLIENT_2,
                 generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_2,
-                    derp_1_limits=ConnectionLimits(1, 1),
-                    ping_limits=ConnectionLimits(None, None),
-                    ping6_limits=ConnectionLimits(None, None),
+                    derp_1_limits=(1, 1),
+                    ping_limits=(None, None),
+                    ping6_limits=(None, None),
                 ),
             )
         )
@@ -1900,8 +1891,8 @@ async def test_lana_with_disconnected_node(
             == beta_events[0].fp
             == beta_events[1].fp
         )
-        assert await alpha_conn_tracker.get_out_of_limits() is None
-        assert await beta_conn_tracker.get_out_of_limits() is None
+        assert await alpha_conn_tracker.find_conntracker_violations() is None
+        assert await beta_conn_tracker.find_conntracker_violations() is None
 
 
 @pytest.mark.moose
@@ -1918,7 +1909,7 @@ async def test_lana_with_second_node_joining_later_meshnet_id_can_change(
                 ConnectionTag.DOCKER_CONE_CLIENT_2,
                 generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_2,
-                    derp_1_limits=ConnectionLimits(1, None),
+                    derp_1_limits=(1, None),
                 ),
             )
         )
@@ -1945,7 +1936,7 @@ async def test_lana_with_second_node_joining_later_meshnet_id_can_change(
                 ConnectionTag.DOCKER_CONE_CLIENT_1,
                 generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
-                    derp_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
                 ),
             )
         )
@@ -1995,8 +1986,8 @@ async def test_lana_with_second_node_joining_later_meshnet_id_can_change(
         else:
             assert False, "[PANIC] Public keys match!"
 
-        assert await alpha_conn_tracker.get_out_of_limits() is None
-        assert await beta_conn_tracker.get_out_of_limits() is None
+        assert await alpha_conn_tracker.find_conntracker_violations() is None
+        assert await beta_conn_tracker.find_conntracker_violations() is None
 
         # LLT-5532: To be cleaned up...
         client_alpha.allow_errors(

--- a/nat-lab/tests/test_mesh_exit_through_peer.py
+++ b/nat-lab/tests/test_mesh_exit_through_peer.py
@@ -7,7 +7,6 @@ from mesh_api import API
 from telio import Client
 from utils import testing, stun
 from utils.bindings import PathType, NodeState, RelayState, TelioAdapterType
-from utils.connection_tracker import ConnectionLimits
 from utils.connection_util import (
     generate_connection_tracker_config,
     ConnectionTag,
@@ -42,7 +41,7 @@ from utils.router import IPProto, IPStack
                 adapter_type_override=TelioAdapterType.NEP_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
-                    derp_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
                 ),
             )
         ),
@@ -53,7 +52,7 @@ from utils.router import IPProto, IPStack
                 adapter_type_override=TelioAdapterType.LINUX_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
-                    derp_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
                 ),
             ),
             marks=pytest.mark.linux_native,
@@ -65,7 +64,7 @@ from utils.router import IPProto, IPStack
                 adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
-                    derp_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
                 ),
             ),
             marks=pytest.mark.windows,
@@ -77,7 +76,7 @@ from utils.router import IPProto, IPStack
                 adapter_type_override=TelioAdapterType.WIREGUARD_GO_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
-                    derp_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
                 ),
             ),
             marks=pytest.mark.windows,
@@ -89,7 +88,7 @@ from utils.router import IPProto, IPStack
                 adapter_type_override=TelioAdapterType.NEP_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.MAC_VM,
-                    derp_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
                 ),
             ),
             marks=pytest.mark.mac,
@@ -104,8 +103,8 @@ from utils.router import IPProto, IPStack
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_2,
-                    derp_1_limits=ConnectionLimits(1, 1),
-                    stun_limits=ConnectionLimits(1, 2),
+                    derp_1_limits=(1, 1),
+                    stun_limits=(1, 2),
                 ),
             )
         )
@@ -242,8 +241,8 @@ async def test_ipv6_exit_node(
                 alpha_connection_tag,
                 generate_connection_tracker_config(
                     alpha_connection_tag,
-                    derp_1_limits=ConnectionLimits(1, 1),
-                    ping6_limits=ConnectionLimits(None, None),
+                    derp_1_limits=(1, 1),
+                    ping6_limits=(None, None),
                 ),
             )
         )
@@ -252,10 +251,10 @@ async def test_ipv6_exit_node(
                 ConnectionTag.DOCKER_OPEN_INTERNET_CLIENT_DUAL_STACK,
                 generate_connection_tracker_config(
                     ConnectionTag.DOCKER_OPEN_INTERNET_CLIENT_DUAL_STACK,
-                    derp_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
                     # Dual stack doesn't have a gw so conntrack is launched on its interface
-                    stun6_limits=ConnectionLimits(1, 1),
-                    ping6_limits=ConnectionLimits(None, None),
+                    stun6_limits=(1, 1),
+                    ping6_limits=(None, None),
                 ),
             )
         )
@@ -294,5 +293,5 @@ async def test_ipv6_exit_node(
         ip_beta = await stun.get(connection_beta, config.STUNV6_SERVER)
         assert ip_alpha == ip_beta
 
-        assert await alpha_conn_tracker.get_out_of_limits() is None
-        assert await beta_conn_tracker.get_out_of_limits() is None
+        assert await alpha_conn_tracker.find_conntracker_violations() is None
+        assert await beta_conn_tracker.find_conntracker_violations() is None

--- a/nat-lab/tests/test_mesh_plus_vpn.py
+++ b/nat-lab/tests/test_mesh_plus_vpn.py
@@ -15,7 +15,6 @@ from utils.bindings import (
     RelayState,
     NodeState,
 )
-from utils.connection_tracker import ConnectionLimits
 from utils.connection_util import (
     generate_connection_tracker_config,
     ConnectionTag,
@@ -35,8 +34,8 @@ from utils.ping import ping
                 adapter_type_override=TelioAdapterType.NEP_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
-                    derp_1_limits=ConnectionLimits(1, 1),
-                    vpn_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
+                    vpn_1_limits=(1, 1),
                 ),
             )
         ),
@@ -46,8 +45,8 @@ from utils.ping import ping
                 adapter_type_override=TelioAdapterType.LINUX_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
-                    derp_1_limits=ConnectionLimits(1, 1),
-                    vpn_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
+                    vpn_1_limits=(1, 1),
                 ),
             ),
             marks=pytest.mark.linux_native,
@@ -58,8 +57,8 @@ from utils.ping import ping
                 adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
-                    derp_1_limits=ConnectionLimits(1, 1),
-                    vpn_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
+                    vpn_1_limits=(1, 1),
                 ),
             ),
             marks=pytest.mark.windows,
@@ -70,8 +69,8 @@ from utils.ping import ping
                 adapter_type_override=TelioAdapterType.WIREGUARD_GO_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
-                    derp_1_limits=ConnectionLimits(1, 1),
-                    vpn_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
+                    vpn_1_limits=(1, 1),
                 ),
             ),
             marks=[
@@ -84,8 +83,8 @@ from utils.ping import ping
                 adapter_type_override=TelioAdapterType.NEP_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.MAC_VM,
-                    derp_1_limits=ConnectionLimits(1, 1),
-                    vpn_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
+                    vpn_1_limits=(1, 1),
                 ),
             ),
             marks=pytest.mark.mac,
@@ -100,7 +99,7 @@ from utils.ping import ping
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_2,
-                    derp_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
                 ),
             )
         )
@@ -146,8 +145,8 @@ async def test_mesh_plus_vpn_one_peer(
                 adapter_type_override=TelioAdapterType.NEP_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
-                    derp_1_limits=ConnectionLimits(1, 1),
-                    vpn_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
+                    vpn_1_limits=(1, 1),
                 ),
             )
         ),
@@ -157,8 +156,8 @@ async def test_mesh_plus_vpn_one_peer(
                 adapter_type_override=TelioAdapterType.LINUX_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
-                    derp_1_limits=ConnectionLimits(1, 1),
-                    vpn_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
+                    vpn_1_limits=(1, 1),
                 ),
             ),
             marks=pytest.mark.linux_native,
@@ -169,8 +168,8 @@ async def test_mesh_plus_vpn_one_peer(
                 adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
-                    derp_1_limits=ConnectionLimits(1, 1),
-                    vpn_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
+                    vpn_1_limits=(1, 1),
                 ),
             ),
             marks=pytest.mark.windows,
@@ -181,8 +180,8 @@ async def test_mesh_plus_vpn_one_peer(
                 adapter_type_override=TelioAdapterType.WIREGUARD_GO_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
-                    derp_1_limits=ConnectionLimits(1, 1),
-                    vpn_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
+                    vpn_1_limits=(1, 1),
                 ),
             ),
             marks=[
@@ -195,8 +194,8 @@ async def test_mesh_plus_vpn_one_peer(
                 adapter_type_override=TelioAdapterType.NEP_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.MAC_VM,
-                    derp_1_limits=ConnectionLimits(1, 1),
-                    vpn_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
+                    vpn_1_limits=(1, 1),
                 ),
             ),
             marks=pytest.mark.mac,
@@ -211,8 +210,8 @@ async def test_mesh_plus_vpn_one_peer(
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_2,
-                    derp_1_limits=ConnectionLimits(1, 1),
-                    vpn_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
+                    vpn_1_limits=(1, 1),
                 ),
             )
         )
@@ -311,9 +310,9 @@ async def test_vpn_plus_mesh(
                 alpha_connection_tag,
                 generate_connection_tracker_config(
                     alpha_connection_tag,
-                    derp_1_limits=ConnectionLimits(1, 1),
-                    vpn_1_limits=ConnectionLimits(1, 1),
-                    stun_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
+                    vpn_1_limits=(1, 1),
+                    stun_limits=(1, 1),
                 ),
             )
         )
@@ -322,7 +321,7 @@ async def test_vpn_plus_mesh(
                 ConnectionTag.DOCKER_CONE_CLIENT_2,
                 generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_2,
-                    derp_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
                 ),
             )
         )
@@ -372,8 +371,8 @@ async def test_vpn_plus_mesh(
         ip = await stun.get(connection_alpha, config.STUN_SERVER)
         assert ip == wg_server["ipv4"], f"wrong public IP when connected to VPN {ip}"
 
-        assert await alpha_conn_tracker.get_out_of_limits() is None
-        assert await beta_conn_tracker.get_out_of_limits() is None
+        assert await alpha_conn_tracker.find_conntracker_violations() is None
+        assert await beta_conn_tracker.find_conntracker_violations() is None
 
 
 @pytest.mark.asyncio
@@ -387,8 +386,8 @@ async def test_vpn_plus_mesh(
                 adapter_type_override=TelioAdapterType.NEP_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
-                    derp_1_limits=ConnectionLimits(1, 1),
-                    vpn_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
+                    vpn_1_limits=(1, 1),
                 ),
                 features=features_with_endpoint_providers(
                     [EndpointProvider.LOCAL, EndpointProvider.STUN]
@@ -401,8 +400,8 @@ async def test_vpn_plus_mesh(
                 adapter_type_override=TelioAdapterType.LINUX_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
-                    derp_1_limits=ConnectionLimits(1, 1),
-                    vpn_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
+                    vpn_1_limits=(1, 1),
                 ),
                 features=features_with_endpoint_providers(
                     [EndpointProvider.LOCAL, EndpointProvider.STUN]
@@ -418,8 +417,8 @@ async def test_vpn_plus_mesh(
                 adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
-                    derp_1_limits=ConnectionLimits(1, 1),
-                    vpn_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
+                    vpn_1_limits=(1, 1),
                 ),
                 features=features_with_endpoint_providers(
                     [EndpointProvider.LOCAL, EndpointProvider.STUN]
@@ -435,8 +434,8 @@ async def test_vpn_plus_mesh(
                 adapter_type_override=TelioAdapterType.WIREGUARD_GO_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
-                    derp_1_limits=ConnectionLimits(1, 1),
-                    vpn_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
+                    vpn_1_limits=(1, 1),
                 ),
                 features=features_with_endpoint_providers(
                     [EndpointProvider.LOCAL, EndpointProvider.STUN]
@@ -452,8 +451,8 @@ async def test_vpn_plus_mesh(
                 adapter_type_override=TelioAdapterType.NEP_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.MAC_VM,
-                    derp_1_limits=ConnectionLimits(1, 1),
-                    vpn_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
+                    vpn_1_limits=(1, 1),
                 ),
                 features=features_with_endpoint_providers(
                     [EndpointProvider.LOCAL, EndpointProvider.STUN]
@@ -473,8 +472,8 @@ async def test_vpn_plus_mesh(
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_2,
-                    derp_1_limits=ConnectionLimits(1, 1),
-                    vpn_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
+                    vpn_1_limits=(1, 1),
                 ),
                 features=features_with_endpoint_providers(
                     [EndpointProvider.LOCAL, EndpointProvider.STUN]
@@ -549,8 +548,8 @@ async def test_vpn_plus_mesh_over_direct(
                 adapter_type_override=TelioAdapterType.NEP_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
-                    derp_1_limits=ConnectionLimits(1, 1),
-                    vpn_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
+                    vpn_1_limits=(1, 1),
                 ),
                 features=features_with_endpoint_providers(
                     [EndpointProvider.LOCAL, EndpointProvider.STUN]
@@ -563,8 +562,8 @@ async def test_vpn_plus_mesh_over_direct(
                 adapter_type_override=TelioAdapterType.LINUX_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
-                    derp_1_limits=ConnectionLimits(1, 1),
-                    vpn_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
+                    vpn_1_limits=(1, 1),
                 ),
                 features=features_with_endpoint_providers(
                     [EndpointProvider.LOCAL, EndpointProvider.STUN]
@@ -578,8 +577,8 @@ async def test_vpn_plus_mesh_over_direct(
                 adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
-                    derp_1_limits=ConnectionLimits(1, 1),
-                    vpn_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
+                    vpn_1_limits=(1, 1),
                 ),
                 features=features_with_endpoint_providers(
                     [EndpointProvider.LOCAL, EndpointProvider.STUN]
@@ -593,8 +592,8 @@ async def test_vpn_plus_mesh_over_direct(
                 adapter_type_override=TelioAdapterType.WIREGUARD_GO_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
-                    derp_1_limits=ConnectionLimits(1, 1),
-                    vpn_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
+                    vpn_1_limits=(1, 1),
                 ),
                 features=features_with_endpoint_providers(
                     [EndpointProvider.LOCAL, EndpointProvider.STUN]
@@ -610,8 +609,8 @@ async def test_vpn_plus_mesh_over_direct(
                 adapter_type_override=TelioAdapterType.NEP_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.MAC_VM,
-                    derp_1_limits=ConnectionLimits(1, 1),
-                    vpn_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
+                    vpn_1_limits=(1, 1),
                 ),
                 features=features_with_endpoint_providers(
                     [EndpointProvider.LOCAL, EndpointProvider.STUN]
@@ -631,8 +630,8 @@ async def test_vpn_plus_mesh_over_direct(
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_2,
-                    derp_1_limits=ConnectionLimits(1, 1),
-                    vpn_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
+                    vpn_1_limits=(1, 1),
                 ),
                 features=features_with_endpoint_providers(
                     [EndpointProvider.LOCAL, EndpointProvider.STUN]
@@ -649,8 +648,8 @@ async def test_vpn_plus_mesh_over_direct(
                 connection_tag=ConnectionTag.DOCKER_SYMMETRIC_CLIENT_1,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_SYMMETRIC_CLIENT_1,
-                    derp_1_limits=ConnectionLimits(1, 1),
-                    vpn_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
+                    vpn_1_limits=(1, 1),
                 ),
             )
         )

--- a/nat-lab/tests/test_mesh_remove_node.py
+++ b/nat-lab/tests/test_mesh_remove_node.py
@@ -4,7 +4,6 @@ from contextlib import AsyncExitStack
 from helpers import SetupParameters, setup_mesh_nodes
 from mesh_api import API
 from utils.bindings import TelioAdapterType
-from utils.connection_tracker import ConnectionLimits
 from utils.connection_util import generate_connection_tracker_config, ConnectionTag
 from utils.ping import ping
 
@@ -19,7 +18,7 @@ from utils.ping import ping
                 adapter_type_override=TelioAdapterType.NEP_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
-                    derp_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
                 ),
             )
         ),
@@ -29,7 +28,7 @@ from utils.ping import ping
                 adapter_type_override=TelioAdapterType.LINUX_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
-                    derp_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
                 ),
             ),
             marks=pytest.mark.linux_native,
@@ -40,7 +39,7 @@ from utils.ping import ping
                 adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
-                    derp_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
                 ),
             ),
             marks=[
@@ -53,7 +52,7 @@ from utils.ping import ping
                 adapter_type_override=TelioAdapterType.WIREGUARD_GO_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
-                    derp_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
                 ),
             ),
             marks=pytest.mark.windows,
@@ -64,7 +63,7 @@ from utils.ping import ping
                 adapter_type_override=TelioAdapterType.NEP_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.MAC_VM,
-                    derp_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
                 ),
             ),
             marks=[
@@ -81,7 +80,7 @@ from utils.ping import ping
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_2,
-                    derp_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
                 ),
             )
         )
@@ -95,7 +94,7 @@ from utils.ping import ping
                 connection_tag=ConnectionTag.DOCKER_SYMMETRIC_CLIENT_1,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_SYMMETRIC_CLIENT_1,
-                    derp_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
                 ),
             )
         )

--- a/nat-lab/tests/test_node_state_flickering.py
+++ b/nat-lab/tests/test_node_state_flickering.py
@@ -12,7 +12,6 @@ from utils.bindings import (
     NodeState,
     RelayState,
 )
-from utils.connection_tracker import ConnectionLimits
 from utils.connection_util import generate_connection_tracker_config, ConnectionTag
 
 
@@ -28,7 +27,7 @@ from utils.connection_util import generate_connection_tracker_config, Connection
                 adapter_type_override=TelioAdapterType.NEP_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
-                    derp_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
                 ),
             )
         ),
@@ -38,7 +37,7 @@ from utils.connection_util import generate_connection_tracker_config, Connection
                 adapter_type_override=TelioAdapterType.LINUX_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
-                    derp_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
                 ),
             ),
             marks=pytest.mark.linux_native,
@@ -49,7 +48,7 @@ from utils.connection_util import generate_connection_tracker_config, Connection
                 adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
-                    derp_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
                 ),
             ),
             marks=pytest.mark.windows,
@@ -60,7 +59,7 @@ from utils.connection_util import generate_connection_tracker_config, Connection
                 adapter_type_override=TelioAdapterType.WIREGUARD_GO_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
-                    derp_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
                 ),
             ),
             marks=pytest.mark.windows,
@@ -71,7 +70,7 @@ from utils.connection_util import generate_connection_tracker_config, Connection
                 adapter_type_override=TelioAdapterType.NEP_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.MAC_VM,
-                    derp_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
                 ),
             ),
             marks=pytest.mark.mac,
@@ -86,7 +85,7 @@ from utils.connection_util import generate_connection_tracker_config, Connection
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_2,
-                    derp_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
                 ),
             )
         )

--- a/nat-lab/tests/test_pinging.py
+++ b/nat-lab/tests/test_pinging.py
@@ -15,7 +15,7 @@ from utils.bindings import (
     NodeState,
 )
 from utils.connection import Connection
-from utils.connection_tracker import ConnectionTracker, ConnectionLimits
+from utils.connection_tracker import ConnectionTracker
 from utils.connection_util import (
     generate_connection_tracker_config,
     new_connection_with_node_tracker,
@@ -49,22 +49,22 @@ async def build_conntracker(
     # Set connection tracker expectations according to IP stack parameter
     connection = connectivity_stack(primary_ip_stack, secondary_ip_stack)
 
-    ping_limits = ConnectionLimits(0, 0)
-    ping6_limits = ConnectionLimits(0, 0)
+    ping_limits = (0, 0)
+    ping6_limits = (0, 0)
 
     if connection == IPStack.IPv4:
-        ping_limits = ConnectionLimits(1, 2)
+        ping_limits = (1, 2)
     elif connection == IPStack.IPv6:
-        ping6_limits = ConnectionLimits(1, 2)
+        ping6_limits = (1, 2)
     elif connection == IPStack.IPv4v6:
         # Session keeper prioritizes IPv6, and only when IPv6 is not available, it uses IPv4
         if not for_session_keeper:
-            ping_limits = ConnectionLimits(1, 2)
-        ping6_limits = ConnectionLimits(1, 2)
+            ping_limits = (1, 2)
+        ping6_limits = (1, 2)
 
     conntrack_config = generate_connection_tracker_config(
         tag,
-        derp_1_limits=ConnectionLimits(1, 1),
+        derp_1_limits=(1, 1),
         ping_limits=ping_limits,
         ping6_limits=ping6_limits,
     )
@@ -106,7 +106,7 @@ def nurse_features() -> Features:
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
-                    derp_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
                 ),
                 features=stun_features(),
             )
@@ -117,7 +117,7 @@ def nurse_features() -> Features:
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
-                    derp_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
                 ),
                 features=stun_features(),
             ),
@@ -138,7 +138,7 @@ def nurse_features() -> Features:
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_2,
-                    derp_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
                 ),
                 ip_stack=IPStack.IPv4v6,
                 features=stun_features(),
@@ -180,8 +180,8 @@ async def test_session_keeper(
 
         async def wait_for_conntracker() -> None:
             while True:
-                alpha_limits = await alpha_conntrack.get_out_of_limits()
-                beta_limits = await beta_conntrack.get_out_of_limits()
+                alpha_limits = await alpha_conntrack.find_conntracker_violations()
+                beta_limits = await beta_conntrack.find_conntracker_violations()
                 print(datetime.now(), "Conntracker state: ", alpha_limits, beta_limits)
                 if alpha_limits is None and beta_limits is None:
                     return
@@ -212,7 +212,7 @@ async def test_session_keeper(
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
-                    derp_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
                 ),
                 features=nurse_features(),
                 fingerprint="alpha_fingerprint",
@@ -224,7 +224,7 @@ async def test_session_keeper(
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
-                    derp_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
                 ),
                 features=nurse_features(),
                 fingerprint="alpha_fingerprint",
@@ -245,7 +245,7 @@ async def test_session_keeper(
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_2,
-                    derp_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
                 ),
                 ip_stack=IPStack.IPv4v6,
                 features=default_features(enable_ipv6=True),
@@ -278,7 +278,7 @@ async def test_qos(
 
         async def wait_for_conntracker() -> None:
             while True:
-                alpha_limits = await alpha_conntrack.get_out_of_limits()
+                alpha_limits = await alpha_conntrack.find_conntracker_violations()
                 print("wait_for_conntracker(): ", alpha_limits)
                 if alpha_limits is None:
                     return

--- a/nat-lab/tests/test_pmtu.py
+++ b/nat-lab/tests/test_pmtu.py
@@ -9,11 +9,7 @@ from utils.bindings import (
     FeaturePmtuDiscovery,
     TelioAdapterType,
 )
-from utils.connection_util import (
-    ConnectionTag,
-    generate_connection_tracker_config,
-    ConnectionLimits,
-)
+from utils.connection_util import ConnectionTag, generate_connection_tracker_config
 from utils.ping import ping
 from utils.router import IPStack
 
@@ -166,9 +162,9 @@ async def test_pmtu_without_nexthop(setup_params: SetupParameters) -> None:
                 adapter_type_override=TelioAdapterType.NEP_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
-                    vpn_1_limits=ConnectionLimits(1, 1),
-                    stun_limits=ConnectionLimits(1, 1),
-                    ping_limits=ConnectionLimits(1, 1),
+                    vpn_1_limits=(1, 1),
+                    stun_limits=(1, 1),
+                    ping_limits=(1, 1),
                 ),
                 features=features(),
                 is_meshnet=False,
@@ -179,9 +175,9 @@ async def test_pmtu_without_nexthop(setup_params: SetupParameters) -> None:
                 adapter_type_override=TelioAdapterType.LINUX_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
-                    vpn_1_limits=ConnectionLimits(1, 1),
-                    stun_limits=ConnectionLimits(1, 1),
-                    ping_limits=ConnectionLimits(1, 1),
+                    vpn_1_limits=(1, 1),
+                    stun_limits=(1, 1),
+                    ping_limits=(1, 1),
                 ),
                 features=features(),
                 is_meshnet=False,

--- a/nat-lab/tests/test_pq.py
+++ b/nat-lab/tests/test_pq.py
@@ -6,7 +6,6 @@ from telio import Client
 from utils import stun
 from utils.bindings import TelioAdapterType
 from utils.connection import Connection
-from utils.connection_tracker import ConnectionLimits
 from utils.connection_util import (
     generate_connection_tracker_config,
     ConnectionTag,
@@ -55,8 +54,8 @@ async def inspect_preshared_key(nlx_conn: Connection) -> str:
                 adapter_type_override=TelioAdapterType.NEP_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
-                    stun_limits=ConnectionLimits(1, 1),
-                    nlx_1_limits=ConnectionLimits(1, 2),
+                    stun_limits=(1, 1),
+                    nlx_1_limits=(1, 2),
                 ),
                 is_meshnet=False,
             ),
@@ -68,8 +67,8 @@ async def inspect_preshared_key(nlx_conn: Connection) -> str:
                 adapter_type_override=TelioAdapterType.LINUX_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
-                    stun_limits=ConnectionLimits(1, 1),
-                    nlx_1_limits=ConnectionLimits(1, 2),
+                    stun_limits=(1, 1),
+                    nlx_1_limits=(1, 2),
                 ),
                 is_meshnet=False,
             ),
@@ -82,8 +81,8 @@ async def inspect_preshared_key(nlx_conn: Connection) -> str:
                 adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
-                    stun_limits=ConnectionLimits(1, 1),
-                    nlx_1_limits=ConnectionLimits(1, 2),
+                    stun_limits=(1, 1),
+                    nlx_1_limits=(1, 2),
                 ),
                 is_meshnet=False,
             ),
@@ -98,8 +97,8 @@ async def inspect_preshared_key(nlx_conn: Connection) -> str:
                 adapter_type_override=TelioAdapterType.WIREGUARD_GO_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
-                    stun_limits=ConnectionLimits(1, 1),
-                    nlx_1_limits=ConnectionLimits(1, 2),
+                    stun_limits=(1, 1),
+                    nlx_1_limits=(1, 2),
                 ),
                 is_meshnet=False,
             ),
@@ -114,8 +113,8 @@ async def inspect_preshared_key(nlx_conn: Connection) -> str:
                 adapter_type_override=TelioAdapterType.NEP_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.MAC_VM,
-                    stun_limits=ConnectionLimits(1, 1),
-                    nlx_1_limits=ConnectionLimits(1, 2),
+                    stun_limits=(1, 1),
+                    nlx_1_limits=(1, 2),
                 ),
                 is_meshnet=False,
             ),
@@ -154,8 +153,8 @@ async def test_pq_vpn_connection(
                 adapter_type_override=TelioAdapterType.NEP_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
-                    stun_limits=ConnectionLimits(1, 1),
-                    nlx_1_limits=ConnectionLimits(1, 2),
+                    stun_limits=(1, 1),
+                    nlx_1_limits=(1, 2),
                 ),
                 is_meshnet=False,
             ),
@@ -167,8 +166,8 @@ async def test_pq_vpn_connection(
                 adapter_type_override=TelioAdapterType.LINUX_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
-                    stun_limits=ConnectionLimits(1, 1),
-                    nlx_1_limits=ConnectionLimits(1, 2),
+                    stun_limits=(1, 1),
+                    nlx_1_limits=(1, 2),
                 ),
                 is_meshnet=False,
             ),
@@ -181,8 +180,8 @@ async def test_pq_vpn_connection(
                 adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
-                    stun_limits=ConnectionLimits(1, 1),
-                    nlx_1_limits=ConnectionLimits(1, 2),
+                    stun_limits=(1, 1),
+                    nlx_1_limits=(1, 2),
                 ),
                 is_meshnet=False,
             ),
@@ -197,8 +196,8 @@ async def test_pq_vpn_connection(
                 adapter_type_override=TelioAdapterType.WIREGUARD_GO_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
-                    stun_limits=ConnectionLimits(1, 1),
-                    nlx_1_limits=ConnectionLimits(1, 2),
+                    stun_limits=(1, 1),
+                    nlx_1_limits=(1, 2),
                 ),
                 is_meshnet=False,
             ),
@@ -213,8 +212,8 @@ async def test_pq_vpn_connection(
                 adapter_type_override=TelioAdapterType.NEP_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.MAC_VM,
-                    stun_limits=ConnectionLimits(1, 1),
-                    nlx_1_limits=ConnectionLimits(1, 2),
+                    stun_limits=(1, 1),
+                    nlx_1_limits=(1, 2),
                 ),
                 is_meshnet=False,
             ),
@@ -275,7 +274,7 @@ async def test_pq_vpn_rekey(
                 adapter_type_override=TelioAdapterType.NEP_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
-                    nlx_1_limits=ConnectionLimits(1, 2),
+                    nlx_1_limits=(1, 2),
                 ),
                 is_meshnet=False,
             ),
@@ -286,7 +285,7 @@ async def test_pq_vpn_rekey(
                 adapter_type_override=TelioAdapterType.LINUX_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
-                    nlx_1_limits=ConnectionLimits(1, 2),
+                    nlx_1_limits=(1, 2),
                 ),
                 is_meshnet=False,
             ),
@@ -298,7 +297,7 @@ async def test_pq_vpn_rekey(
                 adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
-                    nlx_1_limits=ConnectionLimits(1, 2),
+                    nlx_1_limits=(1, 2),
                 ),
                 is_meshnet=False,
             ),
@@ -312,7 +311,7 @@ async def test_pq_vpn_rekey(
                 adapter_type_override=TelioAdapterType.WIREGUARD_GO_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
-                    nlx_1_limits=ConnectionLimits(1, 2),
+                    nlx_1_limits=(1, 2),
                 ),
                 is_meshnet=False,
             ),
@@ -326,7 +325,7 @@ async def test_pq_vpn_rekey(
                 adapter_type_override=TelioAdapterType.NEP_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.MAC_VM,
-                    nlx_1_limits=ConnectionLimits(1, 2),
+                    nlx_1_limits=(1, 2),
                 ),
                 is_meshnet=False,
             ),

--- a/nat-lab/tests/test_reconnections.py
+++ b/nat-lab/tests/test_reconnections.py
@@ -4,7 +4,6 @@ from contextlib import AsyncExitStack
 from helpers import setup_mesh_nodes, SetupParameters
 from utils import asyncio_util
 from utils.bindings import NodeState, RelayState, TelioAdapterType
-from utils.connection_tracker import ConnectionLimits
 from utils.connection_util import generate_connection_tracker_config, ConnectionTag
 from utils.ping import ping
 
@@ -19,7 +18,7 @@ from utils.ping import ping
                 adapter_type_override=TelioAdapterType.NEP_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
-                    derp_1_limits=ConnectionLimits(1, 2),
+                    derp_1_limits=(1, 2),
                 ),
             )
         ),
@@ -29,7 +28,7 @@ from utils.ping import ping
                 adapter_type_override=TelioAdapterType.LINUX_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
-                    derp_1_limits=ConnectionLimits(1, 2),
+                    derp_1_limits=(1, 2),
                 ),
             ),
             marks=pytest.mark.linux_native,
@@ -40,7 +39,7 @@ from utils.ping import ping
                 adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
-                    derp_1_limits=ConnectionLimits(1, 2),
+                    derp_1_limits=(1, 2),
                 ),
             ),
             marks=[
@@ -53,7 +52,7 @@ from utils.ping import ping
                 adapter_type_override=TelioAdapterType.WIREGUARD_GO_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
-                    derp_1_limits=ConnectionLimits(1, 2),
+                    derp_1_limits=(1, 2),
                 ),
             ),
             marks=[
@@ -66,7 +65,7 @@ from utils.ping import ping
                 adapter_type_override=TelioAdapterType.NEP_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.MAC_VM,
-                    derp_1_limits=ConnectionLimits(1, 2),
+                    derp_1_limits=(1, 2),
                 ),
             ),
             marks=pytest.mark.mac,
@@ -81,7 +80,7 @@ from utils.ping import ping
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2,
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_2,
-                    derp_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
                 ),
             )
         )

--- a/nat-lab/tests/test_telio_version_compatibility.py
+++ b/nat-lab/tests/test_telio_version_compatibility.py
@@ -20,7 +20,6 @@ from utils.bindings import (
 )
 from utils.connection_util import (
     ConnectionTag,
-    ConnectionLimits,
     generate_connection_tracker_config,
     new_connection_with_conn_tracker,
 )
@@ -136,7 +135,7 @@ async def test_connect_different_telio_version_through_relay(
                 client1_type,
                 generate_connection_tracker_config(
                     client1_type,
-                    derp_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
                 ),
             )
         )
@@ -149,7 +148,7 @@ async def test_connect_different_telio_version_through_relay(
                 client2_type,
                 generate_connection_tracker_config(
                     client2_type,
-                    derp_1_limits=ConnectionLimits(1, 1),
+                    derp_1_limits=(1, 1),
                 ),
             )
         )
@@ -201,5 +200,5 @@ async def test_connect_different_telio_version_through_relay(
             testing.unpack_optional(beta.get_ip_address(IPProto.IPv4)),
         )
 
-        assert await alpha_conn_tracker.get_out_of_limits() is None
-        assert await beta_conn_tracker.get_out_of_limits() is None
+        assert await alpha_conn_tracker.find_conntracker_violations() is None
+        assert await beta_conn_tracker.find_conntracker_violations() is None

--- a/nat-lab/tests/utils/dns.py
+++ b/nat-lab/tests/utils/dns.py
@@ -9,14 +9,17 @@ async def query_dns(
     host_name: str,
     expected_output: Optional[List[str]] = None,
     dns_server: Optional[str] = None,
-    options: Optional[str] = None,
+    options: Optional[List[str]] = None,
 ) -> None:
-    response = await connection.create_process([
-        "nslookup",
-        options if options else "-timeout=1",
-        host_name,
-        dns_server if dns_server else LIBTELIO_DNS_IPV4,
-    ]).execute()
+    args = ["nslookup"]
+    if options:
+        args += options
+    else:
+        args.append("-timeout=1")
+    args.append(host_name)
+    args.append(dns_server if dns_server else LIBTELIO_DNS_IPV4)
+
+    response = await connection.create_process(args).execute()
     dns_output = response.get_stdout()
     if expected_output:
         for expected_str in expected_output:


### PR DESCRIPTION
### Problem
`test_dns_duplicate_requests_on_multiple_forward_servers` is sometimes failing. Seems like the test was written long time ago, when conntracker was not yet widly used. As starting various captures and then verifying results is generally race-condition-prone practice, the first agreed upon step is to convert the test to use conntracker, which already have sync points helping to reduce likelyhood of any race conditions. 

What is more, the assertion is rather strange, the DNS should not issue the same query to multiple servers, but assertion verifies whether one, the other or both servers are being used, which is strictly asserting, that on succesfull DNS query any DNS servers have been reached, which is not really useful assertion. This PR strictens the assertion a little bit, to make sure that when issuing DNS query with only `A` query (previously there were two queries, one for `A` and one for `AAAA`) - only one DNS server is contacted. 

### For reviewers

After a discussion [here](https://github.com/NordSecurity/libtelio/pull/933#discussion_r1832862106) we have decided to refactor connection tracker a little bit. I was thinking how best to implement it, and decided on something similar to this:
![conntrack-uml](https://github.com/user-attachments/assets/0c1ac6b1-0e9d-4f50-bbf4-e23cd1381d61)
E.g. connection tracker has a list of validators, which are implementations of abstract class `ConnTrackerEventsValidator`. This allows a way of "providing names" for common conntracker validators. One which is limiting number of connections - `ConnectionCountLimit` and one (`TCPStateSequence`) which requires TCP connection to end in specified sequence of TCP states.

The DNS test, which spurred the discussion has its own validator which is named `SingleConnectionToAnyNatlabDNS` and it verifies exactly that, e.g. there is overall single DNS connection, and it is connecting to one of the natlab DNS servers.

The refactoring is wider, than I would have liked, but hopefully it makes sense.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
