### PR TITLE
bump trust-dns version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1711,7 +1711,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 [[package]]
 name = "hickory-proto"
 version = "0.24.0"
-source = "git+https://github.com/NordSecurity/trust-dns.git?tag=v3.0.1#88204024fd3ecdadccf4574eb7976167e7c52001"
+source = "git+https://github.com/NordSecurity/trust-dns.git?tag=v3.0.2#85613d003f6c7aa41510cfd3c0733a4d5fec420d"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -1735,7 +1735,7 @@ dependencies = [
 [[package]]
 name = "hickory-resolver"
 version = "0.24.0"
-source = "git+https://github.com/NordSecurity/trust-dns.git?tag=v3.0.1#88204024fd3ecdadccf4574eb7976167e7c52001"
+source = "git+https://github.com/NordSecurity/trust-dns.git?tag=v3.0.2#85613d003f6c7aa41510cfd3c0733a4d5fec420d"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1756,7 +1756,7 @@ dependencies = [
 [[package]]
 name = "hickory-server"
 version = "0.24.0"
-source = "git+https://github.com/NordSecurity/trust-dns.git?tag=v3.0.1#88204024fd3ecdadccf4574eb7976167e7c52001"
+source = "git+https://github.com/NordSecurity/trust-dns.git?tag=v3.0.2#85613d003f6c7aa41510cfd3c0733a4d5fec420d"
 dependencies = [
  "async-trait",
  "bytes",

--- a/crates/telio-dns/Cargo.toml
+++ b/crates/telio-dns/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 rand = { default-features = false, version = "0.8" }
-hickory-server = { git = "https://github.com/NordSecurity/trust-dns.git", tag = "v3.0.1", features = ["hickory-resolver"], default-features = false }
+hickory-server = { git = "https://github.com/NordSecurity/trust-dns.git", tag = "v3.0.2", features = ["hickory-resolver"], default-features = false }
 async-trait.workspace = true
 base64.workspace = true
 neptun.workspace = true


### PR DESCRIPTION
### Problem
dns tests fail in nat-lab. Root cause isn't known yet and it is a bit difficult to pinpoint the problem.

### Solution
Sprinkle logs in trust-dns and hopefully that would help narrow the problem.
This would be a temp bump to get to the root cause of dns test failing


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
