### PR TITLE
Make node diff more readable

### DIFF
--- a/nat-lab/Pipfile
+++ b/nat-lab/Pipfile
@@ -51,6 +51,7 @@ asyncssh = "==2.14.2"
 aiodocker = "*"
 scapy="2.5"
 paho-mqtt = "*"
+deepdiff = "*"
 
 [dev-packages]
 

--- a/nat-lab/Pipfile.lock
+++ b/nat-lab/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "af3aea0124a9146df2dc6d36dbc8b6505477a791e0781b3a7d479b3778d6d73b"
+            "sha256": "33fb29011128808ad1d36860d40aaf9d0e2de793c801963cfa202f515a6f6c00"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -387,6 +387,15 @@
             "markers": "python_version >= '3.7' and python_version < '4.0'",
             "version": "==0.6.7"
         },
+        "deepdiff": {
+            "hashes": [
+                "sha256:b0231fa3afb0f7184e82535f2b4a36636442ed21e94a0cf3aaa7982157e7ebca",
+                "sha256:dd7bc7d5c8b51b5b90f01b0e2fe23c801fd8b4c6a7ee7e31c5a3c3663fcc7ceb"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==8.1.1"
+        },
         "exceptiongroup": {
             "hashes": [
                 "sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b",
@@ -751,6 +760,14 @@
             "index": "pypi",
             "markers": "python_version >= '3.5'",
             "version": "==1.0.0"
+        },
+        "orderly-set": {
+            "hashes": [
+                "sha256:571ed97c5a5fca7ddeb6b2d26c19aca896b0ed91f334d9c109edd2f265fb3017",
+                "sha256:d357cedcf67f4ebff0d4cbd5b0997e98eeb65dd24fdf5c990a501ae9e82c7d34"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==5.2.3"
         },
         "packaging": {
             "hashes": [

--- a/nat-lab/tests/test_events.py
+++ b/nat-lab/tests/test_events.py
@@ -331,6 +331,8 @@ async def test_event_content_vpn_connection(
                     allowed_ips=["0.0.0.0/0", "::/0"],
                     endpoint=f'{wg_server["ipv4"]}:{wg_server["port"]}',
                     path=PathType.DIRECT,
+                    allow_multicast=False,
+                    peer_allows_multicast=False,
                 ),
             )
             is None
@@ -361,6 +363,8 @@ async def test_event_content_vpn_connection(
                     allowed_ips=["0.0.0.0/0", "::/0"],
                     endpoint=f'{wg_server["ipv4"]}:{wg_server["port"]}',
                     path=PathType.DIRECT,
+                    allow_multicast=False,
+                    peer_allows_multicast=False,
                 ),
             )
             is None

--- a/nat-lab/tests/utils/bindings.py
+++ b/nat-lab/tests/utils/bindings.py
@@ -72,8 +72,8 @@ def telio_node(  # pylint: disable=dangerous-default-value
     allow_peer_traffic_routing: bool = False,
     allow_peer_local_network_access: bool = False,
     link_state: Optional[LinkState] = None,
-    allow_multicast: bool = False,
-    peer_allows_multicast: bool = False,
+    allow_multicast: bool = True,
+    peer_allows_multicast: bool = True,
 ) -> TelioNode:
     return TelioNode(
         identifier=identifier,


### PR DESCRIPTION
### Problem
node diff wasnt clear

### Solution
make node diff more clear by introducing deepdiff

Mini test to show differences in output:
```python
def test_diff():
    alpha = telio_node(
        identifier="alpha-id",
        public_key="alpha-pub",
        state=NodeState.CONNECTED,
        ip_addresses=["1.1.1.1"],
        allowed_ips=["1.1.1.1/32"],
        nickname="alpha",
        hostname="alpha.nord",
        allow_incoming_connections=True,
        allow_peer_send_files=True,
        path=PathType.DIRECT,
    )
    beta = telio_node(
        identifier="alpha-id",
        public_key="alpha-pub",
        state=NodeState.CONNECTED,
        ip_addresses=["1.1.1.1"],
        allowed_ips=["1.1.1.1/32"],
        nickname="alpha",
        hostname="alpha.nord",
        allow_incoming_connections=True,
        allow_peer_send_files=True,
        path=PathType.DIRECT,
    )
    assert node_diff(alpha, beta) is None
    beta.identifier = "beta-id"
    assert node_diff(alpha, beta) is None
```
Output before changes:
```
>       assert node_diff(alpha, beta)
E       assert False
E        +  where False = node_diff(<uniffi.telio_bindings.TelioNode object at 0x7c01e1eebce0>, <uniffi.telio_bindings.TelioNode object at 0x7c01e1eea5a0>)
```
Output after changes:
```
>       assert node_diff(alpha, beta) is None
E       assert 'Value of root[\'identifier\'] changed from "alpha-id" to "beta-id".' is None
E        +  where 'Value of root[\'identifier\'] changed from "alpha-id" to "beta-id".' = node_diff(<uniffi.telio_bindings.TelioNode object at 0x7270707bacc0>, <uniffi.telio_bindings.TelioNode object at 0x72707057bc20>)
```

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
