### PR TITLE
Wait for interface to report Connected state

### DIFF
--- a/nat-lab/tests/utils/command_grepper.py
+++ b/nat-lab/tests/utils/command_grepper.py
@@ -29,6 +29,9 @@ class CommandGrepper:
         self._timeout = timeout
         self._last_stdout = None
 
+    def get_stdout(self) -> Optional[str]:
+        return self._last_stdout
+
     async def check_exists(
         self, exp_primary: str, exp_secondary: Optional[List[str]] = None
     ) -> bool:


### PR DESCRIPTION
Windows tests fail sometimes by not reporting any
IP which is set without errors. Experimentation
revealed that the device might not have been
in a `Connected` state, so we enforce that.

### Problem
*--describe problem being solved--*

### Solution
*--describe selected solution--*


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
