### PR TITLE
Overwrite SessionKeeper entry on Proxy->Direct upgrade

### DIFF
--- a/crates/telio-traversal/src/session_keeper.rs
+++ b/crates/telio-traversal/src/session_keeper.rs
@@ -196,6 +196,8 @@ impl SessionKeeperTrait for SessionKeeper {
         interval: Duration,
         threshold: Option<Duration>,
     ) -> Result<()> {
+        telio_log_debug!("Add {}", public_key);
+
         let dual_target = DualTarget::new(target).map_err(Error::DualTargetError)?;
         match threshold {
             Some(t) => task_exec!(&self.task, async move |s| {


### PR DESCRIPTION
    Overwrite SessionKeeper entry on Proxy->Direct upgrade
    
    There is a bug when batching is enabled and peer is upgraded
    from Proxying to Direct. The issue exists because
    entry to SessionKeeper is added initially, however
    once the upgrade happens, it is not updated.
    
    Given the scenario where one of the peer is offline and then comes
    online after a delay it results in SessionKeeper not emitting ping
    when upgrading from relayed to direct connection.
    
    The ping, however, must be done in order to provide a NAT(wg) mapping
    and both peers must do that to establish a mapping.
    
    Additionally this breaks alignment of keepalives between
    both peers since the upgrade process is highly synchronized, thus
    if both libtelio SessionKeeper instances emit at the same time,
    they are aligned and work well for battery.

### Problem
*--describe problem being solved--*

### Solution
*--describe selected solution--*


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
