### PR TITLE
Point to libtelio-build with audit logs disabled

### DIFF
--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -24,4 +24,4 @@ jobs:
     with:
       schedule: ${{ github.event_name == 'schedule' }}
       cancel-outdated-pipelines: ${{ github.ref_name != 'main' }}
-      triggered-ref: v2.8.6 # REMEMBER to also update in .gitlab-ci.yml
+      triggered-ref: lukasp/disable-audit-logs # REMEMBER to also update in .gitlab-ci.yml

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,4 +15,4 @@ libtelio-build-pipeline:
 
   trigger:
     project: $LIBTELIO_BUILD_PROJECT_PATH
-    branch: v2.8.6 # REMEMBER to also update in .github/workflows/gitlab.yml
+    branch: lukasp/disable-audit-logs # REMEMBER to also update in .github/workflows/gitlab.yml


### PR DESCRIPTION
Vagrantfile in libtelio-build has provisioning script with audit logs disabled. They are found to be
the root cause of most IO on `default` VM. Not a
guarantee this will fix anything though.

### Problem
*--describe problem being solved--*

### Solution
*--describe selected solution--*


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
