### PR TITLE
Remove Apple code signing

### DIFF
--- a/ci/insert_libtelio_version.py
+++ b/ci/insert_libtelio_version.py
@@ -29,9 +29,6 @@ def insert_version_to_libtelio_binaries_in_dir(new_version: str, path: str):
                 replace_string.replace_string_in_file(
                     path, VERSION_PLACEHOLDER, new_version
                 )
-                if target_os == "macos":
-                    os.system(f"codesign --remove-signature {path}")
-                    os.system(f"codesign --sign - {path}")
         else:
             for dirname, subdirnames, filenames in os.walk(path):
                 if "dSYM" in dirname:
@@ -46,9 +43,6 @@ def insert_version_to_libtelio_binaries_in_dir(new_version: str, path: str):
                         replace_string.replace_string_in_file(
                             binary, VERSION_PLACEHOLDER, new_version
                         )
-                        if target_os == "macos":
-                            os.system(f"codesign --remove-signature {binary}")
-                            os.system(f"codesign --sign - {binary}")
     if not is_valid_package:
         raise ValueError(f"Path {path} doesn't contain any libtelio packages")
 


### PR DESCRIPTION
### Problem
Currently libtelio is the only LLT library we use which is provided with code signing. This is causing a problem following adoption of Framework wrapped-dylibs, because the code signing is setting an identity on the dylib binary which is being preserved throughout the later build pipeline which conflicts with the Framework identity

### Solution
Remove code signing in libtelio


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
