### PR TITLE
LLT-6071: Change DuplicateCounter log level to debug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2640,7 +2640,7 @@ dependencies = [
 [[package]]
 name = "neptun"
 version = "0.6.0"
-source = "git+https://github.com/NordSecurity/neptun.git?tag=v1.0.4#975bf34987342bd663cfdf5b464386142b56d3f7"
+source = "git+https://github.com/NordSecurity/neptun.git?tag=v1.0.5#f94cb1280a9a8f18920aecf10e1c084041f9b72a"
 dependencies = [
  "aead",
  "base64 0.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,7 +174,7 @@ windows = { version = "0.60", features = [
     "Win32_NetworkManagement_IpHelper",
 ] }
 
-neptun = { git = "https://github.com/NordSecurity/neptun.git", tag = "v1.0.4", features = ["device"] }
+neptun = { git = "https://github.com/NordSecurity/neptun.git", tag = "v1.0.5", features = ["device"] }
 x25519-dalek = { version = "2.0.1", features = ["reusable_secrets", "static_secrets"] }
 
 


### PR DESCRIPTION
Forward-port a fix for v5.1 and v5.2 so it can be included in v5.3 release candidates. The only change in NepTUN between v1.0.4 and v1.0.5 is changing the log level for DuplicateCounter errors


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
