### PR TITLE
Disable moose option for qnap build

### DIFF
--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -22,4 +22,4 @@ jobs:
     with:
       schedule: ${{ github.event_name == 'schedule' }}
       cancel-outdated-pipelines: ${{ github.ref_name != 'main' }}
-      triggered-ref: v2.6.4 # REMEMBER to also update in .gitlab-ci.yml
+      triggered-ref: v2.6.5 # REMEMBER to also update in .gitlab-ci.yml

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,4 +15,4 @@ libtelio-build-pipeline:
 
   trigger:
     project: $LIBTELIO_BUILD_PROJECT_PATH
-    branch: v2.6.4 # REMEMBER to also update in .github/workflows/gitlab.yml
+    branch: v2.6.5 # REMEMBER to also update in .github/workflows/gitlab.yml

--- a/ci/build_libtelio.py
+++ b/ci/build_libtelio.py
@@ -296,7 +296,7 @@ LIBTELIO_CONFIG = {
             "x86_64": {
                 "env": {
                     "RUSTFLAGS": (
-                        f" -L {PROJECT_ROOT}/3rd-party/libmoose/{LIBTELIO_ENV_MOOSE_RELEASE_TAG}/bin/common/qnap/{MOOSE_MAP['x86_64']} -l static=sqlite3",
+                        f" -L {PROJECT_ROOT}/3rd-party/libmoose/{LIBTELIO_ENV_MOOSE_RELEASE_TAG}/bin/common/qnap/{MOOSE_MAP['x86_64']}",
                         "set",
                     )
                 },
@@ -513,7 +513,8 @@ def exec_build(args):
         return
 
     if args.moose:
-        if args.os in ["linux", "windows", "android", "qnap"]:
+        # Currently, moose is not supported on qnap
+        if args.os in ["linux", "windows", "android"]:
             sys.path.append(f"{PROJECT_ROOT}/ci")
             moose_utils.fetch_moose_dependencies(args.os, MOOSE_MAP[args.arch])
 

--- a/ci/moose_utils.py
+++ b/ci/moose_utils.py
@@ -8,7 +8,7 @@ from env import LIBTELIO_ENV_MOOSE_RELEASE_TAG
 PROJECT_ROOT = os.path.normpath(os.path.dirname(os.path.realpath(__file__)) + "/..")
 
 
-def _output_dir(opsys: str, arch: str) -> str:
+def _output_dir(target_os: str, arch: str) -> str:
     return os.path.join(
         PROJECT_ROOT,
         "3rd-party",
@@ -16,19 +16,19 @@ def _output_dir(opsys: str, arch: str) -> str:
         LIBTELIO_ENV_MOOSE_RELEASE_TAG,
         "bin",
         "common",
-        opsys,
+        target_os,
         arch,
     )
 
 
-def _download_moose_file(opsys: str, arch: str, file_name: str):
+def _download_moose_file(target_os: str, arch: str, file_name: str):
     MOOSE_PROJECT_ID = 5644
 
-    output_path = os.path.join(_output_dir(opsys, arch), file_name)
+    output_path = os.path.join(_output_dir(target_os, arch), file_name)
     if os.path.isfile(output_path):
         return
 
-    print(f"Moose utils: Downloading {opsys}/{arch}/{file_name}")
+    print(f"Moose utils: Downloading {target_os}/{arch}/{file_name}")
 
     if not os.path.isdir(os.path.dirname(output_path)):
         os.makedirs(os.path.dirname(output_path))
@@ -42,23 +42,18 @@ def _download_moose_file(opsys: str, arch: str, file_name: str):
     if nexus_url is None:
         raise ValueError("LIBTELIO_ENV_SEC_NEXUS_URL not set")
 
-    if opsys == "qnap":
-        url = f"{nexus_url}/repository/ll-gitlab-release/{MOOSE_PROJECT_ID}/{LIBTELIO_ENV_MOOSE_RELEASE_TAG}/bin/common/linux/{arch}/{file_name}"
-    else:
-        url = f"{nexus_url}/repository/ll-gitlab-release/{MOOSE_PROJECT_ID}/{LIBTELIO_ENV_MOOSE_RELEASE_TAG}/bin/common/{opsys}/{arch}/{file_name}"
+    url = f"{nexus_url}/repository/ll-gitlab-release/{MOOSE_PROJECT_ID}/{LIBTELIO_ENV_MOOSE_RELEASE_TAG}/bin/common/{target_os}/{arch}/{file_name}"
 
     subprocess.check_call(
         ["curl", "-f", "-u", nexus_credentials, url, "-o", output_path]
     )
 
 
-def fetch_moose_dependencies(opsys: str, arch: str):
-    if opsys == "windows":
-        _download_moose_file(opsys, arch, "sqlite3.dll")
-    elif opsys == "qnap":
-        _download_moose_file(opsys, arch, "libsqlite3.a")
+def fetch_moose_dependencies(target_os: str, arch: str):
+    if target_os == "windows":
+        _download_moose_file(target_os, arch, "sqlite3.dll")
     else:
-        _download_moose_file(opsys, arch, "libsqlite3.so")
+        _download_moose_file(target_os, arch, "libsqlite3.so")
 
 
 def create_msvc_import_library(arch: str):


### PR DESCRIPTION
### Problem
To fully integrate `moose` to `qnap` (and other embedded platforms), we have to integrate moose-worker, as well have a static build of `libsqlite3`.

### Solution
Moose integration was postponed, so building qnap without `--moose` option.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
