### PR TITLE
Crash if thread is unparked for too long

### DIFF
--- a/crates/telio-utils/src/tokio.rs
+++ b/crates/telio-utils/src/tokio.rs
@@ -48,6 +48,8 @@ impl ThreadTracker {
         }
     }
 
+    // TODO(mathiaspeters): remove after testing is done
+    #[allow(clippy::panic)]
     fn check_for_long_unparked_threads(&self) {
         let now = Instant::now();
         for (tid, (status, last_status_change)) in &self.statuses {
@@ -55,6 +57,8 @@ impl ThreadTracker {
                 let delta = now - *last_status_change;
                 if delta > 2 * UNPARKED_THRESHOLD {
                     telio_log_debug!("{tid:?} is unparked for {delta:?}");
+                    // TODO(mathiaspeters): remove after testing is done
+                    panic!("Manual panic due to thread being unparked for too long");
                 }
             }
         }


### PR DESCRIPTION
### Problem
We can see in nightly DNS tests that a thread is sometimes parked for too long, in the same place where we see that the test is timing out. We want to get core dumps so that we can investigate more deeply

### Solution
`panic!` if a thread is unparked for too long

Note: This will be removed as soon as our investigation is complete


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
