### PR TITLE
LLT-5886: Protected RTT QoS pings

### DIFF
--- a/.unreleased/LLT-5886_protected_pinger
+++ b/.unreleased/LLT-5886_protected_pinger
@@ -1,0 +1,2 @@
+Use the SocketPool component in order to bind the Pinger raw socket to the tunnel interface on macOS.
+LinkDetection component was also updated to use the new Pinger.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4663,6 +4663,7 @@ dependencies = [
  "telio-nat-detect",
  "telio-network-monitors",
  "telio-nurse",
+ "telio-pinger",
  "telio-pmtu",
  "telio-pq",
  "telio-proto",
@@ -4848,6 +4849,7 @@ dependencies = [
  "telio-model",
  "telio-nat-detect",
  "telio-nurse",
+ "telio-pinger",
  "telio-proto",
  "telio-sockets",
  "telio-task",
@@ -4857,6 +4859,19 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "telio-pinger"
+version = "0.1.0"
+dependencies = [
+ "rand",
+ "socket2",
+ "surge-ping",
+ "telio-sockets",
+ "telio-utils",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -5116,7 +5131,6 @@ dependencies = [
  "smart-default",
  "sn_fake_clock",
  "socket2",
- "surge-ping",
  "telio-test",
  "thiserror 1.0.69",
  "tokio",
@@ -5151,6 +5165,7 @@ dependencies = [
  "telio-crypto",
  "telio-firewall",
  "telio-model",
+ "telio-pinger",
  "telio-sockets",
  "telio-task",
  "telio-test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ telio-task.workspace = true
 telio-traversal.workspace = true
 telio-utils.workspace = true
 telio-wg.workspace = true
+telio-pinger.workspace = true
 once_cell.workspace = true
 nat-detect.workspace = true
 smart-default.workspace = true
@@ -199,6 +200,7 @@ telio-utils = { version = "0.1.0", path = "./crates/telio-utils" }
 telio-wg = { version = "0.1.0", path = "./crates/telio-wg" }
 telio-pq = { version = "0.1.0", path = "./crates/telio-pq" }
 telio-pmtu = { version = "0.1.0", path = "./crates/telio-pmtu" }
+telio-pinger = { version = "0.1.0", path = "./crates/telio-pinger" }
 
 [profile.release]
 opt-level = "s"

--- a/crates/telio-nurse/Cargo.toml
+++ b/crates/telio-nurse/Cargo.toml
@@ -36,10 +36,12 @@ telio-proto.workspace = true
 telio-task.workspace = true
 telio-utils.workspace = true
 telio-wg.workspace = true
+telio-pinger.workspace = true
+telio-sockets.workspace = true
 once_cell.workspace = true
 
 [dev-dependencies]
-telio-sockets.workspace = true
+telio-sockets = { workspace = true, features = ["mockall"] }
 telio-wg = { workspace = true, features = ["mockall"] }
 tokio = { workspace = true, features = ["net", "sync", "test-util"] }
 telio-nurse = { workspace = true, features = ["mockall"] }

--- a/crates/telio-nurse/src/nurse.rs
+++ b/crates/telio-nurse/src/nurse.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use telio_crypto::{PublicKey, SecretKey};
 use telio_lana::*;
 use telio_model::event::Event;
+use telio_sockets::SocketPool;
 use telio_task::{
     io::{chan, mc_chan, Chan, McChan},
     task_exec, ExecError, Runtime, RuntimeExt, Task, WaitResponse,
@@ -60,9 +61,20 @@ impl Nurse {
         io: NurseIo<'_>,
         aggregator: Arc<ConnectivityDataAggregator>,
         ipv6_enabled: bool,
+        socket_pool: Arc<SocketPool>,
     ) -> Self {
         Self {
-            task: Task::start(State::new(public_key, config, io, aggregator, ipv6_enabled).await),
+            task: Task::start(
+                State::new(
+                    public_key,
+                    config,
+                    io,
+                    aggregator,
+                    ipv6_enabled,
+                    socket_pool,
+                )
+                .await,
+            ),
         }
     }
 
@@ -120,6 +132,9 @@ impl State {
     /// * `public_key` - Used for heartbeat requests.
     /// * `config` - Contains configuration for heartbeats and QoS.
     /// * `io` - Nurse io channels.
+    /// * `aggregator` - ConnectivityDataAggregator.
+    /// * `ipv6_enabled` - IPv6 support.
+    /// * `socket_pool` - SocketPool used to protect the sockets.
     ///
     /// # Returns
     ///
@@ -130,6 +145,7 @@ impl State {
         io: NurseIo<'_>,
         aggregator: Arc<ConnectivityDataAggregator>,
         ipv6_enabled: bool,
+        socket_pool: Arc<SocketPool>,
     ) -> Self {
         let meshnet_id = Self::meshnet_id();
         telio_log_debug!("Meshnet ID: {meshnet_id}");
@@ -181,6 +197,7 @@ impl State {
                     config_update_channel: config_update_channel.subscribe(),
                 },
                 ipv6_enabled,
+                socket_pool,
             )))
         } else {
             None

--- a/crates/telio-pinger/Cargo.toml
+++ b/crates/telio-pinger/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "telio-pinger"
+version = "0.1.0"
+edition = "2021"
+license = "GPL-3.0-only"
+repository = "https://github.com/NordSecurity/libtelio"
+publish = false
+
+[dependencies]
+socket2.workspace = true
+telio-utils.workspace = true
+telio-sockets.workspace = true
+surge-ping.workspace = true
+rand.workspace = true
+tracing.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["net", "sync", "test-util"] }
+telio-sockets = { workspace = true, features = ["mockall"] }

--- a/crates/telio-sockets/Cargo.toml
+++ b/crates/telio-sockets/Cargo.toml
@@ -15,6 +15,7 @@ parking_lot.workspace = true
 socket2.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["full"] }
+mockall = { workspace = true, optional = true }
 
 telio-utils.workspace = true
 once_cell.workspace = true

--- a/crates/telio-sockets/src/protector.rs
+++ b/crates/telio-sockets/src/protector.rs
@@ -1,3 +1,13 @@
+//! Provides cross-platform abstractions for managing socket-level protection
+//!
+//! Operations like binding to an external or internal interface, applying firewall marks,
+//! watching for default interface and route changes, etc.
+//!
+//! Some methods are no_op on specific platforms:
+//! - [`Protector::set_fwmark`] on macOS and Windows since they don't have iptables.
+//! - [`Protector::set_tunnel_interface`] on Linux since firewall marks are used to route packets.
+//! - [`Protector::make_internal`] on Linux and Windows since the sockets by default are bound to the tunnel interface.
+
 use std::{io, panic::RefUnwindSafe, sync::Arc};
 
 use crate::native::NativeSocket;
@@ -18,22 +28,39 @@ pub mod platform;
 #[path = "protector/unsupported.rs"]
 pub mod platform;
 
+/// Re-export the implementation for the current platform.
 pub use platform::NativeProtector;
 
+/// Alias for a closure that accepts a native socket.
+///
+/// Used as a callback in the [`make_external_protector`] function.
 pub type Protect = Arc<dyn Fn(NativeSocket) + Send + Sync + RefUnwindSafe + 'static>;
 
+/// A trait describing common operations on a socket.
+///
+/// Used to manage binding, automatic re-binding and routing rules on various platforms.
+/// Some of the methods are no-op on specific platforms.
+#[cfg_attr(any(test, feature = "mockall"), mockall::automock)]
 pub trait Protector: Send + Sync {
+    /// Configure the provided socket to send packets externally (outside of the tunnel).
     fn make_external(&self, socket: NativeSocket) -> io::Result<()>;
 
+    /// Configure the provided socket to send packets internally (inside of the tunnel).
     fn make_internal(&self, socket: NativeSocket) -> io::Result<()>;
 
+    /// Clean up any references associated with the given socket.
     fn clean(&self, socket: NativeSocket);
 
+    /// Update the firewall mark for this socket used in iptables and routing rules.
     fn set_fwmark(&self, fwmark: u32);
 
+    /// Update the tunnel interface identifier to be applied when making the socket internal.
     fn set_tunnel_interface(&self, interface: u64);
 }
 
+/// A blanket implementation of `Arc<Protector>`.
+///
+/// Used to call [`Protector`] methods directly without having to dereference.
 impl<T: Protector + ?Sized> Protector for Arc<T> {
     fn make_external(&self, socket: NativeSocket) -> io::Result<()> {
         self.as_ref().make_external(socket)
@@ -56,6 +83,9 @@ impl<T: Protector + ?Sized> Protector for Arc<T> {
     }
 }
 
+/// Construct a [`Protector`] instance that applies a closure.
+///
+/// The closure is called only during [`Protector::make_external`], all other methods are no-op.
 pub fn make_external_protector(protect: Protect) -> Arc<(dyn Protector + 'static)> {
     struct ProtectorMakeExternalCb(Protect);
     impl Protector for ProtectorMakeExternalCb {

--- a/crates/telio-sockets/src/socket_pool.rs
+++ b/crates/telio-sockets/src/socket_pool.rs
@@ -235,25 +235,16 @@ mod tests {
         sync::Mutex,
     };
 
-    use mockall::mock;
     use rstest::rstest;
 
-    use crate::{native::NativeSocket, protector::make_external_protector, Protect};
+    use crate::{
+        protector::{make_external_protector, MockProtector},
+        Protect,
+    };
 
     use super::*;
 
     const PACKET: [u8; 8] = *b"libtelio";
-
-    mock! {
-        Protector {}
-        impl Protector for Protector {
-            fn make_external(&self, socket: NativeSocket) -> io::Result<()>;
-            fn clean(&self, socket: NativeSocket);
-            fn set_fwmark(&self, fwmark: u32);
-            fn set_tunnel_interface(&self, interface: u64);
-            fn make_internal(&self, interface: NativeSocket) -> Result<(), std::io::Error>;
-        }
-    }
 
     #[tokio::test]
     async fn test_external_drops_protector() {

--- a/crates/telio-utils/Cargo.toml
+++ b/crates/telio-utils/Cargo.toml
@@ -24,7 +24,6 @@ serde.workspace = true
 smart-default.workspace = true
 sn_fake_clock = { workspace = true, optional = true }
 socket2.workspace = true
-surge-ping.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["time"] }
 tracing.workspace = true

--- a/crates/telio-utils/src/lib.rs
+++ b/crates/telio-utils/src/lib.rs
@@ -47,10 +47,6 @@ pub use interval::*;
 pub mod ip_stack;
 pub use ip_stack::*;
 
-/// Basic ICMP Pinger
-pub mod pinger;
-pub use pinger::*;
-
 /// Testing tools
 pub mod test;
 

--- a/crates/telio-wg/Cargo.toml
+++ b/crates/telio-wg/Cargo.toml
@@ -32,9 +32,10 @@ tokio = { workspace = true, features = ["full"] }
 
 telio-crypto.workspace = true
 telio-model.workspace = true
-telio-sockets.workspace = true
+telio-sockets = { workspace = true, features = ["mockall"] }
 telio-task.workspace = true
 telio-utils.workspace = true
+telio-pinger.workspace = true
 itertools.workspace = true
 
 [dev-dependencies]
@@ -46,6 +47,7 @@ tokio = { workspace = true, features = ["test-util"] }
 
 telio-firewall.workspace = true
 telio-task = { workspace = true, features = ["test-util"] }
+telio-sockets = { workspace = true, features = ["mockall"] }
 telio-test.workspace = true
 proptest.workspace = true
 

--- a/crates/telio-wg/src/link_detection.rs
+++ b/crates/telio-wg/src/link_detection.rs
@@ -13,6 +13,7 @@ use telio_model::{
     features::FeatureLinkDetection,
     mesh::{LinkState, NodeState},
 };
+use telio_sockets::SocketPool;
 use telio_task::io::{chan, Chan};
 use telio_utils::{
     get_ip_stack, telio_err_with_log, telio_log_debug, telio_log_error, telio_log_trace,
@@ -35,10 +36,20 @@ pub struct LinkDetection {
 }
 
 impl LinkDetection {
-    pub fn new(cfg: FeatureLinkDetection, ipv6_enabled: bool) -> Self {
+    pub fn new(
+        cfg: FeatureLinkDetection,
+        ipv6_enabled: bool,
+        socket_pool: Arc<SocketPool>,
+    ) -> Self {
         let ping_channel = Chan::default();
         let enhanced_detection = if cfg.no_of_pings != 0 {
-            EnhancedDetection::start_with(ping_channel.rx, cfg.no_of_pings, ipv6_enabled).ok()
+            EnhancedDetection::start_with(
+                ping_channel.rx,
+                cfg.no_of_pings,
+                ipv6_enabled,
+                socket_pool,
+            )
+            .ok()
         } else {
             None
         };

--- a/crates/telio-wg/src/link_detection/enhanced_detection.rs
+++ b/crates/telio-wg/src/link_detection/enhanced_detection.rs
@@ -1,8 +1,10 @@
 use async_trait::async_trait;
-use std::net::IpAddr;
+use std::{net::IpAddr, sync::Arc};
 
+use telio_pinger::Pinger;
+use telio_sockets::SocketPool;
 use telio_task::{io::chan, task_exec, Runtime, RuntimeExt, Task, WaitResponse};
-use telio_utils::{ip_stack, DualTarget, IpStack, Pinger};
+use telio_utils::{ip_stack, DualTarget, IpStack};
 
 use telio_utils::telio_log_debug;
 /// Component used to check the link state when we think it's down.
@@ -17,9 +19,15 @@ impl EnhancedDetection {
         ping_channel: chan::Rx<(Vec<IpAddr>, Option<IpStack>)>,
         no_of_pings: u32,
         ipv6_enabled: bool,
+        socket_pool: Arc<SocketPool>,
     ) -> std::io::Result<Self> {
         Ok(Self {
-            task: Task::start(State::new(ping_channel, no_of_pings, ipv6_enabled)?),
+            task: Task::start(State::new(
+                ping_channel,
+                no_of_pings,
+                ipv6_enabled,
+                socket_pool,
+            )?),
         })
     }
 
@@ -38,10 +46,11 @@ impl State {
         ping_channel: chan::Rx<(Vec<IpAddr>, Option<IpStack>)>,
         no_of_pings: u32,
         ipv6_enabled: bool,
+        socket_pool: Arc<SocketPool>,
     ) -> std::io::Result<Self> {
         Ok(State {
             ping_channel,
-            pinger: Pinger::new(no_of_pings, ipv6_enabled)?,
+            pinger: Pinger::new(no_of_pings, ipv6_enabled, socket_pool)?,
         })
     }
 }

--- a/crates/telio-wg/src/wg.rs
+++ b/crates/telio-wg/src/wg.rs
@@ -345,11 +345,18 @@ impl DynamicWg {
             io,
             adapter,
             link_detection,
-            cfg,
+            cfg.try_clone()?,
             ipv6_enabled,
+            cfg.socket_pool,
         ));
         #[cfg(windows)]
-        return Ok(Self::start_with(io, adapter, link_detection, ipv6_enabled));
+        return Ok(Self::start_with(
+            io,
+            adapter,
+            link_detection,
+            ipv6_enabled,
+            cfg.socket_pool,
+        ));
     }
 
     fn start_with(
@@ -358,6 +365,7 @@ impl DynamicWg {
         link_detection: Option<FeatureLinkDetection>,
         #[cfg(unix)] cfg: Config,
         ipv6_enabled: bool,
+        socket_pool: Arc<SocketPool>,
     ) -> Self {
         let interval = interval(Duration::from_millis(POLL_MILLIS));
         Self {
@@ -370,7 +378,8 @@ impl DynamicWg {
                 event: io.events,
                 analytics_tx: io.analytics_tx,
                 uapi_fail_counter: 0,
-                link_detection: link_detection.map(|ld| LinkDetection::new(ld, ipv6_enabled)),
+                link_detection: link_detection
+                    .map(|ld| LinkDetection::new(ld, ipv6_enabled, socket_pool)),
                 libtelio_event: io.libtelio_wide_event_publisher,
                 stats: HashMap::new(),
                 ip_stack: None,
@@ -1102,7 +1111,7 @@ pub mod tests {
     use mockall::predicate;
     use rand::{Rng, RngCore, SeedableRng};
     use telio_crypto::PresharedKey;
-    use telio_sockets::NativeProtector;
+    use telio_sockets::protector::MockProtector;
     use telio_utils::Hidden;
     use tokio::{runtime::Handle, sync::Mutex, task, time::sleep};
 
@@ -1257,6 +1266,8 @@ pub mod tests {
                 })
             });
 
+        let socket_pool = Arc::new(SocketPool::new(MockProtector::default()));
+
         let wg = DynamicWg::start_with(
             Io {
                 events: events_ch.tx.clone(),
@@ -1270,6 +1281,7 @@ pub mod tests {
             #[cfg(all(unix, not(test)))]
             cfg,
             true,
+            socket_pool,
         );
         time::advance(Duration::from_millis(0)).await;
         adapter.lock().await.checkpoint();

--- a/src/device.rs
+++ b/src/device.rs
@@ -1166,6 +1166,14 @@ impl Runtime {
             config.private_key.public(),
         ));
 
+        #[cfg(windows)]
+        {
+            let adapter_luid = wireguard_interface.get_adapter_luid().await?;
+            socket_pool.set_tunnel_interface(adapter_luid);
+        }
+        #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
+        set_tunnel_interface(&socket_pool, config);
+
         let nurse = if telio_lana::is_lana_initialized() {
             if let Some(nurse_features) = &features.nurse {
                 let nurse_io = NurseIo {
@@ -1188,6 +1196,7 @@ impl Runtime {
                         nurse_io,
                         aggregator.clone(),
                         features.ipv6,
+                        socket_pool.clone(),
                     )
                     .await,
                 ))
@@ -1199,14 +1208,6 @@ impl Runtime {
             telio_log_debug!("lana not initialized");
             None
         };
-
-        #[cfg(windows)]
-        {
-            let adapter_luid = wireguard_interface.get_adapter_luid().await?;
-            socket_pool.set_tunnel_interface(adapter_luid);
-        }
-        #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
-        set_tunnel_interface(&socket_pool, config);
 
         let requested_state = RequestedState {
             device_config: config.clone(),


### PR DESCRIPTION
### Problem
Due to the nature of Apple's NetworkExtension control protocol, packets originating from the NetworkExtension process are routed outside of the tunnel. 
Because of this on macOS AppStore and iOS platforms, raw ICMP packets from QoS RTT and Link detection components destined for the tunnel interface, leave the main interface instead.

### Solution
Use the `SocketPool` component in order to bind the ping raw socket to the tunnel interface. The Pinger component had to moved into it's own crate in order to avoid circular dependencies between Utils and Sockets.
LinkDetection component was also updated to use the new Pinger.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
