### PR TITLE
Fix panic if empty direct config is passed

### DIFF
--- a/.unreleased/LLT-5605
+++ b/.unreleased/LLT-5605
@@ -1,0 +1,1 @@
+Fix libtelio panic when epty Direct config is passed, now a proper error is returned instead

--- a/src/device.rs
+++ b/src/device.rs
@@ -185,6 +185,8 @@ pub enum Error {
     TransportError(#[from] telio_starcast::transport::Error),
     #[error("Events processing thread failed to start: {0}")]
     EventsProcessingThreadStartError(std::io::Error),
+    #[error("Polling period cannot be zero")]
+    PollingPeriodZero,
 }
 
 pub type Result<T = ()> = std::result::Result<T, Error>;
@@ -1370,7 +1372,9 @@ impl Runtime {
                 self.requested_state.device_config.private_key.clone(),
             )));
             let mut endpoint_providers: Vec<Arc<dyn EndpointProvider>> = Vec::new();
-
+            if direct.endpoint_interval_secs == 0 {
+                return Err(Error::PollingPeriodZero);
+            }
             // Create Local Interface Endpoint Provider
             let local_interfaces_endpoint_provider = if has_provider(Local) {
                 let ep = Arc::new(LocalInterfacesEndpointProvider::new(


### PR DESCRIPTION
### Problem
libtelio panic's if an empty `Direct` config is passed, since then it passes `0` as the period for `interval_at`.

### Solution
Added a check for empty config to prevent 0 as interval and return a proper error instead.
