### PR TITLE
fix: Readd unset moose dependencies

### DIFF
--- a/ci/build_libtelio.py
+++ b/ci/build_libtelio.py
@@ -504,6 +504,8 @@ def exec_build(args):
             moose_utils.fetch_moose_dependencies(args.os, MOOSE_MAP[args.arch])
 
         moose_utils.set_cargo_dependencies()
+    else:
+        moose_utils.unset_cargo_dependencies()
 
     if args.os == "windows":
         if args.msvc:


### PR DESCRIPTION
### Problem
On https://github.com/NordSecurity/libtelio/pull/981 `unset_cargo_dependencies()` function was mistakenly removed.

### Solution
Readd it back so that when building without `--moose` flag, moose dependencies get removed.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
