### PR TITLE
Bump libtelio-build reference to v2.9.0

### DIFF
--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -24,4 +24,4 @@ jobs:
     with:
       schedule: ${{ github.event_name == 'schedule' }}
       cancel-outdated-pipelines: ${{ github.ref_name != 'main' }}
-      triggered-ref: v2.8.7 # REMEMBER to also update in .gitlab-ci.yml
+      triggered-ref: v2.9.0 # REMEMBER to also update in .gitlab-ci.yml

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,4 +15,4 @@ libtelio-build-pipeline:
 
   trigger:
     project: $LIBTELIO_BUILD_PROJECT_PATH
-    branch: v2.8.7 # REMEMBER to also update in .github/workflows/gitlab.yml
+    branch: v2.9.0 # REMEMBER to also update in .github/workflows/gitlab.yml


### PR DESCRIPTION
### Problem
Bump libtelio-build reference to v2.9.0.
Enables downloading artifacts from main for GitHub scheduled pipelines (nightlies) instead of building it for each pipeline. 

### Solution
*--describe selected solution--*


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
