### PR TITLE
Bring back stricter events assertion in test-direct-working-path test

### DIFF
--- a/nat-lab/tests/uniffi/libtelio_proxy.py
+++ b/nat-lab/tests/uniffi/libtelio_proxy.py
@@ -56,7 +56,7 @@ class LibtelioProxy:
                 "Unknown" if container_or_vm_name is None else container_or_vm_name,
             )
 
-        except Pyro5.errors.ConnectionClosedError as e:
+        except (Pyro5.errors.ConnectionClosedError, Pyro5.errors.ConnectionRefusedError) as e:
             # Shutting down the server via client request is naturally racy,
             # as sending of response is racing against process shutdown (and
             # thus server-side socket being closed).


### PR DESCRIPTION
### Problem
I have a feeling that recent PR https://github.com/NordSecurity/libtelio/pull/927 could have made test-direct-working-path a little too loose. For this reason I am bringing back a bit stricter events assertion and will try to reproduce previous the test-direct-working-path failure. With the reproduction, will attempt to find exact root cause for the failure, and hopefully in the end, gather enough information, to enable the test to get back to stricter events verification.


### :ballot_box_with_check: Definition of Done checklist
- [ ] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [ ] README.md is updated
- [ ] Functionality is covered by unit or integration tests
