### PR TITLE
[LLT-5811] qnap: Add cgi script handling REST API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ beta-events.db
 gamma-events.db
 nat-lab/**/report.html
 events-moose.log
+qnap/**/teliod

--- a/qnap/package_routines
+++ b/qnap/package_routines
@@ -113,6 +113,7 @@ PKG_POST_REMOVE="{
     rm -rf /tmp/nordsecmeshnet
     rm -f /home/Qhttpd/Web/NordSecurityMeshnet
     rm -f /home/httpd/cgi-bin/qpkg/teliod.cgi
+    rm -f /var/log/teliod.log
 }"
 #
 ######################################################################

--- a/qnap/package_routines
+++ b/qnap/package_routines
@@ -111,6 +111,8 @@
 #
 PKG_POST_REMOVE="{
     rm -rf /tmp/nordsecmeshnet
+    rm -f /home/Qhttpd/Web/NordSecurityMeshnet
+    rm -f /home/httpd/cgi-bin/qpkg/teliod.cgi
 }"
 #
 ######################################################################

--- a/qnap/shared/NordSecMeshnet.sh
+++ b/qnap/shared/NordSecMeshnet.sh
@@ -9,6 +9,8 @@ export QNAP_QPKG=$QPKG_NAME
 
 NORDSECMESHNET_DIR=/tmp/nordsecuritymeshnet/
 TELIOD_PID_FILE=${NORDSECMESHNET_DIR}/teliod.pid
+TELIOD_CFG_FILE=${QPKG_ROOT}/teliod.cfg
+TELIOD_LOG_FILE="/var/log/teliod.log"
 
 case "$1" in
   start)
@@ -30,7 +32,7 @@ case "$1" in
         fi
     fi
 
-    ${QPKG_ROOT}/teliod daemon ${QPKG_ROOT}/teliod.cfg &
+    ${QPKG_ROOT}/teliod daemon $TELIOD_CFG_FILE > $TELIOD_LOG_FILE 2>&1 &
     echo $! > ${TELIOD_PID_FILE}
     ;;
 

--- a/qnap/shared/NordSecMeshnet.sh
+++ b/qnap/shared/NordSecMeshnet.sh
@@ -19,6 +19,7 @@ case "$1" in
     fi
 
     ln -s ${QPKG_ROOT}/web /home/Qhttpd/Web/NordSecurityMeshnet
+    ln -s ${QPKG_ROOT}/teliod.cgi /home/httpd/cgi-bin/qpkg/teliod.cgi
     mkdir -p -m 0755 $NORDSECMESHNET_DIR
 
     if [ -e ${TELIOD_PID_FILE} ]; then
@@ -29,7 +30,7 @@ case "$1" in
         fi
     fi
 
-    ${QPKG_ROOT}/teliod daemon ${QPKG_ROOT}/config.json &
+    ${QPKG_ROOT}/teliod daemon ${QPKG_ROOT}/teliod.cfg &
     echo $! > ${TELIOD_PID_FILE}
     ;;
 
@@ -39,8 +40,7 @@ case "$1" in
       kill -9 ${PID} || true
       rm -f ${TELIOD_PID_FILE}
     fi
-
-    rm /home/Qhttpd/Web/NordSecurityMeshnet
+    rm -f /run/teliod.sock
     ;;
 
   restart)

--- a/qnap/shared/teliod.cfg
+++ b/qnap/shared/teliod.cfg
@@ -1,6 +1,6 @@
 {
     "log_level": "debug",
-    "log_file_path": "/tmp/nordsecuritymeshnet/meshnet.log",
+    "log_file_path": "/share/CACHEDEV1_DATA/.qpkg/NordSecurityMeshnet/meshnet.log",
     "authentication_token": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
     "app_user_uid": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
     "interface": {

--- a/qnap/shared/teliod.cfg
+++ b/qnap/shared/teliod.cfg
@@ -1,7 +1,11 @@
 {
     "log_level": "debug",
-    "log_file_path": "/tmp/nordsecuritymeshnet/teliod.log",
+    "log_file_path": "/tmp/nordsecuritymeshnet/meshnet.log",
     "authentication_token": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
     "app_user_uid": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
-    "interface_name": "nlx"
+    "interface": {
+      "name": "nlx",
+      "config_provider": "manual"
+    }
 }
+

--- a/qnap/shared/teliod.cgi
+++ b/qnap/shared/teliod.cgi
@@ -1,0 +1,131 @@
+#!/bin/bash
+
+echo "Content-Type: application/json"
+echo ""
+
+# Varibles set by the HTTP web server
+#
+# $REQUEST_METHOD
+# $QUERY_STRING
+# $CONTENT_LENGTH
+
+POST_DATA=""
+
+if [[ "$REQUEST_METHOD" == "POST" || "$REQUEST_METHOD" == "PATCH" ]]; then
+    read -n $CONTENT_LENGTH POST_DATA
+fi
+
+QPKG_DIR="/share/CACHEDEV1_DATA/.qpkg/NordSecurityMeshnet"
+APP_TMP_DIR="/tmp/nordsecuritymeshnet"
+APP_CMD="$QPKG_DIR/teliod"
+CONFIG_FILE="$QPKG_DIR/teliod.cfg"
+LOG_FILE="$APP_TMP_DIR/teliod.log"
+PID_FILE="$APP_TMP_DIR/teliod.pid"
+
+is_application_running() {
+    if [ -f ${PID_FILE} ]; then
+        PID=$(cat ${PID_FILE})
+        if [ -d /proc/${PID}/ ]; then
+            # application is running
+            return 0
+        fi
+    fi
+    # application is NOT running
+    return 1
+}
+
+send_response() {
+    local code=$1
+    local message=$2
+    echo "{\"code\": $code, \"message\": \"$message\"}"
+    exit $code
+}
+
+start_daemon() {
+    if is_application_running; then
+        send_response 400 "Application is already running."
+    fi
+    $APP_CMD daemon $CONFIG_FILE > $LOG_FILE 2>&1 &
+    if [[ $? -eq 0 ]]; then
+        echo $! > ${PID_FILE}
+        send_response 200 "Application started successfully."
+    else
+        echo $! > ${PID_FILE}
+        send_response 500 "Failed to start the application."
+    fi
+}
+
+stop_daemon() {
+    if [ -f ${PID_FILE} ]; then
+        PID=$(cat ${PID_FILE})
+        kill ${PID} || true
+        rm -f ${PID_FILE}
+        send_response 200 "Application stopped successfully."
+    else
+        send_response 400 "Application PID not found."
+    fi
+}
+
+update_config() {
+    NEW_CONFIG=$(echo "$POST_DATA" | jq -r '.config')
+    if [[ -z "$NEW_CONFIG" ]]; then
+        send_response 400 "No configuration provided."
+    fi
+    echo "$NEW_CONFIG" > $CONFIG_FILE
+    if [[ $? -eq 0 ]]; then
+        send_response 200 "Configuration updated successfully."
+    else
+        send_response 500 "Failed to update configuration."
+    fi
+}
+
+get_status() {
+    if is_application_running; then
+        STATUS=$($APP_CMD get-status)
+        echo "{\"code\": 200, \"status-report\": $STATUS}"
+        exit 0
+    else
+        send_response 400 "Application is not running."
+    fi
+}
+
+get_logs() {
+    if [[ -f $LOG_FILE ]]; then
+        LOGS=$(tail -n 100 $LOG_FILE | jq -R -s '.')
+        echo "{\"code\": 200, \"logs\": $LOGS}"
+        exit 0
+    else
+        send_response 404 "Log file not found."
+    fi
+}
+
+case "$REQUEST_METHOD" in
+    POST)
+        if [[ "$QUERY_STRING" == "action=start" ]]; then
+            start_daemon
+        elif [[ "$QUERY_STRING" == "action=stop" ]]; then
+            stop_daemon
+        else
+            send_response 400 "Invalid action for POST."
+        fi
+        ;;
+    PATCH)
+        if [[ "$QUERY_STRING" == "action=update-config" ]]; then
+            update_config
+        else
+            send_response 400 "Invalid action for PATCH."
+        fi
+        ;;
+    GET)
+        if [[ "$QUERY_STRING" == "action=get-status" ]]; then
+            get_status
+        elif [[ "$QUERY_STRING" == "action=get-logs" ]]; then
+            get_logs
+        else
+            send_response 400 "Invalid action for GET."
+        fi
+        ;;
+    *)
+        send_response 405 "Method not allowed."
+        ;;
+esac

--- a/qnap/shared/teliod.cgi
+++ b/qnap/shared/teliod.cgi
@@ -19,7 +19,7 @@ QPKG_DIR="/share/CACHEDEV1_DATA/.qpkg/NordSecurityMeshnet"
 APP_TMP_DIR="/tmp/nordsecuritymeshnet"
 APP_CMD="$QPKG_DIR/teliod"
 CONFIG_FILE="$QPKG_DIR/teliod.cfg"
-LOG_FILE="$APP_TMP_DIR/teliod.log"
+LOG_FILE="/var/log/teliod.log"
 PID_FILE="$APP_TMP_DIR/teliod.pid"
 
 is_application_running() {


### PR DESCRIPTION
This PR introduces a cgi script that the QNAP web UI can execute in order to manage the `teliod` daemon process.

Note: Configuration update and authentication features are going to be tackled in a future PR.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
