### PR TITLE
[LLT-5801] Fix incorrect os preference order for network interfaces on apple

### DIFF
--- a/.unreleased/LLT-5801
+++ b/.unreleased/LLT-5801
@@ -1,0 +1,1 @@
+Make sure apple socket protector respects nw_path_monitor interface preference order

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4761,11 +4761,14 @@ dependencies = [
 name = "telio-sockets"
 version = "0.1.0"
 dependencies = [
+ "block",
  "debug_panic",
+ "dispatch",
  "futures",
  "libc",
  "mockall",
  "neptun",
+ "network-framework-sys",
  "nix 0.28.0",
  "objc",
  "objc-foundation",
@@ -4774,7 +4777,6 @@ dependencies = [
  "rstest",
  "socket2",
  "system-configuration 0.5.1 (git+https://github.com/NordSecurity/system-configuration-rs.git)",
- "telio-network-monitors",
  "telio-utils",
  "thiserror",
  "tokio",

--- a/crates/telio-sockets/Cargo.toml
+++ b/crates/telio-sockets/Cargo.toml
@@ -32,7 +32,10 @@ version-compare = "0.1"
 debug_panic = "0.2.1"
 nix = { version = "0.28", features=["socket"] }
 system-configuration = { git = 'https://github.com/NordSecurity/system-configuration-rs.git' }
-telio-network-monitors.workspace = true
+network-framework-sys = "0.1"
+block = "0.1"
+dispatch = { git = "https://github.com/NordSecurity/rust-dispatch.git", rev = "13447cd7221a74ebcce1277ae0cfc9a421a28ec5" }
+
 
 [target.'cfg(windows)'.dependencies]
 winapi = { workspace = true, features = [

--- a/crates/telio-sockets/src/protector/apple.rs
+++ b/crates/telio-sockets/src/protector/apple.rs
@@ -1,9 +1,12 @@
 use debug_panic::debug_panic;
+use once_cell::sync::Lazy;
 use parking_lot::{Mutex, RwLock};
-use telio_network_monitors::{monitor::LOCAL_ADDRS_CACHE, monitor::PATH_CHANGE_BROADCAST};
 
 use std::{
+    cell::RefCell,
+    ffi::{c_long, c_void, CStr},
     io, os,
+    rc::Rc,
     sync::{Arc, Weak},
 };
 
@@ -20,12 +23,42 @@ use system_configuration::{
     dynamic_store::{self, SCDynamicStore},
     sys::schema_definitions,
 };
-use tokio::{self, sync::Notify, task::JoinHandle};
+use tokio::{
+    self,
+    sync::{broadcast::Sender, Notify},
+    task::JoinHandle,
+};
 
 use crate::native::{interface_index_from_name, NativeSocket};
 use crate::Protector;
+use network_framework_sys::{
+    nw_interface_get_name, nw_interface_t, nw_path_monitor_create, nw_path_monitor_set_queue,
+    nw_path_monitor_start, nw_path_monitor_t, nw_path_t,
+};
 use nix::sys::socket::{getsockname, AddressFamily, SockaddrLike, SockaddrStorage};
 use telio_utils::{telio_log_debug, telio_log_error, telio_log_info, telio_log_warn};
+
+extern "C" {
+    // Obj-c signature:
+    // void nw_path_monitor_set_update_handler(nw_path_monitor_t monitor, nw_path_monitor_update_handler_t update_handler);
+    // typedef void (^nw_path_monitor_update_handler_t)(nw_path_t path);
+    pub fn nw_path_monitor_set_update_handler(
+        monitor: nw_path_monitor_t,
+        update_handler: *const c_void,
+    );
+    // Obj-c signature:
+    // void nw_path_enumerate_interfaces(nw_path_t path, nw_path_enumerate_interfaces_block_t enumerate_block);
+    // typedef bool (^nw_path_enumerate_interfaces_block_t)(nw_interface_t interface);
+    pub fn nw_path_enumerate_interfaces(path: nw_path_t, enumerate_block: *const c_void);
+}
+
+pub const DISPATCH_QUEUE_PRIORITY_HIGH: c_long = 2;
+pub const DISPATCH_QUEUE_PRIORITY_DEFAULT: c_long = 0;
+pub const DISPATCH_QUEUE_PRIORITY_LOW: c_long = -2;
+pub const DISPATCH_QUEUE_PRIORITY_BACKGROUND: c_long = -1 << 15;
+
+static INTERFACE_NAMES_IN_OS_PREFERENCE_ORDER: Mutex<Vec<String>> = Mutex::new(Vec::new());
+static PROTECTOR_PATH_CHANGE_BROADCAST: Lazy<Sender<()>> = Lazy::new(|| Sender::new(1));
 
 #[cfg(any(target_os = "ios", target_os = "tvos"))]
 use objc::{class, msg_send, runtime::Object, sel, sel_impl};
@@ -304,7 +337,7 @@ fn spawn_monitors(
     spawn_dynamic_store_loop(Arc::downgrade(&sockets));
     let nw_path_monitor_monitor_handle = tokio::spawn({
         let sockets = sockets.clone();
-        let mut notify = PATH_CHANGE_BROADCAST.subscribe();
+        let mut notify = PROTECTOR_PATH_CHANGE_BROADCAST.subscribe();
         async move {
             loop {
                 match notify.recv().await {
@@ -376,11 +409,8 @@ fn get_primary_interface_names() -> Vec<String> {
         }
     }
 
-    let mut interface_names_in_os_preference_order: Vec<String> = LOCAL_ADDRS_CACHE
-        .lock()
-        .iter()
-        .map(|interface| interface.name.clone())
-        .collect();
+    let mut interface_names_in_os_preference_order: Vec<String> =
+        INTERFACE_NAMES_IN_OS_PREFERENCE_ORDER.lock().clone();
     telio_log_info!(
         "Discovered these primary IPv4 interfaces for use in socket binding: {:?} (OS pereference order: {interface_names_in_os_preference_order:?})",
         primary_ipv4_interface_names
@@ -448,28 +478,63 @@ fn spawn_dynamic_store_loop(sockets: Weak<Mutex<Sockets>>) {
     });
 }
 
-#[cfg(test)]
-mod tests {
-    use socket2::{Domain, Protocol, Socket, Type};
-    use telio_network_monitors::{
-        apple::setup_network_monitor, local_interfaces::SystemGetIfAddrs, monitor::NetworkMonitor,
-    };
+pub fn setup_network_path_monitor() {
+    let update_handler = block::ConcreteBlock::new(|path: nw_path_t| {
+        let names = Rc::new(RefCell::new(vec![]));
+        let names_copy = names.clone();
 
-    use crate::native::AsNativeSocket;
+        let enumerate_callback =
+            block::ConcreteBlock::new(move |interface: nw_interface_t| -> bool {
+                let c_name = unsafe { nw_interface_get_name(interface) };
+                if !c_name.is_null() {
+                    let name = unsafe { CStr::from_ptr(c_name) };
+                    if let Ok(name) = name.to_str() {
+                        names_copy.borrow_mut().push(name.to_owned());
+                    }
+                }
+                true
+            })
+            .copy();
 
-    use super::*;
+        unsafe {
+            nw_path_enumerate_interfaces(
+                path,
+                &*enumerate_callback as *const block::Block<_, _> as *const c_void,
+            )
+        };
 
-    #[tokio::test]
-    async fn test_ipv6_sk_bind() {
-        setup_network_monitor();
-
-        let socket2_socket = Socket::new(Domain::IPV6, Type::STREAM, Some(Protocol::TCP));
-
-        let socket_fd = socket2_socket.as_ref().unwrap().as_native_socket();
-        let _network_monitor = NetworkMonitor::new(SystemGetIfAddrs).await.unwrap();
-
-        if let Err(e) = bind(get_primary_interface(0).unwrap() as u32, socket_fd) {
-            panic!("Test failed with error : {}", e)
+        *INTERFACE_NAMES_IN_OS_PREFERENCE_ORDER.lock() = names.borrow().clone();
+        if let Err(e) = PROTECTOR_PATH_CHANGE_BROADCAST.send(()) {
+            telio_log_warn!(
+                "Failed to notify about changed path, error: {e}, path: {:?}",
+                names.borrow()
+            );
         }
+
+        telio_log_info!(
+            "Path change notification sent, current network path in os preference order: {:?}",
+            names.borrow()
+        );
+    })
+    .copy();
+    unsafe {
+        let monitor = nw_path_monitor_create();
+        if monitor.is_null() {
+            telio_log_warn!("Failed to start network path monitor");
+            return;
+        }
+
+        let queue = dispatch::ffi::dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0);
+        if queue.is_null() {
+            telio_log_warn!("Failed to get global background queue");
+            return;
+        }
+        nw_path_monitor_set_queue(monitor, std::mem::transmute(queue));
+
+        nw_path_monitor_set_update_handler(
+            monitor,
+            &*update_handler as *const block::Block<_, _> as *const c_void,
+        );
+        nw_path_monitor_start(monitor);
     }
 }

--- a/src/device.rs
+++ b/src/device.rs
@@ -91,6 +91,9 @@ use telio_model::{
 #[cfg(target_os = "android")]
 use telio_network_monitors::monitor::PATH_CHANGE_BROADCAST;
 
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
+static NETWORK_PATH_MONITOR_START: std::sync::Once = std::sync::Once::new();
+
 pub use wg::{
     uapi::Event as WGEvent, uapi::Interface, AdapterType, DynamicWg, Error as AdapterError,
     FirewallCb, Tun, WireGuard,
@@ -475,6 +478,10 @@ impl Device {
                 telio_log_error!("Failed to initialize lana")
             }
         }
+
+        #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
+        NETWORK_PATH_MONITOR_START
+            .call_once(telio_sockets::protector::platform::setup_network_path_monitor);
 
         let thread_tracker = Arc::new(parking_lot::Mutex::new(ThreadTracker::default()));
 


### PR DESCRIPTION
### Problem
With PR 601 a regression was introduced, where interfaces being listed for binding selection would not depend not on OS preference order provided by `nw_path_monitor()`, but basically on `getifaddrs()` function. And getifaddrs generally does not guarantee any preference ordering.

### Solution
This PR rolls back telio-sockets apple protector to the old state. 

### For Reviewers:
libtelio v4.3.5 is a "known good" protector state, this PR reverts back to it. You may verify it by running `git diff v4.3.5 crates/telio-sockets/src/protector/apple.rs`. Note that, in comparison to v4.3.5, due to name clash of `PATH_CHANGE_BROADCAST` in previous variant of apple socket protector and current version of `telio-network-monitor` -> it has been renamed to `PROTECTOR_PATH_CHANGE_BROADCAST`. and empty `set_fwmark()` method added. What is more, `test_ipv6_sk_bind` has been removed. As it is expecting IPv6 bind, where socket protectors exclusively deal with out-of-tunnel traffic. Which currently does not support IPv6.

Note: this PR backports hotfix changes from `release/v5.1` branch. LLT-5806 has been registered to avoid multiple use of nw_path_monitor instance.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
