### PR TITLE
bump libtelio build version and save macos system logs

### DIFF
--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -22,4 +22,4 @@ jobs:
     with:
       schedule: ${{ github.event_name == 'schedule' }}
       cancel-outdated-pipelines: ${{ github.ref_name != 'main' }}
-      triggered-ref: v2.5.1 # REMEMBER to also update in .gitlab-ci.yml
+      triggered-ref: v2.5.2 # REMEMBER to also update in .gitlab-ci.yml

--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -22,4 +22,4 @@ jobs:
     with:
       schedule: ${{ github.event_name == 'schedule' }}
       cancel-outdated-pipelines: ${{ github.ref_name != 'main' }}
-      triggered-ref: v2.5.0 # REMEMBER to also update in .gitlab-ci.yml
+      triggered-ref: v2.5.1 # REMEMBER to also update in .gitlab-ci.yml

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,4 +15,4 @@ libtelio-build-pipeline:
 
   trigger:
     project: $LIBTELIO_BUILD_PROJECT_PATH
-    branch: v2.5.1 # REMEMBER to also update in .github/workflows/gitlab.yml
+    branch: v2.5.2 # REMEMBER to also update in .github/workflows/gitlab.yml

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,4 +15,4 @@ libtelio-build-pipeline:
 
   trigger:
     project: $LIBTELIO_BUILD_PROJECT_PATH
-    branch: v2.5.0 # REMEMBER to also update in .github/workflows/gitlab.yml
+    branch: v2.5.1 # REMEMBER to also update in .github/workflows/gitlab.yml


### PR DESCRIPTION
### Problem
- no macos logs
- poor macos vm provision

### Solution
- bump libtelio-build version with new macos vm provision
- move dmesg host logs collection to before and after pytest
- add macos system and dmesg logs


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
