### PR TITLE
Do not run our CI on push to branch

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -2,6 +2,8 @@ name: Definition of Done
 on:
   pull_request:
     types: [opened, synchronize]
+  merge_group:
+    types: checks_requested
 permissions: {}
 
 jobs:
@@ -14,6 +16,8 @@ jobs:
         with:
           fetch-depth: 0
       - name: Check for new file in .unreleased
+        # Excluding Dependabot PRs and merge_group events from this check.
+        if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
         run: |
           FILE_COUNT=$(git diff --name-only ${{github.event.pull_request.base.sha}}..HEAD -- .unreleased | wc -l)
           if [ "$FILE_COUNT" -eq "0" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,46 +1,29 @@
 name: CI
 on:
   push:
+    branches: ['main', 'release/**']
   pull_request:
   merge_group:
-    types: [checks_requested]
+    types: checks_requested
 
 permissions: {}
 
 jobs:
-  trigger:
-    if: |
-      github.event_name == 'push' ||
-      github.event_name == 'merge_group' ||
-      (
-        github.event_name == 'pull_request' &&
-        github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
-      )
-    runs-on: ubuntu-22.04
-    steps:
-      - name: CI Trigger
-        run: echo "Triggering CI"
-
   build:
-    needs: trigger
     uses: ./.github/workflows/build.yml
   linters:
-    needs: trigger
     uses: ./.github/workflows/linters.yml
   tests:
-    needs: trigger
     uses: ./.github/workflows/tests.yml
   fuzzing:
-    needs: trigger
     uses: ./.github/workflows/fuzzing.yml
   benchmarks:
-    needs: trigger
     uses: ./.github/workflows/benchmarks.yml
   nagger:
-    needs: trigger
     uses: ./.github/workflows/nagger.yml
 
   check-all-green:
+    if: always()
     needs:
     - build
     - linters

--- a/.github/workflows/dod.yml
+++ b/.github/workflows/dod.yml
@@ -11,11 +11,11 @@ jobs:
     permissions:
       pull-requests: write
     runs-on: ubuntu-20.04
-    # Excluding Dependabot PRs from this check.
-    if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       - name: Check DoD
+        # Excluding Dependabot PRs and merge_group events from this check.
+        if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
         uses: platisd/definition-of-done@e69d712b88c93ef88a73da4435155a0054b7df5e # v2.2.0
         with:
           dod_yaml: 'dod.yml'


### PR DESCRIPTION
While implementing the merge queue I've discovered that our CI has a bug. This is caused by jobs marked as skipped. When we have a workflow that is triggerd on both push and pull_reqeust events and then the trigger job that is responsible for cancelling duplicated CI runs on our internal pull requests, GH is treating cancelled job as successful in its 'requred checks' logic which protects branches from merging PRs with failing CI. So in the situation where we push a change that fails the skipped jobs are reported first and the actual runs are reported few minutes later when they actually finish. This creates the window during which the checks are considered successful.
There is also a second bug. check-all-green job was not marked to run 'always' This is a problem because in case any of its needed job fails this job is skipped. And as meantioned earlier skipped job is considered successful.
The first bug could be fixed by setting a commit status in the check-all-green job and then using it as the 'required check' similarly as we use GitLab commit status to signal GitLab pipeline status. But that complicates the CI even further and I think it is just easier and more error prone to not run the CI on the pushes to developers branches. This has a drawback because now you need to open a PR to run a CI but since most branches anyway end up in the PR this is a small cost to pay for a more robust CI IMO.
Funnily enough skipped jobs are NOT considered successful when run in the merge_group context so thats why dod and changelog jobs must actually run checkout even though they do not do anything useful at this stage.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
