### PR TITLE
Add new feature flag for dynamic WireGuard-NT adapter control

### DIFF
--- a/.unreleased/LLT-6086
+++ b/.unreleased/LLT-6086
@@ -1,0 +1,1 @@
+Add feature flag for dynamic WireGuard-NT control

--- a/crates/telio-model/src/features.rs
+++ b/crates/telio-model/src/features.rs
@@ -90,6 +90,9 @@ pub struct FeatureWireguard {
     /// Configurable wireguard polling period
     #[serde(default)]
     pub polling: FeaturePolling,
+    /// Configurable up/down behavior of WireGuard-NT adapter. See RFC LLT-0089 for details
+    #[serde(default)]
+    pub enable_dynamic_wg_nt_control: bool,
 }
 
 impl FeatureWireguard {
@@ -515,7 +518,8 @@ mod tests {
                 "polling": {
                     "wireguard_polling_period": 1000,
                     "wireguard_polling_period_after_state_change": 50
-                }
+                },
+                "enable_dynamic_wg_nt_control": true
             },
             "nurse": {
                 "fingerprint": "test_fingerprint",
@@ -609,7 +613,8 @@ mod tests {
                         polling: FeaturePolling {
                             wireguard_polling_period: 1000,
                             wireguard_polling_period_after_state_change: 50
-                        }
+                        },
+                        enable_dynamic_wg_nt_control: true,
                     },
                     nurse: Some(FeatureNurse {
                         heartbeat_interval: 5,

--- a/crates/telio-wg/src/adapter/linux_native_wg.rs
+++ b/crates/telio-wg/src/adapter/linux_native_wg.rs
@@ -44,7 +44,7 @@ pub enum Error {
 
 impl LinuxNativeWg {
     #[cfg(not(any(test, feature = "test-adapter")))]
-    pub fn start(name: &str, _tun: Option<NativeTun>) -> Result<Self, AdapterError> {
+    pub fn start(name: &str) -> Result<Self, AdapterError> {
         let mut rtsocket = RouteSocket::connect().map_err(Error::from)?;
 
         rtsocket.add_device(name).map_err(Error::from)?;

--- a/nat-lab/tests/test_events_link_state.py
+++ b/nat-lab/tests/test_events_link_state.py
@@ -33,6 +33,7 @@ def long_persistent_keepalive_periods() -> FeatureWireguard:
             wireguard_polling_period=1000,
             wireguard_polling_period_after_state_change=50,
         ),
+        enable_dynamic_wg_nt_control=False,
     )
 
 

--- a/nat-lab/tests/utils/bindings.py
+++ b/nat-lab/tests/utils/bindings.py
@@ -23,6 +23,7 @@ def default_features(
     enable_link_detection: bool = False,
     enable_pmtu_discovery: bool = False,
     enable_multicast: bool = False,
+    enable_dynamic_wg_nt_control: bool = False,
 ) -> Features:
     features_builder = FeaturesDefaultsBuilder()
     if enable_lana is not None:
@@ -45,6 +46,8 @@ def default_features(
         features_builder = features_builder.enable_pmtu_discovery()
     if enable_multicast:
         features_builder = features_builder.enable_multicast()
+    if enable_dynamic_wg_nt_control:
+        features_builder = features_builder.enable_dynamic_wg_nt_control()
 
     features = features_builder.build()
     features.is_test_env = True

--- a/src/device.rs
+++ b/src/device.rs
@@ -1120,12 +1120,13 @@ impl Runtime {
                             firewall_filter_outbound_packets,
                         )),
                         firewall_reset_connections,
+                        enable_dynamic_wg_nt_control: features.wireguard.enable_dynamic_wg_nt_control,
                     },
                     features.link_detection,
                     features.ipv6,
                     Duration::from_millis(features.wireguard.polling.wireguard_polling_period.into()),
                     Duration::from_millis(features.wireguard.polling.wireguard_polling_period_after_state_change.into()),
-                )?);
+                ).await?);
                 let wg_events = wg_events.rx;
             } else {
                 let wg::tests::Env {
@@ -1144,6 +1145,7 @@ impl Runtime {
                                 firewall_filter_outbound_packets,
                             )),
                             firewall_reset_connections,
+                            enable_dynamic_wg_nt_control: features.wireguard.enable_dynamic_wg_nt_control,
                         }
                     ).await;
 

--- a/src/libtelio.udl
+++ b/src/libtelio.udl
@@ -522,6 +522,10 @@ interface FeaturesDefaultsBuilder {
     /// Enable keepalive batching feature
     [Self=ByArc]
     FeaturesDefaultsBuilder enable_batching();
+
+    /// Enable dynamic WireGuard-NT control as per RFC LLT-0089
+    [Self=ByArc]
+    FeaturesDefaultsBuilder enable_dynamic_wg_nt_control();
 };
 
 
@@ -584,6 +588,8 @@ dictionary FeatureWireguard {
     FeaturePersistentKeepalive persistent_keepalive;
     /// Configurable WireGuard polling periods
     FeaturePolling polling;
+    /// Configurable up/down behavior of WireGuard-NT adapter. See RFC LLT-0089 for details
+    boolean enable_dynamic_wg_nt_control;
 };
 
 /// Configurable persistent keepalive periods for different types of peers


### PR DESCRIPTION
### Problem
Windows adapter control based on RFC LLT-0089 was missing feature flag. This PR adds it.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
