### PR TITLE
LLT-5886: Protected pinger refactoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4766,6 +4766,7 @@ dependencies = [
  "surge-ping",
  "telio-sockets",
  "telio-utils",
+ "thiserror 2.0.11",
  "tokio",
  "tracing",
 ]
@@ -4996,6 +4997,7 @@ dependencies = [
  "telio-crypto",
  "telio-model",
  "telio-network-monitors",
+ "telio-pinger",
  "telio-proto",
  "telio-sockets",
  "telio-task",

--- a/crates/telio-nurse/src/qos.rs
+++ b/crates/telio-nurse/src/qos.rs
@@ -255,7 +255,7 @@ impl Analytics {
         let (ping_channel_tx, ping_channel_rx) = mpsc::channel(1);
 
         let ping_backend = if config.rtt_types.contains(&RttType::Ping) {
-            Arc::new(Pinger::new(config.rtt_tries, ipv6_enabled, socket_pool).ok())
+            Arc::new(Pinger::new(config.rtt_tries, ipv6_enabled, socket_pool, "qos_rtt").ok())
         } else {
             Arc::new(None)
         };
@@ -467,7 +467,8 @@ impl Analytics {
                             _ => {}
                         }
 
-                        dpr = Box::pin(pinger.perform(dpt)).await;
+                        telio_log_trace!("Performing ping {:?}", dpt);
+                        dpr = Box::pin(pinger.perform_rtt(&dpt)).await;
 
                         if let Some(results_v4) = &dpr.v4 {
                             if results_v4.successful_pings != 0 {

--- a/crates/telio-pinger/Cargo.toml
+++ b/crates/telio-pinger/Cargo.toml
@@ -13,6 +13,7 @@ telio-sockets.workspace = true
 surge-ping.workspace = true
 rand.workspace = true
 tracing.workspace = true
+thiserror.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["net", "sync", "test-util"] }

--- a/crates/telio-traversal/Cargo.toml
+++ b/crates/telio-traversal/Cargo.toml
@@ -38,6 +38,7 @@ telio-sockets.workspace = true
 telio-task.workspace = true
 telio-utils.workspace = true
 telio-wg.workspace = true
+telio-pinger.workspace = true
 
 [dev-dependencies]
 env_logger.workspace = true


### PR DESCRIPTION
### Problem
There is some logic duplicated between SessionKeeper and `Pinger` component used by QoS and LinkDetection

### Solution

- SessionKeeper is refactored to use the same `Pinger` component.
- A new method `send_ping` is added to issue a "fire and forget" ping as used by SessionKeeper. LinkDetection is also migrated to issue a "fire and forget" ping as it doesn't require to wait for a reply.
- `perform` renamed to `perform_rtt` to make it more explicit.
- `module_name` field added to aid in debugging the module that sent the pings. In debug builds this is also added as ICMP data to be more easily traceable in packet captures.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
