### PR TITLE
Lukasp/llt 6060 reduce dns logs and improve packet output in logs

### DIFF
--- a/crates/telio-dns/src/nameserver.rs
+++ b/crates/telio-dns/src/nameserver.rs
@@ -171,8 +171,8 @@ impl LocalNameServer {
                         {
                             Ok(length) => length,
                             Err(e) => {
-                                telio_log_error!(
-                                    "[DNS] {}. Offending request packet: {:?}",
+                                telio_log_debug!(
+                                    "[DNS] {}. Offending request packet: [{:?}]",
                                     e,
                                     packet
                                 );

--- a/crates/telio-dns/src/nameserver.rs
+++ b/crates/telio-dns/src/nameserver.rs
@@ -27,7 +27,7 @@ use tokio::sync::{RwLock, RwLockMappedWriteGuard, RwLockWriteGuard, Semaphore};
 use tokio::task::JoinHandle;
 use tokio::{net::UdpSocket, sync::Mutex};
 
-use telio_utils::{telio_log_debug, telio_log_error, telio_log_trace, telio_log_warn};
+use telio_utils::{format_hex, telio_log_debug, telio_log_error, telio_log_trace, telio_log_warn};
 
 const IPV4_HEADER: usize = 20; // bytes
 const IPV6_HEADER: usize = 40; // bytes
@@ -174,7 +174,7 @@ impl LocalNameServer {
                                 telio_log_debug!(
                                     "[DNS] {}. Offending request packet: [{:?}]",
                                     e,
-                                    packet
+                                    format_hex(packet)
                                 );
                                 return;
                             }

--- a/crates/telio-starcast/src/nat.rs
+++ b/crates/telio-starcast/src/nat.rs
@@ -8,7 +8,7 @@ use std::{
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     time::Duration,
 };
-use telio_utils::{telio_log_debug, telio_log_warn, LruCache};
+use telio_utils::{format_hex, telio_log_debug, telio_log_warn, LruCache};
 
 #[derive(Debug, PartialEq, thiserror::Error)]
 pub enum Error {
@@ -96,9 +96,9 @@ impl StarcastNat {
         let mut ip_packet = P::new(packet).ok_or(Error::PacketTooShort)?;
         if ip_packet.get_next_level_protocol() != IpNextHeaderProtocols::Udp {
             telio_log_debug!(
-                "Unexpected incoming packet of type {:?}, packet = {:?}",
+                "Unexpected incoming packet of type {:?}, packet = [{:?}]",
                 ip_packet.get_next_level_protocol(),
-                ip_packet.packet()
+                format_hex(ip_packet.packet())
             );
             return Err(Error::UnexpectedTransportProtocol);
         }

--- a/crates/telio-utils/src/lib.rs
+++ b/crates/telio-utils/src/lib.rs
@@ -4,6 +4,8 @@
 /// export utils
 pub mod utils;
 
+pub use utils::format_hex;
+
 /// Utils for rust std map types
 pub mod map;
 pub use map::*;

--- a/crates/telio-utils/src/utils.rs
+++ b/crates/telio-utils/src/utils.rs
@@ -61,6 +61,15 @@ macro_rules! telio_err_with_log {
     }};
 }
 
+/// Format byte array to hex
+pub fn format_hex(bytes: &[u8]) -> String {
+    bytes
+        .iter()
+        .map(|b| format!("{:02X}", b))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};


### PR DESCRIPTION
1. Offending DNS packets are printed as error severity meaning they contain decodable hostnames that are present in user logs.
2. Offending packets are now printed in Hex in multicast and dns error cases to aid debugging


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
