### PR TITLE
Add nat-lab test for starting telio with an existing tunnel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2634,7 +2634,7 @@ dependencies = [
 [[package]]
 name = "neptun"
 version = "0.6.0"
-source = "git+https://github.com/NordSecurity/neptun.git?tag=v1.0.0#db16cadc28efa3c915435d85e5b834834a867a69"
+source = "git+https://github.com/NordSecurity/neptun.git?tag=v1.0.2#b3b66795d748aa1720352a7b92204cc56d1c4daa"
 dependencies = [
  "aead",
  "base64 0.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,7 +174,7 @@ windows = { version = "0.56", features = [
     "Win32_NetworkManagement_IpHelper",
 ] }
 
-neptun = { git = "https://github.com/NordSecurity/neptun.git", tag = "v1.0.0", features = ["device"] }
+neptun = { git = "https://github.com/NordSecurity/neptun.git", tag = "v1.0.2", features = ["device"] }
 x25519-dalek = { version = "2.0.1", features = ["reusable_secrets", "static_secrets"] }
 
 

--- a/crates/telio-wg/src/adapter/neptun.rs
+++ b/crates/telio-wg/src/adapter/neptun.rs
@@ -63,8 +63,6 @@ impl NepTUN {
             protect: socket_pool,
             firewall_process_inbound_callback,
             firewall_process_outbound_callback,
-            #[cfg(target_os = "linux")]
-            uapi_fd: -1,
         };
 
         let device = match tun {

--- a/nat-lab/tests/telio.py
+++ b/nat-lab/tests/telio.py
@@ -520,6 +520,19 @@ class Client:
         if isinstance(self.get_router(), LinuxRouter):
             await self.get_proxy().set_fwmark(int(LINUX_FWMARK_VALUE))
 
+    async def create_tun(self, tun_name: str) -> int:
+        return await self.get_proxy().create_tun(tun_name)
+
+    async def start_with_tun(self, tun: int, tun_name):
+        await self.get_proxy().start_with_tun(
+            private_key=self._node.private_key,
+            adapter=self._adapter_type,
+            tun=tun,
+        )
+        if isinstance(self.get_router(), LinuxRouter):
+            self.get_router().set_interface_name(tun_name)
+            await self.get_proxy().set_fwmark(int(LINUX_FWMARK_VALUE))
+
     async def wait_for_state_peer(
         self,
         public_key,

--- a/nat-lab/tests/test_start_with_tun.py
+++ b/nat-lab/tests/test_start_with_tun.py
@@ -1,0 +1,38 @@
+from contextlib import AsyncExitStack
+from helpers import SetupParameters, ping_between_all_nodes, setup_mesh_nodes
+from typing import List
+from utils.bindings import default_features, TelioAdapterType
+from utils.connection_util import ConnectionTag
+
+
+def _generate_setup_parameters(
+    conn_tags: List[ConnectionTag],
+) -> List[SetupParameters]:
+    return [
+        SetupParameters(
+            connection_tag=conn_tag,
+            adapter_type_override=TelioAdapterType.BORING_TUN,
+            features=default_features(),
+            fingerprint=f"{conn_tag}",
+        )
+        for conn_tag in conn_tags
+    ]
+
+
+async def test_start_with_tun() -> None:
+    setup_params = _generate_setup_parameters([
+        ConnectionTag.DOCKER_CONE_CLIENT_1,
+        ConnectionTag.DOCKER_CONE_CLIENT_2,
+    ])
+
+    async with AsyncExitStack() as exit_stack:
+        env = await setup_mesh_nodes(exit_stack, setup_params)
+        alpha_client, _ = env.clients
+        alpha, _ = env.nodes
+
+        await ping_between_all_nodes(env)
+        await alpha_client.stop_device()
+        tun = await alpha_client.create_tun("tun11")
+        await alpha_client.start_with_tun(tun, "tun11")
+        await alpha_client.set_meshnet_config(env.api.get_meshnet_config(alpha.id))
+        await ping_between_all_nodes(env)

--- a/nat-lab/tests/uniffi/libtelio_proxy.py
+++ b/nat-lab/tests/uniffi/libtelio_proxy.py
@@ -100,6 +100,16 @@ class LibtelioProxy:
         )
 
     @move_to_async_thread
+    def create_tun(self, tun_name: str) -> int:
+        return self._handle_remote_error(lambda r: r.create_tun(tun_name))
+
+    @move_to_async_thread
+    def start_with_tun(self, private_key, adapter, tun: int):
+        self._handle_remote_error(
+            lambda r: r.start_with_tun(private_key, adapter.value, tun)
+        )
+
+    @move_to_async_thread
     def set_fwmark(self, fwmark: int):
         self._handle_remote_error(lambda r: r.set_fwmark(fwmark))
 

--- a/nat-lab/tests/utils/router/linux_router.py
+++ b/nat-lab/tests/utils/router/linux_router.py
@@ -61,6 +61,9 @@ class LinuxRouter(Router):
             ["ip", "link", "set", "up", "dev", self._interface_name]
         ).execute()
 
+    def set_interface_name(self, new_interface_name: str) -> None:
+        self._interface_name = new_interface_name
+
     async def deconfigure_interface(self, addresses: List[str]) -> None:
         for address in addresses:
             await self._connection.create_process(

--- a/nat-lab/tests/utils/router/mac_router.py
+++ b/nat-lab/tests/utils/router/mac_router.py
@@ -180,3 +180,8 @@ class MacRouter(Router):
     @asynccontextmanager
     async def reset_upnpd(self) -> AsyncIterator:
         yield
+
+    def set_interface_name(
+        self, new_interface_name: str  # pylint: disable=unused-argument
+    ) -> None:
+        pass

--- a/nat-lab/tests/utils/router/router.py
+++ b/nat-lab/tests/utils/router/router.py
@@ -71,6 +71,10 @@ class Router(ABC):
         pass
 
     @abstractmethod
+    def set_interface_name(self, new_interface_name: str) -> None:
+        pass
+
+    @abstractmethod
     async def setup_interface(self, addresses: List[str]) -> None:
         pass
 

--- a/nat-lab/tests/utils/router/windows_router.py
+++ b/nat-lab/tests/utils/router/windows_router.py
@@ -324,3 +324,8 @@ class WindowsRouter(Router):
     @asynccontextmanager
     async def reset_upnpd(self) -> AsyncIterator:
         yield
+
+    def set_interface_name(
+        self, new_interface_name: str  # pylint: disable=unused-argument
+    ) -> None:
+        pass


### PR DESCRIPTION
### Problem
`start_with_tun` ffi function wasn't being tested and thus contained bugs on platforms which weren't using that function in production.  

### Solution
Added a nat-lab test for `start_with_tun` function and fixed multiple bugs found on the way.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
