### PR TITLE
Bump libtelio-build to v2.8.7

### DIFF
--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -24,4 +24,4 @@ jobs:
     with:
       schedule: ${{ github.event_name == 'schedule' }}
       cancel-outdated-pipelines: ${{ github.ref_name != 'main' }}
-      triggered-ref: lukasp/disable-audit-logs # REMEMBER to also update in .gitlab-ci.yml
+      triggered-ref: v2.8.7 # REMEMBER to also update in .gitlab-ci.yml

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,4 +15,4 @@ libtelio-build-pipeline:
 
   trigger:
     project: $LIBTELIO_BUILD_PROJECT_PATH
-    branch: lukasp/disable-audit-logs # REMEMBER to also update in .github/workflows/gitlab.yml
+    branch: v2.8.7 # REMEMBER to also update in .github/workflows/gitlab.yml


### PR DESCRIPTION
v2.8.7 contains audit logs disabled as they were
found to be causing a lot of journal entries thus
possibly causing high IO and as a result
flakyness in NatLab

### Problem
*--describe problem being solved--*

### Solution
*--describe selected solution--*
