### PR TITLE
bump libtelio build to v2.6.6

### DIFF
--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -22,4 +22,4 @@ jobs:
     with:
       schedule: ${{ github.event_name == 'schedule' }}
       cancel-outdated-pipelines: ${{ github.ref_name != 'main' }}
-      triggered-ref: v2.6.5 # REMEMBER to also update in .gitlab-ci.yml
+      triggered-ref: v2.6.6 # REMEMBER to also update in .gitlab-ci.yml

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,4 +15,4 @@ libtelio-build-pipeline:
 
   trigger:
     project: $LIBTELIO_BUILD_PROJECT_PATH
-    branch: v2.6.5 # REMEMBER to also update in .github/workflows/gitlab.yml
+    branch: v2.6.6 # REMEMBER to also update in .github/workflows/gitlab.yml


### PR DESCRIPTION
### Problem
Mac vm fails to start due to fail of creating network interfaces

### Solution
in v2.6.6 libtelio build issue was potentially fixed by changing network interface models from `e1000` to `vmxnet3`


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
