### PR TITLE
Allow for more time in await_timout for tests

### DIFF
--- a/crates/telio-test/src/lib.rs
+++ b/crates/telio-test/src/lib.rs
@@ -6,7 +6,7 @@ macro_rules! await_timeout {
     ($s:expr) => {
         tokio::select! {
           v = $s => { v }
-          _ = tokio::time::sleep(std::time::Duration::from_millis(100)) => { panic!("await took too long") }
+          _ = tokio::time::sleep(std::time::Duration::from_millis(500)) => { panic!("await took too long") }
         }
     };
 }


### PR DESCRIPTION
Bumped from 100ms to 500ms. This fixes flakyness in `wait_with_session_start_until_stun_server_wg_peer_is_available` on macos.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
