### PR TITLE
Update trigger-gitlab-pipeline

### DIFF
--- a/.github/workflows/dod.yml
+++ b/.github/workflows/dod.yml
@@ -2,6 +2,8 @@ name: Definition of Done
 on:
   pull_request:
     types: [opened, edited, synchronize]
+  merge_group:
+    types: checks_requested
 permissions: {}
 
 jobs:
@@ -10,7 +12,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-20.04
     # Excluding Dependabot PRs from this check.
-    if: github.actor != 'dependabot[bot]'
+    if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       - name: Check DoD

--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -15,7 +15,7 @@ permissions: {}
 
 jobs:
   trigger-gitlab-pipeline:
-    uses: NordSecurity/trigger-gitlab-pipeline/.github/workflows/trigger-gitlab-pipeline.yml@272b0b859016b5c0ff2c3b7d70799270b0a047fb
+    uses: NordSecurity/trigger-gitlab-pipeline/.github/workflows/trigger-gitlab-pipeline.yml@924d48acc8250c422e443f285630ec51e78700a0
     secrets:
       ci-api-v4-url: ${{ secrets.CI_API_V4_URL }}
       access-token: ${{ secrets.GITLAB_API_TOKEN }}


### PR DESCRIPTION
New version accepts merge_group as a trigger. Also update dod job to also trigger on the merge_group even though the job will be skipped. This way the dod status check will be set to successful.



### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
