### PR TITLE
Make pollKeepalive optional

### DIFF
--- a/crates/telio-model/src/features.rs
+++ b/crates/telio-model/src/features.rs
@@ -330,7 +330,7 @@ pub struct FeatureDerp {
     /// Poll Keepalive: Application level keepalives meant to replace the TCP keepalives
     /// They will use derp_keepalive as interval
     #[serde(default)]
-    pub poll_keepalive: bool,
+    pub poll_keepalive: Option<bool>,
     /// Enable polling of remote peer states to reduce derp traffic
     pub enable_polling: Option<bool>,
     /// Use Mozilla's root certificates instead of OS ones [default false]
@@ -631,7 +631,7 @@ mod tests {
                     derp: Some(FeatureDerp {
                         tcp_keepalive: Some(13),
                         derp_keepalive: Some(14),
-                        poll_keepalive: true,
+                        poll_keepalive: Some(true),
                         enable_polling: Some(true),
                         use_built_in_root_certificates: true,
                     }),

--- a/crates/telio-relay/src/derp.rs
+++ b/crates/telio-relay/src/derp.rs
@@ -149,7 +149,7 @@ impl From<&Option<FeatureDerp>> for DerpKeepaliveConfig {
             if let Some(derp_ka) = derp.derp_keepalive {
                 derp_keepalive = derp_ka;
             }
-            poll_keepalive = derp.poll_keepalive;
+            poll_keepalive = derp.poll_keepalive.unwrap_or_default();
         }
 
         DerpKeepaliveConfig {

--- a/src/libtelio.udl
+++ b/src/libtelio.udl
@@ -686,7 +686,7 @@ dictionary FeatureDerp {
     u32? derp_keepalive;
     /// Poll Keepalive: Application level keepalives meant to replace the TCP keepalives
     /// They will reuse the derp_keepalive interval
-    boolean poll_keepalive;
+    boolean? poll_keepalive;
     /// Enable polling of remote peer states to reduce derp traffic
     boolean? enable_polling;
     /// Use Mozilla's root certificates instead of OS ones [default false]


### PR DESCRIPTION
### Problem
`pool_keepalive` was made a required field. This is causing failures in unaligned clients (the fact that it has a default serde value in the json doesn't help).

### Solution
Make the field optional in the udl.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
