### PR TITLE
Install also toolchain from toolchain-file when running unused lint

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -102,7 +102,7 @@ autoflake:
 _udeps-install: _nightly-install
     cargo +{{ nightly }} install cargo-udeps@0.1.47 --locked
 
-_unused-install: _rust1_80-install
+_unused-install: _rust1_80-install _rust-from-toolchain-file-install
     cargo +{{ rust1_80 }} install --version 0.2.0 cargo-unused-features --locked
 
 _deny-install:
@@ -113,3 +113,6 @@ _nightly-install:
 
 _rust1_80-install:
     rustup toolchain add {{ rust1_80}}
+
+_rust-from-toolchain-file-install:
+    rustup toolchain install


### PR DESCRIPTION
Latest rustup release (1.28.0) broke / changed behaviour regarding implicit installing of toolchains specified in the toolchain file.

See for details: https://github.com/rust-lang/rustup/issues/4211#issuecomment-2695620307

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
