### PR TITLE
bump libtelio build to v2.6.8

### DIFF
--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -22,4 +22,4 @@ jobs:
     with:
       schedule: ${{ github.event_name == 'schedule' }}
       cancel-outdated-pipelines: ${{ github.ref_name != 'main' }}
-      triggered-ref: v2.6.7 # REMEMBER to also update in .gitlab-ci.yml
+      triggered-ref: v2.6.8 # REMEMBER to also update in .gitlab-ci.yml

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,4 +15,4 @@ libtelio-build-pipeline:
 
   trigger:
     project: $LIBTELIO_BUILD_PROJECT_PATH
-    branch: v2.6.7 # REMEMBER to also update in .github/workflows/gitlab.yml
+    branch: v2.6.8 # REMEMBER to also update in .github/workflows/gitlab.yml


### PR DESCRIPTION
### Problem
vagrant don't like syncing python provision script for windows (fails sometimes)

### Solution
revert provision script to powershell and don't use sync
