### PR TITLE
Print backtrace on panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4874,6 +4874,7 @@ dependencies = [
 name = "telio-utils"
 version = "0.1.0"
 dependencies = [
+ "backtrace",
  "blake3",
  "futures",
  "hashlink",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -208,7 +208,6 @@ debug = "full"
 [profile.dev]
 debug = 0
 strip = "debuginfo"
-overflow-checks = false
 
 #TODO: remove this when anyone starts using telio-starcast
 [workspace.metadata.cargo-udeps.ignore]

--- a/crates/telio-utils/Cargo.toml
+++ b/crates/telio-utils/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 sn_fake_clock = ["dep:sn_fake_clock"]
 
 [dependencies]
+backtrace = "0.3.74"
 blake3 = "1.5.4"
 futures.workspace = true
 hashlink.workspace = true

--- a/crates/telio-utils/src/backtrace.rs
+++ b/crates/telio-utils/src/backtrace.rs
@@ -1,0 +1,31 @@
+use crate::telio_log_debug;
+use backtrace;
+
+/// Print to debug log current backtrace
+pub fn log_current_backtrace() {
+    let mut counter = 0;
+    backtrace::trace(|frame| {
+        let ip = frame.ip();
+        let symbol_address = frame.symbol_address();
+
+        // Resolve this instruction pointer to a symbol name
+        backtrace::resolve_frame(frame, |symbol| {
+            let name = symbol
+                .name()
+                .map(|symbol| symbol.to_string())
+                .unwrap_or_else(|| format!("{symbol_address:?}"));
+
+            let filename = symbol
+                .filename()
+                .map(|filename| filename.to_string_lossy().into_owned())
+                .unwrap_or_else(|| "uknown.file".to_owned());
+
+            let lineno = symbol.lineno().unwrap_or(0);
+
+            telio_log_debug!("backtrace: {counter:3} {ip:?} {filename}:{lineno} {name}");
+            counter += 1;
+        });
+
+        true
+    });
+}

--- a/crates/telio-utils/src/lib.rs
+++ b/crates/telio-utils/src/lib.rs
@@ -59,3 +59,6 @@ pub mod const_ipnet;
 
 /// Log censoring via postprocessing utilities
 pub mod log_censor;
+
+/// Utilities for working with backtraces/stacktraces/callstacks
+pub mod backtrace;

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -33,7 +33,8 @@ use nat_detect::NatType;
 
 // debug tools
 use telio_utils::{
-    commit_sha, telio_log_debug, telio_log_error, telio_log_info, telio_log_warn, version_tag,
+    backtrace::log_current_backtrace, commit_sha, telio_log_debug, telio_log_error, telio_log_info,
+    telio_log_warn, version_tag,
 };
 
 const DEFAULT_PANIC_MSG: &str = "libtelio panicked";
@@ -211,7 +212,9 @@ impl Telio {
             let events = panic_event_dispatcher;
             panic::set_hook(Box::new(move |info| {
                 // We need it on the logs as well ...
-                error!("{}", info);
+                telio_log_error!("{}", info);
+
+                log_current_backtrace();
 
                 let err = {
                     let message = {


### PR DESCRIPTION
### Problem
Only the inner most backtrace frame is printed when we handle panic

### Solution
Print whole backtrace (on debug level) when panic happens. Also re-enable integer overflow checks in debug builds.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
