### PR TITLE
LLT-6113 Drop blacklisted packets in firewall

### DIFF
--- a/crates/telio-firewall/Cargo.toml
+++ b/crates/telio-firewall/Cargo.toml
@@ -33,6 +33,8 @@ proptest-derive.workspace = true
 rand.workspace = true
 sn_fake_clock.workspace = true
 
+telio-utils = {workspace = true, features = ["sn_fake_clock"] }
+
 [[bench]]
 name = "firewall_bench"
 harness = false

--- a/crates/telio-firewall/benches/firewall_bench.rs
+++ b/crates/telio-firewall/benches/firewall_bench.rs
@@ -91,7 +91,7 @@ pub fn firewall_tcp_inbound_benchmarks(c: &mut Criterion) {
                     BenchmarkId::from_parameter(parameter.clone()),
                     &parameter,
                     |b, param| {
-                        let firewall = StatefullFirewall::new(true, FeatureFirewall::default());
+                        let firewall = StatefullFirewall::new(true, &FeatureFirewall::default());
                         firewall.set_ip_addresses(vec![
                             (IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))),
                             IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)),
@@ -135,7 +135,7 @@ pub fn firewall_tcp_inbound_benchmarks(c: &mut Criterion) {
                     BenchmarkId::from_parameter(parameter.clone()),
                     &parameter,
                     |b, param| {
-                        let firewall = StatefullFirewall::new(true, FeatureFirewall::default());
+                        let firewall = StatefullFirewall::new(true, &FeatureFirewall::default());
                         firewall.set_ip_addresses(vec![
                             (IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))),
                             IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)),
@@ -177,7 +177,7 @@ pub fn firewall_tcp_inbound_benchmarks(c: &mut Criterion) {
                     BenchmarkId::from_parameter(parameter.clone()),
                     &parameter,
                     |b, param| {
-                        let firewall = StatefullFirewall::new(true, FeatureFirewall::default());
+                        let firewall = StatefullFirewall::new(true, &FeatureFirewall::default());
                         firewall.set_ip_addresses(vec![
                             (IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))),
                             IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)),
@@ -224,7 +224,7 @@ pub fn firewall_tcp_inbound_benchmarks(c: &mut Criterion) {
                     BenchmarkId::from_parameter(parameter.clone()),
                     &parameter,
                     |b, param| {
-                        let firewall = StatefullFirewall::new(true, FeatureFirewall::default());
+                        let firewall = StatefullFirewall::new(true, &FeatureFirewall::default());
                         firewall.set_ip_addresses(vec![
                             (IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))),
                             IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)),
@@ -270,7 +270,7 @@ pub fn firewall_tcp_outbound_benchmarks(c: &mut Criterion) {
                     BenchmarkId::from_parameter(parameter.clone()),
                     &parameter,
                     |b, param| {
-                        let firewall = StatefullFirewall::new(true, FeatureFirewall::default());
+                        let firewall = StatefullFirewall::new(true, &FeatureFirewall::default());
                         for _ in 0..param.peers {
                             let public_key = SecretKey::gen().public();
                             firewall.add_to_peer_whitelist(
@@ -315,7 +315,7 @@ pub fn firewall_tcp_outbound_benchmarks(c: &mut Criterion) {
                     BenchmarkId::from_parameter(parameter.clone()),
                     &parameter,
                     |b, param| {
-                        let firewall = StatefullFirewall::new(true, FeatureFirewall::default());
+                        let firewall = StatefullFirewall::new(true, &FeatureFirewall::default());
                         for _ in 0..param.peers {
                             let public_key = SecretKey::gen().public();
                             firewall.add_to_peer_whitelist(
@@ -353,7 +353,7 @@ pub fn firewall_tcp_outbound_benchmarks(c: &mut Criterion) {
                     BenchmarkId::from_parameter(parameter.clone()),
                     &parameter,
                     |b, param| {
-                        let firewall = StatefullFirewall::new(true, FeatureFirewall::default());
+                        let firewall = StatefullFirewall::new(true, &FeatureFirewall::default());
                         let mut peers = vec![];
                         for _ in 0..param.peers {
                             let public_key = SecretKey::gen().public();
@@ -396,7 +396,7 @@ pub fn firewall_udp_inbound_benchmarks(c: &mut Criterion) {
                     BenchmarkId::from_parameter(parameter.clone()),
                     &parameter,
                     |b, param| {
-                        let firewall = StatefullFirewall::new(true, FeatureFirewall::default());
+                        let firewall = StatefullFirewall::new(true, &FeatureFirewall::default());
                         firewall.set_ip_addresses(vec![
                             (IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))),
                             IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)),
@@ -440,7 +440,7 @@ pub fn firewall_udp_inbound_benchmarks(c: &mut Criterion) {
                     BenchmarkId::from_parameter(parameter.clone()),
                     &parameter,
                     |b, param| {
-                        let firewall = StatefullFirewall::new(true, FeatureFirewall::default());
+                        let firewall = StatefullFirewall::new(true, &FeatureFirewall::default());
                         firewall.set_ip_addresses(vec![
                             (IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))),
                             IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)),
@@ -482,7 +482,7 @@ pub fn firewall_udp_inbound_benchmarks(c: &mut Criterion) {
                     BenchmarkId::from_parameter(parameter.clone()),
                     &parameter,
                     |b, param| {
-                        let firewall = StatefullFirewall::new(true, FeatureFirewall::default());
+                        let firewall = StatefullFirewall::new(true, &FeatureFirewall::default());
                         firewall.set_ip_addresses(vec![
                             (IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))),
                             IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)),
@@ -529,7 +529,7 @@ pub fn firewall_udp_inbound_benchmarks(c: &mut Criterion) {
                     BenchmarkId::from_parameter(parameter.clone()),
                     &parameter,
                     |b, param| {
-                        let firewall = StatefullFirewall::new(true, FeatureFirewall::default());
+                        let firewall = StatefullFirewall::new(true, &FeatureFirewall::default());
                         firewall.set_ip_addresses(vec![
                             (IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))),
                             IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)),
@@ -571,7 +571,7 @@ pub fn firewall_udp_outbound_benchmarks(c: &mut Criterion) {
                     BenchmarkId::from_parameter(parameter.clone()),
                     &parameter,
                     |b, param| {
-                        let firewall = StatefullFirewall::new(true, FeatureFirewall::default());
+                        let firewall = StatefullFirewall::new(true, &FeatureFirewall::default());
                         let mut peers = vec![];
                         for _ in 0..param.peers {
                             let public_key = SecretKey::gen().public();
@@ -608,7 +608,7 @@ pub fn firewall_udp_outbound_benchmarks(c: &mut Criterion) {
                     BenchmarkId::from_parameter(parameter.clone()),
                     &parameter,
                     |b, param| {
-                        let firewall = StatefullFirewall::new(true, FeatureFirewall::default());
+                        let firewall = StatefullFirewall::new(true, &FeatureFirewall::default());
                         let mut peers = vec![];
                         for _ in 0..param.peers {
                             let public_key = SecretKey::gen().public();

--- a/crates/telio-wg/src/wg.rs
+++ b/crates/telio-wg/src/wg.rs
@@ -198,7 +198,7 @@ impl DynamicWg {
     ///         fn set_tunnel_interface(&self, interface: u64);
     ///         }
     ///     }
-    ///     let firewall = Arc::new(StatefullFirewall::new(true,  FeatureFirewall::default(),));
+    ///     let firewall = Arc::new(StatefullFirewall::new(true,  &FeatureFirewall::default(),));
     ///     let firewall_filter_inbound_packets = {
     ///         let fw = firewall.clone();
     ///         move |peer: &[u8; 32], packet: &[u8]| fw.process_inbound_packet(peer, packet)

--- a/nat-lab/tests/test_features_builder.py
+++ b/nat-lab/tests/test_features_builder.py
@@ -1,4 +1,9 @@
-from uniffi import FeaturesDefaultsBuilder, deserialize_feature_config
+from uniffi import (
+    FeaturesDefaultsBuilder,
+    deserialize_feature_config,
+    FirewallBlacklistTuple,
+    IpProtocol,
+)
 
 
 def test_telio_features_builder_empty():
@@ -25,12 +30,21 @@ def test_telio_features_builder_empty():
 def test_telio_features_builder_firewall():
     built = FeaturesDefaultsBuilder().build()
     built.firewall.exclude_private_ip_range = "1.2.3.4/10"
+    built.firewall.outgoing_blacklist = [
+        FirewallBlacklistTuple(IpProtocol.UDP, "8.8.4.4", 30)
+    ]
+
     json = """
     {
         "lana": null,
         "nurse": null,
         "firewall": {
             "exclude_private_ip_range": "1.2.3.4/10",
+            "outgoing_blacklist": [{
+                    "protocol": "UDP",
+                    "ip": "8.8.4.4",
+                    "port": 30
+            }],
             "neptun_reset_conns": false
         },
         "direct": null,

--- a/src/device.rs
+++ b/src/device.rs
@@ -1044,7 +1044,7 @@ impl Runtime {
         features: Features,
         protect: Option<Arc<dyn Protector>>,
     ) -> Result<Self> {
-        let firewall = Arc::new(StatefullFirewall::new(features.ipv6, features.firewall));
+        let firewall = Arc::new(StatefullFirewall::new(features.ipv6, &features.firewall));
 
         let firewall_filter_inbound_packets = {
             let fw = firewall.clone();

--- a/src/libtelio.udl
+++ b/src/libtelio.udl
@@ -715,6 +715,24 @@ dictionary FeatureDerp {
     boolean use_built_in_root_certificates;
 };
 
+/// Next layer protocol for IP packet
+enum IpProtocol {
+    /// UDP protocol
+    "UDP",
+    /// TCP protocol
+    "TCP"
+};
+
+/// Tuple used to blacklist outgoing connections in Telio firewall
+dictionary FirewallBlacklistTuple {
+    /// Protocol of the packet to be blacklisted
+    IpProtocol protocol;
+    /// Destination IP address of the packet
+    IpAddr ip;
+    /// Destination port of the packet
+    u16 port;
+};
+
 /// Feature config for firewall
 dictionary FeatureFirewall {
     /// Turns on connection resets upon VPN server change
@@ -723,6 +741,8 @@ dictionary FeatureFirewall {
     boolean boringtun_reset_conns;
     /// Ip range from RFC1918 to exclude from firewall blocking
     Ipv4Net? exclude_private_ip_range;
+    /// Blackist for outgoing connections
+    sequence<FirewallBlacklistTuple> outgoing_blacklist;
 };
 
 /// Link detection mechanism


### PR DESCRIPTION
Add firewall blacklist for outgoing packets that can be configured via feature config


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
