### PR TITLE
Prepare VPN containers only whenever needed

### DIFF
--- a/nat-lab/tests/helpers.py
+++ b/nat-lab/tests/helpers.py
@@ -217,6 +217,7 @@ async def setup_environment(
     exit_stack: AsyncExitStack,
     instances: List[SetupParameters],
     provided_api: Optional[API] = None,
+    prepare_vpn: bool = False,
 ) -> AsyncIterator[Environment]:
     """Sets up the basic environment based on the given parameters.
 
@@ -224,6 +225,7 @@ async def setup_environment(
     * `setup_api` (creates mocked core API (if not provided)),
     * `setup_connections` (sets up the connections to the docker containers) and
     * `setup_clients` (creates clients using the given configuration)
+    * `prepare_vpn` - Indicates whether VPN containers are needed for the test.
     which results in the fully prepared test configuration.
     It also checks whether the number of connections is correct with the conntrackers.
 
@@ -265,6 +267,7 @@ async def setup_environment(
     * `exit_stack` - contextlib.AsyncExitStack instance to manage the async context managers execution
     * `instances` - list of the parameters for each meshnet node to be created
     * `provided_api` - optional mocked Core API instance, if provided a new one won't be created
+    * `prepare_vpn` - Indicates whether VPN containers are needed for the test.
 
     # Returns
 
@@ -288,6 +291,9 @@ async def setup_environment(
             for instance in instances
         ],
     )
+
+    if prepare_vpn:
+        api.prepare_all_vpn_servers()
 
     clients = await setup_clients(
         exit_stack,
@@ -327,6 +333,7 @@ async def setup_mesh_nodes(
     instances: List[SetupParameters],
     is_timeout_expected: bool = False,
     provided_api: Optional[API] = None,
+    prepare_vpn: bool = False,
 ) -> Environment:
     """The default way of setting up the test environment.
 
@@ -343,6 +350,7 @@ async def setup_mesh_nodes(
     * `instances` - list of the parameters for each meshnet node to be created
     * `is_timeout_expected` - indicates whether the nodes connection should timeout
     * `provided_api` - optional mocked Core API instance, if provided a new one won't be created
+    * `prepare_vpn` - Indicates whether VPN containers needs to be configured
 
     # Returns
 
@@ -350,7 +358,7 @@ async def setup_mesh_nodes(
     """
 
     env = await exit_stack.enter_async_context(
-        setup_environment(exit_stack, instances, provided_api)
+        setup_environment(exit_stack, instances, provided_api, prepare_vpn)
     )
 
     await asyncio.gather(*[

--- a/nat-lab/tests/mesh_api.py
+++ b/nat-lab/tests/mesh_api.py
@@ -436,12 +436,13 @@ class API:
             if ip_stack in [IPStack.IPv6, IPStack.IPv4v6]:
                 self.assign_ip(node.id, ipv6)
 
-        for wg_server in WG_SERVERS:
-            self.setup_vpn_servers(list(self.nodes.values()), wg_server)
-
         assert (len(node_configs) + current_node_list_len) == len(self.nodes)
 
         return tuple(list(self.nodes.values())[current_node_list_len:])
+
+    def prepare_all_vpn_servers(self):
+        for wg_server in WG_SERVERS:
+            self.setup_vpn_servers(list(self.nodes.values()), wg_server)
 
 
 def start_tcpdump(container_names: List[str]):

--- a/nat-lab/tests/test_dns.py
+++ b/nat-lab/tests/test_dns.py
@@ -299,6 +299,7 @@ async def test_vpn_dns(alpha_ip_stack: IPStack) -> None:
                         is_meshnet=False,
                     )
                 ],
+                prepare_vpn=True,
             )
         )
         api = env.api
@@ -591,6 +592,7 @@ async def test_dns_update(alpha_ip_stack: IPStack) -> None:
                         is_meshnet=False,
                     )
                 ],
+                prepare_vpn=True,
             )
         )
         connection, *_ = [conn.connection for conn in env.connections]

--- a/nat-lab/tests/test_events.py
+++ b/nat-lab/tests/test_events.py
@@ -301,7 +301,7 @@ async def test_event_content_vpn_connection(
 ) -> None:
     async with AsyncExitStack() as exit_stack:
         env = await exit_stack.enter_async_context(
-            setup_environment(exit_stack, [alpha_setup_params])
+            setup_environment(exit_stack, [alpha_setup_params], prepare_vpn=True)
         )
         connection, *_ = [conn.connection for conn in env.connections]
         client_alpha, *_ = env.clients

--- a/nat-lab/tests/test_lana.py
+++ b/nat-lab/tests/test_lana.py
@@ -367,6 +367,8 @@ async def run_default_scenario(
         )
     )
 
+    api.prepare_all_vpn_servers()
+
     await add_5ms_delay_to_connections(
         exit_stack, [connection_alpha, connection_beta, connection_gamma]
     )

--- a/nat-lab/tests/test_mesh_plus_vpn.py
+++ b/nat-lab/tests/test_mesh_plus_vpn.py
@@ -111,7 +111,7 @@ async def test_mesh_plus_vpn_one_peer(
 ) -> None:
     async with AsyncExitStack() as exit_stack:
         env = await setup_mesh_nodes(
-            exit_stack, [alpha_setup_params, beta_setup_params]
+            exit_stack, [alpha_setup_params, beta_setup_params], prepare_vpn=True
         )
 
         _, beta = env.nodes
@@ -223,7 +223,7 @@ async def test_mesh_plus_vpn_both_peers(
 ) -> None:
     async with AsyncExitStack() as exit_stack:
         env = await setup_mesh_nodes(
-            exit_stack, [alpha_setup_params, beta_setup_params]
+            exit_stack, [alpha_setup_params, beta_setup_params], prepare_vpn=True
         )
 
         alpha, beta = env.nodes
@@ -326,6 +326,8 @@ async def test_vpn_plus_mesh(
                 ),
             )
         )
+
+        api.prepare_all_vpn_servers()
 
         ip = await stun.get(connection_alpha, config.STUN_SERVER)
         assert ip == public_ip, f"wrong public IP before connecting to VPN {ip}"
@@ -486,7 +488,7 @@ async def test_vpn_plus_mesh_over_direct(
 ) -> None:
     async with AsyncExitStack() as exit_stack:
         env = await setup_mesh_nodes(
-            exit_stack, [alpha_setup_params, beta_setup_params]
+            exit_stack, [alpha_setup_params, beta_setup_params], prepare_vpn=True
         )
 
         alpha, beta = env.nodes
@@ -661,7 +663,9 @@ async def test_vpn_plus_mesh_over_different_connection_types(
 ) -> None:
     async with AsyncExitStack() as exit_stack:
         env = await setup_mesh_nodes(
-            exit_stack, [alpha_setup_params, beta_setup_params, gamma_setup_params]
+            exit_stack,
+            [alpha_setup_params, beta_setup_params, gamma_setup_params],
+            prepare_vpn=True,
         )
 
         connection_alpha, connection_beta, connection_gamma = [

--- a/nat-lab/tests/test_network_switch.py
+++ b/nat-lab/tests/test_network_switch.py
@@ -185,7 +185,7 @@ async def test_mesh_network_switch(
 async def test_vpn_network_switch(alpha_setup_params: SetupParameters) -> None:
     async with AsyncExitStack() as exit_stack:
         env = await exit_stack.enter_async_context(
-            setup_environment(exit_stack, [alpha_setup_params])
+            setup_environment(exit_stack, [alpha_setup_params], prepare_vpn=True)
         )
         client_alpha, *_ = env.clients
         alpha_conn_mngr, *_ = env.connections

--- a/nat-lab/tests/test_pmtu.py
+++ b/nat-lab/tests/test_pmtu.py
@@ -193,7 +193,7 @@ async def test_pmtu_without_nexthop(setup_params: SetupParameters) -> None:
 async def test_vpn_conn_with_pmtu_enabled(params: SetupParameters) -> None:
     async with AsyncExitStack() as exit_stack:
         env = await exit_stack.enter_async_context(
-            setup_environment(exit_stack, [params])
+            setup_environment(exit_stack, [params], prepare_vpn=True)
         )
 
         alpha, *_ = env.nodes

--- a/nat-lab/tests/test_pq.py
+++ b/nat-lab/tests/test_pq.py
@@ -339,7 +339,7 @@ async def test_dns_with_pq(
 ) -> None:
     async with AsyncExitStack() as exit_stack:
         env = await exit_stack.enter_async_context(
-            setup_environment(exit_stack, [alpha_setup_params])
+            setup_environment(exit_stack, [alpha_setup_params], prepare_vpn=True)
         )
 
         client_conn, *_ = [conn.connection for conn in env.connections]

--- a/nat-lab/tests/test_vpn.py
+++ b/nat-lab/tests/test_vpn.py
@@ -186,7 +186,7 @@ async def test_vpn_connection(
             raise ValueError(f"Unknown connection tag {vpn_conf.conn_tag}")
 
         env = await exit_stack.enter_async_context(
-            setup_environment(exit_stack, [alpha_setup_params])
+            setup_environment(exit_stack, [alpha_setup_params], prepare_vpn=True)
         )
 
         alpha, *_ = env.nodes
@@ -315,7 +315,7 @@ async def test_vpn_reconnect(
 ) -> None:
     async with AsyncExitStack() as exit_stack:
         env = await exit_stack.enter_async_context(
-            setup_environment(exit_stack, [alpha_setup_params])
+            setup_environment(exit_stack, [alpha_setup_params], prepare_vpn=True)
         )
 
         alpha, *_ = env.nodes
@@ -386,7 +386,7 @@ async def test_kill_external_tcp_conn_on_vpn_reconnect(
 
     async with AsyncExitStack() as exit_stack:
         env = await exit_stack.enter_async_context(
-            setup_environment(exit_stack, [setup_params])
+            setup_environment(exit_stack, [setup_params], prepare_vpn=True)
         )
 
         alpha, *_ = env.nodes
@@ -515,7 +515,7 @@ async def test_kill_external_udp_conn_on_vpn_reconnect(
 
     async with AsyncExitStack() as exit_stack:
         env = await exit_stack.enter_async_context(
-            setup_environment(exit_stack, [setup_params])
+            setup_environment(exit_stack, [setup_params], prepare_vpn=True)
         )
 
         alpha, *_ = env.nodes
@@ -646,7 +646,7 @@ async def test_vpn_connection_private_key_change(
 ) -> None:
     async with AsyncExitStack() as exit_stack:
         env = await exit_stack.enter_async_context(
-            setup_environment(exit_stack, [alpha_setup_params])
+            setup_environment(exit_stack, [alpha_setup_params], prepare_vpn=True)
         )
 
         alpha, *_ = env.nodes


### PR DESCRIPTION
### Problem
VPN containres are being overprepared for every container/every node on every test. This is excessive, 

### Solution
This PR introduces an indicator whether VPN containers are needed in `setup_environment()` and skips VPN container preparation when not needed. What is more, it only prepares containers in setup_environment once instead of doing it for every node separately.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
