### PR TITLE
Update triggered-ref to v2.7.3 which adds ARCH to qnap build job name

### DIFF
--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -22,4 +22,4 @@ jobs:
     with:
       schedule: ${{ github.event_name == 'schedule' }}
       cancel-outdated-pipelines: ${{ github.ref_name != 'main' }}
-      triggered-ref: v2.7.2 # REMEMBER to also update in .gitlab-ci.yml
+      triggered-ref: v2.7.3 # REMEMBER to also update in .gitlab-ci.yml

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,4 +15,4 @@ libtelio-build-pipeline:
 
   trigger:
     project: $LIBTELIO_BUILD_PROJECT_PATH
-    branch: v2.7.2 # REMEMBER to also update in .github/workflows/gitlab.yml
+    branch: v2.7.3 # REMEMBER to also update in .github/workflows/gitlab.yml


### PR DESCRIPTION
### Problem
qnap build job didn't have architecture in the name which cause the release pipeline to file when trying to download prebuilt qnap artifacts.

### Solution
add a matrix build with one architecture for qnap


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
