### PR TITLE
Bump check-dod Ubuntu version

### DIFF
--- a/.github/workflows/dod.yml
+++ b/.github/workflows/dod.yml
@@ -10,7 +10,7 @@ jobs:
   check-dod:
     permissions:
       pull-requests: write
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       - name: Check DoD


### PR DESCRIPTION
### Problem
Ubuntu 20.04 is being deprecated by github.
https://github.com/actions/runner-images/issues/11101

### Solution
Update the workflow Ubuntu version.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
