### PR TITLE
Fix FiveTuple printing

### DIFF
--- a/nat-lab/tests/utils/connection_tracker.py
+++ b/nat-lab/tests/utils/connection_tracker.py
@@ -41,6 +41,9 @@ class FiveTuple:
             (self.protocol, self.src_ip, self.dst_ip, self.src_port, self.dst_port)
         )
 
+    def __str__(self) -> str:
+        return f"{self.protocol} {self.src_ip}:{self.src_port} -> {self.dst_ip}:{self.dst_port}"
+
 
 class EventType(Enum):
     """Event type reported by conntrack"""
@@ -147,7 +150,7 @@ class ConnectionCountLimit(ConnTrackerEventsValidator):
     ):
         if max_limit is not None and min_limit is not None and max_limit < min_limit:
             raise ValueError(
-                f"Max limit {max_limit} is smaller then min limit {min_limit}"
+                f"Max limit {max_limit} is smaller than min limit {min_limit}"
             )
 
         self.key = key
@@ -172,12 +175,12 @@ class ConnectionCountLimit(ConnTrackerEventsValidator):
         if self.max_limit is not None and count > self.max_limit:
             return ConnTrackerViolation(
                 recoverable=False,
-                reason=f"In {self.key} there has been {count} connections to {FiveTuple} which is more then max limit of {self.max_limit}",
+                reason=f"In {self.key} there has been {count} connections to {FiveTuple} which is more than max limit of {self.max_limit}",
             )
         if self.min_limit is not None and count < self.min_limit:
             return ConnTrackerViolation(
                 recoverable=True,
-                reason=f"In {self.key} there has been {count} connections to {FiveTuple} which is less then min limit of {self.min_limit}",
+                reason=f"In {self.key} there has been {count} connections to {FiveTuple} which is less than min limit of {self.min_limit}",
             )
 
         return None


### PR DESCRIPTION
### Problem
FiveTuple from connection tracker, when printed would produce the following output:
```
In nlx_1 there has been 3 connections to <class 'utils.connection_tracker.FiveTuple'> which is more then max limit of 2
```
Obviously `<class 'utils.connection_Tracker.FiveTuple>` is not desirable, hence this PR adds `def __str__` implementation to the class.

This is the result:
![2024-12-17_17-20-44_grim](https://github.com/user-attachments/assets/048d402d-81a7-4e75-b3b8-5b747c713641)


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
