### PR TITLE
LLT-6123: Teliod daemonize CGI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5194,6 +5194,7 @@ dependencies = [
  "signal-hook-tokio",
  "smart-default",
  "telio",
+ "temp-dir",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -5201,6 +5202,12 @@ dependencies = [
  "tracing-subscriber",
  "uuid",
 ]
+
+[[package]]
+name = "temp-dir"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83176759e9416cf81ee66cb6508dbfe9c96f20b8b56265a39917551c23c70964"
 
 [[package]]
 name = "tempfile"

--- a/clis/teliod/API.md
+++ b/clis/teliod/API.md
@@ -67,28 +67,17 @@ This REST API allows interaction with the Teliod daemon. It provides endpoints f
         ...
     }
     ```
-  - **502 Internal Server Error**: Failed to retrieve status (Bad daemon response).
+  - **500 Internal Server Error**: Failed to retrieve status (Bad daemon response).
   - **410 Gone**: Failed to communicate with the daemon (Couldn't send command/Daemon not accessible).
   - **502 Gateway Timeout**: Failed to communicate with the daemon (Timeout while waiting daemon).
 
-#### 5. **Get Meshnet Logs**
-- **Endpoint**: `/?info=get-meshnet-logs`
-- **Method**: `GET`
-- **Description**: Retrieves the latest logs of the Meshnet.
-- **Request Body**: None
-- **Responses**:
-  - **200 OK**: Log content in text format.
-    ```
-    {
-        "Log line 1\nLog line 2\nLog line 3\n..."
-    }
-    ```
-  - **502 Bad Gateway**: Error reading log file.
-
-#### 6. **Get Teliod Logs**
-- **Endpoint**: `/?info=get-teliod-logs`
+#### 5. **Get Logs**
+- **Endpoint**: `/?info=get-logs`
 - **Method**: `GET`
 - **Description**: Retrieves the latest logs of the Teliod Daemon.
+Optional `days_count` parameter to specify a custom number of past day's
+logs to return. For example `/get-logs?days_count=5` will return the logs
+from the past 5 days if present.
 - **Request Body**: None
 - **Responses**:
   - **200 OK**: Log content in text format.
@@ -97,7 +86,7 @@ This REST API allows interaction with the Teliod daemon. It provides endpoints f
         "Log line 1\nLog line 2\nLog line 3\n..."
     }
     ```
-  - **502 Bad Gateway**: Error reading log file.
+  - **500 Internal Server Error **: Error reading log file.
 
 ### Error Handling
 
@@ -117,9 +106,9 @@ curl -X POST http://<NAS-IP>:8080/
 curl -X DELETE http://<NAS-IP>:8080/
 ```
 
-#### Get Meshnet logs:
+#### Get Teliod logs:
 ```bash
-curl -X GET "http://<NAS-IP>:8080/?info=get-meshnet-logs"
+curl -X GET "http://<NAS-IP>:8080/?info=get-logs"
 ```
 
 #### Update Config:

--- a/clis/teliod/Cargo.toml
+++ b/clis/teliod/Cargo.toml
@@ -44,6 +44,7 @@ rust-cgi = { version = "0.7.2", optional = true }
 [dev-dependencies]
 rand = "0.9.1"
 serial_test = "3.2.0"
+temp-dir = "0.1.16"
 
 [features]
 cgi = ["const_format", "rust-cgi", "lazy_static", "maud", "form_urlencoded"]

--- a/clis/teliod/src/cgi/constants.rs
+++ b/clis/teliod/src/cgi/constants.rs
@@ -7,7 +7,17 @@ pub const APP_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../../target/deb
 
 pub const TELIOD_BIN: &str = concatcp!(APP_DIR, "/teliod");
 pub const TELIOD_CFG: &str = concatcp!(APP_DIR, "/teliod.cfg");
-pub const MESHNET_LOG: &str = concatcp!(APP_DIR, "/meshnet.log");
-pub const TELIOD_LOG: &str = "/var/log/teliod.log";
+
+/// Base directory for the rotating libtelio trace logs
+pub const TELIOD_LIB_LOG_DIR: &str = "/var/log";
+/// Filename prefix for the rotating libtelio trace logs
+pub const TELIOD_LIB_LOG_PREFIX: &str = "teliod_lib.log";
+/// Path to the rotating long files (without suffix)
+pub const TELIOD_LIB_LOG: &str = concatcp!(TELIOD_LIB_LOG_DIR, "/", TELIOD_LIB_LOG_PREFIX);
+/// Path to the redirected STDOUT and STDERR streams
+pub const TELIOD_STDOUT_LOG: &str = "/var/log/teliod.log";
+/// Path to the redirected STDOUT and STDERR streams before daemonizing
+pub const TELIOD_INIT_LOG: &str = "/var/log/teliod_init.log";
+
 #[cfg(debug_assertions)]
 pub const CGI_LOG: &str = concatcp!(APP_DIR, "/cgi.log");

--- a/clis/teliod/src/cgi/web.rs
+++ b/clis/teliod/src/cgi/web.rs
@@ -393,7 +393,7 @@ fn meshnet(app: &AppState) -> Markup {
             {
             div class="flex justify-between items-center" {
                 span class="text-primary body-md-medium" { ({meshnet_status_text}) }
-                a href="get-teliod-logs" class="body-xs-medium text-accent hover:text-blue-400 active:text-blue-700 dark:hover:text-blue-400 dark:active:text-blue-700" {"Logs"}
+                a href="get-logs" class="body-xs-medium text-accent hover:text-blue-400 active:text-blue-700 dark:hover:text-blue-400 dark:active:text-blue-700" {"Logs"}
             }
 
             div class="flex flex-col gap-4" {

--- a/clis/teliod/src/config.rs
+++ b/clis/teliod/src/config.rs
@@ -182,13 +182,14 @@ impl Default for TeliodDaemonConfig {
                 Level::INFO
             }),
             log_file_path: {
+                // TODO: Should this path be different for CGI?
                 #[cfg(feature = "cgi")]
                 {
-                    crate::cgi::constants::TELIOD_LOG.to_string()
+                    crate::cgi::constants::TELIOD_LIB_LOG.to_string()
                 }
                 #[cfg(not(feature = "cgi"))]
                 {
-                    "./teliod.log".to_string()
+                    "/var/log/teliod_lib.log".to_string()
                 }
             },
             log_file_count: default_log_file_count(),

--- a/qnap/shared/NordSecurityMeshnet.sh
+++ b/qnap/shared/NordSecurityMeshnet.sh
@@ -8,7 +8,7 @@ QPKG_ROOT=`/sbin/getcfg $QPKG_NAME Install_Path -f ${CONF}`
 export QNAP_QPKG=$QPKG_NAME
 
 TELIOD_CFG_FILE=${QPKG_ROOT}/teliod.cfg
-TELIOD_LOG_FILE="/var/log/teliod.log"
+TELIOD_INIT_LOG_FILE="/var/log/teliod_init.log"
 
 # Change the config file permissions. It contains the auth token so we should prohibit it being read by other users
 chmod 0660 $TELIOD_CFG_FILE
@@ -51,7 +51,7 @@ case "$1" in
         exit 0
     fi
 
-    ${QPKG_ROOT}/teliod start --no-detach $TELIOD_CFG_FILE > $TELIOD_LOG_FILE 2>&1 &
+    ${QPKG_ROOT}/teliod start $TELIOD_CFG_FILE > $TELIOD_INIT_LOG_FILE 2>&1
     system_log INFO "Teliod daemon started."
     ;;
 

--- a/qnap/shared/teliod.cfg
+++ b/qnap/shared/teliod.cfg
@@ -1,6 +1,6 @@
 {
   "log_level": "info",
-  "log_file_path": "/var/log/teliod.log",
+  "log_file_path": "/var/log/teliod_lib.log",
   "adapter_type": "neptun",
   "interface": {
     "name": "nlx",


### PR DESCRIPTION
### Problem
`teliod` now daemonizes itself, so we don't have to send the process to the background manually.

### Solution
Update CGI and QNAP scripts launching `teliod` to make use of it daemonizing itself.
`get_teliod_logs` endpoint was rename to `get_logs` and now it returns combined logs from all the sources.

`MESHNET_LOG` and `get_meshnet_logs` were removed as they were not used anywhere.

STDOUT and STDERR before daemonizing is redirected to `TELIOD_INIT_LOG` (`/var/log/teliod_init.log`).
STDOUT and STDERR after daemonizing is redirected to `TELIOD_STDOUT_LOG` (`/var/log/teliod_stdout.log`).

`libtelio` and `teliod` tracing logs are directed to `TELIOD_LIB_LOG` (`/var/log/teliod_lib.log`) and are rotated daily. 
Therefore `get_logs()` was updated to handle the `teliod_lib.log.YYYY_MM_DD` files, and concatenates up to `days_count` files together.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
