### PR TITLE
Supress autoflake output

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -108,7 +108,7 @@ jobs:
         - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
         - run: pip3 install --no-deps -r requirements.txt
         - run: pipenv install --system
-        - run: autoflake --check .
+        - run: autoflake --quiet --check .
           working-directory: nat-lab
   python-lint:
       needs: uniffi-bindings


### PR DESCRIPTION
Autoflake lists each file having no problems
which makes it difficult to see what actually failed.

Add quiet flag to only output what is wrong

### Problem
*--describe problem being solved--*

### Solution
*--describe selected solution--*


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
