### PR TITLE
Improve socket rebinding on Apple platforms

### DIFF
--- a/.unreleased/NMACOS-8047
+++ b/.unreleased/NMACOS-8047
@@ -1,0 +1,1 @@
+Improve socket rebinding on Apple platforms to fix no-net in some cases


### PR DESCRIPTION
### Problem
When [includeAllNetworks](https://developer.apple.com/documentation/networkextension/nevpnprotocol/includeallnetworks) parameter is set, and the user changes the network interface (e.g. connects/disconnects Ethernet cable to a mac) we end up in a no-net situation. When `includeAllNetworks` flag is set we cannot call the `bind` method too soon, as the system will block the traffic

### Solution
The solution to this problem is to call `bind` method as soon as the new network interface is fully reconfigured. This brings the challenge of knowing when this has happened. I tried to find some indication in `nw_path_monitor` or in the DynamicStore, unfortunately, I didn't find a single indicator that would say it is 100% safe to rebind the sockets.

I settled on a solution to observe 2 keys in the DynamicStore:
1. `State:/Network/Interface/.*/IPConfigurationBusy`
2. `State:/Network/Global/IPv4`

The 1st one (`IPConfigurationBusy`) appears on a network interface when it is being reconfigured and disappears once the reconfiguration is finished. It is the most reliable one on my real device (macOS 15.4), but I found it problematic in a VM for macOS 14.0, where it tends to be advertised much quicker, and we end up rebinding too soon. To solve that problem I also added an observer for `State:/Network/Global/IPv4` and this combination seems to work perfectly fine.

As a drawback, we ended up rebinding sockets around 4 - 5 times per network change event.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
