### PR TITLE
Revert to old signature in firewall

### DIFF
--- a/crates/telio-model/src/features.rs
+++ b/crates/telio-model/src/features.rs
@@ -356,7 +356,7 @@ pub struct FeatureFirewall {
     pub boringtun_reset_conns: bool,
     /// Customizable private IP range to treat certain private IP ranges
     /// as public IPs for testing purposes.
-    pub custom_private_ip_range: Option<Ipv4Net>,
+    pub exclude_private_ip_range: Option<Ipv4Net>,
 }
 
 /// Turns on post quantum VPN tunnel
@@ -545,7 +545,7 @@ mod tests {
             "firewall": {
                 "neptun_reset_conns": true,
                 "boringtun_reset_conns": true,
-                "custom_private_ip_range": null
+                "exclude_private_ip_range": null
             },
             "flush_events_on_stop_timeout_seconds": 15,
             "post_quantum_vpn": {
@@ -635,7 +635,7 @@ mod tests {
                     firewall: FeatureFirewall {
                         neptun_reset_conns: true,
                         boringtun_reset_conns: true,
-                        custom_private_ip_range: None,
+                        exclude_private_ip_range: None,
                     },
                     flush_events_on_stop_timeout_seconds: Some(15),
                     post_quantum_vpn: FeaturePostQuantumVPN {

--- a/nat-lab/tests/test_dns_through_exit.py
+++ b/nat-lab/tests/test_dns_through_exit.py
@@ -96,7 +96,7 @@ from utils.router import IPStack
                     ConnectionTag.DOCKER_CONE_CLIENT_2,
                     derp_1_limits=(1, 1),
                 ),
-                features=default_features(enable_firewall=("10.0.0.0/8", False)),
+                features=default_features(enable_firewall_exclusion_range="10.0.0.0/8"),
             )
         )
     ],

--- a/nat-lab/tests/test_events.py
+++ b/nat-lab/tests/test_events.py
@@ -436,7 +436,7 @@ async def test_event_content_vpn_connection(
                     derp_1_limits=(1, 1),
                     stun_limits=(1, 2),
                 ),
-                features=default_features(enable_firewall=("10.0.0.0/8", False)),
+                features=default_features(enable_firewall_exclusion_range="10.0.0.0/8"),
             )
         )
     ],

--- a/nat-lab/tests/test_features_builder.py
+++ b/nat-lab/tests/test_features_builder.py
@@ -23,13 +23,14 @@ def test_telio_features_builder_empty():
 
 
 def test_telio_features_builder_firewall():
-    built = FeaturesDefaultsBuilder().enable_firewall("1.2.3.4/10", False).build()
+    built = FeaturesDefaultsBuilder().build()
+    built.firewall.exclude_private_ip_range = "1.2.3.4/10"
     json = """
     {
         "lana": null,
         "nurse": null,
         "firewall": {
-            "custom_private_ip_range": "1.2.3.4/10",
+            "exclude_private_ip_range": "1.2.3.4/10",
             "neptun_reset_conns": false
         },
         "direct": null,

--- a/nat-lab/tests/test_lana.py
+++ b/nat-lab/tests/test_lana.py
@@ -128,13 +128,13 @@ IP_STACK_TEST_CONFIGS = [
 def build_telio_features(
     initial_heartbeat_interval: int = 300,
     rtt_interval: int = RTT_INTERVAL,
-    custom_ip_range: str = "",
+    exclude_ip_range_check: Optional[str] = None,
 ) -> Features:
     features = default_features(
         enable_lana=(CONTAINER_EVENT_PATH, False),
         enable_direct=True,
         enable_nurse=True,
-        enable_firewall=(custom_ip_range, False),
+        enable_firewall_exclusion_range=exclude_ip_range_check,
     )
     assert features.direct
     features.direct.providers = [EndpointProvider.STUN]
@@ -1327,8 +1327,8 @@ async def test_lana_with_meshnet_exit_node(
             beta,
             connection_alpha,
             connection_beta,
-            build_telio_features(custom_ip_range="10.0.0.0/8"),
-            build_telio_features(custom_ip_range="10.0.0.0/8"),
+            build_telio_features(exclude_ip_range_check="10.0.0.0/8"),
+            build_telio_features(exclude_ip_range_check="10.0.0.0/8"),
         )
 
         await asyncio.gather(

--- a/nat-lab/tests/test_mesh_exit_through_peer.py
+++ b/nat-lab/tests/test_mesh_exit_through_peer.py
@@ -112,7 +112,7 @@ from utils.router import IPProto, IPStack
                     derp_1_limits=(1, 1),
                     stun_limits=(1, 2),
                 ),
-                features=default_features(enable_firewall=("10.0.0.0/8", False)),
+                features=default_features(enable_firewall_exclusion_range="10.0.0.0/8"),
             )
         )
     ],

--- a/nat-lab/tests/test_mesh_firewall.py
+++ b/nat-lab/tests/test_mesh_firewall.py
@@ -41,7 +41,7 @@ def _setup_params(
     adapter_type_override: Optional[TelioAdapterType] = None,
     stun_limits=(0, 0),
     features: Features = default_features(
-        enable_firewall=("10.0.0.0/8", False),
+        enable_firewall_exclusion_range="10.0.0.0/8",
     ),
 ) -> SetupParameters:
     return SetupParameters(
@@ -263,12 +263,16 @@ async def test_blocking_incoming_connections_from_exit_node() -> None:
                     ConnectionTag.DOCKER_CONE_CLIENT_1,
                     TelioAdapterType.NEP_TUN,
                     stun_limits=(1, 1),
-                    features=default_features(enable_firewall=("10.0.0.0/8", False)),
+                    features=default_features(
+                        enable_firewall_exclusion_range="10.0.0.0/8"
+                    ),
                 ),
                 _setup_params(
                     ConnectionTag.DOCKER_CONE_CLIENT_2,
                     stun_limits=(1, 5),
-                    features=default_features(enable_firewall=("10.0.0.0/8", False)),
+                    features=default_features(
+                        enable_firewall_exclusion_range="10.0.0.0/8"
+                    ),
                 ),
             ],
         )

--- a/nat-lab/tests/test_vpn.py
+++ b/nat-lab/tests/test_vpn.py
@@ -335,7 +335,10 @@ async def test_vpn_reconnect(
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
                 adapter_type_override=TelioAdapterType.NEP_TUN,
                 ip_stack=IPStack.IPv4,
-                features=default_features(enable_firewall=("10.0.0.0/8", True)),
+                features=default_features(
+                    enable_firewall_connection_reset=True,
+                    enable_firewall_exclusion_range="10.0.0.0/8",
+                ),
             )
         ),
         # TODO(msz): IPv6 public server, it doesn't work with the current VPN implementation
@@ -447,7 +450,10 @@ async def test_kill_external_tcp_conn_on_vpn_reconnect(
                 connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
                 adapter_type_override=TelioAdapterType.NEP_TUN,
                 ip_stack=IPStack.IPv4,
-                features=default_features(enable_firewall=("10.0.0.0/8", True)),
+                features=default_features(
+                    enable_firewall_connection_reset=True,
+                    enable_firewall_exclusion_range="10.0.0.0/8",
+                ),
             )
         ),
         pytest.param(
@@ -455,7 +461,10 @@ async def test_kill_external_tcp_conn_on_vpn_reconnect(
                 connection_tag=ConnectionTag.MAC_VM,
                 adapter_type_override=TelioAdapterType.NEP_TUN,
                 ip_stack=IPStack.IPv4,
-                features=default_features(enable_firewall=("10.0.0.0/8", True)),
+                features=default_features(
+                    enable_firewall_connection_reset=True,
+                    enable_firewall_exclusion_range="10.0.0.0/8",
+                ),
             ),
             marks=pytest.mark.mac,
         ),

--- a/nat-lab/tests/utils/bindings.py
+++ b/nat-lab/tests/utils/bindings.py
@@ -15,7 +15,8 @@ def features_with_endpoint_providers(
 def default_features(
     enable_lana: Optional[Tuple[str, bool]] = None,
     enable_nurse: bool = False,
-    enable_firewall: Optional[Tuple[str, bool]] = None,
+    enable_firewall_connection_reset: bool = False,
+    enable_firewall_exclusion_range: Optional[str] = None,
     enable_direct: bool = False,
     enable_ipv6: bool = False,
     enable_nicknames: bool = False,
@@ -30,9 +31,8 @@ def default_features(
 
     if enable_nurse:
         features_builder = features_builder.enable_nurse()
-    if enable_firewall is not None:
-        ips, reset_conns = enable_firewall
-        features_builder = features_builder.enable_firewall(ips, reset_conns)
+    if enable_firewall_connection_reset:
+        features_builder = features_builder.enable_firewall_connection_reset()
     if enable_direct:
         features_builder = features_builder.enable_direct()
     if enable_ipv6:
@@ -50,6 +50,8 @@ def default_features(
     features.is_test_env = True
     features.hide_user_data = False
     features.dns.exit_dns = FeatureExitDns(auto_switch_dns_ips=True)
+    if enable_firewall_exclusion_range is not None:
+        features.firewall.exclude_private_ip_range = enable_firewall_exclusion_range
     return features
 
 

--- a/src/ffi/defaults_builder.rs
+++ b/src/ffi/defaults_builder.rs
@@ -1,10 +1,9 @@
-use std::{str::FromStr, sync::Arc};
+use std::sync::Arc;
 
-use ipnet::Ipv4Net;
 use parking_lot::Mutex;
 use telio_model::features::{
-    FeatureDerp, FeatureFirewall, FeatureLana, FeaturePersistentKeepalive, FeatureValidateKeys,
-    FeatureWireguard, Features,
+    FeatureDerp, FeatureLana, FeaturePersistentKeepalive, FeatureValidateKeys, FeatureWireguard,
+    Features,
 };
 
 pub struct FeaturesDefaultsBuilder {
@@ -66,20 +65,9 @@ impl FeaturesDefaultsBuilder {
         self
     }
 
-    /// Enable firewall connection resets when boringtun is enabled
-    /// custom_ips are needed only for integration tests as the stun server
-    /// is in a private_ip and it gets blocked, so in order to circumvent that
-    /// custom_ips was added as a feature
-    pub fn enable_firewall(
-        self: Arc<Self>,
-        custom_ips: String,
-        neptun_reset_conns: bool,
-    ) -> Arc<Self> {
-        self.config.lock().firewall = FeatureFirewall {
-            custom_private_ip_range: Ipv4Net::from_str(&custom_ips).ok(),
-            neptun_reset_conns,
-            boringtun_reset_conns: neptun_reset_conns,
-        };
+    /// Enable firewall connection resets when NepTUN is enabled
+    pub fn enable_firewall_connection_reset(self: Arc<Self>) -> Arc<Self> {
+        self.config.lock().firewall.neptun_reset_conns = true;
         self
     }
 

--- a/src/libtelio.udl
+++ b/src/libtelio.udl
@@ -478,7 +478,7 @@ interface FeaturesDefaultsBuilder {
 
     /// Enable firewall connection resets when NepTUN is used
     [Self=ByArc]
-    FeaturesDefaultsBuilder enable_firewall(string custom_ips, boolean neptun_reset_conns);
+    FeaturesDefaultsBuilder enable_firewall_connection_reset();
 
     /// Enable direct connections with defaults;
     [Self=ByArc]
@@ -693,8 +693,8 @@ dictionary FeatureFirewall {
     boolean neptun_reset_conns;
     /// Turns on connection resets upon VPN server change (Deprecated alias for neptun_reset_conns)
     boolean boringtun_reset_conns;
-    /// Custom private IP range
-    Ipv4Net? custom_private_ip_range;
+    /// Ip range from RFC1918 to exclude from firewall blocking
+    Ipv4Net? exclude_private_ip_range;
 };
 
 /// Link detection mechanism


### PR DESCRIPTION
### Problem
Merging https://github.com/NordSecurity/libtelio/pull/529 created a problem in builds because of backward compatibility in ffi signature `enable_reset_boringtun_conns` which was changed to `enable_firewall`.

This PR fixes reverts and fixes the issue.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
