### PR TITLE
Implement suspend-aware replacement for `tokio::time::Instant`

### DIFF
--- a/.github/workflows/nagger.yml
+++ b/.github/workflows/nagger.yml
@@ -5,7 +5,7 @@ permissions: {}
 jobs:
   nagger:
     runs-on: ubuntu-22.04
-    container: ghcr.io/nordsecurity/nagger:v4.0.0
+    container: ghcr.io/nordsecurity/nagger:v4.1.0
     steps:
       - name: Checkout
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 #v4.1.6

--- a/.unreleased/LLT-6057
+++ b/.unreleased/LLT-6057
@@ -1,0 +1,1 @@
+Change the way time is measured to include the time spent sleeping

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -453,8 +453,7 @@ dependencies = [
 [[package]]
 name = "boot-time"
 version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce2b094c3b8fd302af9393806bb8af1b83a5a948ca7a91e87a92ea32167157f6"
+source = "git+https://github.com/NordSecurity/boot_time.git?rev=14f9a90d43a601ae50e69044894538c1398120a7#14f9a90d43a601ae50e69044894538c1398120a7"
 dependencies = [
  "cfg-if",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,6 +451,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "boot-time"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2b094c3b8fd302af9393806bb8af1b83a5a948ca7a91e87a92ea32167157f6"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5112,6 +5122,7 @@ version = "0.1.0"
 dependencies = [
  "backtrace",
  "blake3",
+ "boot-time",
  "futures",
  "hashlink",
  "ipnet",

--- a/Justfile
+++ b/Justfile
@@ -29,7 +29,7 @@ clippy: _clippy-install
 
 # Run udeps
 udeps: _udeps-install
-    cargo +{{ nightly }} udeps --workspace --locked --output human --backend depinfo
+    cargo +{{ nightly }} udeps --workspace --locked --output human --backend depinfo --release
 
 # Run unused features
 unused: _unused-install

--- a/clis/teliod/src/nc.rs
+++ b/clis/teliod/src/nc.rs
@@ -14,12 +14,12 @@ use telio::telio_utils::{
     exponential_backoff::{
         Backoff, Error as BackoffError, ExponentialBackoff, ExponentialBackoffBounds,
     },
-    Hidden,
+    sleep_until, Hidden, Instant,
 };
 use tokio::{
     select,
     sync::Mutex,
-    time::{error::Elapsed, timeout, Instant},
+    time::{error::Elapsed, timeout},
 };
 use tracing::{debug, error, info, warn};
 use uuid::Uuid;
@@ -126,7 +126,7 @@ async fn start_mqtt(nc_config: NCConfig) -> Result<(), Error> {
 
             loop {
                 select! {
-                    _ = tokio::time::sleep_until(expires_at) => {
+                    _ = sleep_until(expires_at) => {
                         info!("Notification Center credentials expired, mqtt will be restarted");
                         break;
                     },

--- a/crates/telio-model/src/config.rs
+++ b/crates/telio-model/src/config.rs
@@ -4,8 +4,7 @@ use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use serde_json::{from_value, Error, Value};
 use smart_default::SmartDefault;
-use telio_utils::{telio_log_error, telio_log_warn, Hidden};
-use tokio::time::Instant;
+use telio_utils::{telio_log_error, telio_log_warn, Hidden, Instant};
 
 use std::{
     io::ErrorKind,

--- a/crates/telio-nurse/src/aggregator.rs
+++ b/crates/telio-nurse/src/aggregator.rs
@@ -1,6 +1,6 @@
 use std::{collections::hash_map::Entry, mem, net::SocketAddr, sync::Arc, time::Duration};
 
-use tokio::{sync::Mutex, time::Instant};
+use tokio::sync::Mutex;
 
 use serde::{ser::SerializeTuple, Serialize};
 
@@ -11,7 +11,7 @@ use telio_model::{
     features::EndpointProvider,
     HashMap,
 };
-use telio_utils::{telio_log_debug, telio_log_info, telio_log_warn};
+use telio_utils::{telio_log_debug, telio_log_info, telio_log_warn, Instant};
 use telio_wg::{
     uapi::{AnalyticsEvent, PeerState},
     WireGuard,

--- a/crates/telio-nurse/src/heartbeat.rs
+++ b/crates/telio-nurse/src/heartbeat.rs
@@ -1088,6 +1088,7 @@ impl Analytics {
 
 /// Resets the Sleep instance to a new deadline.
 pub fn reset_sleep(sleep: &mut std::pin::Pin<Box<Sleep>>, offset: Duration) {
+    #[allow(instant)]
     sleep.as_mut().reset(tokio::time::Instant::now() + offset);
 }
 

--- a/crates/telio-nurse/src/heartbeat.rs
+++ b/crates/telio-nurse/src/heartbeat.rs
@@ -25,11 +25,11 @@ use telio_task::{
     Runtime, RuntimeExt, WaitResponse,
 };
 use telio_utils::{
-    get_ip_stack, interval_at, map_enum, telio_log_debug, telio_log_error, telio_log_trace,
-    telio_log_warn, IpStack,
+    get_ip_stack, interval_after, map_enum, reset_after, telio_log_debug, telio_log_error,
+    telio_log_trace, telio_log_warn, IpStack,
 };
 use telio_wg::uapi::PeerState;
-use tokio::time::{sleep, Duration, Instant, Interval, Sleep};
+use tokio::time::{sleep, Duration, Interval, Sleep};
 use uuid::Uuid;
 
 #[mockall_double::double]
@@ -382,8 +382,7 @@ impl Analytics {
         io: Io,
         aggregator: Arc<ConnectivityDataAggregator>,
     ) -> Self {
-        let far_future_from_now = Instant::now() + FAR_FUTURE;
-        let interval: Interval = interval_at(far_future_from_now, config.collect_interval);
+        let interval: Interval = interval_after(FAR_FUTURE, config.collect_interval);
 
         let mut config_nodes = HashMap::new();
         // Add self in config_nodes hashset
@@ -416,8 +415,10 @@ impl Analytics {
             derp_event_channel,
         }) = meshnet_entities
         {
-            let start_time = Instant::now() + self.config.initial_collect_interval;
-            self.task_interval.reset_at(start_time);
+            reset_after(
+                &mut self.task_interval,
+                self.config.initial_collect_interval,
+            );
 
             self.io.chan = Some(multiplexer);
             self.io.derp_event_channel = Some(derp_event_channel.subscribe());
@@ -569,15 +570,12 @@ impl Analytics {
             }
         }
 
-        // Check whether there are any responses to wait for
-        let collection_deadline = if requests_sent {
-            Instant::now() + self.config.collect_answer_timeout
+        let collection_offset = if requests_sent {
+            self.config.collect_answer_timeout
         } else {
-            Instant::now()
+            Duration::ZERO
         };
-
-        // Start collection timer before starting to aggregate the data
-        self.collect_period.as_mut().reset(collection_deadline);
+        reset_sleep(&mut self.collect_period, collection_offset);
 
         // Transition to the collection state
         self.state = RuntimeState::Collecting;
@@ -880,9 +878,7 @@ impl Analytics {
         }
 
         // Shamelessly stolen from tokio's far_future(), we set the timer to timeout in the far future, effectively pausing it until needed again
-        self.collect_period
-            .as_mut()
-            .reset(Instant::now() + FAR_FUTURE);
+        reset_sleep(&mut self.collect_period, FAR_FUTURE);
 
         // Transition back to the monitoring state afterwards
         self.state = RuntimeState::Monitoring;
@@ -1090,13 +1086,18 @@ impl Analytics {
     }
 }
 
+/// Resets the Sleep instance to a new deadline.
+pub fn reset_sleep(sleep: &mut std::pin::Pin<Box<Sleep>>, offset: Duration) {
+    sleep.as_mut().reset(tokio::time::Instant::now() + offset);
+}
+
 #[cfg(test)]
 mod tests {
     use std::net::{IpAddr, Ipv4Addr, SocketAddr};
     use telio_model::{features::FeatureNurse, mesh::Node};
     use telio_sockets::{native::NativeSocket, Protector};
     use telio_task::{io::McChan, Task};
-    use telio_utils::sync::mpsc::Receiver;
+    use telio_utils::{sync::mpsc::Receiver, Instant};
     use tokio::time::{self, timeout};
 
     use crate::aggregator::{
@@ -1429,6 +1430,10 @@ mod tests {
         assert_eq!("vpn:7600617f9f9db5691a8c2768bd9d8110:2", external_links);
     }
 
+    fn reset_before(interval: &mut Interval, offset: Duration) {
+        interval.reset_at(time::Instant::now() - offset);
+    }
+
     #[tokio::test]
     // After a pause libtelio should send only one analytic even
     // if it missed more than one analytic interval.
@@ -1440,9 +1445,7 @@ mod tests {
         } = setup(Some(Duration::from_secs(5)), None);
 
         // Reset analytic timer 25s in the past
-        analytics
-            .task_interval
-            .reset_at(Instant::now() - Duration::from_secs(25));
+        reset_before(&mut analytics.task_interval, Duration::from_secs(25));
 
         // Set analytic collect interval 200 ms
         analytics.config.collect_answer_timeout = Duration::from_millis(200);

--- a/crates/telio-nurse/src/qos.rs
+++ b/crates/telio-nurse/src/qos.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use telio_model::constants::{VPN_INTERNAL_IPV4, VPN_INTERNAL_IPV6};
 
 use tokio::sync::mpsc;
-use tokio::time::{Duration, Instant, Interval};
+use tokio::time::{Duration, Interval};
 
 use telio_crypto::PublicKey;
 use telio_model::features::RttType;
@@ -15,7 +15,7 @@ use telio_wg::uapi::{AnalyticsEvent, PeerState};
 
 use telio_pinger::{DualPingResults, Pinger};
 use telio_sockets::SocketPool;
-use telio_utils::{interval, telio_log_debug, telio_log_trace, DualTarget, IpStack};
+use telio_utils::{interval, telio_log_debug, telio_log_trace, DualTarget, Instant, IpStack};
 
 use crate::{config::QoSConfig, data::MeshConfigUpdateEvent};
 

--- a/crates/telio-pq/src/conn.rs
+++ b/crates/telio-pq/src/conn.rs
@@ -4,7 +4,7 @@ use tokio::task::JoinHandle;
 
 use telio_model::features::FeaturePostQuantumVPN;
 use telio_task::io::chan;
-use telio_utils::{telio_log_debug, telio_log_warn};
+use telio_utils::{reset_after, telio_log_debug, telio_log_warn};
 
 use crate::proto;
 
@@ -89,7 +89,7 @@ impl ConnKeyRotation {
                     }
                     Ok(Err(err)) => {
                         telio_log_warn!("Failed to perform PQ rekey: {err}");
-                        interval.reset_after(request_retry);
+                        reset_after(&mut interval, request_retry);
                     }
                     Err(_timeout) => {
                         telio_log_warn!(

--- a/crates/telio-relay/src/derp/http.rs
+++ b/crates/telio-relay/src/derp/http.rs
@@ -15,7 +15,7 @@ use std::{
 };
 use telio_sockets::{SocketBufSizes, SocketPool, TcpParams};
 use telio_task::io::Chan;
-use telio_utils::{interval_at, telio_log_debug, telio_log_warn};
+use telio_utils::{interval_after, telio_log_debug, telio_log_warn};
 use webpki_roots::TLS_SERVER_ROOTS;
 
 use crate::{Config, DerpKeepaliveConfig};
@@ -222,7 +222,7 @@ async fn connect_and_start<RW: AsyncRead + AsyncWrite + Send + 'static>(
         join_receiver: tokio::spawn(async move {
             start_write(writer, receiver_relayed, receiver_direct, addr).await
         }),
-        poll_timer: { interval_at(tokio::time::Instant::now() + poll_interval, poll_interval) },
+        poll_timer: { interval_after(poll_interval, poll_interval) },
     })
 }
 
@@ -311,7 +311,7 @@ mod tests {
     use hyper::server::conn::http1;
     use hyper::service::service_fn;
     use hyper::{
-        body::{Body, Bytes, Incoming},
+        body::{Bytes, Incoming},
         Request, Response,
     };
     use hyper_util::rt::TokioIo;

--- a/crates/telio-traversal/src/connectivity_check.rs
+++ b/crates/telio-traversal/src/connectivity_check.rs
@@ -5,10 +5,10 @@ use telio_utils::exponential_backoff;
 use thiserror::Error as TError;
 
 use telio_model::{features::EndpointProvider, SocketAddr};
+use telio_utils::Instant;
 
 use telio_crypto::PublicKey;
 use telio_proto::{CallMeMaybeMsg, Session};
-use tokio::time::Instant;
 
 #[derive(Debug, TError)]
 pub enum Error {

--- a/crates/telio-traversal/src/connectivity_check/cross_ping_check.rs
+++ b/crates/telio-traversal/src/connectivity_check/cross_ping_check.rs
@@ -25,10 +25,10 @@ use telio_proto::{CallMeMaybeMsg, CallMeMaybeType, Session};
 use telio_task::{io::chan, io::Chan, task_exec, BoxAction, Runtime, Task};
 use telio_utils::{
     exponential_backoff::{Backoff, ExponentialBackoff, ExponentialBackoffBounds},
-    interval, telio_log_debug, telio_log_info, telio_log_trace, telio_log_warn, LruCache,
+    interval, telio_log_debug, telio_log_info, telio_log_trace, telio_log_warn, Instant, LruCache,
 };
 use tokio::sync::Mutex;
-use tokio::time::{Instant, Interval};
+use tokio::time::Interval;
 
 const CPC_TIMEOUT: Duration = Duration::from_secs(10);
 const UPGRADE_TIMEOUT: Duration = Duration::from_secs(60);
@@ -993,7 +993,7 @@ mod tests {
     use rstest::rstest;
     use tokio::{
         sync::mpsc::{Receiver, Sender},
-        time::{self, Instant},
+        time,
     };
 
     use telio_crypto::{PublicKey, SecretKey};

--- a/crates/telio-traversal/src/endpoint_providers/upnp.rs
+++ b/crates/telio-traversal/src/endpoint_providers/upnp.rs
@@ -24,10 +24,9 @@ use telio_task::{io::chan::Tx, task_exec, BoxAction, Runtime, Task};
 use telio_utils::interval;
 use telio_utils::{
     exponential_backoff::{Backoff, ExponentialBackoff, ExponentialBackoffBounds},
-    telio_log_debug, telio_log_info, telio_log_warn, PinnedSleep,
+    telio_log_debug, telio_log_info, telio_log_warn, Instant, PinnedSleep,
 };
 use telio_wg::{DynamicWg, WireGuard};
-use tokio::time::Instant;
 use tokio::{net::UdpSocket, pin, sync::Mutex};
 
 #[cfg(test)]

--- a/crates/telio-traversal/src/upgrade_sync.rs
+++ b/crates/telio-traversal/src/upgrade_sync.rs
@@ -9,11 +9,8 @@ use telio_crypto::{smaller_key_in_meshnet_canonical_order, PublicKey};
 use telio_model::features::EndpointProvider;
 use telio_proto::{Decision, Session, UpgradeDecisionMsg, UpgradeMsg};
 use telio_task::{io::chan, io::Chan, task_exec, BoxAction, Runtime, Task};
-use telio_utils::{interval, telio_log_debug, telio_log_info, telio_log_warn, LruCache};
-use tokio::{
-    sync::mpsc::error::SendError,
-    time::{Instant, Interval},
-};
+use telio_utils::{interval, telio_log_debug, telio_log_info, telio_log_warn, Instant, LruCache};
+use tokio::{sync::mpsc::error::SendError, time::Interval};
 
 use crate::cross_ping_check::UpgradeController;
 

--- a/crates/telio-utils/Cargo.toml
+++ b/crates/telio-utils/Cargo.toml
@@ -12,6 +12,7 @@ sn_fake_clock = ["dep:sn_fake_clock"]
 [dependencies]
 backtrace = "0.3.74"
 blake3 = "1.5.4"
+boot-time = "0.1.2"
 futures.workspace = true
 hashlink.workspace = true
 ipnet.workspace = true

--- a/crates/telio-utils/Cargo.toml
+++ b/crates/telio-utils/Cargo.toml
@@ -12,7 +12,7 @@ sn_fake_clock = ["dep:sn_fake_clock"]
 [dependencies]
 backtrace = "0.3.74"
 blake3 = "1.5.4"
-boot-time = "0.1.2"
+boot-time = { git = "https://github.com/NordSecurity/boot_time.git", rev = "14f9a90d43a601ae50e69044894538c1398120a7" }
 futures.workspace = true
 hashlink.workspace = true
 ipnet.workspace = true

--- a/crates/telio-utils/src/bytes_and_timestamps.rs
+++ b/crates/telio-utils/src/bytes_and_timestamps.rs
@@ -13,7 +13,7 @@ pub const WG_KEEPALIVE: Duration = Duration::from_secs(10);
 #[cfg(kani)]
 type Instant = kani_instant::Instant;
 #[cfg(not(kani))]
-type Instant = tokio::time::Instant;
+type Instant = crate::Instant;
 
 #[derive(Copy, Clone, Debug)]
 /// A structure to hold the bytes and timestamps for received and transmitted data.

--- a/crates/telio-utils/src/instant.rs
+++ b/crates/telio-utils/src/instant.rs
@@ -16,6 +16,7 @@ pub struct Instant(InnerInstant);
 impl Instant {
     /// Returns an instant corresponding to “now”.
     pub fn now() -> Self {
+        #[allow(instant)]
         Self(InnerInstant::now())
     }
 

--- a/crates/telio-utils/src/instant.rs
+++ b/crates/telio-utils/src/instant.rs
@@ -1,0 +1,95 @@
+use std::time::Duration;
+
+const CHECK_PERIOD: Duration = Duration::from_secs(60);
+
+/// Wrapper for the `tokio::time::Instant`
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Instant(tokio::time::Instant);
+
+impl Instant {
+    /// Returns an instant corresponding to “now”.
+    pub fn now() -> Self {
+        Self(tokio::time::Instant::now())
+    }
+
+    /// Returns the amount of time elapsed from another instant to this one, or zero duration if that instant is later than this one.
+    pub fn duration_since(&self, earlier: Self) -> Duration {
+        self.0.duration_since(earlier.0)
+    }
+
+    /// Returns `Some(t)` where `t` is the time `self + duration` if `t` can be represented as `Instant` (which means it’s inside the bounds of the underlying data structure), `None` otherwise.
+    pub fn checked_add(&self, duration: Duration) -> Option<Self> {
+        self.0.checked_add(duration).map(Self)
+    }
+
+    /// Returns the amount of time elapsed since this instant was created, or zero duration if this instant is in the future.
+    pub fn elapsed(&self) -> Duration {
+        self.0.elapsed()
+    }
+
+    /// Returns the amount of time elapsed from another instant to this one, or None if that instant is later than this one.
+    pub fn checked_duration_since(&self, earlier: Self) -> Option<Duration> {
+        self.0.checked_duration_since(earlier.0)
+    }
+
+    /// Returns the amount of time elapsed from another instant to this one, or zero duration if that instant is later than this one.
+    pub fn saturating_duration_since(&self, earlier: Self) -> Duration {
+        self.0.saturating_duration_since(earlier.0)
+    }
+}
+
+impl std::ops::Add<Duration> for Instant {
+    type Output = Self;
+
+    fn add(self, rhs: Duration) -> Self::Output {
+        Self(self.0 + rhs)
+    }
+}
+
+impl std::ops::AddAssign<Duration> for Instant {
+    fn add_assign(&mut self, rhs: Duration) {
+        self.0 += rhs
+    }
+}
+
+impl std::ops::Sub<Duration> for Instant {
+    type Output = Self;
+
+    fn sub(self, rhs: Duration) -> Self::Output {
+        Self(self.0 - rhs)
+    }
+}
+
+impl std::ops::Sub<Instant> for Instant {
+    type Output = Duration;
+
+    fn sub(self, rhs: Instant) -> Self::Output {
+        self.0 - rhs.0
+    }
+}
+
+/// Suspend aware replacement for tokio::time::sleep_until. In case
+/// operating system was suspended long enough, so that `instant` is
+/// in the past when operating system resumes - in that case `sleep_until`
+/// will complete within 60 seconds after the resume.
+pub async fn sleep_until(instant: Instant) {
+    loop {
+        let now = Instant::now();
+
+        if now >= instant {
+            return;
+        }
+
+        let remaining = instant.duration_since(now);
+
+        if remaining <= CHECK_PERIOD {
+            tokio::time::sleep(remaining).await;
+            return;
+        }
+
+        // Otherwise, sleep for a minute and check again. This sleep can
+        // actually take more than CHECK_PERIOD, if the operating system
+        // was suspended after the `sleep` was called.
+        tokio::time::sleep(CHECK_PERIOD).await;
+    }
+}

--- a/crates/telio-utils/src/instant.rs
+++ b/crates/telio-utils/src/instant.rs
@@ -2,14 +2,21 @@ use std::time::Duration;
 
 const CHECK_PERIOD: Duration = Duration::from_secs(60);
 
-/// Wrapper for the `tokio::time::Instant`
+#[cfg(debug_assertions)]
+type InnerInstant = tokio::time::Instant;
+#[cfg(not(debug_assertions))]
+type InnerInstant = boot_time::Instant;
+
+/// A measurement of a monotonically nondecreasing clock. Opaque and useful only with Duration.
+/// In the Debug mode, it is a trivial wrapper for `tokio::time::Instant`. In the Release mode,
+/// it measures the time including time spent when the operating system is sleeping / suspended.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct Instant(tokio::time::Instant);
+pub struct Instant(InnerInstant);
 
 impl Instant {
     /// Returns an instant corresponding to “now”.
     pub fn now() -> Self {
-        Self(tokio::time::Instant::now())
+        Self(InnerInstant::now())
     }
 
     /// Returns the amount of time elapsed from another instant to this one, or zero duration if that instant is later than this one.

--- a/crates/telio-utils/src/interval.rs
+++ b/crates/telio-utils/src/interval.rs
@@ -1,16 +1,22 @@
-use tokio::time::{self, Duration, Instant, Interval, MissedTickBehavior};
+use tokio::time::{self, Duration, Interval, MissedTickBehavior};
 
 /// Just like `tokio::time::interval` but the missed tick behaviour
 /// is set to `Delay`.
 pub fn interval(period: Duration) -> Interval {
-    interval_at(Instant::now(), period)
+    interval_after(Duration::ZERO, period)
 }
 
-/// Just like `tokio::time::interval_at` but the missed tick behaviour
-/// is set to `Delay`.
+/// Just like `tokio::time::interval_at(Instant::now() + offest, period)`, but the missed
+/// tick behaviour is set to `Delay`.
 #[allow(tokio_time_interval)]
-pub fn interval_at(start: Instant, period: Duration) -> Interval {
+pub fn interval_after(offset: Duration, period: Duration) -> Interval {
+    let start = time::Instant::now() + offset;
     let mut interval = time::interval_at(start, period);
     interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
     interval
+}
+
+/// Resets the interval after the specified `std::time::Duration`.
+pub fn reset_after(interval: &mut Interval, offset: Duration) {
+    interval.reset_at(time::Instant::now() + offset);
 }

--- a/crates/telio-utils/src/interval.rs
+++ b/crates/telio-utils/src/interval.rs
@@ -10,6 +10,7 @@ pub fn interval(period: Duration) -> Interval {
 /// tick behaviour is set to `Delay`.
 #[allow(tokio_time_interval)]
 pub fn interval_after(offset: Duration, period: Duration) -> Interval {
+    #[allow(instant)]
     let start = time::Instant::now() + offset;
     let mut interval = time::interval_at(start, period);
     interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
@@ -18,5 +19,6 @@ pub fn interval_after(offset: Duration, period: Duration) -> Interval {
 
 /// Resets the interval after the specified `std::time::Duration`.
 pub fn reset_after(interval: &mut Interval, offset: Duration) {
+    #[allow(instant)]
     interval.reset_at(time::Instant::now() + offset);
 }

--- a/crates/telio-utils/src/lib.rs
+++ b/crates/telio-utils/src/lib.rs
@@ -64,3 +64,7 @@ pub mod backtrace;
 /// Types needed by to recover internal WG timers state
 pub mod bytes_and_timestamps;
 pub use bytes_and_timestamps::*;
+
+/// suspend-aware replacement for {std,tokio}::time::Instant
+pub mod instant;
+pub use instant::*;

--- a/crates/telio-utils/src/lru_cache.rs
+++ b/crates/telio-utils/src/lru_cache.rs
@@ -11,7 +11,7 @@ use std::{
 #[cfg(any(test, feature = "sn_fake_clock"))]
 use sn_fake_clock::FakeClock as Instant;
 #[cfg(not(any(test, feature = "sn_fake_clock")))]
-use std::time::Instant;
+type Instant = crate::Instant;
 
 /// A view into a single entry in a map, which may either be vacant or occupied.
 pub enum Entry<'a, K, V> {

--- a/crates/telio-utils/src/repeated_actions.rs
+++ b/crates/telio-utils/src/repeated_actions.rs
@@ -5,13 +5,13 @@ use std::{
 };
 use thiserror::Error as ThisError;
 
-use crate::{interval, interval_at};
+use crate::{interval, interval_after};
 use futures::{
     future::BoxFuture,
     stream::{FuturesUnordered, StreamExt},
     FutureExt,
 };
-use tokio::time::{Duration, Instant, Interval};
+use tokio::time::{Duration, Interval};
 
 /// Possible [RepeatedAction] errors.
 #[derive(ThisError, Debug)]
@@ -91,8 +91,7 @@ where
         self.actions.get_mut(key).map_or_else(
             || Err(RepeatedActionError::RepeatedActionNotFound),
             |a| {
-                let interval = interval_at(Instant::now() + dur, dur);
-                a.0 = interval;
+                a.0 = interval_after(dur, dur);
                 Ok(())
             },
         )
@@ -137,6 +136,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::Instant;
     use maplit::hashset;
     use telio_test::assert_elapsed;
     use tokio::time;

--- a/crates/telio-utils/src/tokio.rs
+++ b/crates/telio-utils/src/tokio.rs
@@ -3,7 +3,7 @@ use rustc_hash::FxHashMap;
 use std::{
     sync::Arc,
     thread::{current, sleep, spawn, ThreadId},
-    time::{Duration, Instant},
+    time::Duration,
 };
 
 const ALERT_DURATION: Duration = Duration::from_secs(10);
@@ -19,22 +19,22 @@ enum ThreadStatus {
 
 /// ThreadTracker will track changes of state of tokio's threads.
 pub struct ThreadTracker {
-    statuses: FxHashMap<ThreadId, (ThreadStatus, Instant)>,
-    last_change: Instant,
+    statuses: FxHashMap<ThreadId, (ThreadStatus, crate::Instant)>,
+    last_change: crate::Instant,
 }
 
 impl Default for ThreadTracker {
     fn default() -> Self {
         Self {
             statuses: Default::default(),
-            last_change: Instant::now(),
+            last_change: crate::Instant::now(),
         }
     }
 }
 
 impl ThreadTracker {
     fn set_status(&mut self, status: ThreadStatus) {
-        let now = Instant::now();
+        let now = crate::Instant::now();
         let tid = current().id();
 
         self.last_change = now;
@@ -49,7 +49,7 @@ impl ThreadTracker {
     }
 
     fn check_for_long_unparked_threads(&self) {
-        let now = Instant::now();
+        let now = crate::Instant::now();
         for (tid, (status, last_status_change)) in &self.statuses {
             if *status == ThreadStatus::Unparked {
                 let delta = now - *last_status_change;
@@ -99,7 +99,7 @@ impl Monitor for Arc<parking_lot::Mutex<ThreadTracker>> {
             let mut last_alert = None;
             loop {
                 sleep(ALERT_DURATION);
-                let now = Instant::now();
+                let now = crate::Instant::now();
                 let thread_tracker = self.lock();
                 let time_since_last_change = now - thread_tracker.last_change;
                 thread_tracker.check_for_long_unparked_threads();

--- a/crates/telio-wg/src/link_detection.rs
+++ b/crates/telio-wg/src/link_detection.rs
@@ -6,7 +6,6 @@ use std::{
     sync::{Arc, Mutex},
     time::Duration,
 };
-use tokio::time::Instant;
 
 use telio_crypto::PublicKey;
 use telio_model::{
@@ -17,7 +16,7 @@ use telio_sockets::SocketPool;
 use telio_task::io::{chan, Chan};
 use telio_utils::{
     get_ip_stack, telio_err_with_log, telio_log_debug, telio_log_error, telio_log_trace,
-    telio_log_warn, IpStack,
+    telio_log_warn, Instant, IpStack,
 };
 
 use crate::{

--- a/crates/telio-wg/src/uapi.rs
+++ b/crates/telio-wg/src/uapi.rs
@@ -4,8 +4,7 @@ use ipnet::{AddrParseError as IpnetParseError, IpNet};
 use serde::{Deserialize, Serialize};
 use telio_crypto::{KeyDecodeError, PresharedKey, PublicKey, SecretKey};
 use telio_model::mesh::{LinkState, Node, NodeState};
-use telio_utils::{telio_log_warn, DualTarget, DualTargetError};
-use tokio::time::Instant;
+use telio_utils::{telio_log_warn, DualTarget, DualTargetError, Instant};
 use wireguard_uapi::{get, xplatform::set};
 
 use std::{
@@ -45,7 +44,7 @@ pub struct Peer {
     /// Peer's endpoint with `IP address` and `UDP port` number
     pub endpoint: Option<SocketAddr>,
     /// At what point in time, was last endpoint changed
-    pub endpoint_changed_at: Option<(tokio::time::Instant, UpdateReason)>,
+    pub endpoint_changed_at: Option<(Instant, UpdateReason)>,
     /// Mesh's IP addresses of peer
     pub ip_addresses: Vec<IpAddr>,
     /// Keep alive interval, `seconds` or `None`

--- a/crates/telio-wg/src/windows/service.rs
+++ b/crates/telio-wg/src/windows/service.rs
@@ -1,8 +1,8 @@
 #![cfg(windows)]
 
 use std::convert::{TryFrom, TryInto};
-use std::time::{Duration, Instant};
-use telio_utils::{telio_log_debug, telio_log_warn};
+use std::time::Duration;
+use telio_utils::{telio_log_debug, telio_log_warn, Instant};
 use windows::{
     core::{w, Error, Result as WindowsResult, HRESULT, PCWSTR},
     Win32::System::Services::{

--- a/src/device.rs
+++ b/src/device.rs
@@ -66,7 +66,7 @@ use std::{
     io::{self, Error as IoError},
     net::{IpAddr, Ipv4Addr, SocketAddr},
     sync::Arc,
-    time::{Duration, Instant},
+    time::Duration,
 };
 
 use cfg_if::cfg_if;
@@ -77,7 +77,7 @@ use telio_utils::{
     exponential_backoff::ExponentialBackoffBounds,
     get_ip_stack, interval, telio_log_debug, telio_log_error, telio_log_info, telio_log_warn,
     tokio::{Monitor, ThreadTracker},
-    version_tag,
+    version_tag, Instant,
 };
 
 use telio_model::{

--- a/src/device/wg_controller.rs
+++ b/src/device/wg_controller.rs
@@ -22,12 +22,11 @@ use telio_traversal::{
     cross_ping_check::CrossPingCheckTrait, endpoint_providers::EndpointProvider,
     SessionKeeperTrait, UpgradeSyncTrait, WireGuardEndpointCandidateChangeEvent,
 };
-use telio_utils::{build_ping_endpoint, telio_log_debug, telio_log_info, telio_log_warn};
+use telio_utils::{build_ping_endpoint, telio_log_debug, telio_log_info, telio_log_warn, Instant};
 use telio_wg::uapi::{AnalyticsEvent, UpdateReason};
 use telio_wg::{uapi::Peer, WireGuard};
 use thiserror::Error as TError;
 use tokio::sync::Mutex;
-use tokio::time::Instant;
 
 pub const DEFAULT_PEER_UPGRADE_WINDOW: u64 = 15;
 
@@ -1366,7 +1365,6 @@ mod tests {
     use telio_traversal::{MockSessionKeeperTrait, MockUpgradeSyncTrait, UpgradeRequest};
     use telio_wg::uapi::Interface;
     use telio_wg::MockWireGuard;
-    use tokio::time::Instant;
 
     type AllowIncomingConnections = bool;
     type AllowLocalAreaAccess = bool;

--- a/src/ffi/logging.rs
+++ b/src/ffi/logging.rs
@@ -7,11 +7,11 @@ use std::{
         Arc, Barrier, Mutex,
     },
     thread::Builder,
-    time::{Instant, SystemTime},
+    time::SystemTime,
 };
 
 use once_cell::sync::Lazy;
-use telio_utils::log_censor::LogCensor;
+use telio_utils::{log_censor::LogCensor, Instant};
 use tracing::{level_filters::LevelFilter, Subscriber};
 use tracing_subscriber::{
     fmt::{self, FormatEvent, FormatFields, MakeWriter},


### PR DESCRIPTION
### Problem
Both `std::time::Instant` and `tokio::time::Instant` do not track the time spent by the operating system in suspend mode. This can lead to telio not reacting in time to various events or timeouts.

### Solution
Add a custom suspend-aware replacement `Instant` implementation. The key points:
- most of the work is done by already existing create `boot_time` which is used in release builds
- in debug builds, this new `Instant` is using `tokio::time::Instant` which means that time suspending used in rust tests is still working and can be used
- `boot_time` crate doesn't compile for Linux 32bit systems, which is why for now we use our own fork with a fix for those platform
- this PR only tackles time measurement, notifications via `tokio::time::Interval` are left unchanged - this might be fixed in a future PR

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
