### PR TITLE
qnap: Do authentication before handling any request

### DIFF
--- a/clis/teliod/src/cgi/mod.rs
+++ b/clis/teliod/src/cgi/mod.rs
@@ -85,6 +85,12 @@ pub trait AuthorizationValidator {
 
 pub fn handle_request(request: Request) -> Response {
     let request = CgiRequest::new(request);
+
+    #[cfg(feature = "qnap")]
+    if let Err(error) = authorize::<QnapUserAuthorization>(&request) {
+        return text_response(StatusCode::UNAUTHORIZED, format!("Unauthorized: {}", error));
+    }
+
     if let Some(response) = web::handle_web_ui(&request) {
         trace!(
             "Returning response..: {:?}",
@@ -92,11 +98,6 @@ pub fn handle_request(request: Request) -> Response {
         );
 
         return response;
-    }
-
-    #[cfg(feature = "qnap")]
-    if let Err(error) = authorize::<QnapUserAuthorization>(&request) {
-        return text_response(StatusCode::UNAUTHORIZED, format!("Unauthorized: {}", error));
     }
 
     if let Some(response) = api::handle_api(&request) {


### PR DESCRIPTION
### Problem
Web UI is being served to unauthenticated users. This gives unauthorized access to nord access token and meshnet information.

### Solution
Authenticate the user before handling any request.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
