### PR TITLE
Temporary disable tcpdump for windows

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -65,7 +65,7 @@ black fix="false":
     fi
 
 pylint:
-    docker run --rm -t -v$(pwd):/code 'ubuntu:24.04' sh -c "apt-get update && apt-get -y install python3-pip && cd code && pip3 install --no-deps -r requirements.txt && pipenv install --system && cd nat-lab && pipenv install --system && pylint -f colorized . --ignore telio_bindings.py"
+    docker run --rm -t -v$(pwd):/code 'ubuntu:24.04' sh -c "export DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get -y install python3-pip && rm -f /usr/lib/python3.12/EXTERNALLY-MANAGED && cd code && pip3 install --no-deps -r requirements.txt && pipenv install --system && cd nat-lab && pipenv install --system && pylint -f colorized . --ignore telio_bindings.py"
 
 # Start a dev web cgi server, for local teliod cgi development
 web:

--- a/nat-lab/tests/test_batching.py
+++ b/nat-lab/tests/test_batching.py
@@ -3,7 +3,7 @@ import itertools
 import pytest
 from contextlib import AsyncExitStack
 from helpers import setup_api, setup_connections, SetupParameters, setup_mesh_nodes
-from scapy.layers.inet import TCP, UDP, ICMP  # type: ignore
+from scapy.layers.inet import TCP  # type: ignore
 from scapy.layers.l2 import ARP  # type: ignore
 from telio import Client
 from timeouts import TEST_BATCHING_TIMEOUT
@@ -146,7 +146,6 @@ async def test_batching(
             clients.append(client)
 
         alpha_client, beta_client, *_ = clients
-        alpha_node, beta_node, *_ = nodes
 
         # Start capture tasks
 

--- a/nat-lab/tests/utils/tcpdump.py
+++ b/nat-lab/tests/utils/tcpdump.py
@@ -162,6 +162,10 @@ async def make_tcpdump(
     try:
         async with AsyncExitStack() as exit_stack:
             for conn in connection_list:
+                # TODO(gytsto): temporary disable windows tcpdump
+                if conn.target_os == TargetOS.Windows:
+                    continue
+
                 await exit_stack.enter_async_context(
                     TcpDump(conn, session=session).run()
                 )
@@ -171,6 +175,10 @@ async def make_tcpdump(
             log_dir = get_current_test_log_path()
             os.makedirs(log_dir, exist_ok=True)
             for conn in connection_list:
+                # TODO(gytsto): temporary disable windows tcpdump
+                if conn.target_os == TargetOS.Windows:
+                    continue
+
                 path = find_unique_path_for_tcpdump(
                     store_in if store_in else log_dir, conn.target_name()
                 )
@@ -180,5 +188,6 @@ async def make_tcpdump(
             await conn.create_process(
                 ["rm", "-f", PCAP_FILE_PATH[conn.target_os]]
             ).execute()
-        else:
-            await conn.create_process(["del", PCAP_FILE_PATH[conn.target_os]]).execute()
+        # TODO(gytsto): temporary disable windows tcpdump
+        # else:
+        #     await conn.create_process(["del", PCAP_FILE_PATH[conn.target_os]]).execute()

--- a/nat-lab/tests/utils/tcpdump.py
+++ b/nat-lab/tests/utils/tcpdump.py
@@ -162,7 +162,7 @@ async def make_tcpdump(
     try:
         async with AsyncExitStack() as exit_stack:
             for conn in connection_list:
-                # TODO(gytsto): temporary disable windows tcpdump
+                # TODO(LLT-5942): temporary disable windows tcpdump
                 if conn.target_os == TargetOS.Windows:
                     continue
 
@@ -175,7 +175,7 @@ async def make_tcpdump(
             log_dir = get_current_test_log_path()
             os.makedirs(log_dir, exist_ok=True)
             for conn in connection_list:
-                # TODO(gytsto): temporary disable windows tcpdump
+                # TODO(LLT-5942): temporary disable windows tcpdump
                 if conn.target_os == TargetOS.Windows:
                     continue
 
@@ -188,6 +188,6 @@ async def make_tcpdump(
             await conn.create_process(
                 ["rm", "-f", PCAP_FILE_PATH[conn.target_os]]
             ).execute()
-        # TODO(gytsto): temporary disable windows tcpdump
+        # TODO(LLT-5942): temporary disable windows tcpdump
         # else:
         #     await conn.create_process(["del", PCAP_FILE_PATH[conn.target_os]]).execute()


### PR DESCRIPTION
### Problem
windump might be causing issues for windows vms and make tests fail

### Solution
temporary disable windump


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
