### PR TITLE
LLT-5935: Only restart PQ if there was actually a previous handshake

### DIFF
--- a/nat-lab/tests/test_pq.py
+++ b/nat-lab/tests/test_pq.py
@@ -1,4 +1,3 @@
-import asyncio
 import config
 import pytest
 from contextlib import AsyncExitStack
@@ -90,7 +89,7 @@ async def inspect_preshared_key(nlx_conn: Connection) -> str:
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
                     stun_limits=(1, 1),
-                    nlx_1_limits=(1, 3),
+                    nlx_1_limits=(1, 2),
                 ),
                 is_meshnet=False,
             ),
@@ -106,7 +105,7 @@ async def inspect_preshared_key(nlx_conn: Connection) -> str:
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
                     stun_limits=(1, 1),
-                    nlx_1_limits=(1, 3),
+                    nlx_1_limits=(1, 2),
                 ),
                 is_meshnet=False,
             ),
@@ -189,7 +188,7 @@ async def test_pq_vpn_connection(
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
                     stun_limits=(1, 1),
-                    nlx_1_limits=(1, 3),
+                    nlx_1_limits=(1, 2),
                 ),
                 is_meshnet=False,
             ),
@@ -205,7 +204,7 @@ async def test_pq_vpn_connection(
                 connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.WINDOWS_VM_1,
                     stun_limits=(1, 1),
-                    nlx_1_limits=(1, 3),
+                    nlx_1_limits=(1, 2),
                 ),
                 is_meshnet=False,
             ),
@@ -546,6 +545,6 @@ async def test_pq_vpn_handshake_after_nonet() -> None:
         async with client_alpha.get_router().break_udp_conn_to_host(
             str(config.NLX_SERVER["ipv4"])
         ):
-            await asyncio.sleep(195)
+            await client_alpha.wait_for_log("Restarting postquantum entity")
 
         await ping(client_conn, config.PHOTO_ALBUM_IP, timeout=10)


### PR DESCRIPTION
### Problem
There was a potential race condition in our PQ restart logic that could cause restart to be called erroneously before the initial handshake was performed. The decision on whether to restart PQ was done based on the time since last handshake, as reported by the wireguard interface. The problem was that wireguard will uses None to represent both the case where no handshake has been performed and the case where a connection has been rejected after 180 seconds, so our PQ restart logic would incorrectly trigger if there was a wg consolidation happening between PQ peer being added and a handshake happening

### Solution
Now there's an additional timestamp in the PQ entity to help guide if PQ should be restarted


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
