### PR TITLE
Bump depecrated actions version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
           submodules: true
       - name: Generate bindings
         run: python3 ci/build_libtelio.py bindings --dockerized
-      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: libtelio-bindings
           path: dist/
@@ -50,7 +50,7 @@ jobs:
         run: pip3 install requests==2.32.3 --break-system-packages
       - name: Build libtelio
         run: python3 ci/build_libtelio.py build ${{ matrix.target_os }} ${{ matrix.arch }} --msvc
-      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: libtelio-build-${{ matrix.target_os }}-${{ matrix.arch }}
           path: dist/
@@ -93,7 +93,7 @@ jobs:
           key: ${{ matrix.target_os }}-${{ matrix.arch }}
       - name: Build libtelio
         run: python3 ci/build_libtelio.py build ${{ matrix.target_os }} ${{ matrix.arch }}
-      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: libtelio-build-${{ matrix.target_os }}-${{ matrix.arch }}
           path: dist/

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -110,7 +110,7 @@ jobs:
       runs-on: ubuntu-24.04
       steps:
         - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
-        - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
           with:
             name: telio_bindings.py
             path: dist/bindings
@@ -124,7 +124,7 @@ jobs:
       runs-on: ubuntu-24.04
       steps:
         - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
-        - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
           with:
             name: telio_bindings.py
             path: dist/bindings

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -12,7 +12,7 @@ jobs:
         - run: uniffi-bindgen generate src/libtelio.udl --language python
         - run: mkdir -p dist/bindings/
         - run: cp src/telio.py dist/bindings/telio_bindings.py
-        - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
           with:
             name: telio_bindings.py
             path: dist/bindings

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -27,7 +27,7 @@ jobs:
           publish_results: true
           repo_token: ${{ secrets.SCORECARD_TOKEN }}
       - name: "Upload artifact"
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: SARIF file
           path: results.sarif

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -102,7 +102,7 @@ jobs:
           python ./ci/insert_libtelio_version.py -n TEST_VERSION -p ./dist/windows
           Start-Process -FilePath dist/windows/release/x86_64/tcli.exe -WindowStyle Hidden
           type tcli.log | findstr /C:"TEST_VERSION"
-      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: libtelio-build-${{ matrix.target_os }}-${{ matrix.arch }}-with-replaced-version
           path: dist/


### PR DESCRIPTION
### Problem
download-artifact and upload-artifact actions v3.x.x were depecrated.

### Solution
Bump versions both actions versions to v4.x.x.

see: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
