### PR TITLE
Make sure that build scripts use rerun-if-changed in a correct way

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -73,9 +73,6 @@ fn check_git_hooks() -> Result<()> {
 }
 
 fn verify_llt_secrets() {
-    println!("cargo:rerun-if-changed=./crates");
-    println!("cargo:rerun-if-changed=./src");
-
     if !env::var("GITLAB_CI")
         .or(env::var("GITHUB_ACTIONS"))
         .is_ok_and(|value| value == "true")
@@ -84,6 +81,9 @@ fn verify_llt_secrets() {
             println!("cargo:warning=BYPASS_LLT_SECRETS IS SET, COMMIT CAREFULLY!!");
             return;
         }
+
+        println!("cargo:rerun-if-changed=./crates");
+        println!("cargo:rerun-if-changed=./src");
 
         #[allow(clippy::panic)]
         match check_git_secrets().and_then(|_| check_git_hooks()) {

--- a/crates/telio-lana/build.rs
+++ b/crates/telio-lana/build.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 #[allow(unwrap_check)]
 fn main() -> Result<()> {
+    println!("cargo:rerun-if-changed=build.rs");
     let target_os = std::env::var("CARGO_CFG_TARGET_OS")?;
     if target_os == "windows" {
         if let Some(path) = std::option_env!("OUT_DIR") {


### PR DESCRIPTION
For lana, this script is self contained so it should explicitly depend only on itself. For toplevel, we don't need to check changes in crates and src if the bypass is in place.

After this change, subsequent invocations of `run_local.py` or `build.sh`, will not rebuild/relink anything if there are no changes.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
