### PR TITLE
[LLT-5834] Add direct connections to teliod features

### DIFF
--- a/clis/teliod/src/daemon.rs
+++ b/clis/teliod/src/daemon.rs
@@ -6,7 +6,8 @@ use std::{fs, net::IpAddr, sync::Arc};
 use telio::{
     crypto::SecretKey,
     device::{Device, DeviceConfig, Error as DeviceError},
-    telio_model::{config::Config as MeshMap, features::Features},
+    ffi::defaults_builder::FeaturesDefaultsBuilder,
+    telio_model::config::Config as MeshMap,
     telio_utils::select,
     telio_wg::AdapterType,
 };
@@ -51,8 +52,14 @@ fn telio_task(
     interface_config: &InterfaceConfig,
 ) -> Result<(), TeliodError> {
     debug!("Initializing telio device");
+
+    // Create default features with direct connections enabled
+    let features = Arc::new(FeaturesDefaultsBuilder::new())
+        .enable_direct()
+        .build();
+
     let mut telio = Device::new(
-        Features::default(),
+        features,
         // TODO: replace this with some real event handling
         move |event| info!("Incoming event: {:?}", event),
         None,


### PR DESCRIPTION
### Problem
`teliod` does not specify direct connections.

### Solution
Adds a helper function that creates default Features and enables direct connections.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
