### PR TITLE
Revert "Overwrite SessionKeeper entry on Proxy->Direct upgrade"

### DIFF
--- a/crates/telio-traversal/src/session_keeper.rs
+++ b/crates/telio-traversal/src/session_keeper.rs
@@ -196,8 +196,6 @@ impl SessionKeeperTrait for SessionKeeper {
         interval: Duration,
         threshold: Option<Duration>,
     ) -> Result<()> {
-        telio_log_debug!("Add {}", public_key);
-
         let dual_target = DualTarget::new(target).map_err(Error::DualTargetError)?;
         match threshold {
             Some(t) => task_exec!(&self.task, async move |s| {

--- a/src/device/wg_controller.rs
+++ b/src/device/wg_controller.rs
@@ -513,23 +513,28 @@ async fn consolidate_wg_peers<
                 .await?;
             }
 
-            if let Some(sk) = session_keeper {
-                let target = build_ping_endpoint(&requested_peer.peer.ip_addresses, features.ipv6);
-
-                if target.0.is_some() || target.1.is_some() {
-                    sk.add_node(
-                        requested_peer.peer.public_key,
-                        target,
-                        Duration::from_secs(
-                            requested_peer
-                                .peer
-                                .persistent_keepalive_interval
-                                .unwrap_or(requested_state.keepalive_periods.direct)
-                                .into(),
-                        ),
-                        batcher_threshold,
-                    )
-                    .await?;
+            // If the batcher is disabled we still have to enable session keeper for the direct connections
+            if features.batching.is_none() {
+                if let Some(sk) = session_keeper {
+                    let target =
+                        build_ping_endpoint(&requested_peer.peer.ip_addresses, features.ipv6);
+                    if target.0.is_some() || target.1.is_some() {
+                        sk.add_node(
+                            requested_peer.peer.public_key,
+                            target,
+                            Duration::from_secs(
+                                requested_peer
+                                    .peer
+                                    .persistent_keepalive_interval
+                                    .unwrap_or(requested_state.keepalive_periods.direct)
+                                    .into(),
+                            ),
+                            None,
+                        )
+                        .await?;
+                    } else {
+                        telio_log_warn!("Peer {:?} has no ip address", key);
+                    }
                 }
             }
         }
@@ -2225,33 +2230,13 @@ mod tests {
             allowed_ips.iter().copied().map(|ip| ip.into()).collect(),
             allowed_ips,
         )]);
-
-        let default_batcher_threshold = Duration::from_secs(
-            f.features
-                .batching
-                .unwrap()
-                .direct_connection_threshold
-                .into(),
-        );
-
-        // first for proxied
         f.then_keeper_add_node(vec![(
             pub_key,
             ip1,
             Some(ip1v6),
             direct_keepalive_period,
-            Some(default_batcher_threshold),
+            Some(Duration::from_secs(0)),
         )]);
-
-        // second for direct(should be triggered immediately)
-        f.then_keeper_add_node(vec![(
-            pub_key,
-            ip1,
-            Some(ip1v6),
-            direct_keepalive_period,
-            Some(default_batcher_threshold),
-        )]);
-
         f.session_keeper
             .expect_get_interval()
             .return_const(Some(direct_keepalive_period));


### PR DESCRIPTION
Reverts NordSecurity/libtelio#992

The fix was incomplete: it rather rewrote entries in SessionKeeper no matter what when iterating through `update_keys` so it fixed the alignment issue when upgrading from Proxying to Direct, however now will excessively overwrite those. Need a better solution

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
