### PR TITLE
Add daily log rotation for the teliod

### DIFF
--- a/clis/teliod/README.md
+++ b/clis/teliod/README.md
@@ -22,7 +22,8 @@ There is a command for running the daemon:
      - `debug`
      - `trace`
      - `off`
-   - `log_file_path` - a path to the daemon's logging file (relative paths are starting in Teliod's working directory)
+   - `log_file_path` - a path to the daemon's logging file, needs to specify both the directory and the file name
+   - `log_file_count` - number of recent log files (log files are rotated daily)
    - `authentication_token` - Token from Nord VPN account to authenticate API calls
    - `app_user_uid` - A unique number for each user of the application
    - `interface`

--- a/clis/teliod/example_teliod_config.json
+++ b/clis/teliod/example_teliod_config.json
@@ -1,6 +1,6 @@
 {
     "log_level": "trace",
-    "log_file_path": "example_log_file.log",
+    "log_file_path": "./example_log_file.log",
     "authentication_token": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
     "interface": {
       "name": "utun10",

--- a/clis/teliod/src/cgi/api.rs
+++ b/clis/teliod/src/cgi/api.rs
@@ -278,6 +278,7 @@ mod tests {
         let mut expected_config = TeliodDaemonConfig {
             log_level: LevelFilter::DEBUG,
             log_file_path: "/path/to/log".to_owned(),
+            log_file_count: 7,
             interface: InterfaceConfig {
                 name: "eth0".to_owned(),
                 config_provider: InterfaceConfigurationProvider::Manual,
@@ -319,6 +320,7 @@ mod tests {
 
         expected_config.log_level = LevelFilter::INFO;
         expected_config.log_file_path = "/new/path/to/log".to_owned();
+        expected_config.log_file_count = 8;
         expected_config.authentication_token =
             "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_owned();
         expected_config.interface = InterfaceConfig {
@@ -335,6 +337,7 @@ mod tests {
         {
             "log_level": "info",
             "log_file_path": "/new/path/to/log",
+            "log_file_count": 8,
             "authentication_token": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
             "interface": {
                 "name": "eth1",
@@ -362,6 +365,7 @@ mod tests {
         let mut expected_config = TeliodDaemonConfig {
             log_level: LevelFilter::DEBUG,
             log_file_path: "/path/to/log".to_owned(),
+            log_file_count: 7,
             interface: InterfaceConfig {
                 name: "eth0".to_owned(),
                 config_provider: InterfaceConfigurationProvider::Manual,

--- a/clis/teliod/src/config.rs
+++ b/clis/teliod/src/config.rs
@@ -98,6 +98,8 @@ pub struct TeliodDaemonConfig {
     )]
     pub log_level: LevelFilter,
     pub log_file_path: String,
+    #[serde(default = "default_log_file_count")]
+    pub log_file_count: usize,
     pub interface: InterfaceConfig,
 
     #[serde(
@@ -121,6 +123,9 @@ impl TeliodDaemonConfig {
         }
         if let Some(log_file_path) = update.log_file_path {
             self.log_file_path = log_file_path;
+        }
+        if let Some(log_file_count) = update.log_file_count {
+            self.log_file_count = log_file_count;
         }
         if let Some(authentication_token) = update.authentication_token {
             self.authentication_token = authentication_token;
@@ -155,6 +160,7 @@ impl Default for TeliodDaemonConfig {
                     "./teliod.log".to_string()
                 }
             },
+            log_file_count: default_log_file_count(),
             interface: InterfaceConfig {
                 name: "nlx".to_string(),
                 config_provider: Default::default(),
@@ -229,6 +235,10 @@ where
     }
 }
 
+const fn default_log_file_count() -> usize {
+    7
+}
+
 #[derive(Default, PartialEq, Eq, Deserialize, Serialize, Debug, Clone)]
 pub struct InterfaceConfig {
     pub name: String,
@@ -241,6 +251,7 @@ pub struct TeliodDaemonConfigPartial {
     #[serde(default, deserialize_with = "deserialize_partial_log_level")]
     pub log_level: Option<LevelFilter>,
     pub log_file_path: Option<String>,
+    pub log_file_count: Option<usize>,
     pub interface: Option<InterfaceConfig>,
     pub app_user_uid: Option<Uuid>,
     #[serde(default, deserialize_with = "deserialize_partial_authentication_token")]
@@ -302,6 +313,7 @@ mod tests {
         let expected = TeliodDaemonConfig {
             log_level: LevelFilter::INFO,
             log_file_path: "test.log".to_owned(),
+            log_file_count: 7,
             interface: InterfaceConfig {
                 name: "utun10".to_owned(),
                 config_provider: InterfaceConfigurationProvider::Manual,

--- a/clis/teliod/src/logging.rs
+++ b/clis/teliod/src/logging.rs
@@ -1,0 +1,58 @@
+use std::{
+    path::{Path, PathBuf},
+    str::FromStr,
+};
+
+use tracing::level_filters::LevelFilter;
+use tracing_appender::{
+    non_blocking::WorkerGuard,
+    rolling::{Builder, Rotation},
+};
+
+use crate::TeliodError;
+
+pub async fn setup_logging(
+    log_file_path: &str,
+    log_level: LevelFilter,
+    log_file_count: usize,
+) -> Result<WorkerGuard, TeliodError> {
+    let log_file_pathbuf = PathBuf::from_str(log_file_path).map_err(|e| {
+        TeliodError::InvalidConfigOption(
+            "log_file_path".to_owned(),
+            e.to_string(),
+            log_file_path.to_string(),
+        )
+    })?;
+
+    let empty: &Path = Path::new("");
+
+    let (log_dir, log_file) = match (log_file_pathbuf.parent(), log_file_pathbuf.file_name()) {
+        (Some(log_dir), Some(file_name)) if log_dir != empty && file_name != empty => {
+            (log_dir, file_name)
+        }
+        _ => {
+            return Err(TeliodError::InvalidConfigOption(
+                "log_file_path".to_owned(),
+                "log_file_path needs to contain both directory and file name".to_owned(),
+                log_file_path.to_owned(),
+            ))
+        }
+    };
+
+    let log_appender = Builder::new()
+        .rotation(Rotation::DAILY)
+        .filename_prefix(log_file.to_string_lossy())
+        .max_log_files(log_file_count)
+        .build(log_dir)?;
+
+    let (non_blocking_writer, tracing_worker_guard) = tracing_appender::non_blocking(log_appender);
+    tracing_subscriber::fmt()
+        .with_max_level(log_level)
+        .with_writer(non_blocking_writer)
+        .with_ansi(false)
+        .with_line_number(true)
+        .with_level(true)
+        .init();
+
+    Ok(tracing_worker_guard)
+}

--- a/nat-lab/data/teliod/config.json
+++ b/nat-lab/data/teliod/config.json
@@ -1,6 +1,6 @@
 {
     "log_level": "trace",
-    "log_file_path": "teliod_natlab.log",
+    "log_file_path": "./teliod_natlab.log",
     "authentication_token": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
     "interface": {
       "name": "teliod",


### PR DESCRIPTION
### Problem
Logs generated by teliod can, over time, fill up the filesystem.

### Solution
Keep the logs from last `log_file_count` (default 7) days.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
