### PR TITLE
Manually revert back pqcrypto-internals to 0.2.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3128,9 +3128,9 @@ dependencies = [
 
 [[package]]
 name = "pqcrypto-internals"
-version = "0.2.7"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62cd8ebf02b43967cda06e6a3f54d0bd9659459c3003d16aeedd07b44c6db06c"
+checksum = "d9d34bec6abe2283e6de7748b68b292d1ffa2203397e3e71380ff8418a49fb46"
 dependencies = [
  "cc",
  "dunce",


### PR DESCRIPTION
Darwin runners fail after the update of this crate which is a transient dependency, this is a manual patch that will not need any action further(cargo update will just update it again).

There's outstanding PR which claims to fix the issue: https://github.com/rustpq/pqcrypto/pull/72

The error in question from compilation:
```
cargo:warning=<instantiation>:79:5: error: instruction requires: sha3
```

### Problem
*--describe problem being solved--*

### Solution
*--describe selected solution--*


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
