### PR TITLE
LLT-5996: Reset PQ handshake ts on successful rekey

### DIFF
--- a/crates/telio-pq/src/entity.rs
+++ b/crates/telio-pq/src/entity.rs
@@ -72,6 +72,7 @@ impl Entity {
                             // and only then update the preshared key,
                             // otherwise we're connecting to different node already
                             keys.pq_shared = pq_shared;
+                            peer.last_handshake_ts = Some(Instant::now());
                         } else {
                             telio_log_debug!(
                                 "PQ secret key does not match, ignoring shared secret rotation"


### PR DESCRIPTION
### Problem
PQ needs to be restarted if more than 180s pass since last handshake, but for this purpose a successful rekey is also considered a handshake, which was not taking into consideration, which meant that 180s after a connection was established, PQ would erroneously be restarted

### Solution
Reset PQ handshake timestamp on successful rekey


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
