### PR TITLE
Reduce MulticastClient timeout

### DIFF
--- a/nat-lab/tests/utils/multicast.py
+++ b/nat-lab/tests/utils/multicast.py
@@ -29,7 +29,7 @@ class MulticastClient:
             f"--{protocol}",
             "-c",
             "-t",
-            "10",
+            "5",
         ])
 
     async def execute(self) -> None:


### PR DESCRIPTION
### Problem
Test `test_multicast_disallowed` is occasionally failing.

### Solution
Reduce multicast client timeout so that it always fails before the server.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
