### PR TITLE
Automate day to day rust development tasks with Just(file)

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -28,30 +28,26 @@ jobs:
       runs-on: ubuntu-22.04
       steps:
         - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
-        - uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.6
+        - uses: extractions/setup-just@dd310ad5a97d8e7b41793f8ef055398d51ad4de6 # v2.0.0
           with:
-            components: clippy
-        - uses: actions-rs/cargo@ae10961054e4aa8b4aa7dffede299aaf087aa33b # v1.0.3
-          with:
-            command: clippy
-            args: --target "x86_64-unknown-linux-gnu" --lib --color always -- --deny warnings --allow unknown-lints -W clippy::expect_used -W clippy::panic -W clippy::unwrap_used
+            just-version: 1.37.0
+        - run: just clippy
   clippy-win:
       runs-on: windows-2022
       steps:
         - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
-        - uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.6
+        - uses: extractions/setup-just@dd310ad5a97d8e7b41793f8ef055398d51ad4de6 # v2.0.0
           with:
-            target: x86_64-pc-windows-gnu
-            components: clippy
-        - uses: actions-rs/cargo@ae10961054e4aa8b4aa7dffede299aaf087aa33b # v1.0.3
-          with:
-            command: clippy
-            args: --target "x86_64-pc-windows-gnu" --lib --color always -- --deny warnings --allow unknown-lints -W clippy::expect_used -W clippy::panic -W clippy::unwrap_used
+            just-version: 1.37.0
+        - run: just clippy
   clippy-mac:
       runs-on: macos-13
       steps:
         - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
-        - run: cargo clippy --verbose --target "x86_64-apple-darwin" --lib --color always -- --deny warnings --allow unknown-lints -W clippy::expect_used -W clippy::panic -W clippy::unwrap_used
+        - uses: extractions/setup-just@dd310ad5a97d8e7b41793f8ef055398d51ad4de6 # v2.0.0
+          with:
+            just-version: 1.37.0
+        - run: just clippy
   clippy-teliod:
       runs-on: ubuntu-22.04
       steps:
@@ -62,21 +58,18 @@ jobs:
       runs-on: ubuntu-22.04
       steps:
         - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
-        - uses: EmbarkStudios/cargo-deny-action@3f4a782664881cf5725d0ffd23969fcce89fd868 # v1.6.3
+        - uses: extractions/setup-just@dd310ad5a97d8e7b41793f8ef055398d51ad4de6 # v2.0.0
           with:
-            rust-version: 1.77.2 # NOTE: Runs in its own docker container and doesn't support toolchain files
+            just-version: 1.37.0
+        - run: just deny
   udeps:
       runs-on: ubuntu-22.04
       steps:
         - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
-        - uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.6
+        - uses: extractions/setup-just@dd310ad5a97d8e7b41793f8ef055398d51ad4de6 # v2.0.0
           with:
-            toolchain: nightly-2024-05-10
-            override: true
-        - uses: aig787/cargo-udeps-action@1cd634a329e14ccfbccfe7c96497d14dac24a743 # v1
-          with:
-            version: 'v0.1.47'
-            args: '--workspace --locked --output human --backend depinfo'
+            just-version: 1.37.0
+        - run: just udeps
   rustfmt:
       runs-on: ubuntu-22.04
       steps:
@@ -152,25 +145,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-      - uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.6
+      - uses: extractions/setup-just@dd310ad5a97d8e7b41793f8ef055398d51ad4de6 # v2.0.0
         with:
-          toolchain: 1.80.0
-          override: true
-          default: true
-      - name: Install cargo-unusued-features
-        run: cargo install --version 0.2.0 cargo-unused-features --locked
-      - name: Run cargo-unused-features
-        run: |
-          for dir in ./crates/* ./clis/*; do
-            pushd "$dir"
-            unused-features analyze -l debug
-            unused-features prune -l debug
-            popd
-          done
-      - name: Check results
-        run: |
-          git restore Cargo.lock
-          if ! git diff --quiet; then
-            git diff
-            exit 1
-          fi
+          just-version: 1.37.0
+      - run: just deny

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ gamma-events.db
 nat-lab/**/report.html
 events-moose.log
 qnap/**/teliod
+report.json

--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,56 @@
+set shell := ["sh", "-c"]
+[private]
+alias t := test
+[private]
+alias c := clippy
+[private]
+alias u := udeps
+[private]
+alias un := unused
+[private]
+alias d := deny
+[private]
+alias p := prepush
+nightly := "nightly-2024-04-23"
+
+# Run all rust tests
+test:
+    cargo test --all --quiet
+
+# Run clippy
+clippy:
+    cargo clippy --lib -- --deny warnings --allow unknown-lints -W clippy::expect_used -W clippy::panic -W clippy::unwrap_used
+
+# Run udeps
+udeps: _udeps-install
+    cargo +{{ nightly }} udeps --workspace --locked --output human --backend depinfo
+
+# Run unused features
+unused: _unused-install
+    #!/usr/bin/env bash
+    set -euxo pipefail
+    for dir in ./crates/* ./clis/*; do
+        pushd "$dir"
+        unused-features analyze -l debug
+        unused-features prune -l debug
+        popd
+    done
+
+# Run deny
+deny: _deny-install
+    cargo deny check
+
+# Run rust pre-push checks
+prepush: test clippy udeps unused deny
+
+_udeps-install: _nightly-install
+    cargo +{{ nightly }} install cargo-udeps@0.1.47 --locked
+
+_unused-install:
+    cargo install --version 0.2.0 cargo-unused-features --locked
+
+_deny-install:
+    cargo install --locked cargo-deny@0.15.1
+
+_nightly-install:
+    rustup toolchain add {{ nightly }}

--- a/Justfile
+++ b/Justfile
@@ -1,4 +1,8 @@
 set shell := ["sh", "-c"]
+
+# Aliases to be used only in interactive mode, please use full names when calling
+# just in scripts or gitlab jobs.
+
 [private]
 alias t := test
 [private]
@@ -11,7 +15,9 @@ alias un := unused
 alias d := deny
 [private]
 alias p := prepush
+
 nightly := "nightly-2024-04-23"
+rust1_80 := "1.80.0"
 
 # Run all rust tests
 test:
@@ -35,6 +41,11 @@ unused: _unused-install
         unused-features prune -l debug
         popd
     done
+    git restore Cargo.lock
+    if ! git diff --quiet; then
+        git diff
+        exit 1
+    fi
 
 # Run deny
 deny: _deny-install
@@ -46,11 +57,14 @@ prepush: test clippy udeps unused deny
 _udeps-install: _nightly-install
     cargo +{{ nightly }} install cargo-udeps@0.1.47 --locked
 
-_unused-install:
-    cargo install --version 0.2.0 cargo-unused-features --locked
+_unused-install: _rust1_80-install
+    cargo +{{ rust1_80 }} install --version 0.2.0 cargo-unused-features --locked
 
 _deny-install:
     cargo install --locked cargo-deny@0.15.1
 
 _nightly-install:
     rustup toolchain add {{ nightly }}
+
+_rust1_80-install:
+    rustup toolchain add {{ rust1_80}}


### PR DESCRIPTION
### Problem
There are many shorter and longer commands that we (sometimes) want to also run locally. Most of them are long enough that I don't remember them and have to pull them out of shell history or even worse from CI config.

### Solution
Use [just](https://just.systems/) to automate this. `Just` is a recent rewrite/replacement for make. You can run it like that:

```
$ just # will run the default 'test' / 'cargo test...' command
$ just clippy # will run the clippy target
$ just d # will run the 'deny' target' (cargo deny check) using the 'd' alias
```

Second commits replaces our CI jobs which started those various commands directly, with `just` invocations so that we can easily keep them in sync with what we run locally.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
