### PR TITLE
Bump trigger-gitlab-pipeline version

### DIFF
--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -15,7 +15,7 @@ permissions: {}
 
 jobs:
   trigger-gitlab-pipeline:
-    uses: NordSecurity/trigger-gitlab-pipeline/.github/workflows/trigger-gitlab-pipeline.yml@924d48acc8250c422e443f285630ec51e78700a0
+    uses: NordSecurity/trigger-gitlab-pipeline/.github/workflows/trigger-gitlab-pipeline.yml@05827593c874bc6e81ed14158cefa7cb40a7bcc0
     secrets:
       ci-api-v4-url: ${{ secrets.CI_API_V4_URL }}
       access-token: ${{ secrets.GITLAB_API_TOKEN }}


### PR DESCRIPTION
### Problem
Previous version of `trigger-gitlab-pipeline` contained a reference to `canonical/get-workflow-version-action` which has minor security issue which can partially expose GITHUB_TOKEN if it's defined in workflow actions.

### Solution
*--describe selected solution--*
