### PR TITLE
Use SystemTime instead of Instant in PQ restart

### DIFF
--- a/.unreleased/LLT-6041-pq-restart-instant
+++ b/.unreleased/LLT-6041-pq-restart-instant
@@ -1,0 +1,1 @@
+Use SystemTime in PQ restart logic to avoid problems when OS is asleep


### PR DESCRIPTION
Instant does not give any guarantees when it comes to whether it counts time that elapsed during the system sleep. Because we need to measure real passage of time in PQ restart logic let's use SystemTime instead.



### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
