### PR TITLE
Fix derp restart test race condition

### DIFF
--- a/nat-lab/tests/test_derp_connect.py
+++ b/nat-lab/tests/test_derp_connect.py
@@ -257,7 +257,7 @@ async def test_derp_reconnect_3clients(setup_params: List[SetupParameters]) -> N
 
 
 @asynccontextmanager
-async def restart_container(container_name: str):
+async def stop_container(container_name: str):
     try:
         os.system(f"docker stop {container_name}")
         yield
@@ -366,7 +366,7 @@ async def test_derp_restart(setup_params: List[SetupParameters]) -> None:
         #  [GW1]    [GW2]   [Symmetric-GW]
         #    |        |        |
         # [ALPHA]   [BETA]  [GAMMA]
-        async with restart_container("nat-lab-derp-01-1"):
+        async with stop_container("nat-lab-derp-01-1"):
             await asyncio.gather(
                 alpha_client.wait_for_state_derp(_DERP2_IP, [RelayState.CONNECTED]),
                 beta_client.wait_for_state_derp(_DERP2_IP, [RelayState.CONNECTED]),
@@ -396,7 +396,7 @@ async def test_derp_restart(setup_params: List[SetupParameters]) -> None:
         #    |        |        |
         # [ALPHA]   [BETA]  [GAMMA]
 
-        async with restart_container("nat-lab-derp-02-1"):
+        async with stop_container("nat-lab-derp-02-1"):
             await asyncio.gather(
                 alpha_client.wait_for_state_derp(_DERP1_IP, [RelayState.CONNECTED]),
                 beta_client.wait_for_state_derp(_DERP3_IP, [RelayState.CONNECTED]),
@@ -426,7 +426,7 @@ async def test_derp_restart(setup_params: List[SetupParameters]) -> None:
         #    |        |        |
         # [ALPHA]   [BETA]  [GAMMA]
 
-        async with restart_container("nat-lab-derp-03-1"):
+        async with stop_container("nat-lab-derp-03-1"):
             await asyncio.gather(
                 alpha_client.wait_for_state_derp(_DERP1_IP, [RelayState.CONNECTED]),
                 beta_client.wait_for_state_derp(_DERP2_IP, [RelayState.CONNECTED]),

--- a/nat-lab/tests/test_derp_connect.py
+++ b/nat-lab/tests/test_derp_connect.py
@@ -358,13 +358,15 @@ async def test_derp_restart(setup_params: List[SetupParameters]) -> None:
         #    |        |        |
         # [ALPHA]   [BETA]  [GAMMA]
 
-        os.system("docker restart nat-lab-derp-01-1")
+        os.system("docker stop nat-lab-derp-01-1")
 
         await asyncio.gather(
             alpha_client.wait_for_state_derp(_DERP2_IP, [RelayState.CONNECTED]),
             beta_client.wait_for_state_derp(_DERP2_IP, [RelayState.CONNECTED]),
             gamma_client.wait_for_state_derp(_DERP3_IP, [RelayState.CONNECTED]),
         )
+
+        os.system("docker start nat-lab-derp-01-1")
 
         # Ping ALPHA --> BETA
         await ping(alpha_connection, beta.ip_addresses[0])
@@ -389,13 +391,15 @@ async def test_derp_restart(setup_params: List[SetupParameters]) -> None:
         #    |        |        |
         # [ALPHA]   [BETA]  [GAMMA]
 
-        os.system("docker restart nat-lab-derp-02-1")
+        os.system("docker stop nat-lab-derp-02-1")
 
         await asyncio.gather(
             alpha_client.wait_for_state_derp(_DERP1_IP, [RelayState.CONNECTED]),
             beta_client.wait_for_state_derp(_DERP3_IP, [RelayState.CONNECTED]),
             gamma_client.wait_for_state_derp(_DERP3_IP, [RelayState.CONNECTED]),
         )
+
+        os.system("docker start nat-lab-derp-02-1")
 
         # Ping ALPHA --> BETA
         await ping(alpha_connection, beta.ip_addresses[0])
@@ -420,13 +424,15 @@ async def test_derp_restart(setup_params: List[SetupParameters]) -> None:
         #    |        |        |
         # [ALPHA]   [BETA]  [GAMMA]
 
-        os.system("docker restart nat-lab-derp-03-1")
+        os.system("docker stop nat-lab-derp-03-1")
 
         await asyncio.gather(
             alpha_client.wait_for_state_derp(_DERP1_IP, [RelayState.CONNECTED]),
             beta_client.wait_for_state_derp(_DERP2_IP, [RelayState.CONNECTED]),
             gamma_client.wait_for_state_derp(_DERP2_IP, [RelayState.CONNECTED]),
         )
+
+        os.system("docker start nat-lab-derp-03-1")
 
         # Ping ALPHA --> BETA
         await ping(alpha_connection, beta.ip_addresses[0])


### PR DESCRIPTION
### Problem
When we restart derp server, race condition appears. Server can be started faster than we actually connect to any other server, therefore, connecting to same derp server again.

### Solution
Shutdown derp server, connect to other derp server and then bring back previous derp server


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
