### PR TITLE
Fix dod status on merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
     uses: ./.github/workflows/nagger.yml
 
   check-all-green:
+    if: always()
     needs:
     - build
     - linters

--- a/.github/workflows/dod.yml
+++ b/.github/workflows/dod.yml
@@ -11,11 +11,11 @@ jobs:
     permissions:
       pull-requests: write
     runs-on: ubuntu-20.04
-    # Excluding Dependabot PRs from this check.
-    if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       - name: Check DoD
+        # Excluding Dependabot PRs and checks_requested events from this check.
+        if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
         uses: platisd/definition-of-done@e69d712b88c93ef88a73da4435155a0054b7df5e # v2.2.0
         with:
           dod_yaml: 'dod.yml'


### PR DESCRIPTION
Seems that skipped status is not enough, we need success status for check-dod job. So let's execute checkout always and dod step only when we should.



### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
