### PR TITLE
Bump libtelio build to v2.6.2

### DIFF
--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -22,4 +22,4 @@ jobs:
     with:
       schedule: ${{ github.event_name == 'schedule' }}
       cancel-outdated-pipelines: ${{ github.ref_name != 'main' }}
-      triggered-ref: v2.6.1 # REMEMBER to also update in .gitlab-ci.yml
+      triggered-ref: v2.6.2 # REMEMBER to also update in .gitlab-ci.yml

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,4 +15,4 @@ libtelio-build-pipeline:
 
   trigger:
     project: $LIBTELIO_BUILD_PROJECT_PATH
-    branch: v2.6.1 # REMEMBER to also update in .github/workflows/gitlab.yml
+    branch: v2.6.2 # REMEMBER to also update in .github/workflows/gitlab.yml

--- a/nat-lab/tests/test_cleanup.py
+++ b/nat-lab/tests/test_cleanup.py
@@ -41,7 +41,7 @@ async def test_get_network_interface_tunnel_keys(adapter_type, name) -> None:
         # that might have managed to survive the end of the previous test.
         keys = await _get_network_interface_tunnel_keys(connection)
         assert [
-            "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Class\\{4d36e972-e325-11ce-bfc1-08002be10318}\\0006"
+            "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Class\\{4d36e972-e325-11ce-bfc1-08002be10318}\\0005"
         ] == keys
 
         assert (


### PR DESCRIPTION
### Problem    
Bump libtelio build to v2.6.2
    
test_cleanup.py was changed, due to removal of additional controller from windows VM, which was accidenatlly introduced by disabling `qemu-guest-agent` in previous version (causing libvirt to automatically add one more controller for host and guest communication).
    
So initally it was 5 devices, with v2.6.1 another device appeared, increasing number to 6, but with v2.6.2 it is again removed, returning back to 5 devices.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
