### PR TITLE
LLT-5866: Remove app_user_uid from the config.

### DIFF
--- a/clis/teliod/example_teliod_config.json
+++ b/clis/teliod/example_teliod_config.json
@@ -2,7 +2,6 @@
     "log_level": "trace",
     "log_file_path": "example_log_file.log",
     "authentication_token": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-    "app_user_uid": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
     "interface": {
       "name": "utun10",
       "config_provider": "manual"

--- a/clis/teliod/src/daemon.rs
+++ b/clis/teliod/src/daemon.rs
@@ -194,8 +194,6 @@ pub async fn daemon_event_loop(config: TeliodDaemonConfig) -> Result<(), TeliodE
 
     let socket = DaemonSocket::new(&DaemonSocket::get_ipc_socket_path()?)?;
 
-    let nc = NotificationCenter::new(&config).await?;
-
     // Tx is unused here, but this channel can be used to communicate with the
     // telio task
     let (tx, rx) = mpsc::channel(10);
@@ -207,8 +205,11 @@ pub async fn daemon_event_loop(config: TeliodDaemonConfig) -> Result<(), TeliodE
     // are dummy and program will not run as it expects real tokens.
     let mut identity = DeviceIdentity::default();
     if !config.authentication_token.eq(EMPTY_TOKEN) {
-        identity = init_with_api(&config.authentication_token, &config.interface.name).await?;
+        identity = init_with_api(&config.authentication_token).await?;
     }
+
+    let nc = NotificationCenter::new(&config, &identity.hw_identifier).await?;
+
     let tx_clone = tx.clone();
 
     let token_ptr = Arc::new(config.authentication_token);

--- a/clis/teliod/src/nc.rs
+++ b/clis/teliod/src/nc.rs
@@ -86,12 +86,15 @@ struct NCConfig {
 }
 
 impl NotificationCenter {
-    pub async fn new(config: &super::TeliodDaemonConfig) -> Result<Self, Error> {
+    pub async fn new(
+        config: &super::TeliodDaemonConfig,
+        app_user_uid: &Uuid,
+    ) -> Result<Self, Error> {
         let callbacks = Arc::new(Mutex::new(vec![]));
 
         let nc_config = NCConfig {
             authentication_token: config.authentication_token.clone(),
-            app_user_uid: config.app_user_uid,
+            app_user_uid: *app_user_uid,
             callbacks: callbacks.clone(),
 
             http_certificate_file_path: config.http_certificate_file_path.clone(),

--- a/nat-lab/data/teliod/config.json
+++ b/nat-lab/data/teliod/config.json
@@ -2,7 +2,6 @@
     "log_level": "trace",
     "log_file_path": "teliod_natlab.log",
     "authentication_token": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-    "app_user_uid": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
     "interface": {
       "name": "teliod",
       "config_provider": "manual"


### PR DESCRIPTION
### Problem
Currently `app_user_id` used for notification center is part of the user provided config for teliod. It shouldn’t be user configurable, we can reuse the the meshnet `hardware_id` for it instead which should be generated when the device is registered.

### Solution
Remove `app_user_uid` from the user config.
Use a randomly generated UUID instead of the public key for `hw_identifier`.
Use the `hw_identifier` as `app_user_uid` in notification center.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
