### PR TITLE
Fix wait_for_log case sensitivity

### DIFF
--- a/nat-lab/tests/telio.py
+++ b/nat-lab/tests/telio.py
@@ -927,7 +927,10 @@ class Client:
         if case_insensitive:
             what = what.lower()
         while True:
-            if (await self.get_log()).lower().count(what) >= count:
+            log = await self.get_log()
+            if case_insensitive:
+                log = log.lower()
+            if log.count(what) >= count:
                 break
             await asyncio.sleep(1)
 


### PR DESCRIPTION
### Problem
`wait_for_log` has an option to be case insensitive (which is the default) in which case it will convert your search string to lowercase, but it always converts the log to lower case. So if you were to pass `case_insensitive=False` and a search string that's not just lowercase letters, you would never get a hit. The reason we haven't seen it happen so far is that no callsite is passing `case_insensitive=False`

### Solution
Convert log to lowercase only if  `case_insensitive` is `True`


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
