### PR TITLE
Fix natlab logger issues

### DIFF
--- a/nat-lab/pyproject.toml
+++ b/nat-lab/pyproject.toml
@@ -154,6 +154,11 @@ addopts = [
     "--html=report.html",
     "--self-contained-html"
 ]
+filterwarnings = [
+    "ignore::DeprecationWarning"
+]
+log_format = "%(asctime)s,%(msecs)03d | %(levelname)s %(message)s"
+log_date_format = "%Y-%m-%d %H:%M:%S"
 markers = [
     "nat: the test only passes once, before environment needs to be restarted",
     "windows: tests that require Windows VM to be running",
@@ -166,7 +171,4 @@ markers = [
     "ipv4v6: tests dual stack WG connectivity",
     "batching: tests packet batching",
     "utils: tests the natlab utilities",
-]
-filterwarnings = [
-    "ignore::DeprecationWarning"
 ]

--- a/nat-lab/tests/conftest.py
+++ b/nat-lab/tests/conftest.py
@@ -487,7 +487,7 @@ def setup_logger(tmp_path, request):
         file_handler = logging.FileHandler(log_file, mode="w")
         file_handler.setLevel(logging.DEBUG)
         file_handler.setFormatter(
-            logging.Formatter("[%(asctime)s] %(levelname)s: %(message)s")
+            logging.Formatter("%(asctime)s,%(msecs)03d | %(levelname)s %(message)s")
         )
         log.addHandler(file_handler)
 
@@ -495,6 +495,7 @@ def setup_logger(tmp_path, request):
         yield
     finally:
         if file_handler:
+            file_handler.flush()
             log.removeHandler(file_handler)
             file_handler.close()
         else:

--- a/nat-lab/tests/telio.py
+++ b/nat-lab/tests/telio.py
@@ -482,10 +482,17 @@ class Client:
                 )
                 if isinstance(self._connection, DockerConnection):
                     await self.collect_core_dumps()
-                log.info("[%s", self._node.name)
+
+                log.info(
+                    "[%s] Test cleanup: Saving MacOS network info",
+                    self._node.name,
+                )
                 await self.save_mac_network_info()
 
-                log.info("[%s", self._node.name)
+                log.info(
+                    "[%s] Test cleanup: Stopping device",
+                    self._node.name,
+                )
                 if self._process.is_executing():
                     if self._libtelio_proxy:
                         await self.stop_device()

--- a/nat-lab/tests/telio.py
+++ b/nat-lab/tests/telio.py
@@ -919,11 +919,6 @@ class Client:
                         event = await self.get_proxy().next_event()
                 await asyncio.sleep(1)
             except:
-                log.error(
-                    "[%s] Exception thrown:",
-                    self.get_connection().tag.name,
-                    exc_info=True,
-                )
                 if self._quit:
                     return
                 raise

--- a/nat-lab/tests/utils/logger.py
+++ b/nat-lab/tests/utils/logger.py
@@ -13,7 +13,7 @@ class Logger:
             console_handler = logging.StreamHandler()
             console_handler.setLevel(level)
             console_handler.setFormatter(
-                logging.Formatter("[%(asctime)s]: %(message)s")
+                logging.Formatter("%(asctime)s,%(msecs)03d | %(message)s")
             )
             self.logger.addHandler(console_handler)
 


### PR DESCRIPTION
### Problem
1. Ctime is missing from the pytest report logs.
2. Expected CancelledError exceptions are being unnecessarily logged.
3. A few log messages were unintentionally removed.

### Solution
1. Add Ctime to every log handler.
2. Remove logging of client request loop exception.
3. Add missing log messages.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
