### PR TITLE
Collect DiagnosticReports from Mac VM after all test are completed

### DIFF
--- a/nat-lab/tests/conftest.py
+++ b/nat-lab/tests/conftest.py
@@ -8,7 +8,7 @@ from interderp_cli import InterDerpClient
 from itertools import combinations
 from mesh_api import start_tcpdump, stop_tcpdump
 from utils.bindings import TelioAdapterType
-from utils.connection import DockerConnection, SshConnection
+from utils.connection import DockerConnection
 from utils.connection_util import (
     ConnectionTag,
     container_id,

--- a/nat-lab/tests/utils/analytics/event_loader.py
+++ b/nat-lab/tests/utils/analytics/event_loader.py
@@ -70,7 +70,7 @@ class Event(DataClassJsonMixin):
     )
 
 
-def fetch_moose_events(database_name):
+def fetch_moose_events(database_name) -> list[Event]:
     database_connection = sqlite3.connect(database_name)
     database_cursor = database_connection.cursor()
 

--- a/nat-lab/tests/utils/connection/connection.py
+++ b/nat-lab/tests/utils/connection/connection.py
@@ -33,6 +33,10 @@ class Connection(ABC):
     def target_name(self) -> str:
         pass
 
+    @abstractmethod
+    async def download(self, remote_path: str, local_path: str) -> None:
+        pass
+
     async def get_ip_address(self) -> tuple[str, str]:
         ip = "127.0.0.1"
         return (ip, ip)

--- a/nat-lab/tests/utils/connection/docker_connection.py
+++ b/nat-lab/tests/utils/connection/docker_connection.py
@@ -1,8 +1,10 @@
 from .connection import Connection, TargetOS
 from aiodocker import Docker
 from aiodocker.containers import DockerContainer
+from asyncio import to_thread
 from config import LINUX_INTERFACE_NAME
 from datetime import datetime
+from subprocess import run
 from typing import List, Type
 from typing_extensions import Self
 from utils.process import Process, DockerProcess
@@ -32,6 +34,12 @@ class DockerConnection(Connection):
 
     def target_name(self) -> str:
         return self.container_name()
+
+    async def download(self, remote_path: str, local_path: str) -> None:
+        def aux():
+            run(["docker", "cp", self._name + ":" + remote_path, local_path])
+
+        await to_thread(aux)
 
     def create_process(self, command: List[str], kill_id=None) -> "Process":
         process = DockerProcess(self._container, command, kill_id)

--- a/nat-lab/tests/utils/connection/ssh_connection.py
+++ b/nat-lab/tests/utils/connection/ssh_connection.py
@@ -33,3 +33,14 @@ class SshConnection(Connection):
 
     def target_name(self) -> str:
         return str(self._target_os)
+
+    async def download(self, remote_path, local_path):
+        """Copy file from 'remote_path' on the node connected via this connection, to local directory 'local_path'"""
+        try:
+            await asyncssh.scp(
+                (self._connection, remote_path), local_path, recurse=True
+            )
+        except asyncssh.SFTPFailure as e:
+            if "No such file or directory" in e.reason:
+                return
+            raise e

--- a/nat-lab/tests/utils/connection/ssh_connection.py
+++ b/nat-lab/tests/utils/connection/ssh_connection.py
@@ -34,7 +34,7 @@ class SshConnection(Connection):
     def target_name(self) -> str:
         return str(self._target_os)
 
-    async def download(self, remote_path, local_path):
+    async def download(self, remote_path: str, local_path: str) -> None:
         """Copy file from 'remote_path' on the node connected via this connection, to local directory 'local_path'"""
         try:
             await asyncssh.scp(

--- a/nat-lab/tests/utils/process/docker_process.py
+++ b/nat-lab/tests/utils/process/docker_process.py
@@ -43,6 +43,7 @@ class DockerProcess(Process):
         self,
         stdout_callback: Optional[StreamCallback] = None,
         stderr_callback: Optional[StreamCallback] = None,
+        privileged=False,
     ) -> "DockerProcess":
         self._execute = await self._container.exec(
             self._command,
@@ -53,6 +54,7 @@ class DockerProcess(Process):
                 "RUST_BACKTRACE": "full",
                 "KILL_ID": self._kill_id,
             },
+            privileged=privileged,
         )
         if self._execute is None:
             return self

--- a/nat-lab/tests/utils/process/process.py
+++ b/nat-lab/tests/utils/process/process.py
@@ -31,6 +31,7 @@ class Process(ABC):
         self,
         stdout_callback: Optional[StreamCallback] = None,
         stderr_callback: Optional[StreamCallback] = None,
+        privileged=False,
     ) -> "Process":
         pass
 

--- a/nat-lab/tests/utils/process/ssh_process.py
+++ b/nat-lab/tests/utils/process/ssh_process.py
@@ -38,7 +38,10 @@ class SshProcess(Process):
         self,
         stdout_callback: Optional[StreamCallback] = None,
         stderr_callback: Optional[StreamCallback] = None,
+        privileged=False,
     ) -> "SshProcess":
+        if privileged:
+            print("'privileged' does nothing for ssh processes")
         escaped = [self._escape_argument(arg) for arg in self._command]
         command_str = " ".join(escaped)
 

--- a/nat-lab/tests/utils/vm/mac_vm_util.py
+++ b/nat-lab/tests/utils/vm/mac_vm_util.py
@@ -18,10 +18,13 @@ VM_UNIFFI_DIR = UNIFFI_PATH_MAC_VM
 
 @asynccontextmanager
 async def new_connection(
-    ip: str = MAC_VM_IP, copy_binaries: bool = False
+    ip: str = MAC_VM_IP,
+    copy_binaries: bool = False,
+    reenable_nat=True,
 ) -> AsyncIterator[Connection]:
-    subprocess.check_call(["sudo", "bash", "vm_nat.sh", "disable"])
-    subprocess.check_call(["sudo", "bash", "vm_nat.sh", "enable"])
+    if reenable_nat:
+        subprocess.check_call(["sudo", "bash", "vm_nat.sh", "disable"])
+        subprocess.check_call(["sudo", "bash", "vm_nat.sh", "enable"])
 
     # Speedup large file transfer: https://github.com/ronf/asyncssh/issues/374
     ssh_options = asyncssh.SSHClientConnectionOptions(

--- a/nat-lab/tests/utils/vm/windows_vm_util.py
+++ b/nat-lab/tests/utils/vm/windows_vm_util.py
@@ -20,10 +20,13 @@ VM_SYSTEM32 = "C:\\Windows\\System32"
 
 @asynccontextmanager
 async def new_connection(
-    ip: str = WINDOWS_1_VM_IP, copy_binaries: bool = False
+    ip: str = WINDOWS_1_VM_IP,
+    copy_binaries: bool = False,
+    reenable_nat=True,
 ) -> AsyncIterator[Connection]:
-    subprocess.check_call(["sudo", "bash", "vm_nat.sh", "disable"])
-    subprocess.check_call(["sudo", "bash", "vm_nat.sh", "enable"])
+    if reenable_nat:
+        subprocess.check_call(["sudo", "bash", "vm_nat.sh", "disable"])
+        subprocess.check_call(["sudo", "bash", "vm_nat.sh", "enable"])
 
     # Speedup large file transfer: https://github.com/ronf/asyncssh/issues/374
     ssh_options = asyncssh.SSHClientConnectionOptions(


### PR DESCRIPTION
### Problem
It's not always clear if/when/why a process crashed on mac vm in nat-lab.

### Solution
Collect diagnostic reports from mac vm which contain crashes.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
