### PR TITLE
Enable VM nat once during pytest session

### DIFF
--- a/nat-lab/tests/conftest.py
+++ b/nat-lab/tests/conftest.py
@@ -259,7 +259,7 @@ async def _copy_vm_binaries(tag: ConnectionTag):
         try:
             print(f"copying for {tag}")
             async with windows_vm_util.new_connection(
-                LAN_ADDR_MAP[tag], copy_binaries=True
+                LAN_ADDR_MAP[tag], copy_binaries=True, reenable_nat=True
             ):
                 pass
         except OSError as e:
@@ -268,7 +268,9 @@ async def _copy_vm_binaries(tag: ConnectionTag):
             print(e)
     elif tag is ConnectionTag.MAC_VM:
         try:
-            async with mac_vm_util.new_connection(copy_binaries=True):
+            async with mac_vm_util.new_connection(
+                copy_binaries=True, reenable_nat=True
+            ):
                 pass
         except OSError as e:
             if is_ci:
@@ -446,7 +448,7 @@ async def collect_mac_diagnostic_reports():
         return
     print("Collect mac diagnostic reports")
     try:
-        async with mac_vm_util.new_connection(reenable_nat=False) as connection:
+        async with mac_vm_util.new_connection() as connection:
             await connection.download(
                 "/Library/Logs/DiagnosticReports", "logs/system_diagnostic_reports"
             )

--- a/nat-lab/tests/utils/vm/mac_vm_util.py
+++ b/nat-lab/tests/utils/vm/mac_vm_util.py
@@ -20,7 +20,7 @@ VM_UNIFFI_DIR = UNIFFI_PATH_MAC_VM
 async def new_connection(
     ip: str = MAC_VM_IP,
     copy_binaries: bool = False,
-    reenable_nat=True,
+    reenable_nat=False,
 ) -> AsyncIterator[Connection]:
     if reenable_nat:
         subprocess.check_call(["sudo", "bash", "vm_nat.sh", "disable"])

--- a/nat-lab/tests/utils/vm/windows_vm_util.py
+++ b/nat-lab/tests/utils/vm/windows_vm_util.py
@@ -22,7 +22,7 @@ VM_SYSTEM32 = "C:\\Windows\\System32"
 async def new_connection(
     ip: str = WINDOWS_1_VM_IP,
     copy_binaries: bool = False,
-    reenable_nat=True,
+    reenable_nat=False,
 ) -> AsyncIterator[Connection]:
     if reenable_nat:
         subprocess.check_call(["sudo", "bash", "vm_nat.sh", "disable"])


### PR DESCRIPTION
### Problem
re-enabling vm nat on every test spams too much logs

### Solution
enable vm nat once per pytest session


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
