### PR TITLE
LLL-5772 handle upnp lease expiry when battery optimizations are on

### DIFF
--- a/nat-lab/data/upnpd/upnpd.conf
+++ b/nat-lab/data/upnpd/upnpd.conf
@@ -1,0 +1,124 @@
+# To change the interfaces used edit:
+#   /etc/default/linux-igd
+
+#
+# The full path and name of the iptables executable,
+# (enclosed in quotes).
+#
+iptables_location = "/usr/sbin/iptables"
+
+#
+# Daemon debug level. Messages are logged via syslog to debug.
+# 0 - no debug messages
+# 1 - log errors
+# 2 - log errors and basic info
+# 3 - log errors and verbose info
+# default = 0
+debug_mode = 3
+
+#
+# Should the daemon create rules in the forward chain, or not.
+# This is necessary if your firewall has a drop or reject
+# policy in your forward chain.
+# allowed values: yes,no
+# default = no
+create_forward_rules = yes
+
+#
+# Should the daemon insert or append rules in the forward chain.
+# Normally you will want to insert rules at the beginning of the
+# forward chain, so that they apply before any drop or reject rules
+# later in the chain.
+# This option only applies if "create_forward_rules = yes".
+#
+# As an experiment, this setting now also affects the PREROUTING chain
+# in the same way.  If this causes you problems please let me (Debian
+# maintainer) know through the BTS.
+#
+# Tip: If you need to insert rules somewhere in the middle of the PREROUTING
+# or FORWARD chains, instead of first or last, then you should create a
+# new empty chain, e.g forwardUPnP, and set forward_chain_name to that
+# chain. Then insert a rule to jump to forwardUPnP in the appropriate place
+# in the PREROUTING or FORWARD chain. (The value of forward_rules_append
+# probably won't matter much in that case.)
+#
+# allowed values: yes,no
+# default = no
+forward_rules_append = no
+
+#
+# The name of the chain to put the forward rules in.
+# This option only applies if "create_forward_rules = yes".
+# allowed values: a-z, A-Z, _, -
+# default = FORWARD
+#
+forward_chain_name = FORWARD
+
+#
+# The name of the chain to put prerouting rules in.
+# allowed values: a-z, A-Z, _, -
+# default = PREROUTING
+prerouting_chain_name = PREROUTING 
+
+#
+# The internet line upstream bit rate reported from
+# the daemon. Value in bits per second
+# default = 0
+upstream_bitrate = 512000
+
+#
+# The internet line downstream bit rate reported from
+# the daemon. Value in bits per second
+# default = 0
+downstream_bitrate = 512000
+
+#
+# The default duration of port mappings, used when the client
+# doesn't specify a duration.
+# Can have the following values:
+# 0 - no default duration specified
+# seconds | HH:MM - duration from the time of addition
+# @seconds | @HH:MM - expire mapping at the specified time of day
+# default = 0
+#duration = 86400 # One day from time of addition
+duration = 0
+
+# The name of the igd device xml description document
+# default = gatedesc.xml
+description_document_name = gatedesc.xml
+
+# The path to the xml documents
+# Do not include the trailing "/"
+# default = /etc/linuxigd
+# WARNING! The make install does put the xml files
+# in /etc/linuxigd, if you change this variable
+# you have to make sure the xml docs are in the
+# right place
+xml_document_path = /etc/linuxigd
+
+# The UPnP port to listen on.
+# default = 0 (first free UPnP port, starting with 49152)
+listenport = 0
+
+# paranoid forwarding option
+# 0, allow all forwarding
+# 1, only allow internal hosts to forward to themselves.
+# default = 0
+paranoid = 0
+
+# libupnp debug log file name
+#  If this setting is enabled then linux-igd debug entries will also be written
+#  to this file as well as to syslog (see debug_mode, above).  This makes it
+#  easier to debug linux-igd without having to enable all debug-level messages
+#  in syslog.  You are responsible for clearing or rotating this file yourself.
+# allowed values: any valid filename, relative or absolute.  Must not be blank
+# default = none
+upnp_log_filename = "/var/log/linux-igd.log"
+
+# libupnp debug logging level
+#  UPNP_CRITICAL
+#  UPNP_PACKET
+#  UPNP_INFO
+#  UPNP_ALL
+# default = UPNP_INFO
+upnp_log_level = UPNP_ALL

--- a/nat-lab/docker-compose.yml
+++ b/nat-lab/docker-compose.yml
@@ -369,6 +369,8 @@ services:
       upnp-net-01:
         ipv4_address: 192.168.105.254
         priority: 900
+    volumes:
+      - ./data/upnpd/upnpd.conf:/etc/upnpd.conf
   upnp-gw-02:
     hostname: upnp-gw-02
     <<: *common-gw

--- a/nat-lab/tests/test_upnp_connection.py
+++ b/nat-lab/tests/test_upnp_connection.py
@@ -207,6 +207,7 @@ async def test_upnp_without_support(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("battery_optimization", [True, False])
 @pytest.mark.parametrize(
     "alpha_setup_params",
     [
@@ -228,7 +229,9 @@ async def test_upnp_without_support(
     ],
 )
 async def test_upnp_port_lease_duration(
-    alpha_setup_params: SetupParameters, beta_setup_params: SetupParameters
+    battery_optimization: bool,
+    alpha_setup_params: SetupParameters,
+    beta_setup_params: SetupParameters,
 ) -> None:
     async with AsyncExitStack() as exit_stack:
         # once the endpoint interval expires, the endpoint is validated and if
@@ -245,7 +248,7 @@ async def test_upnp_port_lease_duration(
         alpha_setup_params.features.direct.endpoint_interval_secs = 5
         assert alpha_setup_params.features.direct.endpoint_providers_optimization
         alpha_setup_params.features.direct.endpoint_providers_optimization.optimize_direct_upgrade_upnp = (
-            False
+            battery_optimization
         )
 
         env = await exit_stack.enter_async_context(

--- a/src/device.rs
+++ b/src/device.rs
@@ -1386,11 +1386,13 @@ impl Runtime {
                         .as_ref()
                         .unwrap_or(&Default::default())
                         .optimize_direct_upgrade_upnp,
-                    direct
-                        .upnp_features
-                        .as_ref()
-                        .unwrap_or(&Default::default())
-                        .lease_duration_s,
+                    Duration::from_secs(
+                        direct
+                            .upnp_features
+                            .as_ref()
+                            .unwrap_or(&Default::default())
+                            .lease_duration_s as u64,
+                    ),
                 )?);
                 endpoint_providers.push(ep.clone());
                 Some(ep)


### PR DESCRIPTION
### Problem
UPNP lease is not renewed when battery optimizations are turned on and UPNP endpoint provider is paused.

### Solution
Ignore battery optimizations when it't time (at least 75% of the whole lease duration) to renew the lease.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
