### PR TITLE
Detach batcher and direct feature

### DIFF
--- a/nat-lab/tests/telio.py
+++ b/nat-lab/tests/telio.py
@@ -114,6 +114,7 @@ class Runtime:
         paths: List[PathType],
         is_exit: bool = False,
         is_vpn: bool = False,
+        link_state: Optional[LinkState] = None,
     ) -> None:
         while True:
             peer = self.get_peer_info(public_key)
@@ -123,6 +124,7 @@ class Runtime:
                 and peer.state in states
                 and is_exit == peer.is_exit
                 and is_vpn == peer.is_vpn
+                and (link_state is None or peer.link_state == link_state)
             ):
                 return
             await asyncio.sleep(0.1)
@@ -251,9 +253,12 @@ class Events:
         is_exit: bool = False,
         is_vpn: bool = False,
         timeout: Optional[float] = None,
+        link_state: Optional[LinkState] = None,
     ) -> None:
         await asyncio.wait_for(
-            self._runtime.notify_peer_state(public_key, state, paths, is_exit, is_vpn),
+            self._runtime.notify_peer_state(
+                public_key, state, paths, is_exit, is_vpn, link_state
+            ),
             timeout,
         )
 
@@ -522,6 +527,7 @@ class Client:
         is_exit: bool = False,
         is_vpn: bool = False,
         timeout: Optional[float] = None,
+        link_state: Optional[LinkState] = None,
     ) -> None:
         await self.get_events().wait_for_state_peer(
             public_key,
@@ -530,6 +536,7 @@ class Client:
             is_exit,
             is_vpn,
             timeout,
+            link_state,
         )
 
     async def wait_for_event_peer(

--- a/nat-lab/tests/test_batching.py
+++ b/nat-lab/tests/test_batching.py
@@ -2,7 +2,7 @@ import asyncio
 import itertools
 import pytest
 from contextlib import AsyncExitStack
-from helpers import SetupParameters, setup_environment
+from helpers import SetupParameters, setup_environment, setup_mesh_nodes
 from itertools import zip_longest
 from scapy.layers.inet import TCP, UDP, ICMP  # type: ignore
 from scapy.layers.l2 import ARP  # type: ignore
@@ -10,18 +10,20 @@ from timeouts import TEST_BATCHING_TIMEOUT
 from typing import List
 from utils.asyncio_util import run_async_context
 from utils.bindings import (
+    default_features,
     features_with_endpoint_providers,
     FeatureLinkDetection,
     FeaturePersistentKeepalive,
     FeatureBatching,
     EndpointProvider,
     RelayState,
+    LinkState,
     NodeState,
     PathType,
     TelioAdapterType,
 )
 from utils.connection import DockerConnection
-from utils.connection_util import DOCKER_GW_MAP, ConnectionTag, container_id
+from utils.connection_util import ConnectionTag, DOCKER_GW_MAP, container_id
 from utils.traffic import (
     capture_traffic,
     render_chart,
@@ -240,3 +242,77 @@ async def test_batching(
 
             print("Delay chart below")
             print(delay_chart)
+
+
+def proxying_peer_parameters(clients: List[ConnectionTag]):
+    def features():
+        features = default_features(enable_direct=False, enable_nurse=False)
+        features.wireguard.persistent_keepalive.proxying = 5
+        features.link_detection = FeatureLinkDetection(
+            rtt_seconds=2, no_of_pings=0, use_for_downgrade=False
+        )
+
+        features.batching = FeatureBatching(
+            direct_connection_threshold=5,
+            trigger_cooldown_duration=60,
+            trigger_effective_duration=10,
+        )
+        return features
+
+    return [
+        SetupParameters(
+            connection_tag=conn_tag,
+            adapter_type_override=TelioAdapterType.NEP_TUN,
+            features=features(),
+            fingerprint=f"{conn_tag}",
+        )
+        for conn_tag in clients
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "setup_params",
+    [
+        proxying_peer_parameters(
+            [ConnectionTag.DOCKER_CONE_CLIENT_1, ConnectionTag.DOCKER_CONE_CLIENT_2]
+        )
+    ],
+)
+@pytest.mark.timeout(60)
+async def test_proxying_peer_keepalive(setup_params: List[SetupParameters]) -> None:
+    # Since batching keepalives are performed on application level instead of Wireguard
+    # backend we need to ensure that proxying peers are receiving the keepalives. To test
+    # for that we can enable link detection that guarantees quick detection if there's no corresponding
+    # received traffic(WireGuard PassiveKeepalive). If batcher correctly emits pings, it
+    # should trigger link detection quite quickly.
+    async with AsyncExitStack() as exit_stack:
+        env = await setup_mesh_nodes(exit_stack, setup_params)
+
+        await asyncio.gather(*[
+            await exit_stack.enter_async_context(
+                run_async_context(
+                    client.wait_for_state_peer(
+                        node.public_key, [NodeState.CONNECTED], [PathType.RELAY]
+                    )
+                )
+            )
+            for client, node in itertools.product(env.clients, env.nodes)
+            if not client.is_node(node)
+        ])
+
+        alpha, beta = env.clients
+        await beta.stop_device()
+
+        _, beta_node = env.nodes
+
+        # 20 seconds should be enough since:
+        # * 10 seconds is for WireGuard's Passive-Keepalive
+        # * RTT is configured to be 2 seconds
+        # * no pings to validate
+        # * PersistentKeepalive configured to 5seconds
+        # Given all these it should be worst case latency until detection: 10+2+5=17
+        await asyncio.sleep(20)
+
+        link_events = alpha.get_link_state_events(beta_node.public_key)
+        assert link_events[-1] == LinkState.DOWN

--- a/nat-lab/tests/test_derp_connect.py
+++ b/nat-lab/tests/test_derp_connect.py
@@ -6,7 +6,7 @@ from contextlib import AsyncExitStack
 from copy import deepcopy
 from helpers import SetupParameters, setup_mesh_nodes
 from typing import List
-from utils.bindings import RelayState
+from utils.bindings import RelayState, FeatureBatching, default_features
 from utils.connection_util import ConnectionTag
 from utils.ping import ping
 
@@ -15,13 +15,46 @@ DERP2_IP = str(DERP_SECONDARY.ipv4)
 DERP3_IP = str(DERP_TERTIARY.ipv4)
 
 
+def generate_features(batching: bool):
+    features = default_features()
+    features.wireguard.persistent_keepalive.proxying = 10
+    features.batching = (
+        FeatureBatching(
+            # It is used for direct, stun, proxy, vpn peers so the name can be confusing.
+            # TODO: rename to a better name
+            direct_connection_threshold=5,
+            trigger_cooldown_duration=60,
+            trigger_effective_duration=10,
+        )
+        if batching
+        else None
+    )
+    return features
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "setup_params",
     [
         [
-            SetupParameters(connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1),
-            SetupParameters(connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2),
+            SetupParameters(
+                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
+                features=generate_features(batching=False),
+            ),
+            SetupParameters(
+                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2,
+                features=generate_features(batching=False),
+            ),
+        ],
+        [
+            SetupParameters(
+                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
+                features=generate_features(batching=True),
+            ),
+            SetupParameters(
+                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2,
+                features=generate_features(batching=True),
+            ),
         ],
     ],
 )
@@ -83,9 +116,32 @@ async def test_derp_reconnect_2clients(setup_params: List[SetupParameters]) -> N
     "setup_params",
     [
         [
-            SetupParameters(connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1),
-            SetupParameters(connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2),
-            SetupParameters(connection_tag=ConnectionTag.DOCKER_SYMMETRIC_CLIENT_1),
+            SetupParameters(
+                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
+                features=generate_features(batching=False),
+            ),
+            SetupParameters(
+                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2,
+                features=generate_features(batching=False),
+            ),
+            SetupParameters(
+                connection_tag=ConnectionTag.DOCKER_SYMMETRIC_CLIENT_1,
+                features=generate_features(batching=False),
+            ),
+        ],
+        [
+            SetupParameters(
+                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
+                features=generate_features(batching=True),
+            ),
+            SetupParameters(
+                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2,
+                features=generate_features(batching=True),
+            ),
+            SetupParameters(
+                connection_tag=ConnectionTag.DOCKER_SYMMETRIC_CLIENT_1,
+                features=generate_features(batching=True),
+            ),
         ],
     ],
 )
@@ -224,9 +280,32 @@ async def test_derp_reconnect_3clients(setup_params: List[SetupParameters]) -> N
     "setup_params",
     [
         [
-            SetupParameters(connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1),
-            SetupParameters(connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2),
-            SetupParameters(connection_tag=ConnectionTag.DOCKER_SYMMETRIC_CLIENT_1),
+            SetupParameters(
+                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
+                features=generate_features(batching=False),
+            ),
+            SetupParameters(
+                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2,
+                features=generate_features(batching=False),
+            ),
+            SetupParameters(
+                connection_tag=ConnectionTag.DOCKER_SYMMETRIC_CLIENT_1,
+                features=generate_features(batching=False),
+            ),
+        ],
+        [
+            SetupParameters(
+                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
+                features=generate_features(batching=True),
+            ),
+            SetupParameters(
+                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2,
+                features=generate_features(batching=True),
+            ),
+            SetupParameters(
+                connection_tag=ConnectionTag.DOCKER_SYMMETRIC_CLIENT_1,
+                features=generate_features(batching=True),
+            ),
         ],
     ],
 )
@@ -409,8 +488,24 @@ async def test_derp_restart(setup_params: List[SetupParameters]) -> None:
     "setup_params",
     [
         [
-            SetupParameters(connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1),
-            SetupParameters(connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2),
+            SetupParameters(
+                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
+                features=generate_features(batching=False),
+            ),
+            SetupParameters(
+                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2,
+                features=generate_features(batching=False),
+            ),
+        ],
+        [
+            SetupParameters(
+                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
+                features=generate_features(batching=True),
+            ),
+            SetupParameters(
+                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2,
+                features=generate_features(batching=True),
+            ),
         ],
     ],
 )

--- a/nat-lab/tests/test_derp_connect.py
+++ b/nat-lab/tests/test_derp_connect.py
@@ -6,7 +6,7 @@ from contextlib import AsyncExitStack
 from copy import deepcopy
 from helpers import SetupParameters, setup_mesh_nodes
 from typing import List
-from utils.bindings import RelayState, FeatureBatching, default_features
+from utils.bindings import RelayState
 from utils.connection_util import ConnectionTag
 from utils.ping import ping
 
@@ -15,46 +15,13 @@ DERP2_IP = str(DERP_SECONDARY.ipv4)
 DERP3_IP = str(DERP_TERTIARY.ipv4)
 
 
-def generate_features(batching: bool):
-    features = default_features()
-    features.wireguard.persistent_keepalive.proxying = 10
-    features.batching = (
-        FeatureBatching(
-            # It is used for direct, stun, proxy, vpn peers so the name can be confusing.
-            # TODO: rename to a better name
-            direct_connection_threshold=5,
-            trigger_cooldown_duration=60,
-            trigger_effective_duration=10,
-        )
-        if batching
-        else None
-    )
-    return features
-
-
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "setup_params",
     [
         [
-            SetupParameters(
-                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                features=generate_features(batching=False),
-            ),
-            SetupParameters(
-                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2,
-                features=generate_features(batching=False),
-            ),
-        ],
-        [
-            SetupParameters(
-                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                features=generate_features(batching=True),
-            ),
-            SetupParameters(
-                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2,
-                features=generate_features(batching=True),
-            ),
+            SetupParameters(connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1),
+            SetupParameters(connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2),
         ],
     ],
 )
@@ -116,32 +83,9 @@ async def test_derp_reconnect_2clients(setup_params: List[SetupParameters]) -> N
     "setup_params",
     [
         [
-            SetupParameters(
-                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                features=generate_features(batching=False),
-            ),
-            SetupParameters(
-                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2,
-                features=generate_features(batching=False),
-            ),
-            SetupParameters(
-                connection_tag=ConnectionTag.DOCKER_SYMMETRIC_CLIENT_1,
-                features=generate_features(batching=False),
-            ),
-        ],
-        [
-            SetupParameters(
-                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                features=generate_features(batching=True),
-            ),
-            SetupParameters(
-                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2,
-                features=generate_features(batching=True),
-            ),
-            SetupParameters(
-                connection_tag=ConnectionTag.DOCKER_SYMMETRIC_CLIENT_1,
-                features=generate_features(batching=True),
-            ),
+            SetupParameters(connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1),
+            SetupParameters(connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2),
+            SetupParameters(connection_tag=ConnectionTag.DOCKER_SYMMETRIC_CLIENT_1),
         ],
     ],
 )
@@ -280,32 +224,9 @@ async def test_derp_reconnect_3clients(setup_params: List[SetupParameters]) -> N
     "setup_params",
     [
         [
-            SetupParameters(
-                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                features=generate_features(batching=False),
-            ),
-            SetupParameters(
-                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2,
-                features=generate_features(batching=False),
-            ),
-            SetupParameters(
-                connection_tag=ConnectionTag.DOCKER_SYMMETRIC_CLIENT_1,
-                features=generate_features(batching=False),
-            ),
-        ],
-        [
-            SetupParameters(
-                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                features=generate_features(batching=True),
-            ),
-            SetupParameters(
-                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2,
-                features=generate_features(batching=True),
-            ),
-            SetupParameters(
-                connection_tag=ConnectionTag.DOCKER_SYMMETRIC_CLIENT_1,
-                features=generate_features(batching=True),
-            ),
+            SetupParameters(connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1),
+            SetupParameters(connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2),
+            SetupParameters(connection_tag=ConnectionTag.DOCKER_SYMMETRIC_CLIENT_1),
         ],
     ],
 )
@@ -488,24 +409,8 @@ async def test_derp_restart(setup_params: List[SetupParameters]) -> None:
     "setup_params",
     [
         [
-            SetupParameters(
-                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                features=generate_features(batching=False),
-            ),
-            SetupParameters(
-                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2,
-                features=generate_features(batching=False),
-            ),
-        ],
-        [
-            SetupParameters(
-                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                features=generate_features(batching=True),
-            ),
-            SetupParameters(
-                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2,
-                features=generate_features(batching=True),
-            ),
+            SetupParameters(connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1),
+            SetupParameters(connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2),
         ],
     ],
 )

--- a/src/device/wg_controller.rs
+++ b/src/device/wg_controller.rs
@@ -449,37 +449,36 @@ async fn consolidate_wg_peers<
                 .await?;
         }
 
-        // Check if we need to update sesion keeper
-        match (
-            session_keeper,
-            features.batching.is_some(),
-            requested_peer.batching_keepalive_interval,
-        ) {
-            (Some(sk), true, Some(interval)) => {
-                if sk.get_interval(key).await != Some(interval)
-                    || requested_peer.peer.ip_addresses != actual_peer.ip_addresses
-                {
-                    let target =
-                        build_ping_endpoint(&requested_peer.peer.ip_addresses, features.ipv6);
-                    if target.0.is_some() || target.1.is_some() {
-                        sk.add_node(
-                            *key,
-                            target,
-                            Duration::from_secs(interval as u64),
-                            batcher_threshold,
-                        )
-                        .await?;
-                    } else {
-                        telio_log_warn!("Peer {:?} has no ip address", key);
+        let is_actual_peer_proxying = is_peer_proxying(actual_peer, &proxy_endpoints);
+        let is_requested_peer_proxying = is_peer_proxying(&requested_peer.peer, &proxy_endpoints);
+
+        if let Some(sk) = session_keeper {
+            if !is_actual_peer_proxying && is_requested_peer_proxying && features.batching.is_none()
+            {
+                sk.remove_node(key).await?;
+            } else if let Some(interval) = requested_peer.batching_keepalive_interval {
+                if let Some(sk) = session_keeper {
+                    if sk.get_interval(key).await != Some(interval)
+                        || (requested_peer.peer.ip_addresses != actual_peer.ip_addresses)
+                        || (is_actual_peer_proxying != is_requested_peer_proxying)
+                    {
+                        let target =
+                            build_ping_endpoint(&requested_peer.peer.ip_addresses, features.ipv6);
+                        if target.0.is_some() || target.1.is_some() {
+                            sk.add_node(
+                                *key,
+                                target,
+                                Duration::from_secs(interval as u64),
+                                batcher_threshold,
+                            )
+                            .await?;
+                        } else {
+                            telio_log_warn!("Peer {:?} has no ip address", key);
+                        }
                     }
                 }
             }
-            (Some(_), _, _) => (),
-            (None, _, _) => telio_log_debug!("The session keeper is missing!"),
         }
-
-        let is_actual_peer_proxying = is_peer_proxying(actual_peer, &proxy_endpoints);
-        let is_reqested_peer_proxying = is_peer_proxying(&requested_peer.peer, &proxy_endpoints);
 
         let event = AnalyticsEvent {
             public_key: *key,
@@ -489,6 +488,7 @@ async fn consolidate_wg_peers<
             peer_state: actual_peer.state(),
             timestamp: Instant::now(),
         };
+
         if is_actual_peer_proxying {
             aggregator.report_peer_state_relayed(&event).await;
         } else if let Some(us) = upgrade_sync {
@@ -503,7 +503,7 @@ async fn consolidate_wg_peers<
             }
         }
 
-        if is_actual_peer_proxying && !is_reqested_peer_proxying {
+        if is_actual_peer_proxying && !is_requested_peer_proxying {
             // We have upgraded the connection. If the upgrade happened because we have
             // selected a new direct endpoint candidate -> notify the other node about our own
             // local side endpoint, such that the other node can do this upgrade too.
@@ -533,7 +533,6 @@ async fn consolidate_wg_peers<
                 .await?;
             }
 
-            // If the batcher is disabled we still have to enable session keeper for the direct connections
             if features.batching.is_none() {
                 if let Some(sk) = session_keeper {
                     let target =
@@ -1306,8 +1305,10 @@ fn peer_state(
 #[cfg(test)]
 mod tests {
     use super::*;
+
     use crate::device::{DeviceConfig, DNS};
     use mockall::predicate::{self, eq};
+    use rstest::*;
     use telio_nurse::config::AggregatorConfig;
 
     use std::net::{Ipv4Addr, Ipv6Addr, SocketAddrV4};
@@ -1933,7 +1934,8 @@ mod tests {
                             endpoint: Some(i.1),
                             endpoint_changed_at: Some(i.4),
                             persistent_keepalive_interval: Some(i.2),
-                            allowed_ips: i.3.into_iter().map(|ip| ip.into()).collect(),
+                            allowed_ips: i.3.clone().into_iter().map(|ip| ip.into()).collect(),
+                            ip_addresses: i.3.clone().into_iter().map(|ip| ip).collect(),
                             ..Default::default()
                         },
                     )
@@ -2225,8 +2227,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn when_fresh_start_then_proxy_enpoint_is_added() {
+    #[rstest]
+    #[case(true)]
+    #[case(false)]
+    async fn when_fresh_start_then_proxy_endpoint_is_added(#[case] batching: bool) {
         let mut f = Fixture::new();
+        if batching {
+            f.features.batching = Some(FeatureBatching::default());
+        }
 
         let pub_key = SecretKey::gen().public();
         let ip1 = IpAddr::from([1, 2, 3, 4]);
@@ -2250,62 +2258,38 @@ mod tests {
         f.then_add_peer(vec![(
             pub_key,
             proxy_endpoint,
-            Some(proxying_keepalive_time),
+            if batching {
+                None
+            } else {
+                Some(proxying_keepalive_time)
+            },
             allowed_ips.iter().copied().map(|ip| ip.into()).collect(),
             allowed_ips,
         )]);
+
+        if batching {
+            f.then_keeper_add_node(vec![(
+                pub_key,
+                ip1,
+                Some(ip1v6),
+                proxying_keepalive_time,
+                Some(Duration::default()),
+            )]);
+        }
 
         f.consolidate_peers().await;
     }
 
     #[tokio::test]
-    async fn when_fresh_start_and_batching_enabled_then_proxy_enpoint_is_added_with_batching() {
-        let mut f = Fixture::new();
-        f.features.batching = Some(FeatureBatching::default());
-
-        let pub_key = SecretKey::gen().public();
-        let ip1 = IpAddr::from([1, 2, 3, 4]);
-        let ip1v6 = IpAddr::from([1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4]);
-        let ip2 = IpAddr::from([5, 6, 7, 8]);
-        let ip2v6 = IpAddr::from([5, 6, 7, 8, 5, 6, 7, 8, 5, 6, 7, 8, 5, 6, 7, 8]);
-        let allowed_ips = vec![ip1, ip1v6, ip2, ip2v6];
-        let mapped_port = 18;
-        let proxy_endpoint = SocketAddr::from(([127, 0, 0, 1], mapped_port));
-
-        let proxying_keepalive_time = 1234;
-        f.requested_state.keepalive_periods.proxying = Some(proxying_keepalive_time);
-
-        f.when_requested_meshnet_config(vec![(pub_key, allowed_ips.clone())]);
-        f.when_proxy_mapping(vec![(pub_key, mapped_port)]);
-        f.when_current_peers(vec![]);
-        f.when_time_since_last_rx(vec![]);
-        f.when_cross_check_validated_endpoints(vec![]);
-        f.when_upgrade_requests(vec![]);
-
-        f.then_add_peer(vec![(
-            pub_key,
-            proxy_endpoint,
-            None, // WG keepalives should be disabled
-            allowed_ips.iter().copied().map(|ip| ip.into()).collect(),
-            allowed_ips,
-        )]);
-
-        f.then_keeper_add_node(vec![(
-            pub_key,
-            ip1,
-            Some(ip1v6),
-            proxying_keepalive_time,
-            Some(Duration::from_secs(0)),
-        )]);
-
-        f.consolidate_peers().await;
-    }
-
-    #[tokio::test]
-    async fn when_upgrade_requested_by_peer_then_upgrade_and_batching() {
+    #[rstest]
+    #[case(true)]
+    #[case(false)]
+    async fn when_upgrade_requested_by_peer_then_upgrade(#[case] batching: bool) {
         let mut f = Fixture::new();
         f.features.ipv6 = true;
-        f.features.batching = Some(Default::default());
+        if batching {
+            f.features.batching = Some(Default::default());
+        }
 
         let pub_key = SecretKey::gen().public();
         let ip1 = IpAddr::from([1, 2, 3, 4]);
@@ -2340,86 +2324,34 @@ mod tests {
         f.then_add_peer(vec![(
             pub_key,
             remote_wg_endpoint,
-            None, // The WG persistent keepalives should be disabled
+            if batching {
+                None
+            } else {
+                Some(direct_keepalive_period)
+            },
             allowed_ips.iter().copied().map(|ip| ip.into()).collect(),
             allowed_ips,
         )]);
+
         f.then_keeper_add_node(vec![(
             pub_key,
             ip1,
             Some(ip1v6),
             direct_keepalive_period,
-            Some(Duration::from_secs(0)),
+            if batching {
+                Some(Duration::default())
+            } else {
+                None
+            },
         )]);
+
         f.session_keeper
             .expect_get_interval()
             .return_const(Some(direct_keepalive_period));
+
         f.then_proxy_mute(vec![(
             pub_key,
             Some(Duration::from_secs(DEFAULT_PEER_UPGRADE_WINDOW)),
-        )]);
-
-        f.consolidate_peers().await;
-    }
-
-    #[tokio::test]
-    async fn when_upgrade_requested_by_peer_then_upgrade() {
-        let mut f = Fixture::new();
-        f.features.ipv6 = true;
-
-        let pub_key = SecretKey::gen().public();
-        let ip1 = IpAddr::from([1, 2, 3, 4]);
-        let ip1v6 = IpAddr::V6(Ipv6Addr::from([
-            1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4,
-        ]));
-        let ip2 = IpAddr::from([5, 6, 7, 8]);
-        let ip2v6 = IpAddr::V6(Ipv6Addr::from([
-            5, 6, 7, 8, 5, 6, 7, 8, 5, 6, 7, 8, 5, 6, 7, 8,
-        ]));
-        let allowed_ips = vec![ip1, ip1v6, ip2, ip2v6];
-        let remote_wg_endpoint = SocketAddr::from(([192, 168, 0, 1], 13));
-        let mapped_port = 12;
-        let proxy_endpoint = SocketAddr::from(([127, 0, 0, 1], mapped_port));
-
-        let direct_keepalive_period = 1234;
-        f.requested_state.keepalive_periods.direct = direct_keepalive_period;
-
-        let upgrade_request_at = Instant::now();
-        // Should never be so ahead, but upgrade request should always override
-        // Newer endpoint changes
-        let peer_endpoint_change_at = upgrade_request_at + Duration::from_secs(5);
-
-        f.when_requested_meshnet_config(vec![(pub_key, allowed_ips.clone())]);
-        f.when_proxy_mapping(vec![(pub_key, mapped_port)]);
-        f.when_current_peers(vec![(
-            pub_key,
-            proxy_endpoint,
-            TEST_PERSISTENT_KEEPALIVE_PERIOD,
-            allowed_ips.clone(),
-            (peer_endpoint_change_at, UpdateReason::Push),
-        )]);
-        f.when_time_since_last_rx(vec![(pub_key, 5)]);
-        f.when_cross_check_validated_endpoints(vec![]);
-        f.when_upgrade_requests(vec![(pub_key, remote_wg_endpoint, upgrade_request_at)]);
-
-        f.then_add_peer(vec![(
-            pub_key,
-            remote_wg_endpoint,
-            Some(direct_keepalive_period),
-            allowed_ips.iter().copied().map(|ip| ip.into()).collect(),
-            allowed_ips,
-        )]);
-        f.session_keeper.expect_get_interval().return_const(None);
-        f.then_proxy_mute(vec![(
-            pub_key,
-            Some(Duration::from_secs(DEFAULT_PEER_UPGRADE_WINDOW)),
-        )]);
-        f.then_keeper_add_node(vec![(
-            pub_key,
-            ip1,
-            Some(ip1v6),
-            direct_keepalive_period,
-            None,
         )]);
 
         f.consolidate_peers().await;
@@ -2681,9 +2613,18 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn when_cross_check_validated_is_old_but_set_by_telio_then_upgrade() {
+    #[rstest]
+    #[case(true)]
+    #[case(false)]
+    async fn when_cross_check_validated_is_old_but_set_by_telio_then_upgrade(
+        #[case] batching: bool,
+    ) {
         let mut f = Fixture::new();
         f.features.ipv6 = true;
+
+        if batching {
+            f.features.batching = Some(FeatureBatching::default());
+        }
 
         let pub_key = SecretKey::gen().public();
         let ip1 = IpAddr::from([1, 2, 3, 4]);
@@ -2730,7 +2671,11 @@ mod tests {
         f.then_add_peer(vec![(
             pub_key,
             remote_wg_endpoint,
-            Some(direct_keepalive_period),
+            if batching {
+                None
+            } else {
+                Some(direct_keepalive_period)
+            },
             allowed_ips.iter().copied().map(|ip| ip.into()).collect(),
             allowed_ips,
         )]);
@@ -2744,12 +2689,17 @@ mod tests {
             pub_key,
             Some(Duration::from_secs(DEFAULT_PEER_UPGRADE_WINDOW)),
         )]);
+
         f.then_keeper_add_node(vec![(
             pub_key,
             ip1,
             Some(ip1v6),
             direct_keepalive_period,
-            None,
+            if batching {
+                Some(Duration::default())
+            } else {
+                None
+            },
         )]);
 
         f.consolidate_peers().await;
@@ -2891,60 +2841,94 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn when_vpn_peer_is_added() {
+    #[rstest]
+    #[case(true)]
+    #[case(false)]
+    async fn when_proxy_endpoint_present_direct_peer_downgraded(#[case] batching: bool) {
         let mut f = Fixture::new();
+        if batching {
+            f.features.batching = Some(FeatureBatching::default());
+        }
 
-        let public_key = SecretKey::gen().public();
-        let allowed_ips = vec![
-            IpNet::new(IpAddr::from([7, 6, 5, 4]), 23).unwrap(),
-            IpNet::new(
-                IpAddr::from([5, 6, 7, 8, 5, 6, 7, 8, 5, 6, 7, 8, 5, 6, 7, 8]),
-                128,
-            )
-            .unwrap(),
-        ];
-        let ip_addresses = vec![
-            VPN_INTERNAL_IPV4.into(),
-            VPN_INTERNAL_IPV6.into(),
-            VPN_EXTERNAL_IPV4.into(),
-        ];
+        let pub_key = SecretKey::gen().public();
+        let allowed_ips = vec![IpAddr::from([1, 2, 3, 4])];
 
-        let endpoint_raw = SocketAddr::from(([192, 168, 0, 1], 13));
-        let endpoint = Some(endpoint_raw);
+        let _remote_wg_endpoint = SocketAddr::from(([192, 168, 0, 1], 13));
+        let mapped_port = 12;
+        let proxy_endpoint = SocketAddr::from(([127, 0, 0, 1], mapped_port));
+        let local_endpoint = SocketAddr::from(([192, 168, 0, 1], 13));
+        let proxying_keepalive_period = 5;
 
-        let vpn_persistent_keepalive = 4321;
-        f.requested_state.keepalive_periods.vpn = Some(vpn_persistent_keepalive);
-        f.requested_state.exit_node = Some(ExitNode {
-            identifier: "".to_owned(),
-            public_key,
-            allowed_ips: Some(allowed_ips.clone()),
-            endpoint,
-        });
-        f.features.ipv6 = true;
+        f.requested_state.keepalive_periods.proxying = Some(proxying_keepalive_period);
+        f.requested_state.keepalive_periods.direct = 5;
 
-        f.when_requested_meshnet_config(vec![]);
-        f.when_proxy_mapping(vec![]);
-        f.when_current_peers(vec![]);
-        f.when_time_since_last_rx(vec![]);
+        f.when_requested_meshnet_config(vec![(pub_key, allowed_ips.clone())]);
+        f.when_proxy_mapping(vec![(pub_key, mapped_port)]);
+        f.when_current_peers(vec![(
+            pub_key,
+            local_endpoint,
+            TEST_DIRECT_PERSISTENT_KEEPALIVE_PERIOD,
+            allowed_ips.clone(),
+            (
+                Instant::now() - Duration::from_secs(DEFAULT_PEER_UPGRADE_WINDOW),
+                UpdateReason::Pull,
+            ),
+        )]);
+
         f.when_cross_check_validated_endpoints(vec![]);
+
+        f.upgrade_sync
+            .expect_get_accepted_session()
+            .once()
+            .with(eq(pub_key))
+            .return_once(|_| None);
+
+        f.when_time_since_last_rx(vec![(pub_key, 16)]);
+
         f.when_upgrade_requests(vec![]);
 
         f.then_add_peer(vec![(
-            public_key,
-            endpoint_raw,
-            Some(vpn_persistent_keepalive),
-            allowed_ips,
-            ip_addresses,
+            pub_key,
+            proxy_endpoint,
+            if batching {
+                None
+            } else {
+                Some(proxying_keepalive_period)
+            },
+            allowed_ips.iter().copied().map(|ip| ip.into()).collect(),
+            allowed_ips.clone(),
         )]);
-        f.then_post_quantum_is_checked();
+
+        if batching {
+            f.session_keeper
+                .expect_get_interval()
+                .once()
+                .with(eq(pub_key))
+                .return_const(Some(proxying_keepalive_period));
+
+            f.then_keeper_add_node(vec![(
+                pub_key,
+                allowed_ips[0],
+                None,
+                proxying_keepalive_period,
+                Some(Duration::from_secs(0)),
+            )]);
+        } else {
+            f.then_keeper_del_node(vec![(pub_key)]);
+        }
 
         f.consolidate_peers().await;
     }
 
     #[tokio::test]
-    async fn when_vpn_peer_is_added_with_batching() {
+    #[rstest]
+    #[case(true)]
+    #[case(false)]
+    async fn when_vpn_peer_is_added(#[case] batching: bool) {
         let mut f = Fixture::new();
-        f.features.batching = Some(FeatureBatching::default());
+        if batching {
+            f.features.batching = Some(FeatureBatching::default());
+        }
 
         let public_key = SecretKey::gen().public();
         let allowed_ips = vec![
@@ -2984,19 +2968,26 @@ mod tests {
         f.then_add_peer(vec![(
             public_key,
             endpoint_raw,
-            None, // WG keepalives should be disabled
+            if batching {
+                None
+            } else {
+                Some(vpn_persistent_keepalive)
+            },
             allowed_ips,
             ip_addresses,
         )]);
+
         f.then_post_quantum_is_checked();
 
-        f.then_keeper_add_node(vec![(
-            public_key,
-            IpAddr::from(VPN_INTERNAL_IPV4),
-            Some(IpAddr::from(VPN_INTERNAL_IPV6)),
-            vpn_persistent_keepalive,
-            Some(Duration::from_secs(0)),
-        )]);
+        if batching {
+            f.then_keeper_add_node(vec![(
+                public_key,
+                IpAddr::from(VPN_INTERNAL_IPV4),
+                Some(IpAddr::from(VPN_INTERNAL_IPV6)),
+                vpn_persistent_keepalive,
+                Some(Duration::from_secs(0)),
+            )]);
+        }
 
         f.consolidate_peers().await;
     }
@@ -3086,9 +3077,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn when_stun_peer_is_added_with_batching() {
+    #[rstest]
+    #[case(true)]
+    #[case(false)]
+    async fn when_stun_peer_is_added(#[case] batching: bool) {
         let mut f = Fixture::new();
-        f.features.batching = Some(FeatureBatching::default());
+        if batching {
+            f.features.batching = Some(FeatureBatching::default());
+        }
 
         let public_key = SecretKey::gen().public();
 
@@ -3125,18 +3121,24 @@ mod tests {
         f.then_add_peer(vec![(
             public_key,
             endpoint_raw,
-            None, // WG keepalives should be disabled
+            if batching {
+                None
+            } else {
+                Some(stun_persistent_keepalive)
+            },
             allowed_ips,
             ip_addresses,
         )]);
 
-        f.then_keeper_add_node(vec![(
-            public_key,
-            IpAddr::from([100, 64, 0, 4]),
-            Some(IpAddr::from([0xfd74, 0x656c, 0x696f, 0, 0, 0, 0, 4])),
-            stun_persistent_keepalive,
-            Some(Duration::from_secs(0)),
-        )]);
+        if batching {
+            f.then_keeper_add_node(vec![(
+                public_key,
+                IpAddr::from([100, 64, 0, 4]),
+                Some(IpAddr::from([0xfd74, 0x656c, 0x696f, 0, 0, 0, 0, 4])),
+                stun_persistent_keepalive,
+                Some(Duration::from_secs(0)),
+            )]);
+        }
 
         f.consolidate_peers().await;
     }

--- a/src/device/wg_controller.rs
+++ b/src/device/wg_controller.rs
@@ -1935,7 +1935,7 @@ mod tests {
                             endpoint_changed_at: Some(i.4),
                             persistent_keepalive_interval: Some(i.2),
                             allowed_ips: i.3.clone().into_iter().map(|ip| ip.into()).collect(),
-                            ip_addresses: i.3.clone().into_iter().map(|ip| ip).collect(),
+                            ip_addresses: i.3.clone().into_iter().collect(),
                             ..Default::default()
                         },
                     )


### PR DESCRIPTION
Batching relies on Sessionkeeper(is baked into it) which is not present when direct feature is disabled or if SessionKeeper::start fails.

This breaks cases where batching is enabled but direct feature is not for VPN reestablishment for example(added testcases fail on `main`). This is a limitation of the decision to keep SessionKeeper instead of introducing a separate entity for batching.

The fix is to override the batching feature when either SessionKeeper or Direct are None which is done here.

However I did an extra step and moved SessionKeeper outside the Direct entities as I think it doesn't belong there anymore due to being repurposed for more stuff(vpn, proxy, stun keepalives when batching, derp keepalives in progress). This moving out provided very minimal changes, though the diff looks huge.

Please see individual commits for more details

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
