### PR TITLE
LLT-5950: test event content meshnet sleep to event

### DIFF
--- a/nat-lab/tests/test_events.py
+++ b/nat-lab/tests/test_events.py
@@ -186,10 +186,16 @@ async def test_event_content_meshnet(
 
         await client_alpha.set_meshnet_config(api.get_meshnet_config(alpha.id))
 
+        # Telio and NatLab both have a sampling rate of 1 second.
+        # As a result, in the worst case, an event could be delayed by up
+        # to 2seconds. So 2 second is the minimum amount of time. Still
+        # the ping might not come within 2 seconds if there's latency.
+        await client_alpha.wait_for_state_peer(
+            beta.public_key, [NodeState.DISCONNECTED], [PathType.DIRECT], timeout=5
+        )
+
         with pytest.raises(asyncio.TimeoutError):
             await ping(connection_alpha, beta.ip_addresses[0], 5)
-
-        await asyncio.sleep(1)
 
         beta_node_state = client_alpha.get_node_state(beta.public_key)
         assert beta_node_state

--- a/src/device.rs
+++ b/src/device.rs
@@ -520,7 +520,10 @@ impl Device {
             .name("libtelio-events".to_owned())
             .spawn(move || loop {
                 match event_rx.blocking_recv() {
-                    Ok(event) => event_cb(event),
+                    Ok(event) => {
+                        telio_log_debug!("Handling event: {:?}", event);
+                        event_cb(event);
+                    }
                     Err(RecvError::Lagged(n)) => {
                         telio_log_warn!("Failed to receive new event, lagged: {n}")
                     }


### PR DESCRIPTION
### Problem
Sleeps in testcases cause flakyness. This PR removes one instance of it.

### Solution
Eliminate sleep from `test_event_content_meshnet` testcase. Also add additional log line just before calling event callback from libtelio since telio and natlab logs show 4sec difference in the logs:
**Telio**:
```
2025-01-19 18:19:48.950786 TelioLogLevel.DEBUG 2025-01-19T18:19:48.9503876Z ThreadId(3) "telio::device":2403 Event is being published to libtelio integrators Node { public_key: "wuNG...vG8=", state: Connected, ...
```
**NatLab**:
```
[alpha]: event [2025-01-19 18:19:52.958807]: Event.NODE(body=TelioNode(public_key=wuNGlTQiOB26qsAhM5Fw/vP3afIP55bBRA1YETjZvG8=, state=NodeState.CONNECTED,
```


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
