### PR TITLE
Reenable windump in natlab

### DIFF
--- a/nat-lab/tests/utils/tcpdump.py
+++ b/nat-lab/tests/utils/tcpdump.py
@@ -162,10 +162,6 @@ async def make_tcpdump(
     try:
         async with AsyncExitStack() as exit_stack:
             for conn in connection_list:
-                # TODO(LLT-5942): temporary disable windows tcpdump
-                if conn.target_os == TargetOS.Windows:
-                    continue
-
                 await exit_stack.enter_async_context(
                     TcpDump(conn, session=session).run()
                 )
@@ -175,10 +171,6 @@ async def make_tcpdump(
             log_dir = get_current_test_log_path()
             os.makedirs(log_dir, exist_ok=True)
             for conn in connection_list:
-                # TODO(LLT-5942): temporary disable windows tcpdump
-                if conn.target_os == TargetOS.Windows:
-                    continue
-
                 path = find_unique_path_for_tcpdump(
                     store_in if store_in else log_dir, conn.target_name()
                 )
@@ -188,6 +180,5 @@ async def make_tcpdump(
             await conn.create_process(
                 ["rm", "-f", PCAP_FILE_PATH[conn.target_os]]
             ).execute()
-        # TODO(LLT-5942): temporary disable windows tcpdump
-        # else:
-        #     await conn.create_process(["del", PCAP_FILE_PATH[conn.target_os]]).execute()
+        else:
+            await conn.create_process(["del", PCAP_FILE_PATH[conn.target_os]]).execute()


### PR DESCRIPTION
### Problem
windump was disabled for debugging purposes in this PR https://github.com/NordSecurity/libtelio/pull/1061

### Solution
reenable it


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
