### PR TITLE
[LLT-5824] When shutting down natlab's telio-proxy, allow ConnectionRefusedError

### DIFF
--- a/nat-lab/tests/uniffi/libtelio_proxy.py
+++ b/nat-lab/tests/uniffi/libtelio_proxy.py
@@ -56,7 +56,7 @@ class LibtelioProxy:
                 "Unknown" if container_or_vm_name is None else container_or_vm_name,
             )
 
-        except Pyro5.errors.ConnectionClosedError as e:
+        except (Pyro5.errors.ConnectionClosedError, ConnectionRefusedError) as e:
             # Shutting down the server via client request is naturally racy,
             # as sending of response is racing against process shutdown (and
             # thus server-side socket being closed).


### PR DESCRIPTION
### Problem
During shutdown via RPC, ConnectionRefusedError may happen naturally. Do not panic in case of this error.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
