### PR TITLE
Network activity triggered batcher

### DIFF
--- a/crates/telio-model/src/features.rs
+++ b/crates/telio-model/src/features.rs
@@ -67,8 +67,17 @@ pub struct Features {
 #[serde(default)]
 pub struct FeatureBatching {
     /// Direct connection threshold when batching (in seconds) [default 0s]
+    /// Reused for Proxy, STUN, VPN peers as well
     #[default(0)]
     pub direct_connection_threshold: u32,
+
+    /// Trigger effective duration [default 10s]
+    #[default(10)]
+    pub trigger_effective_duration: u32,
+
+    /// Trigger cooldown duration [default 60s]
+    #[default(60)]
+    pub trigger_cooldown_duration: u32,
 }
 
 /// Configurable features for Wireguard peers
@@ -550,7 +559,9 @@ mod tests {
             },
             "multicast": true,
             "batching": {
-                "direct_connection_threshold": 60
+                "direct_connection_threshold": 60,
+                "trigger_effective_duration": 10,
+                "trigger_cooldown_duration": 60
             }
         }
         "#,
@@ -637,6 +648,8 @@ mod tests {
                     multicast: true,
                     batching: Some(FeatureBatching {
                         direct_connection_threshold: 60,
+                        trigger_effective_duration: 10,
+                        trigger_cooldown_duration: 60,
                     }),
                 }
             );

--- a/crates/telio-model/src/features.rs
+++ b/crates/telio-model/src/features.rs
@@ -63,7 +63,7 @@ pub struct Features {
 }
 
 /// Configure keepalive batching
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, SmartDefault)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, SmartDefault)]
 #[serde(default)]
 pub struct FeatureBatching {
     /// Direct connection threshold when batching (in seconds) [default 0s]

--- a/crates/telio-traversal/src/batcher.rs
+++ b/crates/telio-traversal/src/batcher.rs
@@ -10,9 +10,9 @@ use std::{collections::HashMap, sync::Arc};
 
 use async_trait::async_trait;
 use telio_utils::{telio_log_debug, telio_log_error, telio_log_warn};
-use tokio::time::{sleep_until, Duration};
 
 use thiserror::Error as ThisError;
+use tokio::time::{sleep_until, Duration, Instant};
 
 type Action<V, R = std::result::Result<(), ()>> =
     Arc<dyn for<'a> Fn(&'a mut V) -> BoxFuture<'a, R> + Sync + Send>;
@@ -22,9 +22,9 @@ pub struct Batcher<K, V> {
 }
 
 struct BatchEntry {
-    deadline: tokio::time::Instant,
-    interval: std::time::Duration,
-    threshold: std::time::Duration,
+    deadline: Instant,
+    interval: Duration,
+    threshold: Duration,
 }
 
 /// Possible [Batcher] errors.
@@ -44,7 +44,10 @@ where
 {
     fn add(&mut self, key: K, interval: Duration, threshold: Duration, action: Action<V>);
     fn remove(&mut self, key: &K);
-    async fn get_actions(&mut self) -> Result<Vec<(K, Action<V>)>, BatcherError>;
+    async fn get_actions(
+        &mut self,
+        last_network_activity: Option<Instant>,
+    ) -> Result<Vec<(K, Action<V>)>, BatcherError>;
     fn get_interval(&self, key: &K) -> Option<Duration>;
 }
 
@@ -67,9 +70,24 @@ where
     // Historically, libtelio had highest frequency action of 5seconds for direct
     // connection keepalive, thus we cap any action to have at least that.
     const MIN_INTERVAL: Duration = Duration::from_secs(5);
+
+    // When traffic triggered, it should only be valid for a certain amount of time.
+    // Based on https://developer.android.com/develop/connectivity/network-ops/network-access-optimization
+    // the value is hardcoded and not up for a configuration at this point though it might be
+    // useful in the future.
+    const TRIGGER_EFFECTIVE_DURATION: Duration = Duration::from_secs(10);
+
     pub fn new() -> Self {
         Self {
             actions: HashMap::new(),
+        }
+    }
+
+    pub fn get_remaining_trigger_duration(latest_network_activity: Instant) -> Option<Duration> {
+        if latest_network_activity.elapsed() < Self::TRIGGER_EFFECTIVE_DURATION {
+            Some(Self::TRIGGER_EFFECTIVE_DURATION - latest_network_activity.elapsed())
+        } else {
+            None
         }
     }
 }
@@ -80,37 +98,61 @@ where
     K: Eq + Hash + Send + Sync + Debug + Clone,
     V: Send + Sync,
 {
-    /// Batching works by sleeping until the nearest future and then trying to batch more actions
-    /// based on the threshold value. Higher delay before calling the function will increase the chances of batching
-    /// because the deadlines will _probably_ be in the past already.
-    /// Adding a new action wakes up the batcher due to immediate trigger of the action.
-    async fn get_actions(&mut self) -> Result<Vec<(K, Action<V>)>, BatcherError> {
+    async fn get_actions(
+        &mut self,
+        last_network_activity: Option<Instant>,
+    ) -> Result<Vec<(K, Action<V>)>, BatcherError> {
         if self.actions.is_empty() {
             return Err(BatcherError::NoActions);
         }
 
-        let mut batched_actions: Vec<(K, Action<V>)> = vec![];
-        let actions = &mut self.actions;
+        fn collect_batch_jobs<K: Clone, V>(
+            actions: &mut HashMap<K, (BatchEntry, Action<V>)>,
+            duration: Option<Duration>,
+        ) -> Vec<(K, Action<V>)> {
+            let now = Instant::now();
 
-        if let Some(closest_entry) = actions.values().min_by_key(|entry| entry.0.deadline) {
-            _ = sleep_until(closest_entry.0.deadline).await;
+            let mut batched_actions: Vec<(K, Action<V>)> = vec![];
 
-            let now = tokio::time::Instant::now();
-            // at this point in time we know we're at the earliest spot for batching, thus we can check if we have more actions to add
             for (key, action) in actions.iter_mut() {
-                let adjusted_action_deadline = now + action.0.threshold;
+                let adjusted_deadline =
+                    now + action.0.threshold + duration.unwrap_or(Duration::from_secs(0));
 
-                if action.0.deadline <= adjusted_action_deadline {
+                if action.0.deadline <= adjusted_deadline {
                     action.0.deadline = now + action.0.interval;
                     batched_actions.push((key.clone(), action.1.clone()));
                 }
             }
 
+            batched_actions
+        }
+
+        let early_batch_remaining_duration =
+            last_network_activity.and_then(Self::get_remaining_trigger_duration);
+
+        if let Some(closest_deadline) = self
+            .actions
+            .values()
+            .min_by_key(|entry| entry.0.deadline)
+            .map(|v| v.0.deadline)
+        {
+            if let Some(duration) = early_batch_remaining_duration {
+                let batched_actions = collect_batch_jobs(&mut self.actions, Some(duration));
+
+                if !batched_actions.is_empty() {
+                    return Ok(batched_actions);
+                }
+            }
+
+            // we failed to early batch any actions, so lets wait until the closest one resolves
+            _ = sleep_until(closest_deadline).await;
+
+            let batched_actions = collect_batch_jobs(&mut self.actions, None);
+
             if batched_actions.is_empty() {
-                telio_log_error!("Batched jobs incorrectly. At least one job should be emitted.");
+                telio_log_error!("Batcher resolves with empty list of jobs");
                 return Err(BatcherError::NoActions);
             }
-            // There should be at least one action here always - the one that triggered everything
             return Ok(batched_actions);
         } else {
             return Err(BatcherError::NoActions);
@@ -186,13 +228,7 @@ where
     /// Thus it's best to aim for:
     /// - as high interval as possible
     /// - threshold being close to half the interval
-    fn add(
-        &mut self,
-        key: K,
-        interval: std::time::Duration,
-        threshold: std::time::Duration,
-        action: Action<V>,
-    ) {
+    fn add(&mut self, key: K, interval: Duration, threshold: Duration, action: Action<V>) {
         telio_log_debug!(
             "adding item to batcher with key({:?}), interval({:?}), threshold({:?})",
             key,
@@ -229,7 +265,7 @@ where
         };
 
         let entry = BatchEntry {
-            deadline: tokio::time::Instant::now(),
+            deadline: Instant::now(),
             interval,
             threshold,
         };
@@ -242,23 +278,367 @@ where
     }
 }
 
-/// Tests provide near-perfect immediate sleeps due to how tokio runtime acts when it's paused(basically sleeps are resolved immediately)
 #[cfg(test)]
 mod tests {
+    use crate::batcher::{Batcher, BatcherError, BatcherTrait};
+    use std::sync::Arc;
+    use tokio::sync::{watch, Mutex};
+    use tokio::time::*;
 
-    pub struct TestChecker {
-        values: Vec<(String, tokio::time::Instant)>,
+    struct TestChecker {
+        values: Vec<(String, Instant)>,
     }
 
-    use std::{sync::Arc, time::Duration};
+    #[derive(Copy, Clone)]
+    struct FakeNetwork {
+        latency: Duration,
+    }
 
-    use crate::batcher::{Batcher, BatcherError, BatcherTrait};
+    impl FakeNetwork {
+        async fn send(
+            &self,
+            peer_a_activity: Arc<watch::Sender<Instant>>,
+            peer_b_activity: Arc<watch::Sender<Instant>>,
+        ) {
+            // We're concerned about any activity, thus we just send to channel of one peer
+            // to simulate the send-trigger and after latency we simulate receival on another
+            // channel
+            peer_a_activity.send(Instant::now()).unwrap();
+
+            // latency sim
+            sleep(self.latency).await;
+
+            // Simulate peer receiving data after some latency
+            peer_b_activity.send(Instant::now()).unwrap();
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_triggered_batching() {
+        struct TestHelperStruct {
+            trigger_enabled: bool,
+            latency: Duration,
+            start_emit_traffic_at: Instant,
+            stop_emit_traffic_at: Instant,
+            emit_packet_every: Duration,
+            test_duration: Duration,
+            delay_to_add_second_peer: Duration,
+        }
+
+        #[derive(Debug)]
+        struct TestHelperResult {
+            left_peer_avg_interval: f64,
+            right_peer_avg_interval: f64,
+            left_peer_avg_interval_1st_half: f64,
+            left_peer_avg_interval_2nd_half: f64,
+            right_peer_avg_interval_1st_half: f64,
+            right_peer_avg_interval_2nd_half: f64,
+
+            avg_aligned_interval: f64,
+            avg_aligned_interval_1st_half: f64,
+            avg_aligned_interval_2nd_half: f64,
+        }
+
+        async fn test_helper(params: TestHelperStruct) -> TestHelperResult {
+            let (left_send, left_recv) = watch::channel(Instant::now());
+            let (right_send, right_recv) = watch::channel(Instant::now());
+
+            let left_send = Arc::new(left_send);
+            let right_send = Arc::new(right_send);
+
+            let fake_network = Arc::new(FakeNetwork {
+                latency: params.latency,
+            });
+
+            let mut batcher_left = Batcher::<String, Arc<Mutex<TestChecker>>>::new();
+            let mut batcher_right = Batcher::<String, Arc<Mutex<TestChecker>>>::new();
+
+            let test_checker_left = Arc::new(Mutex::new(TestChecker { values: Vec::new() }));
+            let test_checker_right = Arc::new(Mutex::new(TestChecker { values: Vec::new() }));
+
+            // simulate emission of some organic traffic
+            {
+                let fake_network = fake_network.clone();
+                let left_send = left_send.clone();
+                let right_send = right_send.clone();
+                let start = params.start_emit_traffic_at;
+                let deadline = params.stop_emit_traffic_at;
+
+                let emit_packet_every = params.emit_packet_every;
+
+                tokio::spawn(async move {
+                    sleep_until(start).await;
+
+                    loop {
+                        tokio::select! {
+                            _ = sleep_until(deadline) => {
+                                break
+                            }
+                            _ = sleep(emit_packet_every) => {
+                            let _ = fake_network
+                                .send(left_send.clone(), right_send.clone())
+                            .await;
+
+                        }
+                        }
+                    }
+                });
+            }
+
+            {
+                let fake_network = fake_network.clone();
+                let left_send = left_send.clone();
+                let right_send = right_send.clone();
+                batcher_left.add(
+                    "key".to_owned(),
+                    Duration::from_secs(100),
+                    Duration::from_secs(50),
+                    Arc::new(move |s: _| {
+                        let fake_net = Arc::clone(&fake_network);
+                        let left_send = left_send.clone();
+                        let right_send = right_send.clone();
+                        Box::pin(async move {
+                            {
+                                let mut s = s.lock().await;
+                                s.values.push(("key".to_owned(), Instant::now()));
+                            }
+
+                            let _ = fake_net.send(left_send, right_send).await;
+                            Ok(())
+                        })
+                    }),
+                );
+            }
+
+            {
+                let left_send = left_send.clone();
+                let right_send = right_send.clone();
+                let fake_network = fake_network.clone();
+
+                batcher_right.add(
+                    "key".to_owned(),
+                    Duration::from_secs(100),
+                    Duration::from_secs(50),
+                    Arc::new(move |s: _| {
+                        let fake_net = Arc::clone(&fake_network);
+                        let left_send = left_send.clone();
+                        let right_send = right_send.clone();
+                        Box::pin(async move {
+                            {
+                                let mut s = s.lock().await;
+                                s.values.push(("key".to_owned(), Instant::now()));
+                            }
+                            let _ = fake_net.send(right_send, left_send).await;
+                            Ok(())
+                        })
+                    }),
+                );
+            }
+
+            fn spawn_batcher_poller(
+                trigger: bool,
+                mut network_activity_sub: watch::Receiver<Instant>,
+                mut batcher: Batcher<String, Arc<Mutex<TestChecker>>>,
+                mut checker: Arc<Mutex<TestChecker>>,
+            ) {
+                tokio::spawn(async move {
+                    let mut last_activity = {
+                        if trigger {
+                            Some(Instant::now())
+                        } else {
+                            None
+                        }
+                    };
+
+                    loop {
+                        tokio::select! {
+                            Ok( _) = network_activity_sub.changed() => {
+                                if trigger {
+                                    last_activity = Some(*network_activity_sub.borrow_and_update());
+                                } else {
+                                    last_activity = None;
+                            }
+
+                            }
+                            Ok(ac) = batcher.get_actions(last_activity) => {
+                                for a in ac {
+                                    a.1(&mut checker).await.unwrap();
+                                }
+                            }
+                        }
+                    }
+                });
+            }
+
+            // begin the actual test
+            spawn_batcher_poller(
+                params.trigger_enabled,
+                left_recv,
+                batcher_left,
+                test_checker_left.clone(),
+            );
+
+            // add another action after a delay to the peer so they would be misaligned
+            sleep(params.delay_to_add_second_peer).await;
+
+            spawn_batcher_poller(
+                params.trigger_enabled,
+                right_recv,
+                batcher_right,
+                test_checker_right.clone(),
+            );
+
+            sleep(params.test_duration).await;
+
+            let left_values = test_checker_left
+                .lock()
+                .await
+                .values
+                .iter()
+                .map(|v| v.1.elapsed().as_secs() as i64)
+                .collect::<Vec<i64>>();
+            let right_values = test_checker_right
+                .lock()
+                .await
+                .values
+                .iter()
+                .map(|v| v.1.elapsed().as_secs() as i64)
+                .collect::<Vec<i64>>();
+
+            // Produces an average diff between data points. It compares points by finding
+            // the closest value and compares against it. Produces an average of differences. The closer
+            // to 0 the more similar the datasets
+            fn average_alignment(left: &[i64], right: &[i64]) -> f64 {
+                if left.is_empty() || right.is_empty() {
+                    panic!("no data present");
+                }
+
+                fn find_closest_value(v: i64, data: &[i64]) -> i64 {
+                    data.iter()
+                        .min_by_key(|&&ts| (ts - v).abs())
+                        .copied()
+                        .unwrap_or(v)
+                }
+
+                let mut total_diff = 0.0;
+                let mut count = 0;
+
+                for &t1 in left {
+                    let closest_t2 = find_closest_value(t1, right);
+                    total_diff += (t1 - closest_t2).abs() as f64;
+                    count += 1;
+                }
+
+                total_diff / count as f64
+            }
+
+            fn average_difference(numbers: &[i64]) -> f64 {
+                if numbers.len() < 2 {
+                    panic!("not enough elements");
+                }
+
+                let total_diff: i64 = numbers.windows(2).map(|w| w[0] - w[1]).sum();
+
+                let count = (numbers.len() - 1) as f64;
+                total_diff as f64 / count
+            }
+
+            let (first_half_a, second_half_a) =
+                left_values.as_slice().split_at(left_values.len() / 2);
+            let (first_half_b, second_half_b) =
+                right_values.as_slice().split_at(right_values.len() / 2);
+
+            TestHelperResult {
+                left_peer_avg_interval: average_difference(left_values.as_slice()),
+                right_peer_avg_interval: average_difference(right_values.as_slice()),
+
+                left_peer_avg_interval_1st_half: average_difference(first_half_a),
+                left_peer_avg_interval_2nd_half: average_difference(second_half_a),
+
+                right_peer_avg_interval_1st_half: average_difference(first_half_b),
+                right_peer_avg_interval_2nd_half: average_difference(second_half_b),
+
+                avg_aligned_interval: average_alignment(
+                    left_values.as_slice(),
+                    right_values.as_slice(),
+                ),
+                avg_aligned_interval_1st_half: average_alignment(first_half_a, first_half_b),
+                avg_aligned_interval_2nd_half: average_alignment(second_half_a, second_half_b),
+            }
+        }
+
+        // actual tests
+        {
+            // due to traffic being triggered every second for the duration of the testacase, we do
+            // not expect any batching to happen and periods to be effectively shortened by
+            // half due to threshold
+            let res = test_helper(TestHelperStruct {
+                trigger_enabled: true,
+                latency: Duration::from_millis(333),
+                start_emit_traffic_at: Instant::now(),
+                stop_emit_traffic_at: Instant::now() + Duration::from_secs(3600),
+                emit_packet_every: Duration::from_secs(1),
+                delay_to_add_second_peer: Duration::from_secs(17),
+                test_duration: Duration::from_secs(3600),
+            })
+            .await;
+
+            assert!((16.0..17.0).contains(&res.avg_aligned_interval)); // delay until second peer is added
+            assert!((41.0..42.0).contains(&res.left_peer_avg_interval));
+            assert!((41.0..42.0).contains(&res.right_peer_avg_interval));
+        }
+
+        {
+            // organic traffic starts and stops in the middle of the test and lasts for a bit. This
+            // should have minimal effect on batching since it should already have the actions
+            // batched
+            let res = test_helper(TestHelperStruct {
+                trigger_enabled: true,
+                latency: Duration::from_millis(333),
+                start_emit_traffic_at: Instant::now() + Duration::from_secs(1800),
+                stop_emit_traffic_at: Instant::now() + Duration::from_secs(1800),
+                emit_packet_every: Duration::from_secs(1),
+                delay_to_add_second_peer: Duration::from_secs(17),
+                test_duration: Duration::from_secs(3600),
+            })
+            .await;
+
+            assert!((1.0..2.0).contains(&res.avg_aligned_interval));
+            assert!((99.0..=100.0).contains(&res.left_peer_avg_interval));
+            assert!((99.0..=100.0).contains(&res.right_peer_avg_interval));
+        }
+
+        {
+            // organic traffic starts at the beginning until almost half the testcase duration. First half should
+            // have no batching since it's constant triggering and batcher simply tries to batch
+            // jobs within threshold and emit. However in the second half of it, once the organic
+            // traffic stops, batcher's triggering mechanism should make the alignment between the peers
+            let res = test_helper(TestHelperStruct {
+                trigger_enabled: true,
+                latency: Duration::from_millis(333),
+                start_emit_traffic_at: Instant::now(),
+                stop_emit_traffic_at: Instant::now() + Duration::from_secs(1400),
+                emit_packet_every: Duration::from_secs(1),
+                delay_to_add_second_peer: Duration::from_secs(17),
+                test_duration: Duration::from_secs(3600),
+            })
+            .await;
+
+            assert!((41.0..42.0).contains(&res.left_peer_avg_interval_1st_half));
+            assert!((41.0..42.0).contains(&res.right_peer_avg_interval_1st_half));
+            assert!((89.0..90.0).contains(&res.left_peer_avg_interval_2nd_half));
+            assert!((88.0..89.0).contains(&res.right_peer_avg_interval_2nd_half));
+
+            assert!((16.0..17.0).contains(&res.avg_aligned_interval_1st_half));
+            assert!((3.0..4.0).contains(&res.avg_aligned_interval_2nd_half));
+        }
+    }
 
     #[tokio::test]
     async fn no_actions() {
         let mut batcher = Batcher::<String, TestChecker>::new();
         assert!(matches!(
-            batcher.get_actions().await,
+            batcher.get_actions(None).await,
             Err(BatcherError::NoActions)
         ));
     }
@@ -282,12 +662,12 @@ mod tests {
             }),
         );
 
-        for ac in batcher.get_actions().await.unwrap() {
+        for ac in batcher.get_actions(None).await.unwrap() {
             ac.1(&mut test_checker).await.unwrap();
         }
 
         // simulate some delay before adding a second task so they would be misaligned
-        tokio::time::advance(Duration::from_secs(20)).await;
+        advance(Duration::from_secs(20)).await;
 
         batcher.add(
             "key1".to_owned(),
@@ -304,7 +684,7 @@ mod tests {
 
         // Await for few actions to resolve
         for _ in 0..6 {
-            for ac in batcher.get_actions().await.unwrap() {
+            for ac in batcher.get_actions(None).await.unwrap() {
                 ac.1(&mut test_checker).await.unwrap();
             }
         }
@@ -339,13 +719,13 @@ mod tests {
         let mut test_checker = TestChecker { values: Vec::new() };
 
         // pick up the immediate fire
-        for ac in batcher.get_actions().await.unwrap() {
+        for ac in batcher.get_actions(None).await.unwrap() {
             ac.1(&mut test_checker).await.unwrap();
         }
         assert!(test_checker.values.len() == 1);
 
         // pick up the second event
-        for ac in batcher.get_actions().await.unwrap() {
+        for ac in batcher.get_actions(None).await.unwrap() {
             ac.1(&mut test_checker).await.unwrap();
         }
 
@@ -358,7 +738,7 @@ mod tests {
         tokio::time::advance(Duration::from_secs(550)).await;
         assert!(test_checker.values.len() == 2);
 
-        for ac in batcher.get_actions().await.unwrap() {
+        for ac in batcher.get_actions(None).await.unwrap() {
             ac.1(&mut test_checker).await.unwrap();
         }
 
@@ -402,13 +782,13 @@ mod tests {
         let mut test_checker = TestChecker { values: Vec::new() };
 
         // pick up the immediate fires
-        for ac in batcher.get_actions().await.unwrap() {
+        for ac in batcher.get_actions(None).await.unwrap() {
             ac.1(&mut test_checker).await.unwrap();
         }
         assert!(test_checker.values.len() == 2);
 
         // Do again and batching should be in action since the threshold of the second signal is bigger(50) than the delay between the packets(30)
-        for ac in batcher.get_actions().await.unwrap() {
+        for ac in batcher.get_actions(None).await.unwrap() {
             ac.1(&mut test_checker).await.unwrap();
         }
 
@@ -457,7 +837,7 @@ mod tests {
         let mut test_checker = TestChecker { values: Vec::new() };
 
         // pick up the immediate fire
-        for ac in batcher.get_actions().await.unwrap() {
+        for ac in batcher.get_actions(None).await.unwrap() {
             ac.1(&mut test_checker).await.unwrap();
         }
         tokio::time::advance(Duration::from_secs(5)).await;
@@ -476,7 +856,7 @@ mod tests {
         );
 
         for _ in 0..8 {
-            for ac in batcher.get_actions().await.unwrap() {
+            for ac in batcher.get_actions(None).await.unwrap() {
                 ac.1(&mut test_checker).await.unwrap();
             }
         }
@@ -527,7 +907,7 @@ mod tests {
         let mut test_checker = TestChecker { values: Vec::new() };
 
         // pick up the immediate fire
-        for ac in batcher.get_actions().await.unwrap() {
+        for ac in batcher.get_actions(None).await.unwrap() {
             ac.1(&mut test_checker).await.unwrap();
         }
         tokio::time::advance(Duration::from_secs(1)).await;
@@ -547,7 +927,7 @@ mod tests {
         );
 
         for _ in 0..8 {
-            for ac in batcher.get_actions().await.unwrap() {
+            for ac in batcher.get_actions(None).await.unwrap() {
                 ac.1(&mut test_checker).await.unwrap();
             }
         }
@@ -613,7 +993,7 @@ mod tests {
         let mut test_checker = TestChecker { values: Vec::new() };
 
         // pick up the immediate fire
-        for ac in batcher.get_actions().await.unwrap() {
+        for ac in batcher.get_actions(None).await.unwrap() {
             ac.1(&mut test_checker).await.unwrap();
         }
         assert!(
@@ -621,7 +1001,7 @@ mod tests {
             "Both actions should be emitted immediately"
         );
 
-        for ac in batcher.get_actions().await.unwrap() {
+        for ac in batcher.get_actions(None).await.unwrap() {
             ac.1(&mut test_checker).await.unwrap();
         }
 
@@ -630,7 +1010,7 @@ mod tests {
 
     #[tokio::test(start_paused = true)]
     async fn batch_two_no_threshold_nodelay_check() {
-        let start_time = tokio::time::Instant::now();
+        let start_time = Instant::now();
         let mut batcher = Batcher::<String, TestChecker>::new();
         batcher.add(
             "key0".to_owned(),
@@ -638,8 +1018,7 @@ mod tests {
             Duration::from_secs(0),
             Arc::new(|s: _| {
                 Box::pin(async move {
-                    s.values
-                        .push(("key0".to_owned(), tokio::time::Instant::now()));
+                    s.values.push(("key0".to_owned(), Instant::now()));
                     Ok(())
                 })
             }),
@@ -647,7 +1026,7 @@ mod tests {
 
         let mut test_checker = TestChecker { values: Vec::new() };
         // pick up the immediate fire
-        for ac in batcher.get_actions().await.unwrap() {
+        for ac in batcher.get_actions(None).await.unwrap() {
             ac.1(&mut test_checker).await.unwrap();
         }
         assert!(test_checker.values.len() == 1);
@@ -660,20 +1039,19 @@ mod tests {
             Duration::from_secs(0),
             Arc::new(|s: _| {
                 Box::pin(async move {
-                    s.values
-                        .push(("key1".to_owned(), tokio::time::Instant::now()));
+                    s.values.push(("key1".to_owned(), Instant::now()));
                     Ok(())
                 })
             }),
         );
 
         // pick up the immediate fire from the second action
-        for ac in batcher.get_actions().await.unwrap() {
+        for ac in batcher.get_actions(None).await.unwrap() {
             ac.1(&mut test_checker).await.unwrap();
         }
         assert!(test_checker.values.len() == 2);
 
-        for ac in batcher.get_actions().await.unwrap() {
+        for ac in batcher.get_actions(None).await.unwrap() {
             ac.1(&mut test_checker).await.unwrap();
         }
 
@@ -684,7 +1062,7 @@ mod tests {
 
         test_checker.values = vec![];
         for _ in 0..12 {
-            for ac in batcher.get_actions().await.unwrap() {
+            for ac in batcher.get_actions(None).await.unwrap() {
                 ac.1(&mut test_checker).await.unwrap();
             }
         }
@@ -715,14 +1093,15 @@ mod tests {
 
         // Now let's wait a bit so upon iterating again signals would be aligned
         test_checker.values = vec![];
-        tokio::time::advance(tokio::time::Duration::from_secs(500)).await;
+        tokio::time::advance(Duration::from_secs(500)).await;
+
         for _i in 0..11 {
-            for ac in batcher.get_actions().await.unwrap() {
+            for ac in batcher.get_actions(None).await.unwrap() {
                 ac.1(&mut test_checker).await.unwrap();
             }
         }
 
-        let key0sum: tokio::time::Duration = test_checker
+        let key0sum: Duration = test_checker
             .values
             .iter()
             .filter(|e| e.0 == "key0")
@@ -732,7 +1111,7 @@ mod tests {
             .map(|w| w[1] - w[0])
             .sum();
 
-        let key1sum: tokio::time::Duration = test_checker
+        let key1sum: Duration = test_checker
             .values
             .iter()
             .filter(|e| e.0 == "key1")

--- a/nat-lab/tests/test_batching.py
+++ b/nat-lab/tests/test_batching.py
@@ -39,7 +39,13 @@ def _generate_setup_parameters(
         rtt_seconds=1, no_of_pings=1, use_for_downgrade=True
     )
     features.batching = (
-        FeatureBatching(direct_connection_threshold=35) if batching else None
+        FeatureBatching(
+            direct_connection_threshold=35,
+            trigger_effective_duration=10,
+            trigger_cooldown_duration=60,
+        )
+        if batching
+        else None
     )
     features.wireguard.persistent_keepalive = FeaturePersistentKeepalive(
         direct=70,

--- a/nat-lab/tests/test_direct_connection.py
+++ b/nat-lab/tests/test_direct_connection.py
@@ -59,7 +59,13 @@ def _generate_setup_parameters(
         features.direct.providers = providers
         features.wireguard.persistent_keepalive.direct = 10
         features.batching = (
-            FeatureBatching(direct_connection_threshold=5) if batching else None
+            FeatureBatching(
+                direct_connection_threshold=5,
+                trigger_cooldown_duration=60,
+                trigger_effective_duration=10,
+            )
+            if batching
+            else None
         )
         return features
 

--- a/src/device.rs
+++ b/src/device.rs
@@ -1109,6 +1109,7 @@ impl Runtime {
                         firewall_reset_connections,
                     },
                     features.link_detection,
+                    features.batching,
                     features.ipv6,
                 )?);
                 let wg_events = wg_events.rx;
@@ -1451,7 +1452,15 @@ impl Runtime {
                 self.requested_state.device_config.private_key.public(),
             )?);
 
-            match SessionKeeper::start(self.entities.socket_pool.clone()).map(Arc::new) {
+            match SessionKeeper::start(
+                self.entities.socket_pool.clone(),
+                self.entities
+                    .wireguard_interface
+                    .subscribe_to_network_activity()
+                    .await?,
+            )
+            .map(Arc::new)
+            {
                 Ok(session_keeper) => Some(DirectEntities {
                     local_interfaces_endpoint_provider,
                     stun_endpoint_provider,

--- a/src/device.rs
+++ b/src/device.rs
@@ -1454,6 +1454,7 @@ impl Runtime {
 
             match SessionKeeper::start(
                 self.entities.socket_pool.clone(),
+                self.features.batching.unwrap_or_default(),
                 self.entities
                     .wireguard_interface
                     .subscribe_to_network_activity()

--- a/src/device/wg_controller.rs
+++ b/src/device/wg_controller.rs
@@ -2147,9 +2147,7 @@ mod tests {
     #[tokio::test]
     async fn when_fresh_start_and_batching_enabled_then_proxy_enpoint_is_added_with_batching() {
         let mut f = Fixture::new();
-        f.features.batching = Some(FeatureBatching {
-            direct_connection_threshold: 5,
-        });
+        f.features.batching = Some(FeatureBatching::default());
 
         let pub_key = SecretKey::gen().public();
         let ip1 = IpAddr::from([1, 2, 3, 4]);
@@ -2183,7 +2181,7 @@ mod tests {
             ip1,
             Some(ip1v6),
             proxying_keepalive_time,
-            Some(Duration::from_secs(5)),
+            Some(Duration::from_secs(0)),
         )]);
 
         f.consolidate_peers().await;
@@ -2832,9 +2830,7 @@ mod tests {
     #[tokio::test]
     async fn when_vpn_peer_is_added_with_batching() {
         let mut f = Fixture::new();
-        f.features.batching = Some(FeatureBatching {
-            direct_connection_threshold: 5,
-        });
+        f.features.batching = Some(FeatureBatching::default());
 
         let public_key = SecretKey::gen().public();
         let allowed_ips = vec![
@@ -2885,7 +2881,7 @@ mod tests {
             IpAddr::from(VPN_INTERNAL_IPV4),
             Some(IpAddr::from(VPN_INTERNAL_IPV6)),
             vpn_persistent_keepalive,
-            Some(Duration::from_secs(5)),
+            Some(Duration::from_secs(0)),
         )]);
 
         f.consolidate_peers().await;
@@ -2978,9 +2974,7 @@ mod tests {
     #[tokio::test]
     async fn when_stun_peer_is_added_with_batching() {
         let mut f = Fixture::new();
-        f.features.batching = Some(FeatureBatching {
-            direct_connection_threshold: 5,
-        });
+        f.features.batching = Some(FeatureBatching::default());
 
         let public_key = SecretKey::gen().public();
 
@@ -3027,7 +3021,7 @@ mod tests {
             IpAddr::from([100, 64, 0, 4]),
             Some(IpAddr::from([0xfd74, 0x656c, 0x696f, 0, 0, 0, 0, 4])),
             stun_persistent_keepalive,
-            Some(Duration::from_secs(5)),
+            Some(Duration::from_secs(0)),
         )]);
 
         f.consolidate_peers().await;

--- a/src/libtelio.udl
+++ b/src/libtelio.udl
@@ -562,6 +562,12 @@ dictionary Features {
 dictionary FeatureBatching {
     /// direct connection threshold for batching
     u32 direct_connection_threshold;
+
+    /// effective trigger period
+    u32 trigger_effective_duration;
+
+    //// cooldown after trigger was used
+    u32 trigger_cooldown_duration;
 };
 
 /// Configurable features for Wireguard peers


### PR DESCRIPTION
Introduce network activity based trigger to batcher.

Make DynamicWg have `subscribe_to_network_activity` that returns a tokio watch receiver channel to observe the traffic changes. Traffic changes are global WireGuard traffic changes towards and from any peer.

Since the goal is to steer the alignment of batched actions(network activities) between the peers, it's not necessary to be selective per-peer and a global approach should work.

---

No new feature flag introduced, it is enabled alongside batcher. So far no practical results can be observed in natlab cases I tried as it's overshadowed by other things doing network activity, so this is an improvement based on assumptions and RFC at this point.


### Problem


### Solution



### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
