### PR TITLE
LLT-6123: Teliod daemonize

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5196,6 +5196,7 @@ dependencies = [
  "base64 0.22.1",
  "clap 4.5.37",
  "const_format",
+ "daemonize",
  "dirs",
  "form_urlencoded",
  "futures",

--- a/clis/teliod/Cargo.toml
+++ b/clis/teliod/Cargo.toml
@@ -33,6 +33,7 @@ anyhow.workspace = true
 smart-default = "0.7.1"
 base64 = "0.22.1"
 dirs = "6.0.0"
+daemonize = "0.5.0"
 
 form_urlencoded = { version = "1.2.1", optional = true }
 maud = { version = "0.27.0", optional = true }

--- a/clis/teliod/README.md
+++ b/clis/teliod/README.md
@@ -1,42 +1,68 @@
-### Building Teliod
+# Teliod
+
+Teliod is small Meshnet and VPN application, designed to be used in standalone
+and embedded environments.
+
+## Building Teliod
 
 For typical Linux environment it might be built using simply:
 
 ```cargo build```
 
-For OpenWRT you might need a bit more complex command, including your router architecture and the fact the OpenWRT is MUSLE-based, for example:
+For OpenWRT you might need a bit more complex command, including your router architecture
+and the fact the OpenWRT is MUSLE-based, for example:
 
 ```CARGO_TARGET_ARMV7_UNKNOWN_LINUX_MUSLEABIHF_LINKER=rust-lld CC=/path/to/arm-linux-gnueabi-gcc cargo build --package teliod --target armv7-unknown-linux-musleabihf```
 
 You may need to download some sufficient MUSLE toolchains from `musle.cc`.
 
-### Using Teliod daemon
+## Using Teliod
 
-Teliod runs Telio library in the background and provides a simple CLI tool to manage it.
+Teliod runs Telio library in the background and provides a simple CLI tool to
+manage it.
+
 There is a command for running the daemon:
 
-- `teliod daemon <path_to_config_file>` - starts the daemon. The config file should be provided in a JSON format (see `example_teliod_config.json` file). Currently supported configuration variables:
-  - `log_level` - filters the logged messages by priority, possible levels:
-    - `error`
-    - `warn`
-    - `info`
-    - `debug`
-    - `trace`
-    - `off`
-  - `log_file_path` - a path to the daemon's logging file, needs to specify both the directory and the file name
-  - `log_file_count` - number of recent log files (log files are rotated daily)
-  - `authentication_token` - Token from Nord VPN account to authenticate API calls
-  - `app_user_uid` - A unique number for each user of the application
-  - `adapter_type` - Wireguard adapter to use, possible options:
-    - `neptun` - User space implementation, available on multiple platforms
-    - `linux-native` - Linux native implementation
-  - `interface`
-    - `name` - Name of tunnel interface to connect to. Note that for macOS the name has to be in form `tun#` where `#` can be any integer number
-    - `config_provider` - Provider for configuring the interface address, possible options:
-      - `manual` - do not configure interfaces automatically
-      - `ifconfig` - systems using ifconfig command
-      - `iproute` - systems using iproute2 command
+- `teliod start <path_to_config_file>` - starts the daemon.
+  - `--no-detach` - run the teliod in the foreground as a regular process,
+  without detaching from the terminal.
+  - `--stdout-path` - Redirect daemon standard output to the specified file,
+  Defaults to `/var/log/teliod.log`, ignored when used with `--no-detach`
+  Some early logs may still be printed to stdout before redirection.
+  - `--working-directory` - Specifies the daemons working directory,
+  Defaults to `/`, ignored when used with `--no-detach`
+
+The config file should be provided in a JSON format
+(see `example_teliod_config.json` file).
+
+Currently supported configuration variables:
+
+- `log_level` - filters the logged messages by priority, possible levels:
+  - `error`
+  - `warn`
+  - `info`
+  - `debug`
+  - `trace`
+  - `off`
+- `log_file_path` - a path to store the daemon's logs,
+needs be absolute, otherwise will be relative to `working-directory` when daemonized
+- `log_file_count` - number of recent log files (log files are rotated daily)
+- `authentication_token` - Token from Nord VPN account to authenticate API calls
+- `app_user_uid` - A unique number for each user of the application
+- `adapter_type` - Wireguard adapter to use, possible options:
+  - `neptun` - User space implementation, available on multiple platforms
+  - `linux-native` - Linux native implementation
+- `interface`
+  - `name` - Name of tunnel interface to connect to. Note that for macOS
+  the name has to be in form `tun#` where `#` can be any integer number
+  - `config_provider` - Provider for configuring the interface address,
+  possible options:
+    - `manual` - do not configure interfaces automatically
+    - `ifconfig` - systems using ifconfig command
+    - `iproute` - systems using iproute2 command
 
 And following cli commands:
 
 - `teliod get-status` - returns the status of teliod and the meshnet peer list
+- `teliod is-alive` - query if the daemon is running
+- `teliod quit-daemon` - stop daemon execution

--- a/clis/teliod/example_teliod_config.json
+++ b/clis/teliod/example_teliod_config.json
@@ -1,6 +1,6 @@
 {
     "log_level": "trace",
-    "log_file_path": "./example_log_file.log",
+    "log_file_path": "/var/log/example_log_file.log",
     "authentication_token": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
     "adapter_type": "neptun",
     "interface": {

--- a/clis/teliod/src/cgi/api.rs
+++ b/clis/teliod/src/cgi/api.rs
@@ -126,7 +126,8 @@ pub(crate) fn start_daemon() -> (StatusCode, String) {
     };
     match Command::new("setsid")
         .arg(TELIOD_BIN)
-        .arg("daemon")
+        .arg("start")
+        .arg("--no-detach")
         .arg(TELIOD_CFG)
         .stdout(stdout)
         .stderr(stderr)

--- a/clis/teliod/src/command_listener.rs
+++ b/clis/teliod/src/command_listener.rs
@@ -152,7 +152,9 @@ mod tests {
     // Simulate client sending command and waiting for response
     async fn client_send_command(path: &str, cmd: &str) -> std::io::Result<CommandResponse> {
         let mut client_stream = UnixStream::connect(&Path::new(path)).await?;
-        client_stream.write(format!("{}\n", cmd).as_bytes()).await?;
+        client_stream
+            .write_all(format!("{}\n", cmd).as_bytes())
+            .await?;
 
         let mut data = vec![0; 1024];
         let size = client_stream.read(&mut data).await?;
@@ -163,7 +165,9 @@ mod tests {
     // Broken client, closes connection without waiting for response
     async fn broken_client_send_command(path: &str, cmd: &str) -> std::io::Result<()> {
         let mut client_stream = UnixStream::connect(&Path::new(path)).await?;
-        client_stream.write(format!("{}\n", cmd).as_bytes()).await?;
+        client_stream
+            .write_all(format!("{}\n", cmd).as_bytes())
+            .await?;
 
         Ok(())
     }

--- a/clis/teliod/src/core_api.rs
+++ b/clis/teliod/src/core_api.rs
@@ -132,6 +132,7 @@ pub async fn init_with_api(auth_token: &str) -> Result<DeviceIdentity, Error> {
 
     let mut options = OpenOptions::new();
     // User has read/write but others have none
+    // Mode for identity file rw-------
     options.mode(0o600);
     let mut file = options.create(true).write(true).open(identity_path)?;
     serde_json::to_writer(&mut file, &device_identity)?;

--- a/clis/teliod/src/daemon.rs
+++ b/clis/teliod/src/daemon.rs
@@ -11,21 +11,18 @@ use telio::{
     telio_utils::select,
     telio_wg::AdapterType,
 };
-use tokio::sync::mpsc::Sender;
-use tokio::{sync::mpsc, sync::oneshot, time::Duration};
+use tokio::{sync::mpsc, sync::mpsc::Sender, sync::oneshot, time::Duration};
 use tracing::{debug, error, info, trace, warn};
 
-use crate::core_api::{get_meshmap as get_meshmap_from_server, init_with_api};
-use crate::logging::setup_logging;
-use crate::ClientCmd;
 use crate::Hidden;
 use crate::{
     command_listener::CommandListener,
     comms::DaemonSocket,
     config::DeviceIdentity,
     config::{InterfaceConfig, TeliodDaemonConfig},
+    core_api::{get_meshmap as get_meshmap_from_server, init_with_api},
     nc::NotificationCenter,
-    TelioStatusReport, TeliodError,
+    ClientCmd, TelioStatusReport, TeliodError,
 };
 
 #[derive(Debug)]
@@ -209,13 +206,6 @@ async fn daemon_init(
 }
 
 pub async fn daemon_event_loop(config: TeliodDaemonConfig) -> Result<(), TeliodError> {
-    let _tracing_worker_guard = setup_logging(
-        &config.log_file_path,
-        config.log_level,
-        config.log_file_count,
-    )
-    .await?;
-
     debug!("started with config: {config:?}");
 
     let mut signals = Signals::new([SIGHUP, SIGTERM, SIGINT, SIGQUIT])?;
@@ -248,8 +238,6 @@ pub async fn daemon_event_loop(config: TeliodDaemonConfig) -> Result<(), TeliodE
     });
 
     info!("Entering event loop");
-    eprintln!("Daemon started");
-
     loop {
         select! {
             // Check if telio_task completes and exit if it fails

--- a/nat-lab/data/teliod/config.json
+++ b/nat-lab/data/teliod/config.json
@@ -1,6 +1,6 @@
 {
     "log_level": "trace",
-    "log_file_path": "./teliod_natlab.log",
+    "log_file_path": "/var/log/teliod_natlab.log",
     "authentication_token": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
     "adapter_type": "neptun",
     "interface": {

--- a/nat-lab/tests/test_teliod.py
+++ b/nat-lab/tests/test_teliod.py
@@ -1,7 +1,9 @@
 import asyncio
 import pytest
+import time
 from config import LIBTELIO_BINARY_PATH_DOCKER
 from contextlib import AsyncExitStack
+from datetime import datetime
 from helpers import setup_connections
 from utils.connection import ConnectionTag
 from utils.process.process import ProcessExecError
@@ -9,14 +11,26 @@ from utils.process.process import ProcessExecError
 TELIOD_EXEC_PATH = f"{LIBTELIO_BINARY_PATH_DOCKER}/teliod"
 CONFIG_FILE_PATH = "/etc/teliod/config.json"
 SOCKET_FILE_PATH = "/run/teliod.sock"
+STDOUT_FILE_PATH = "/var/log/teliod.log"
+# Build a dated log filename
+LOG_FILE_PATH = f"/var/log/teliod_natlab.log.{datetime.today().strftime('%Y-%m-%d')}"
 
 TELIOD_START_PARAMS = [
     TELIOD_EXEC_PATH,
-    "daemon",
+    "start",
+    CONFIG_FILE_PATH,
+]
+
+TELIOD_START_NODETACH_PARAMS = [
+    TELIOD_EXEC_PATH,
+    "start",
+    "--no-detach",
     CONFIG_FILE_PATH,
 ]
 
 TELIOD_STATUS_PARAMS = [TELIOD_EXEC_PATH, "get-status"]
+TELIOD_IS_ALIVE_PARAMS = [TELIOD_EXEC_PATH, "is-alive"]
+TELIOD_QUIT_DAEMON_PARAMS = [TELIOD_EXEC_PATH, "quit-daemon"]
 
 
 async def is_teliod_running(connection):
@@ -27,23 +41,35 @@ async def is_teliod_running(connection):
         return False
 
 
-async def test_teliod() -> None:
+async def wait_for_teliod(connection, timeout: float):
+    start_time = time.monotonic()
+    while not await is_teliod_running(connection):
+        if time.monotonic() - start_time > timeout:
+            raise TimeoutError("teliod did not start within timeout")
+        await asyncio.sleep(0.1)
+
+
+@pytest.mark.parametrize(
+    "start_daemon_params",
+    [(TELIOD_START_PARAMS), (TELIOD_START_NODETACH_PARAMS)],
+    ids=["daemonized_mode", "no_detach_mode"],
+)
+async def test_teliod(start_daemon_params) -> None:
     async with AsyncExitStack() as exit_stack:
         connection = (
             await setup_connections(exit_stack, [ConnectionTag.DOCKER_CONE_CLIENT_1])
         )[0].connection
 
         # Run teliod
-        teliod_process = await exit_stack.enter_async_context(
-            connection.create_process(TELIOD_START_PARAMS).run()
+        await exit_stack.enter_async_context(
+            connection.create_process(start_daemon_params).run()
         )
 
         # Let the daemon start
-        while not await is_teliod_running(connection):
-            await asyncio.sleep(0.1)
+        await wait_for_teliod(connection, timeout=1)
 
         with pytest.raises(ProcessExecError) as err:
-            await connection.create_process(TELIOD_START_PARAMS).execute()
+            await connection.create_process(start_daemon_params).execute()
         assert err.value.stderr == "Error: DaemonIsRunning"
 
         # Run the get-status command
@@ -54,17 +80,117 @@ async def test_teliod() -> None:
             ).get_stdout()
         )
 
-        assert teliod_process.is_executing()
-
         # Send SIGTERM to the daemon
         await connection.create_process(
             ["killall", "-w", "-s", "SIGTERM", "teliod"]
         ).execute()
 
-        assert not teliod_process.is_executing()
         assert not await is_teliod_running(connection)
 
         # Run the get-status command again - this time it should fail
         with pytest.raises(ProcessExecError) as err:
             await connection.create_process(TELIOD_STATUS_PARAMS).execute()
         assert err.value.stderr == "Error: DaemonIsNotRunning"
+
+
+@pytest.mark.parametrize(
+    "start_daemon_params",
+    [(TELIOD_START_PARAMS), (TELIOD_START_NODETACH_PARAMS)],
+    ids=["daemonized_mode", "no_detach_mode"],
+)
+async def test_teliod_quit(start_daemon_params) -> None:
+    async with AsyncExitStack() as exit_stack:
+        connection = (
+            await setup_connections(exit_stack, [ConnectionTag.DOCKER_CONE_CLIENT_1])
+        )[0].connection
+
+        # Try to quit deamon that is not running
+        with pytest.raises(ProcessExecError) as err:
+            await connection.create_process(TELIOD_QUIT_DAEMON_PARAMS).execute()
+        assert err.value.stderr == "Error: DaemonIsNotRunning"
+
+        # Run teliod
+        await exit_stack.enter_async_context(
+            connection.create_process(start_daemon_params).run()
+        )
+
+        # Let the daemon start
+        await wait_for_teliod(connection, timeout=1)
+
+        # Run the is-alive command
+        assert (
+            "Command executed successfully"
+            in (
+                await connection.create_process(TELIOD_IS_ALIVE_PARAMS).execute()
+            ).get_stdout()
+        )
+
+        # Send quit-daemon command
+        assert (
+            "Command executed successfully"
+            in (
+                await connection.create_process(TELIOD_QUIT_DAEMON_PARAMS).execute()
+            ).get_stdout()
+        )
+
+        assert not await is_teliod_running(connection)
+
+        # Run the is-alive command again - this time it should fail
+        with pytest.raises(ProcessExecError) as err:
+            await connection.create_process(TELIOD_IS_ALIVE_PARAMS).execute()
+        assert err.value.stderr == "Error: DaemonIsNotRunning"
+
+
+async def test_teliod_logs() -> None:
+    async with AsyncExitStack() as exit_stack:
+        connection = (
+            await setup_connections(exit_stack, [ConnectionTag.DOCKER_CONE_CLIENT_1])
+        )[0].connection
+
+        # Delete any old logs
+        await connection.create_process(
+            ["rm", "-f", STDOUT_FILE_PATH, LOG_FILE_PATH]
+        ).execute()
+
+        # Make sure they are indeed deleted
+        for path in [STDOUT_FILE_PATH, LOG_FILE_PATH]:
+            await connection.create_process(["test", "!", "-f", path]).execute()
+
+        # Run teliod
+        await exit_stack.enter_async_context(
+            connection.create_process(TELIOD_START_PARAMS).run()
+        )
+
+        # Let the daemon start
+        await wait_for_teliod(connection, timeout=1)
+
+        # Run the is-alive command
+        assert (
+            "Command executed successfully"
+            in (
+                await connection.create_process(TELIOD_IS_ALIVE_PARAMS).execute()
+            ).get_stdout()
+        )
+
+        # Send quit-daemon command
+        assert (
+            "Command executed successfully"
+            in (
+                await connection.create_process(TELIOD_QUIT_DAEMON_PARAMS).execute()
+            ).get_stdout()
+        )
+
+        assert not await is_teliod_running(connection)
+
+        # expected substrings for each log file
+        expected_log_contents = {
+            STDOUT_FILE_PATH: "task started",
+            LOG_FILE_PATH: "telio::device",
+        }
+
+        # Check if log files exist and are not empty
+        for path, expected_string in expected_log_contents.items():
+            await connection.create_process(["test", "-s", path]).execute()
+            await connection.create_process(
+                ["grep", "-q", expected_string, path]
+            ).execute()

--- a/qnap/shared/NordSecurityMeshnet.sh
+++ b/qnap/shared/NordSecurityMeshnet.sh
@@ -48,7 +48,7 @@ case "$1" in
         exit 0
     fi
 
-    ${QPKG_ROOT}/teliod daemon $TELIOD_CFG_FILE > $TELIOD_LOG_FILE 2>&1 &
+    ${QPKG_ROOT}/teliod start --no-detach $TELIOD_CFG_FILE > $TELIOD_LOG_FILE 2>&1 &
     system_log INFO "Teliod daemon started."
     ;;
 


### PR DESCRIPTION
### Problem
According to the [daemon](https://linux.die.net/man/1/daemonize) convention, a daemon should detach itself from the terminal, disassociate from its process group and run in the background.

### Solution
Use `daemonize` crate to detach the daemon process, set umask, change process group, and redirect stdout and stderr to a file.
The daemon process needs to be forked before starting the `tokio` runtime, otherwise it panics.

`teliod daemon` command was replaced with `teliod start` to make it more semantically correct.
`--no-detach` flag was added to run teliod attached to the terminal as a regular process.
Added a `--stdout-path` parameter to specify where to redirect stdout and stderr.
Added a `--working-directory` parameter to specify which working directory the daemon should use.

The unix socket mode is set to `600` so it's not accessible to the non-root user.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
