### PR TITLE
bump libtelio-build to without windows provision script

### DIFF
--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -24,4 +24,4 @@ jobs:
     with:
       schedule: ${{ github.event_name == 'schedule' }}
       cancel-outdated-pipelines: ${{ github.ref_name != 'main' }}
-      triggered-ref: v2.8.2 # REMEMBER to also update in .gitlab-ci.yml
+      triggered-ref: v2.8.3 # REMEMBER to also update in .gitlab-ci.yml

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,4 +15,4 @@ libtelio-build-pipeline:
 
   trigger:
     project: $LIBTELIO_BUILD_PROJECT_PATH
-    branch: v2.8.2 # REMEMBER to also update in .github/workflows/gitlab.yml
+    branch: v2.8.3 # REMEMBER to also update in .github/workflows/gitlab.yml


### PR DESCRIPTION
### Problem
Windows provision script fails in natlab tests.

### Solution
Remove running provision script in natlab, and let precondition checks handle that. Libtelio-build has already been updated for that.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
