### PR TITLE
natlab: Misc improvements

### DIFF
--- a/.unreleased/misc_natlab_improvements
+++ b/.unreleased/misc_natlab_improvements
@@ -1,0 +1,12 @@
+Fixes:
+
+    Libvirt VMs routing was being configured only when binaries were pushed, this PR configures it as default for every new ssh connection.
+    Exceptions on docker/ssh processes were not being raised against the context manager of the cleanup stage, making pytest hang for the whole test timeout duration. This PR fixes it by running the processes inside a try/except/finally block.
+    If telio fails to launch won't set the client proxy port, creating an infinite loop waiting for the port. This PR fixes it by additionally checking if the telio process is running.
+    Other logging and duplicated code minor fixes.
+
+Features:
+
+    This PR adds link state check as part of the setup_mesh_nodes() helper function.
+    Add enable/disable interface methods to router classes.
+

--- a/crates/telio-wg/src/link_detection.rs
+++ b/crates/telio-wg/src/link_detection.rs
@@ -56,8 +56,8 @@ impl LinkDetection {
 
         telio_log_debug!(
             "instantiating link detection. cfg.rtt_seconds: {:?}, enhanced_detection: {}",
+            cfg.rtt_seconds,
             enhanced_detection.is_some(),
-            cfg.rtt_seconds
         );
 
         LinkDetection {

--- a/nat-lab/tests/conftest.py
+++ b/nat-lab/tests/conftest.py
@@ -274,7 +274,7 @@ async def _copy_vm_binaries(tag: ConnectionTag):
     try:
         log.info("Copying binaries for %s", tag)
         async with SshConnection.new_connection(
-            LAN_ADDR_MAP[tag], tag, copy_binaries=True, reenable_nat=True
+            LAN_ADDR_MAP[tag], tag, copy_binaries=True
         ):
             pass
     except OSError as e:

--- a/nat-lab/tests/telio.py
+++ b/nat-lab/tests/telio.py
@@ -451,7 +451,7 @@ class Client:
                 #   we can't currently use mapped ports. In those cases we let Pyro5 select a port on its own (by giving it 0 as the port number).
                 #   libtelio_remote prints what port was used after binding and we collect it here in self._proxy_port
                 if host_port == "0":
-                    while len(self._proxy_port) == 0:
+                    while len(self._proxy_port) == 0 and self._process.is_executing():
                         await asyncio.sleep(0.25)
                     object_uri = f"PYRO:{object_name}@{host_ip}:{self._proxy_port}"
                 else:

--- a/nat-lab/tests/test_events_link_state.py
+++ b/nat-lab/tests/test_events_link_state.py
@@ -154,13 +154,6 @@ async def wait_for_any_with_timeout(tasks, timeout: float):
         raise asyncio.TimeoutError
 
 
-async def wait_for_up_events(client_alpha, client_beta, alpha_key, beta_key):
-    await asyncio.gather(
-        client_alpha.wait_for_link_state(beta_key, LinkState.UP),
-        client_beta.wait_for_link_state(alpha_key, LinkState.UP),
-    )
-
-
 @pytest.mark.asyncio
 @pytest.mark.parametrize("setup_params", FEATURE_ENABLED_PARAMS)
 async def test_event_link_state_peers_idle_all_time(
@@ -170,10 +163,6 @@ async def test_event_link_state_peers_idle_all_time(
         env = await setup_mesh_nodes(exit_stack, setup_params)
         alpha, beta = env.nodes
         client_alpha, client_beta = env.clients
-
-        await wait_for_up_events(
-            client_alpha, client_beta, alpha.public_key, beta.public_key
-        )
 
         # Expect no link event while peers are idle
         with pytest.raises(asyncio.TimeoutError):
@@ -207,10 +196,6 @@ async def test_event_link_state_peers_exchanging_data_for_a_long_time(
             conn.connection for conn in env.connections
         ]
 
-        await wait_for_up_events(
-            client_alpha, client_beta, alpha.public_key, beta.public_key
-        )
-
         for _ in range(0, 25):
             await asyncio.sleep(1)
             await ping(connection_alpha, beta.ip_addresses[0])
@@ -238,10 +223,6 @@ async def test_event_link_state_peers_exchanging_data_then_idling_then_resume(
         connection_alpha, connection_beta = [
             conn.connection for conn in env.connections
         ]
-
-        await wait_for_up_events(
-            client_alpha, client_beta, alpha.public_key, beta.public_key
-        )
 
         await ping(connection_alpha, beta.ip_addresses[0])
         await ping(connection_beta, alpha.ip_addresses[0])
@@ -308,10 +289,6 @@ async def test_event_link_state_peer_goes_offline(
         connection_alpha, connection_beta = [
             conn.connection for conn in env.connections
         ]
-
-        await wait_for_up_events(
-            client_alpha, client_beta, alpha.public_key, beta.public_key
-        )
 
         await ping(connection_beta, alpha.ip_addresses[0])
         # Sending ping from alpha to beta ensures that the WireGuard's internal timer for Keepalive-Timeout (10s) is
@@ -424,10 +401,6 @@ async def test_event_link_state_peer_doesnt_respond(
         connection_alpha, connection_beta = [
             conn.connection for conn in env.connections
         ]
-
-        await wait_for_up_events(
-            client_alpha, client_beta, alpha.public_key, beta.public_key
-        )
 
         async with ICMP_control(connection_beta):
             with pytest.raises(asyncio.TimeoutError):

--- a/nat-lab/tests/utils/command_grepper.py
+++ b/nat-lab/tests/utils/command_grepper.py
@@ -26,7 +26,7 @@ class CommandGrepper:
         Args:
             connection: Connection object to container to run the command on.
             check_cmd: Command to run.
-            timeout: Timeout for the check. If the check does not have expected results within the timeout, it will return False.
+            timeout: Timeout (in seconds) for the check. If the check does not have expected results within the timeout, it will return False.
         """
         self._connection = connection
         self._check_cmd = check_cmd

--- a/nat-lab/tests/utils/connection/ssh_connection.py
+++ b/nat-lab/tests/utils/connection/ssh_connection.py
@@ -46,19 +46,17 @@ class SshConnection(Connection):
         ip: str,
         tag: ConnectionTag,
         copy_binaries: bool = False,
-        reenable_nat=False,
     ) -> AsyncIterator["SshConnection"]:
-        if reenable_nat:
-            subprocess.check_call(
-                ["sudo", "bash", "vm_nat.sh", "disable"],
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-            )
-            subprocess.check_call(
-                ["sudo", "bash", "vm_nat.sh", "enable"],
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-            )
+        subprocess.check_call(
+            ["sudo", "bash", "vm_nat.sh", "disable"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        subprocess.check_call(
+            ["sudo", "bash", "vm_nat.sh", "enable"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
 
         async with asyncssh.connect(
             ip,

--- a/nat-lab/tests/utils/connection_tracker.py
+++ b/nat-lab/tests/utils/connection_tracker.py
@@ -363,9 +363,6 @@ class ConnectionTracker:
 
         await self._synchronize()
 
-        for v in self._validators:
-            v.find_conntracker_violations(self._events)
-
         return merge_results(
             [v.find_conntracker_violations(self._events) for v in self._validators]
         )

--- a/nat-lab/tests/utils/network_switcher/network_switcher_windows.py
+++ b/nat-lab/tests/utils/network_switcher/network_switcher_windows.py
@@ -70,7 +70,7 @@ class ConfiguredInterfaces:
 
 
 class NetworkSwitcherWindows(NetworkSwitcher):
-    _status_check_timeout: float = 20.0
+    _status_check_timeout_s: float = 20.0
 
     def __init__(
         self, connection: Connection, interfaces: ConfiguredInterfaces
@@ -108,7 +108,7 @@ class NetworkSwitcherWindows(NetworkSwitcher):
                 "show",
                 "route",
             ],
-            timeout=self._status_check_timeout,
+            timeout=self._status_check_timeout_s,
         ).check_exists(
             "0.0.0.0/0",
             [
@@ -141,7 +141,7 @@ class NetworkSwitcherWindows(NetworkSwitcher):
                 "show",
                 "route",
             ],
-            timeout=self._status_check_timeout,
+            timeout=self._status_check_timeout_s,
         ).check_exists(
             "0.0.0.0/0",
             [
@@ -192,7 +192,7 @@ class NetworkSwitcherWindows(NetworkSwitcher):
                 "show",
                 "route",
             ],
-            timeout=self._status_check_timeout,
+            timeout=self._status_check_timeout_s,
         ).check_not_exists(
             "0.0.0.0/0",
             [
@@ -225,7 +225,7 @@ class NetworkSwitcherWindows(NetworkSwitcher):
                     "addresses",
                     self._interfaces.default,
                 ],
-                timeout=self._status_check_timeout,
+                timeout=self._status_check_timeout_s,
             ).check_not_exists(self._interfaces.default, None):
                 raise Exception("Failed to disable management interface")
 

--- a/nat-lab/tests/utils/router/linux_router.py
+++ b/nat-lab/tests/utils/router/linux_router.py
@@ -58,10 +58,7 @@ class LinuxRouter(Router):
                 quiet=True,
             ).execute()
 
-        await self._connection.create_process(
-            ["ip", "link", "set", "up", "dev", self._interface_name],
-            quiet=True,
-        ).execute()
+        await self.enable_interface()
 
     def set_interface_name(self, new_interface_name: str) -> None:
         self._interface_name = new_interface_name
@@ -80,6 +77,16 @@ class LinuxRouter(Router):
                 ],
                 quiet=True,
             ).execute()
+
+        await self.disable_interface()
+
+    async def enable_interface(self) -> None:
+        await self._connection.create_process(
+            ["ip", "link", "set", "up", "dev", self._interface_name],
+            quiet=True,
+        ).execute()
+
+    async def disable_interface(self) -> None:
         await self._connection.create_process(
             ["ip", "link", "set", "down", "dev", self._interface_name],
             quiet=True,

--- a/nat-lab/tests/utils/router/mac_router.py
+++ b/nat-lab/tests/utils/router/mac_router.py
@@ -79,6 +79,18 @@ class MacRouter(Router):
                     quiet=True,
                 ).execute()
 
+    async def enable_interface(self) -> None:
+        await self._connection.create_process(
+            ["ifconfig", self._interface_name, "up"],
+            quiet=True,
+        ).execute()
+
+    async def disable_interface(self) -> None:
+        await self._connection.create_process(
+            ["ifconfig", self._interface_name, "down"],
+            quiet=True,
+        ).execute()
+
     async def create_meshnet_route(self) -> None:
         if self.ip_stack in [IPStack.IPv4, IPStack.IPv4v6]:
             await self._connection.create_process(

--- a/nat-lab/tests/utils/router/router.py
+++ b/nat-lab/tests/utils/router/router.py
@@ -83,6 +83,14 @@ class Router(ABC):
         pass
 
     @abstractmethod
+    async def enable_interface(self) -> None:
+        pass
+
+    @abstractmethod
+    async def disable_interface(self) -> None:
+        pass
+
+    @abstractmethod
     async def create_meshnet_route(self) -> None:
         pass
 

--- a/nat-lab/tests/utils/router/windows_router.py
+++ b/nat-lab/tests/utils/router/windows_router.py
@@ -12,7 +12,7 @@ class WindowsRouter(Router):
     _connection: Connection
     _interface_name: str
     # The average time it takes to set up an interface on Windows is ~3 seconds
-    _status_check_timeout: float = 10.0
+    _status_check_timeout_s: float = 10.0
 
     def __init__(self, connection: Connection, ip_stack: IPStack):
         super().__init__(ip_stack)
@@ -40,7 +40,7 @@ class WindowsRouter(Router):
                     self._interface_name,
                     "dadtransmits=0",
                 ],
-                timeout=self._status_check_timeout,
+                timeout=self._status_check_timeout_s,
                 allow_process_failure=True,
             )
             if not await cmd.check_exists("Ok"):
@@ -163,7 +163,7 @@ class WindowsRouter(Router):
                     "show",
                     "route",
                 ],
-                timeout=self._status_check_timeout,
+                timeout=self._status_check_timeout_s,
             ).check_exists("100.64.0.0/10", [self._interface_name]):
                 raise Exception("Failed to create ipv4 meshnet route")
 
@@ -194,7 +194,7 @@ class WindowsRouter(Router):
                     "show",
                     "route",
                 ],
-                timeout=self._status_check_timeout,
+                timeout=self._status_check_timeout_s,
             ).check_exists(LIBTELIO_IPV6_WG_SUBNET + "::/64", [self._interface_name]):
                 raise Exception("Failed to create ipv6 meshnet route")
 
@@ -223,7 +223,7 @@ class WindowsRouter(Router):
                 "show",
                 "route",
             ],
-            timeout=self._status_check_timeout,
+            timeout=self._status_check_timeout_s,
         ).check_exists("0.0.0.0/0", [self._interface_name]):
             raise Exception("Failed to create ipv4 vpn route")
 
@@ -250,7 +250,7 @@ class WindowsRouter(Router):
                 "show",
                 "route",
             ],
-            timeout=self._status_check_timeout,
+            timeout=self._status_check_timeout_s,
         ).check_exists("::/0", [self._interface_name]):
             raise Exception("Failed to create ipv6 vpn route")
 
@@ -294,7 +294,7 @@ class WindowsRouter(Router):
                     "show",
                     "route",
                 ],
-                timeout=self._status_check_timeout,
+                timeout=self._status_check_timeout_s,
             ).check_not_exists("0.0.0.0/0", [self._interface_name]):
                 raise Exception("Failed to delete ipv4 vpn route")
 
@@ -332,7 +332,7 @@ class WindowsRouter(Router):
                     "show",
                     "route",
                 ],
-                timeout=self._status_check_timeout,
+                timeout=self._status_check_timeout_s,
             ).check_not_exists("::/0", [self._interface_name]):
                 raise Exception("Failed to delete ipv6 vpn route")
 

--- a/nat-lab/tests/utils/router/windows_router.py
+++ b/nat-lab/tests/utils/router/windows_router.py
@@ -109,6 +109,32 @@ class WindowsRouter(Router):
                     quiet=True,
                 ).execute()
 
+    async def enable_interface(self) -> None:
+        await self._connection.create_process(
+            [
+                "netsh",
+                "interface",
+                "set",
+                "interface",
+                self._interface_name,
+                "admin=enable",
+            ],
+            quiet=True,
+        ).execute()
+
+    async def disable_interface(self) -> None:
+        await self._connection.create_process(
+            [
+                "netsh",
+                "interface",
+                "set",
+                "interface",
+                self._interface_name,
+                "admin=disable",
+            ],
+            quiet=True,
+        ).execute()
+
     async def create_meshnet_route(self) -> None:
         if self.ip_stack in [IPStack.IPv4, IPStack.IPv4v6]:
             try:

--- a/nat-lab/tests/utils/vm/mac_vm_util.py
+++ b/nat-lab/tests/utils/vm/mac_vm_util.py
@@ -13,11 +13,15 @@ async def copy_binaries(
 ) -> None:
     for directory in [VM_TCLI_DIR, VM_UNIFFI_DIR]:
         try:
-            await connection.create_process(["rm", "-rf", directory]).execute()
+            await connection.create_process(
+                ["rm", "-rf", directory], quiet=True
+            ).execute()
         except ProcessExecError as exception:
             if exception.stderr.find("The system cannot find the file specified.") < 0:
                 raise exception
-        await connection.create_process(["mkdir", "-p", directory]).execute()
+        await connection.create_process(
+            ["mkdir", "-p", directory], quiet=True
+        ).execute()
 
     DIST_PATH = f"dist/darwin/macos/{os.getenv('TELIO_BIN_PROFILE')}/x86_64/"
     LOCAL_UNIFFI_PATH = "nat-lab/tests/uniffi/"
@@ -52,7 +56,7 @@ async def copy_binaries(
             (ssh_connection, dst),
         )
         if set_exec:
-            await connection.create_process(["chmod", "+x", dst]).execute()
+            await connection.create_process(["chmod", "+x", dst], quiet=True).execute()
 
     await asyncssh.scp(
         get_root_path("nat-lab/bin/mac/list_interfaces_with_router_property.py"),


### PR DESCRIPTION
Fixes:
- Libvirt VMs routing was being configured only when binaries were pushed, this PR configures it as default for every new ssh connection.
- Exceptions on docker/ssh processes were not being raised against the context manager of the cleanup stage, making  pytest hang for the whole test timeout duration. This PR fixes it by running the processes inside a try/except/finally block.
- If telio fails to launch won't set the client proxy port, creating an infinite loop waiting for the port. This PR fixes it by additionally checking if the telio process is running.
- Other logging and duplicated code minor fixes.

Features:
- This PR adds link state check as part of the setup_mesh_nodes() helper function.
- Add enable/disable interface methods to router classes.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
