### PR TITLE
Improve exception message in setup_check_connectivity

### DIFF
--- a/nat-lab/tests/conftest.py
+++ b/nat-lab/tests/conftest.py
@@ -247,7 +247,12 @@ async def setup_check_connectivity():
                     await ping(connection, dest_ip, 5)
                     results[source].append((reverse[dest_ip], True))
             except Exception as e:  # pylint: disable=broad-exception-caught
-                print(f"Failed to connect from {source} to {reverse[dest_ip]}: {e}")
+                print(
+                    f"Failed to connect from {source} to {reverse[dest_ip]}: {repr(e)}"
+                )
+                print(f"Exception type: {e.__class__.__name__}")
+                print(f"Exception args: {e.args}")
+                print(f"Exception attributes: {dir(e)}")
                 results[source].append((reverse[dest_ip], False))
 
     print("Connectivity between VMs (and docker):")


### PR DESCRIPTION
### Problem
During the last nat-lab run, the `setup_check_connectivity` failed while attempting to establish connectivity between the MAC VM and the Windows VM.  However, the exception message was empty, making it difficult to identify the root cause of the failure.

### Solution
Add more verbose exception messages.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
