### PR TITLE
LLT-5790 Bump wg-nt-rust-wrapper

### DIFF
--- a/.unreleased/LLT-5790
+++ b/.unreleased/LLT-5790
@@ -1,0 +1,1 @@
+Decrease wireguard-nt log spaming

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6462,7 +6462,7 @@ dependencies = [
 [[package]]
 name = "wireguard-nt"
 version = "1.0.0"
-source = "git+https://github.com/NordSecurity/wireguard-nt-rust-wrapper?tag=v1.0.5#8ec27423762f110ed4aa243e4b0bd8f7fe599834"
+source = "git+https://github.com/NordSecurity/wireguard-nt-rust-wrapper?tag=v1.0.6#35ba36f1f46d1b1e360c71086d7271a63b43eec5"
 dependencies = [
  "bitflags 1.3.2",
  "ipnet",

--- a/crates/telio-wg/Cargo.toml
+++ b/crates/telio-wg/Cargo.toml
@@ -58,7 +58,7 @@ cc.workspace = true
 sha2.workspace = true
 winapi = { workspace = true, features = ["nldef"] }
 
-wireguard-nt = { git = "https://github.com/NordSecurity/wireguard-nt-rust-wrapper", tag = "v1.0.5" }
+wireguard-nt = { git = "https://github.com/NordSecurity/wireguard-nt-rust-wrapper", tag = "v1.0.6" }
 
 wg-go-rust-wrapper = { path = "../../wireguard-go-rust-wrapper" }
 


### PR DESCRIPTION
### Problem
wg-nt spams logs a lot.

### Solution
Highest log level in wg-nt is info, so change it to debug on interception to avoid spamming on prod builds.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
