### PR TITLE
LLT-5944: Dump a core when tcpdump is stuck

### DIFF
--- a/nat-lab/bin/kill_process_by_natlab_id
+++ b/nat-lab/bin/kill_process_by_natlab_id
@@ -1,20 +1,26 @@
 #!/usr/bin/env bash
 
-if [[ "$#" -ne 1 ]]; then
-    echo "Wrong number of parameters"
+if [[ "$#" -lt 1 || "$#" -gt 2 ]]; then
+    echo "Usage: $0 <NATLAB_ID> [--SEGV]"
     exit 1
 fi
 
 NATLAB_ID=$1
+SIGNAL="-TERM" # default SIGTERM
+
+# If the second argument is '--SEGV', send SIGSEGV (-11) to create a coredump
+if [[ "$2" == "--SEGV" ]]; then
+    SIGNAL="-SEGV"
+fi
 
 for pid in $(ps -e -o pid=); do
     if grep --null-data --text KILL_ID=${NATLAB_ID} /proc/${pid}/environ; then
         cmd=$(tr -d '\000' < /proc/${pid}/cmdline || echo "N/A")
-        echo "$(date) Killing ${pid} ${cmd}"
-        kill "${pid}"
+        echo "$(date) Killing ${pid} ${cmd} with $SIGNAL"
+        kill "${SIGNAL}" "${pid}"
         wait "${pid}" 2>/dev/null
         exit 0
     fi
 done
 
-echo "The process to kill not found"
+echo "The process to kill was not found: $NATLAB_ID"

--- a/nat-lab/tests/utils/tcpdump.py
+++ b/nat-lab/tests/utils/tcpdump.py
@@ -136,7 +136,7 @@ class TcpDump:
     async def run(self) -> AsyncIterator["TcpDump"]:
         async with self.process.run(self.on_stdout, self.on_stderr, True):
             try:
-                await wait_for(self.start_event.wait(), 10)
+                await wait_for(self.start_event.wait(), 0.2)
             except TimeoutError as e:
                 print(
                     datetime.now(),


### PR DESCRIPTION
### Problem
Sometimes jobs time-out because tcpdump testcases are stuck waiting for listening event on output.

### Solution
kill -11 is issued to produce coredumps that are later collected only for timed-out `tcpdump` jobs.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
