### PR TITLE
[LLT-5972] Control Up/Down state of WG-NT adapter according to presence of peers.

### DIFF
--- a/.unreleased/LLT-5972_configure_windows_adapter_according_to_needs
+++ b/.unreleased/LLT-5972_configure_windows_adapter_according_to_needs
@@ -1,0 +1,1 @@
+Bring WG-NT interface up and down according to peer list as per RFC LLT-0089

--- a/crates/telio-dns/tests/nameserver.rs
+++ b/crates/telio-dns/tests/nameserver.rs
@@ -523,11 +523,7 @@ async fn init_client(
     let client = WGClient::new(client_secret_key, server_public_key, server_address).await;
 
     nameserver
-        .start(
-            server_peer.clone(),
-            server_socket.clone(),
-            client.client_address(),
-        )
+        .start(server_peer.clone(), server_socket.clone())
         .await;
 
     client

--- a/src/device.rs
+++ b/src/device.rs
@@ -1729,10 +1729,6 @@ impl Runtime {
 
                 let dns = LocalDnsResolver::new(
                     &public_key,
-                    self.entities
-                        .wireguard_interface
-                        .wait_for_listen_port(Duration::from_millis(100))
-                        .await?,
                     upstream_dns_servers,
                     dns_entity.virtual_host_tun_fd,
                     self.features.dns.exit_dns.clone(),
@@ -1819,12 +1815,6 @@ impl Runtime {
                         .await
                 });
 
-            let wg_port = self
-                .entities
-                .wireguard_interface
-                .wait_for_proxy_listen_port(Duration::from_secs(1))
-                .await?;
-
             let meshnet_entities: MeshnetEntities = if let MeshnetState::Entities(entities) =
                 std::mem::replace(
                     &mut self.entities.meshnet,
@@ -1836,7 +1826,7 @@ impl Runtime {
             };
 
             let proxy_config = ProxyConfig {
-                wg_port: Some(wg_port),
+                wg_port: None,
                 peers: peers.clone(),
             };
 
@@ -1845,7 +1835,7 @@ impl Runtime {
             if let Some(ref starcast) = meshnet_entities.starcast {
                 let starcast_vpeer_config = StarcastPeerConfig {
                     public_key: secret_key.public(),
-                    wg_port,
+                    wg_port: None,
                 };
                 let multicast_peers = config
                     .clone()


### PR DESCRIPTION
### Problem
It may be beneficial to show the adapter as "disconnected" or "down" in case it is idling in libtelio. This is especially useful if one keeps it preconfigured for potential use in the future, as adapter configuration can sometimes take seconds. For this reason this PR adds a logic which makes sure that adapter is down if there are no peers requested for WG and brings it up when peers are added. 


There is RFC LLT-0089 for more details.

Now in order to finalize the PR there had to be a few changes to other places.

### Windows IP address setup
Previously we have been configuring windows adapter IP address with standard `netsh` command and later waiting until the IP address is actually set, Unfortunately due to a fact that this operation now is operating on "disconnected" adapter before any feature is turned on - the waiting would be indefinite, as until any feature is enabled, the adapter will not get its IP. This waiting was added due to a fact that we have observed that it may take seconds for the IP address to be actually set. The delay was coming from windows duplicate address detection, but duplicate address detection on tunnel interface is not useful. For this reason in this PR, the DAD was disabled and waiting for IPs removed.

### Consolidating WG port for proxy and starcast virtual peer
Previously assumption was made that WireGuard listen port never changes during runtime. While this assumption is mostly true, it is a bit dangerous, and out right broken in case we are starting with disabled adapter. For this reason in this PR a runtime consolidation step to align listen port used by `telio-starcast` and `telio-proxy` is added on wg_controller consolidation cycle.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
