### PR TITLE
LLT-6137: teliod configurable adapter type

### DIFF
--- a/clis/teliod/README.md
+++ b/clis/teliod/README.md
@@ -14,24 +14,29 @@ You may need to download some sufficient MUSLE toolchains from `musle.cc`.
 
 Teliod runs Telio library in the background and provides a simple CLI tool to manage it.
 There is a command for running the daemon:
- - `teliod daemon <path_to_config_file>` - starts the daemon. The config file should be provided in a JSON format (see `example_teliod_config.json` file). Currently supported configuration variables:
-   - `log_level` - filters the logged messages by priority, possible levels:
-     - `error`
-     - `warn`
-     - `info`
-     - `debug`
-     - `trace`
-     - `off`
-   - `log_file_path` - a path to the daemon's logging file, needs to specify both the directory and the file name
-   - `log_file_count` - number of recent log files (log files are rotated daily)
-   - `authentication_token` - Token from Nord VPN account to authenticate API calls
-   - `app_user_uid` - A unique number for each user of the application
-   - `interface`
-     - `name` - Name of tunnel interface to connect to. Note that for macOS the name has to be in form `tun#` where `#` can be any integer number
-     - `config_provider` - Provider for configuring the interface address, possible options:
-       - `manual` - do not configure interfaces automatically
-       - `ifconfig` - systems using ifconfig command
-       - `iproute` - systems using iproute2 command
+
+- `teliod daemon <path_to_config_file>` - starts the daemon. The config file should be provided in a JSON format (see `example_teliod_config.json` file). Currently supported configuration variables:
+  - `log_level` - filters the logged messages by priority, possible levels:
+    - `error`
+    - `warn`
+    - `info`
+    - `debug`
+    - `trace`
+    - `off`
+  - `log_file_path` - a path to the daemon's logging file, needs to specify both the directory and the file name
+  - `log_file_count` - number of recent log files (log files are rotated daily)
+  - `authentication_token` - Token from Nord VPN account to authenticate API calls
+  - `app_user_uid` - A unique number for each user of the application
+  - `adapter_type` - Wireguard adapter to use, possible options:
+    - `neptun` - User space implementation, available on multiple platforms
+    - `linux-native` - Linux native implementation
+  - `interface`
+    - `name` - Name of tunnel interface to connect to. Note that for macOS the name has to be in form `tun#` where `#` can be any integer number
+    - `config_provider` - Provider for configuring the interface address, possible options:
+      - `manual` - do not configure interfaces automatically
+      - `ifconfig` - systems using ifconfig command
+      - `iproute` - systems using iproute2 command
 
 And following cli commands:
- - `teliod get-status` - returns the status of teliod and the meshnet peer list
+
+- `teliod get-status` - returns the status of teliod and the meshnet peer list

--- a/clis/teliod/example_teliod_config.json
+++ b/clis/teliod/example_teliod_config.json
@@ -2,6 +2,7 @@
     "log_level": "trace",
     "log_file_path": "./example_log_file.log",
     "authentication_token": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "adapter_type": "neptun",
     "interface": {
       "name": "utun10",
       "config_provider": "manual"

--- a/clis/teliod/src/cgi/api.rs
+++ b/clis/teliod/src/cgi/api.rs
@@ -263,6 +263,7 @@ mod tests {
 
     use reqwest::StatusCode;
     use serial_test::serial;
+    use telio::device::AdapterType;
     use tracing::level_filters::LevelFilter;
 
     use super::{update_config, TeliodDaemonConfig};
@@ -279,6 +280,7 @@ mod tests {
             log_level: LevelFilter::DEBUG,
             log_file_path: "/path/to/log".to_owned(),
             log_file_count: 7,
+            adapter_type: AdapterType::NepTUN,
             interface: InterfaceConfig {
                 name: "eth0".to_owned(),
                 config_provider: InterfaceConfigurationProvider::Manual,
@@ -298,6 +300,7 @@ mod tests {
             "log_level": "debug",
             "log_file_path": "/path/to/log",
             "authentication_token": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "adapter_type": "neptun",
             "interface": {
                 "name": "eth0",
                 "config_provider": "manual"
@@ -339,6 +342,7 @@ mod tests {
             "log_file_path": "/new/path/to/log",
             "log_file_count": 8,
             "authentication_token": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "adapter_type": "neptun",
             "interface": {
                 "name": "eth1",
                 "config_provider": "ifconfig"
@@ -366,6 +370,7 @@ mod tests {
             log_level: LevelFilter::DEBUG,
             log_file_path: "/path/to/log".to_owned(),
             log_file_count: 7,
+            adapter_type: AdapterType::NepTUN,
             interface: InterfaceConfig {
                 name: "eth0".to_owned(),
                 config_provider: InterfaceConfigurationProvider::Manual,
@@ -380,6 +385,7 @@ mod tests {
             "log_level": "debug",
             "log_file_path": "/path/to/log",
             "authentication_token": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "adapter_type": "neptun",
             "interface": {
                 "name": "eth0",
                 "config_provider": "manual"

--- a/clis/teliod/src/config.rs
+++ b/clis/teliod/src/config.rs
@@ -6,7 +6,7 @@ use std::fs;
 use tracing::{debug, info, level_filters::LevelFilter, warn, Level};
 use uuid::Uuid;
 
-use telio::crypto::SecretKey;
+use telio::{crypto::SecretKey, device::AdapterType};
 
 use crate::configure_interface::InterfaceConfigurationProvider;
 
@@ -100,6 +100,7 @@ pub struct TeliodDaemonConfig {
     pub log_file_path: String,
     #[serde(default = "default_log_file_count")]
     pub log_file_count: usize,
+    pub adapter_type: AdapterType,
     pub interface: InterfaceConfig,
 
     #[serde(
@@ -129,6 +130,9 @@ impl TeliodDaemonConfig {
         }
         if let Some(authentication_token) = update.authentication_token {
             self.authentication_token = authentication_token;
+        }
+        if let Some(adapter) = update.adapter_type {
+            self.adapter_type = adapter;
         }
         if let Some(interface) = update.interface {
             self.interface = interface;
@@ -161,6 +165,7 @@ impl Default for TeliodDaemonConfig {
                 }
             },
             log_file_count: default_log_file_count(),
+            adapter_type: AdapterType::default(),
             interface: InterfaceConfig {
                 name: "nlx".to_string(),
                 config_provider: Default::default(),
@@ -252,6 +257,7 @@ pub struct TeliodDaemonConfigPartial {
     pub log_level: Option<LevelFilter>,
     pub log_file_path: Option<String>,
     pub log_file_count: Option<usize>,
+    pub adapter_type: Option<AdapterType>,
     pub interface: Option<InterfaceConfig>,
     pub app_user_uid: Option<Uuid>,
     #[serde(default, deserialize_with = "deserialize_partial_authentication_token")]
@@ -314,6 +320,7 @@ mod tests {
             log_level: LevelFilter::INFO,
             log_file_path: "test.log".to_owned(),
             log_file_count: 7,
+            adapter_type: AdapterType::LinuxNativeWg,
             interface: InterfaceConfig {
                 name: "utun10".to_owned(),
                 config_provider: InterfaceConfigurationProvider::Manual,
@@ -333,6 +340,7 @@ mod tests {
             let json = r#"{
             "log_level": "Info",
             "log_file_path": "test.log",
+            "adapter_type": "linux-native",
             "interface": {
                 "name": "utun10",
                 "config_provider": "manual"
@@ -347,6 +355,7 @@ mod tests {
             let json = r#"{
                 "log_level": "Info",
                 "log_file_path": "test.log",
+                "adapter_type": "linux-native",
                 "interface": {
                     "name": "utun10",
                     "config_provider": "manual"

--- a/clis/teliod/src/daemon.rs
+++ b/clis/teliod/src/daemon.rs
@@ -53,6 +53,7 @@ fn telio_task(
     mut rx_channel: mpsc::Receiver<TelioTaskCmd>,
     tx_channel: mpsc::Sender<TelioTaskCmd>,
     interface_config: &InterfaceConfig,
+    adapter: &AdapterType,
 ) -> Result<(), TeliodError> {
     debug!("Initializing telio device");
 
@@ -81,6 +82,7 @@ fn telio_task(
             &mut telio,
             node_identity.private_key.clone(),
             &interface_config.name,
+            adapter.to_owned(),
         )?;
         task_retrieve_meshmap(node_identity, auth_token, tx_channel.clone());
 
@@ -166,15 +168,16 @@ fn start_telio(
     telio: &mut Device,
     private_key: SecretKey,
     interface_name: &str,
+    adapter: AdapterType,
 ) -> Result<(), DeviceError> {
     telio.start(&DeviceConfig {
         private_key,
         name: Some(interface_name.to_owned()),
-        adapter: AdapterType::NepTUN,
+        adapter,
         ..Default::default()
     })?;
 
-    debug!("started telio with {:?}...", AdapterType::NepTUN,);
+    debug!("started telio with {:?}...", adapter);
     Ok(())
 }
 
@@ -239,6 +242,7 @@ pub async fn daemon_event_loop(config: TeliodDaemonConfig) -> Result<(), TeliodE
             telio_rx,
             tx_clone,
             &config.interface,
+            &config.adapter_type,
         )
     });
 

--- a/nat-lab/data/teliod/config.json
+++ b/nat-lab/data/teliod/config.json
@@ -2,6 +2,7 @@
     "log_level": "trace",
     "log_file_path": "./teliod_natlab.log",
     "authentication_token": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "adapter_type": "neptun",
     "interface": {
       "name": "teliod",
       "config_provider": "manual"

--- a/qnap/shared/teliod.cfg
+++ b/qnap/shared/teliod.cfg
@@ -1,6 +1,7 @@
 {
   "log_level": "info",
   "log_file_path": "/var/log/teliod.log",
+  "adapter_type": "neptun",
   "interface": {
     "name": "nlx",
     "config_provider": "iproute"


### PR DESCRIPTION
### Problem
During PoC is was reviled that NepTun did not work with OpenWRT. It was required to use native implementation, but the adapter type is hard coded in `teliod`.

### Solution
Add `adapter_type` field to the config, and pass it on when creating the device.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
