### PR TITLE
nat-lab investigation

### DIFF
--- a/nat-lab/tests/test_dns.py
+++ b/nat-lab/tests/test_dns.py
@@ -4,6 +4,7 @@ import asyncio
 import config
 import itertools
 import pytest
+import time
 import timeouts
 from config import LIBTELIO_DNS_IPV4, LIBTELIO_DNS_IPV6
 from contextlib import AsyncExitStack
@@ -187,12 +188,23 @@ async def test_dns(
         await client_beta.enable_magic_dns(["10.0.80.82"])
 
         # If everything went correctly, these calls should not timeout
+        start_time = time.time()
         await query_dns(
-            connection_alpha, "google.com", dns_server=dns_server_address_alpha
+            connection_alpha,
+            "google.com",
+            dns_server=dns_server_address_alpha,
+            options=["-timeout=30"],
         )
+        assert time.time() - start_time < 1
+
+        start_time = time.time()
         await query_dns(
-            connection_beta, "google.com", dns_server=dns_server_address_beta
+            connection_beta,
+            "google.com",
+            dns_server=dns_server_address_beta,
+            options=["-timeout=30"],
         )
+        assert time.time() - start_time < 1
 
         # If the previous calls didn't fail, we can assume that the resolver is running so no need to wait for the timeout and test the validity of the response
         await query_dns(

--- a/nat-lab/tests/utils/dns.py
+++ b/nat-lab/tests/utils/dns.py
@@ -1,5 +1,6 @@
 import re
 from config import LIBTELIO_DNS_IPV4
+from datetime import datetime
 from typing import List, Optional
 from utils.connection import Connection
 
@@ -18,9 +19,10 @@ async def query_dns(
         args.append("-timeout=1")
     args.append(host_name)
     args.append(dns_server if dns_server else LIBTELIO_DNS_IPV4)
-
     response = await connection.create_process(args).execute()
     dns_output = response.get_stdout()
+    print(datetime.now(), "nslookup stdout:", dns_output)
+    print(datetime.now(), "nslookup expected_output:", expected_output)
     if expected_output:
         for expected_str in expected_output:
             assert re.search(expected_str, dns_output, re.DOTALL) is not None


### PR DESCRIPTION
1. Print nslookup output in nat-lab
2. Increase timeout of nslookups that fail so we can see if at some point
they get unstuck but fail the test manually if the lookup took more then
the second so we can still see those failures in the nightly runs.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
