### PR TITLE
fix natlab parity when setting ephemeral ports

### DIFF
--- a/nat-lab/tests/conftest.py
+++ b/nat-lab/tests/conftest.py
@@ -74,6 +74,10 @@ async def os_ephemeral_ports(vm_tag):
 
     start_port = random.randint(5000, 55000)
     num_ports = random.randint(2000, 5000)
+
+    if start_port % 2 == num_ports % 2 or start_port == num_ports:
+        num_ports += 1
+
     print(
         datetime.now(),
         f"Setting up ports for {vm_tag}: start={start_port}, num={num_ports}",


### PR DESCRIPTION
### Problem
 ip_local_port_range: prefer different parity for start/end values.

### Solution
make port range even number


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
