### PR TITLE
natlab: Setup ephemeral ports only when needed

### DIFF
--- a/nat-lab/tests/test_multicast_connection.py
+++ b/nat-lab/tests/test_multicast_connection.py
@@ -42,6 +42,7 @@ MUILTICAST_TEST_PARAMS = [
             (ConnectionTag.DOCKER_CONE_CLIENT_1, TelioAdapterType.NEP_TUN),
         ]),
         "ssdp",
+        marks=pytest.mark.windows,
     ),
     pytest.param(
         generate_setup_parameter_pair([
@@ -49,6 +50,7 @@ MUILTICAST_TEST_PARAMS = [
             (ConnectionTag.WINDOWS_VM_1, TelioAdapterType.WINDOWS_NATIVE_TUN),
         ]),
         "mdns",
+        marks=pytest.mark.windows,
     ),
     pytest.param(
         generate_setup_parameter_pair([


### PR DESCRIPTION
### Problem
Ephemeral ports setup takes about 5 seconds, it is being done on every test for every node and that's not required.

### Solution
Do the ephemeral ports setup only when a new connection is created instead.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
