### PR TITLE
Force Pyro to timeout quickly and introduce retries

### DIFF
--- a/nat-lab/tests/uniffi/libtelio_proxy.py
+++ b/nat-lab/tests/uniffi/libtelio_proxy.py
@@ -37,11 +37,13 @@ class LibtelioProxy:
 
     def _handle_remote_error(self, f):
         with Proxy(self._uri) as remote:
+            print(f"[{self._name}]:{datetime.now()}: _handle_remote_error: {self._uri}")
             fn_res = f(remote)
             if fn_res is None:
                 return None
             (res, err) = fn_res
             if err is not None:
+                print(f"[{self._name}]:{datetime.now()}: Pyro error: {err}")
                 raise Exception(err)
             return res
 


### PR DESCRIPTION
We observe that sometimes pyro remote calls are with time gaps in between which should not happen. We guess it might be due to network issues. However the packets still arrive and might be due to TCP retransmission.

Pyro has a timeout property which is not exposed publicly. This property is set and looped over if timeout error is returned to fix the issue.

### Problem
*--describe problem being solved--*

### Solution
*--describe selected solution--*


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
