### PR TITLE
ci: Reenable unused-features linter job

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -166,4 +166,4 @@ jobs:
       - uses: extractions/setup-just@dd310ad5a97d8e7b41793f8ef055398d51ad4de6 # v2.0.0
         with:
           just-version: 1.38.0
-      - run: just deny
+      - run: just unused


### PR DESCRIPTION
### Problem
`unused-features` job was disabled unintentionally on https://github.com/NordSecurity/libtelio/pull/1014.
### Solution
Reenable it.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
