### PR TITLE
Add feature to modify SO buffer size in neptun

### DIFF
--- a/.unreleased/LLT-6095
+++ b/.unreleased/LLT-6095
@@ -1,0 +1,1 @@
+skt_buffer_size parameter added in FeaturesWirguard to configure NepTUN socket buffer size

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2643,7 +2643,7 @@ dependencies = [
 [[package]]
 name = "neptun"
 version = "0.6.0"
-source = "git+https://github.com/NordSecurity/neptun.git?tag=v1.0.6#b9e23920f30c0d9c289fd8cdae5a854da0da7ecf"
+source = "git+https://github.com/NordSecurity/neptun.git?tag=v1.0.7#da23f2b13468efe3754f7e49732c500dd4632e3a"
 dependencies = [
  "aead",
  "base64 0.13.1",
@@ -4535,7 +4535,7 @@ dependencies = [
 
 [[package]]
 name = "telio"
-version = "5.3.0"
+version = "5.4.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "telio"
-version = "5.3.0"
+version = "5.4.0"
 authors = ["info@nordvpn.com"]
 edition = "2018"
 license = "GPL-3.0-only"
@@ -174,7 +174,7 @@ windows = { version = "0.60", features = [
     "Win32_NetworkManagement_IpHelper",
 ] }
 
-neptun = { git = "https://github.com/NordSecurity/neptun.git", tag = "v1.0.6", features = ["device"] }
+neptun = { git = "https://github.com/NordSecurity/neptun.git", tag = "v1.0.7", features = ["device"] }
 x25519-dalek = { version = "2.0.1", features = ["reusable_secrets", "static_secrets"] }
 
 

--- a/crates/telio-model/src/features.rs
+++ b/crates/telio-model/src/features.rs
@@ -93,6 +93,9 @@ pub struct FeatureWireguard {
     /// Configurable up/down behavior of WireGuard-NT adapter. See RFC LLT-0089 for details
     #[serde(default)]
     pub enable_dynamic_wg_nt_control: bool,
+    /// Configurable socket buffer size for NepTUN
+    #[serde(default)]
+    pub skt_buffer_size: Option<u32>,
 }
 
 impl FeatureWireguard {
@@ -519,7 +522,8 @@ mod tests {
                     "wireguard_polling_period": 1000,
                     "wireguard_polling_period_after_state_change": 50
                 },
-                "enable_dynamic_wg_nt_control": true
+                "enable_dynamic_wg_nt_control": true,
+                "skt_buffer_size": 123456
             },
             "nurse": {
                 "fingerprint": "test_fingerprint",
@@ -615,6 +619,7 @@ mod tests {
                             wireguard_polling_period_after_state_change: 50
                         },
                         enable_dynamic_wg_nt_control: true,
+                        skt_buffer_size: Some(123456),
                     },
                     nurse: Some(FeatureNurse {
                         heartbeat_interval: 5,

--- a/crates/telio-wg/src/adapter.rs
+++ b/crates/telio-wg/src/adapter.rs
@@ -172,7 +172,7 @@ pub enum Error {
 }
 
 /// Enumeration of types for `Adapter` struct
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub enum AdapterType {
     /// NepTUN
     NepTUN,
@@ -234,6 +234,7 @@ pub(crate) async fn start(cfg: &Config) -> Result<Box<dyn Adapter>, Error> {
                 cfg.firewall_process_inbound_callback.clone(),
                 cfg.firewall_process_outbound_callback.clone(),
                 cfg.firewall_reset_connections.clone(),
+                cfg.skt_buffer_size,
             )?))
         }
         AdapterType::LinuxNativeWg => {

--- a/crates/telio-wg/src/adapter/neptun.rs
+++ b/crates/telio-wg/src/adapter/neptun.rs
@@ -34,6 +34,7 @@ impl NepTUN {
         firewall_process_inbound_callback: FirewallCb,
         firewall_process_outbound_callback: FirewallCb,
         firewall_reset_connections_callback: super::FirewallResetConnsCb,
+        skt_buffer_size: Option<u32>,
     ) -> Result<Self, AdapterError> {
         let config = DeviceConfig {
             // Apple's NepTUN device runs most efficiently on a single perf-core
@@ -63,6 +64,7 @@ impl NepTUN {
             protect: socket_pool,
             firewall_process_inbound_callback,
             firewall_process_outbound_callback,
+            skt_buffer_size,
         };
 
         let device = match tun {

--- a/crates/telio-wg/src/wg.rs
+++ b/crates/telio-wg/src/wg.rs
@@ -112,6 +112,8 @@ pub struct Config {
     pub firewall_reset_connections: FirewallResetConnsCb,
     /// Configurable up/down behavior of WireGuard-NT adapter. See RFC LLT-0089 for details
     pub enable_dynamic_wg_nt_control: bool,
+    /// Configurable socket buffer size, if None doesn't modify default OS set values
+    pub skt_buffer_size: Option<u32>,
 }
 
 /// Events and analytics transmission channels
@@ -225,6 +227,7 @@ impl DynamicWg {
     ///                 Some(Arc::new(firewall_filter_outbound_packets)),
     ///             firewall_reset_connections: None,
     ///             enable_dynamic_wg_nt_control: false,
+    ///             skt_buffer_size: None
     ///         },
     ///         None,
     ///         true,
@@ -520,6 +523,7 @@ impl Config {
             firewall_process_outbound_callback: self.firewall_process_outbound_callback.clone(),
             firewall_reset_connections: self.firewall_reset_connections.clone(),
             enable_dynamic_wg_nt_control: self.enable_dynamic_wg_nt_control,
+            skt_buffer_size: self.skt_buffer_size,
         })
     }
 }
@@ -1115,6 +1119,7 @@ pub mod tests {
                 firewall_process_outbound_callback: Default::default(),
                 firewall_reset_connections: None,
                 enable_dynamic_wg_nt_control: false,
+                skt_buffer_size: None,
             })
         }
     }

--- a/nat-lab/tests/test_events_link_state.py
+++ b/nat-lab/tests/test_events_link_state.py
@@ -34,6 +34,7 @@ def long_persistent_keepalive_periods() -> FeatureWireguard:
             wireguard_polling_period_after_state_change=50,
         ),
         enable_dynamic_wg_nt_control=False,
+        skt_buffer_size=None,
     )
 
 

--- a/nat-lab/tests/test_neptun.py
+++ b/nat-lab/tests/test_neptun.py
@@ -1,0 +1,32 @@
+import pytest
+from contextlib import AsyncExitStack
+from helpers import setup_mesh_nodes, SetupParameters, ping_between_all_nodes
+from utils.bindings import default_features, TelioAdapterType
+from utils.connection import ConnectionTag
+
+BUFFER_SIZE = 1310720
+
+
+@pytest.mark.asyncio
+async def test_custom_socket_buffers_on_neptun() -> None:
+    async with AsyncExitStack() as exit_stack:
+        env = await setup_mesh_nodes(
+            exit_stack,
+            [
+                SetupParameters(
+                    connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
+                    adapter_type_override=TelioAdapterType.NEP_TUN,
+                    features=default_features(custom_skt_buffer_size=BUFFER_SIZE),
+                ),
+                SetupParameters(
+                    connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2,
+                ),
+            ],
+        )
+
+        [client_alpha, _] = env.clients
+        await client_alpha.wait_for_log(
+            'Socket buffer "RcvBuf" set with value ' + str(BUFFER_SIZE)
+        )
+        # Ping to check connection works both ways
+        await ping_between_all_nodes(env)

--- a/nat-lab/tests/utils/bindings.py
+++ b/nat-lab/tests/utils/bindings.py
@@ -24,6 +24,7 @@ def default_features(
     enable_pmtu_discovery: bool = False,
     enable_multicast: bool = False,
     enable_dynamic_wg_nt_control: bool = False,
+    custom_skt_buffer_size: Optional[int] = None,
 ) -> Features:
     features_builder = FeaturesDefaultsBuilder()
     if enable_lana is not None:
@@ -48,6 +49,8 @@ def default_features(
         features_builder = features_builder.enable_multicast()
     if enable_dynamic_wg_nt_control:
         features_builder = features_builder.enable_dynamic_wg_nt_control()
+    if custom_skt_buffer_size:
+        features_builder = features_builder.set_skt_buffer_size(custom_skt_buffer_size)
 
     features = features_builder.build()
     features.is_test_env = True

--- a/src/ffi/defaults_builder.rs
+++ b/src/ffi/defaults_builder.rs
@@ -141,6 +141,11 @@ impl FeaturesDefaultsBuilder {
         self.config.lock().wireguard.enable_dynamic_wg_nt_control = true;
         self
     }
+
+    pub fn set_skt_buffer_size(self: Arc<Self>, skt_buffer_size: u32) -> Arc<Self> {
+        self.config.lock().wireguard.skt_buffer_size = Some(skt_buffer_size);
+        self
+    }
 }
 
 impl Default for FeaturesDefaultsBuilder {

--- a/src/libtelio.udl
+++ b/src/libtelio.udl
@@ -526,6 +526,10 @@ interface FeaturesDefaultsBuilder {
     /// Enable dynamic WireGuard-NT control as per RFC LLT-0089
     [Self=ByArc]
     FeaturesDefaultsBuilder enable_dynamic_wg_nt_control();
+
+    /// Enable custom socket buffer sizes for NepTUN
+    [Self=ByArc]
+    FeaturesDefaultsBuilder set_skt_buffer_size(u32 skt_buffer_size);
 };
 
 
@@ -590,6 +594,8 @@ dictionary FeatureWireguard {
     FeaturePolling polling;
     /// Configurable up/down behavior of WireGuard-NT adapter. See RFC LLT-0089 for details
     boolean enable_dynamic_wg_nt_control;
+    /// Configurable socket buffer size for NepTUN
+    u32? skt_buffer_size;
 };
 
 /// Configurable persistent keepalive periods for different types of peers


### PR DESCRIPTION
### Problem
Tests done by Android team showed that modifying SO_SND and SO_RECV gives a big boost in speed, hence a need to be able to modify buffer sizes.

### Solution
Add socket buffer size as a feature to be configurable by upstream Apps.

Tests regarding socket buffer sizes have been added in NepTUN. Corresponding NepTUN merged PR
https://github.com/NordSecurity/NepTUN/pull/29. for reference.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
