### PR TITLE
ci: Avoid artifacts conflicting names

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
         run: python3 ci/build_libtelio.py build ${{ matrix.target_os }} ${{ matrix.arch }} --msvc
       - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
-          name: libtelio-build-${{ matrix.target_os }}-${{ matrix.arch }}
+          name: libtelio-build-native-${{ matrix.target_os }}-${{ matrix.arch }}
           path: dist/
 
   build-docker:
@@ -95,7 +95,7 @@ jobs:
         run: python3 ci/build_libtelio.py build ${{ matrix.target_os }} ${{ matrix.arch }}
       - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
-          name: libtelio-build-${{ matrix.target_os }}-${{ matrix.arch }}
+          name: libtelio-build-docker-${{ matrix.target_os }}-${{ matrix.arch }}
           path: dist/
 
   build-tclid:


### PR DESCRIPTION
### Problem
With https://github.com/NordSecurity/libtelio/pull/1065, artifacts with duplicated names are no longer uploaded for each PR.

### Solution
Distinguish artifact names from each job.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
