### PR TITLE
Restrict token permissions for diagram to read-only

### DIFF
--- a/.github/workflows/diagram.yml
+++ b/.github/workflows/diagram.yml
@@ -1,4 +1,5 @@
 name: Diagram
+permissions: read-all
 on:
   pull_request:
     types: [opened, synchronize]


### PR DESCRIPTION
### Problem
Restrict GITHUB_TOKEN permissions for diagram workflow


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
