### PR TITLE
Link can't be up before the first received packet

### DIFF
--- a/.unreleased/is_link_up_is_always_false_before_first_received_packet
+++ b/.unreleased/is_link_up_is_always_false_before_first_received_packet
@@ -1,0 +1,1 @@
+Never report a link state UP before the first packet is received

--- a/crates/telio-utils/src/bytes_and_timestamps.rs
+++ b/crates/telio-utils/src/bytes_and_timestamps.rs
@@ -104,14 +104,15 @@ impl BytesAndTimestamps {
             self.first_tx_after_rx
         );
 
+        if self.rx_ts.is_none() {
+            return false;
+        }
+
         if let Some(first_tx_after_rx) = self.first_tx_after_rx {
             return now.duration_since(first_tx_after_rx) < WG_KEEPALIVE + rtt;
         }
 
-        match (self.rx_ts, self.tx_ts) {
-            (Some(rx_ts), Some(tx_ts)) => tx_ts <= rx_ts,
-            _ => false,
-        }
+        self.tx_ts.is_some()
     }
 }
 
@@ -211,7 +212,7 @@ mod proptests {
     #[rstest]
     #[case(None, None, 0, false)]
     #[case(Some(0), None, 0, false)]
-    #[case(None, Some(0), 0, true)]
+    #[case(None, Some(0), 0, false)]
     #[case(Some(0), Some(0), 0, true)]
     #[case(Some(0), Some(1), 0, true)]
     #[case(Some(1), Some(0), 0, true)]


### PR DESCRIPTION
In the last week's change to link state detection there was a bug for the case before receiving first ever packet. In that case, we should always report that the link is down.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
