### PR TITLE
Fix nat-lab test exception handling

### DIFF
--- a/crates/telio-wg/src/adapter/windows_native_wg.rs
+++ b/crates/telio-wg/src/adapter/windows_native_wg.rs
@@ -222,6 +222,12 @@ impl WindowsNativeWg {
                 return Ok(());
             }
 
+            telio_log_debug!(
+                "Attempting to bring interface {:?}, currently it is: {:?}",
+                want_adapter_state,
+                have_adapter_state
+            );
+
             // The wireguard-nt-rust-wrapper here indicates success using
             // bool for `.up()` or `.down()` functions
             let success = match want_adapter_state {

--- a/crates/telio-wg/src/windows/tunnel/interfacewatcher.rs
+++ b/crates/telio-wg/src/windows/tunnel/interfacewatcher.rs
@@ -307,12 +307,12 @@ impl InterfaceWatcher {
                         if let Err(err) = adapter.set_config_uapi(&last_known_config.config) {
                             telio_log_error!("Failed to set last known config: {}", err);
                         }
+
+                        if !last_known_config.config.peers.is_empty() && !adapter.up() {
+                            telio_log_error!("Adapter could not be set to online state");
+                        }
                     } else {
                         telio_log_info!("Adapter config not set");
-                    }
-
-                    if !adapter.up() {
-                        telio_log_error!("Adapter could not be set to online state");
                     }
                 }
             } else {

--- a/nat-lab/tests/test_events_link_state.py
+++ b/nat-lab/tests/test_events_link_state.py
@@ -387,7 +387,7 @@ class ICMP_control:
         ])
         await proc.execute()
 
-    async def __aexit__(self, _exc_t, exc_v, exc_tb):
+    async def __aexit__(self, *_):
         proc = self._conn.create_process([
             "iptables",
             "-D",

--- a/nat-lab/tests/utils/connection/docker_connection.py
+++ b/nat-lab/tests/utils/connection/docker_connection.py
@@ -94,10 +94,9 @@ class DockerConnection(Connection):
         await setup_ephemeral_ports(self)
         return self
 
-    async def __aexit__(self, *exc_details):
+    async def __aexit__(self, *_):
         await self.restore_ip_tables()
         await self.clean_interface()
-        return self
 
     @classmethod
     @asynccontextmanager

--- a/nat-lab/tests/utils/connection/ssh_connection.py
+++ b/nat-lab/tests/utils/connection/ssh_connection.py
@@ -35,8 +35,8 @@ class SshConnection(Connection):
         await setup_ephemeral_ports(self)
         return self
 
-    async def __aexit__(self, exc_type, exc, tb):
-        return None
+    async def __aexit__(self, *_):
+        pass
 
     @classmethod
     @asynccontextmanager


### PR DESCRIPTION
### Problem
Async contexts must define `__aexit__` method, but it matters what we return out of it. According to [PEP 492](https://peps.python.org/pep-0492/#new-syntax) the `__atexit__` usage is equivalent to this

```python
mgr = (EXPR)
aexit = type(mgr).__aexit__
aenter = type(mgr).__aenter__

VAR = await aenter(mgr)
try:
    BLOCK
except:
    if not await aexit(mgr, *sys.exc_info()):
        raise
else:
    await aexit(mgr, None, None, None)
```

In case of exception -> we need to return something that would evaluate to `False`, or otherwise we will loose exceptions. Omiting `return` statement altogether - is equivalent to `return None` which evaluates to `False`.

This PR fixes `__aexit__` implementation according to that.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
