### PR TITLE
LLT-6122 Reject blacklisted packets in firewall

### DIFF
--- a/.unreleased/LLT-6122-reject-blacklisted-packets-in-firewall
+++ b/.unreleased/LLT-6122-reject-blacklisted-packets-in-firewall
@@ -1,0 +1,1 @@
+LLT-6122 Add blacklist feature to libtelio firewall and reject blacklisted connections

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2660,7 +2660,7 @@ dependencies = [
 [[package]]
 name = "neptun"
 version = "0.6.0"
-source = "git+https://github.com/NordSecurity/neptun.git?tag=v1.0.7#da23f2b13468efe3754f7e49732c500dd4632e3a"
+source = "git+https://github.com/NordSecurity/neptun.git?tag=v2.0.0#8e44118105165d90b6bd149e2f8b93aed47951c8"
 dependencies = [
  "aead",
  "base64 0.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,7 +172,7 @@ windows = { version = "0.60", features = [
 ] }
 winreg = "0.50.0"
 
-neptun = { git = "https://github.com/NordSecurity/neptun.git", tag = "v1.0.7", features = ["device"] }
+neptun = { git = "https://github.com/NordSecurity/neptun.git", tag = "v2.0.0", features = ["device"] }
 x25519-dalek = { version = "2.0.1", features = ["reusable_secrets", "static_secrets"] }
 
 

--- a/crates/telio-dns/src/nameserver.rs
+++ b/crates/telio-dns/src/nameserver.rs
@@ -150,8 +150,7 @@ impl LocalNameServer {
                         }
                     }
                     // DNS packets
-                    TunnResult::WriteToTunnelV4(packet, _)
-                    | TunnResult::WriteToTunnelV6(packet, _) => {
+                    TunnResult::WriteToTunnel(packet, _) => {
                         // !
                         let _lease = match semaphore.try_acquire() {
                             Ok(lease) => lease,

--- a/crates/telio-firewall/benches/firewall_bench.rs
+++ b/crates/telio-firewall/benches/firewall_bench.rs
@@ -285,8 +285,11 @@ pub fn firewall_tcp_outbound_benchmarks(c: &mut Criterion) {
                         let mut which_peer = 0usize;
                         b.iter(|| {
                             for _ in 0..PACKET_COUNT {
-                                assert!(firewall
-                                    .process_outbound_packet(&peers[which_peer], &param.packet));
+                                assert!(firewall.process_outbound_packet(
+                                    &peers[which_peer],
+                                    &param.packet,
+                                    &mut &std::io::sink()
+                                ));
                                 which_peer = (which_peer + 1) % peers.len();
                             }
                         });
@@ -329,8 +332,11 @@ pub fn firewall_tcp_outbound_benchmarks(c: &mut Criterion) {
                         let mut which_peer = 0usize;
                         b.iter(|| {
                             for _ in 0..PACKET_COUNT {
-                                assert!(firewall
-                                    .process_outbound_packet(&peers[which_peer], &param.packet));
+                                assert!(firewall.process_outbound_packet(
+                                    &peers[which_peer],
+                                    &param.packet,
+                                    &mut &std::io::sink()
+                                ));
                                 which_peer = (which_peer + 1) % peers.len();
                             }
                         });
@@ -366,8 +372,11 @@ pub fn firewall_tcp_outbound_benchmarks(c: &mut Criterion) {
                         let mut which_peer = 0usize;
                         b.iter(|| {
                             for _ in 0..PACKET_COUNT {
-                                assert!(firewall
-                                    .process_outbound_packet(&peers[which_peer], &param.packet));
+                                assert!(firewall.process_outbound_packet(
+                                    &peers[which_peer],
+                                    &param.packet,
+                                    &mut &std::io::sink()
+                                ));
                                 which_peer = (which_peer + 1) % peers.len();
                             }
                         });
@@ -584,8 +593,11 @@ pub fn firewall_udp_outbound_benchmarks(c: &mut Criterion) {
                         let mut which_peer = 0usize;
                         b.iter(|| {
                             for _ in 0..PACKET_COUNT {
-                                assert!(firewall
-                                    .process_outbound_packet(&peers[which_peer], &param.packet));
+                                assert!(firewall.process_outbound_packet(
+                                    &peers[which_peer],
+                                    &param.packet,
+                                    &mut &std::io::sink()
+                                ));
                                 which_peer = (which_peer + 1) % peers.len();
                             }
                         });
@@ -618,8 +630,11 @@ pub fn firewall_udp_outbound_benchmarks(c: &mut Criterion) {
                         let mut which_peer = 0usize;
                         b.iter(|| {
                             for _ in 0..PACKET_COUNT {
-                                assert!(firewall
-                                    .process_outbound_packet(&peers[which_peer], &param.packet));
+                                assert!(firewall.process_outbound_packet(
+                                    &peers[which_peer],
+                                    &param.packet,
+                                    &mut &std::io::sink()
+                                ));
                                 which_peer = (which_peer + 1) % peers.len();
                             }
                         });

--- a/crates/telio-pq/src/proto.rs
+++ b/crates/telio-pq/src/proto.rs
@@ -128,8 +128,7 @@ pub async fn fetch_keys(
             noise::TunnResult::Err(err) => {
                 return Err(format!("Failed to decapsulate PQ keys message: {err:?}").into())
             }
-            noise::TunnResult::WriteToTunnelV4(buf, _) => match parse_get_response(buf, local_port)
-            {
+            noise::TunnResult::WriteToTunnel(buf, _) => match parse_get_response(buf, local_port) {
                 Ok(cipehrtext) => break cipehrtext,
                 Err(err) => telio_log_warn!("Invalid PQ keys response: {err:?}"),
             },

--- a/crates/telio-starcast/src/starcast_peer.rs
+++ b/crates/telio-starcast/src/starcast_peer.rs
@@ -320,8 +320,7 @@ impl Runtime for State {
                                         self.packets_present_in_tunnel = true;
                                     },
                                     // Starcast packets
-                                    TunnResult::WriteToTunnelV4(packet, _)
-                                    | TunnResult::WriteToTunnelV6(packet, _) => {
+                                    TunnResult::WriteToTunnel(packet, _) => {
                                         permit.send(packet.to_vec());
                                     },
                                     TunnResult::Done => (),

--- a/crates/telio-wg/src/adapter.rs
+++ b/crates/telio-wg/src/adapter.rs
@@ -28,12 +28,16 @@ use thiserror::Error as TError;
 use crate::uapi::{self, Cmd, Response};
 use crate::wg::Config;
 
-/// Function pointer to Firewall Callback
-pub type FirewallCb = Option<Arc<dyn Fn(&[u8; 32], &[u8]) -> bool + Send + Sync>>;
+/// Function pointer to Firewall Inbound Callback
+pub type FirewallInboundCb = Option<Arc<dyn Fn(&[u8; 32], &[u8]) -> bool + Send + Sync>>;
+
+/// Function pointer to Firewall Outbound Callback
+pub type FirewallOutboundCb =
+    Option<Arc<dyn Fn(&[u8; 32], &[u8], &mut dyn io::Write) -> bool + Send + Sync>>;
 
 /// Function pointer for reseting all the connections
 pub type FirewallResetConnsCb =
-    Option<Arc<dyn Fn(&PublicKey, Ipv4Addr, &mut dyn io::Write, &mut dyn io::Write) + Send + Sync>>;
+    Option<Arc<dyn Fn(&PublicKey, Ipv4Addr, &mut dyn io::Write) + Send + Sync>>;
 
 /// Tunnel file descriptor
 #[cfg(not(target_os = "windows"))]

--- a/crates/telio-wg/src/lib.rs
+++ b/crates/telio-wg/src/lib.rs
@@ -13,6 +13,6 @@ pub mod uapi;
 mod link_detection;
 
 pub use crate::{
-    adapter::{Adapter, AdapterType, Error, FirewallCb, Tun},
+    adapter::{Adapter, AdapterType, Error, FirewallInboundCb, FirewallOutboundCb, Tun},
     wg::*,
 };

--- a/crates/telio-wg/src/wg.rs
+++ b/crates/telio-wg/src/wg.rs
@@ -34,7 +34,7 @@ use crate::{
     adapter::{self, Adapter, AdapterType, Error, FirewallResetConnsCb, Tun},
     link_detection::{self, LinkDetection, LinkDetectionUpdateResult},
     uapi::{self, AnalyticsEvent, Cmd, Event, Interface, Peer, PeerState, Response, UpdateReason},
-    FirewallCb,
+    FirewallInboundCb, FirewallOutboundCb,
 };
 
 use std::{
@@ -104,9 +104,9 @@ pub struct Config {
     /// Sockets to be protected, in order to avoid loopback
     pub socket_pool: Arc<SocketPool>,
     /// Callback of firewall to process incoming packets
-    pub firewall_process_inbound_callback: FirewallCb,
+    pub firewall_process_inbound_callback: FirewallInboundCb,
     /// Callback of firewall to process outgoing packets
-    pub firewall_process_outbound_callback: FirewallCb,
+    pub firewall_process_outbound_callback: FirewallOutboundCb,
     /// Callback of firewall to create connection reset packets
     /// for all active connections
     pub firewall_reset_connections: FirewallResetConnsCb,
@@ -205,7 +205,9 @@ impl DynamicWg {
     ///     };
     ///     let firewall_filter_outbound_packets = {
     ///         let fw = firewall.clone();
-    ///         move |peer: &[u8; 32], packet: &[u8]| fw.process_outbound_packet(peer, packet)
+    ///         move |peer: &[u8; 32], packet: &[u8], sink: &mut dyn io::Write| {
+    ///             fw.process_outbound_packet(peer, packet, sink)
+    ///         }
     ///     };
     ///
     ///     let chan = Chan::default();


### PR DESCRIPTION
Instead of dropping blacklisted packets in telio-firewall reject UDP
packets with ICMP destination unreachable and UDP packets with TCP_RST.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
