### PR TITLE
LLT-5985: qnap: Fix missing aarch64 teliod binary

### DIFF
--- a/ci/build_libtelio.py
+++ b/ci/build_libtelio.py
@@ -34,6 +34,11 @@ MOOSE_MAP = {
     "armv7hf": "armv7_eabihf",
 }
 
+QNAP_MAP = {
+    "x86_64": "x86_64",
+    "aarch64": "arm_64",
+}
+
 PROJECT_CONFIG = rutils.Project(
     rust_version="1.77.2",
     root_dir=PROJECT_ROOT,
@@ -114,8 +119,9 @@ def post_qnap_build_wrap_binary_on_qpkg(config, args):
                 )
                 dst_path = os.path.join(
                     PROJECT_CONFIG.get_root_dir(),
-                    f"qnap/{config.arch}",
+                    f"qnap/{QNAP_MAP[config.arch]}",
                 )
+                os.makedirs(dst_path, exist_ok=True)
                 if os.path.isfile(src_path):
                     shutil.copy2(src_path, dst_path)
         rutils.run_command_with_output(


### PR DESCRIPTION
### Problem
Qnap's QDK builds packages depending on the project directory structure, given that `x86_64` folder was always present, it conflicted with other builds.
### Solution
Create arch directory during build.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
