### PR TITLE
Update rust toolchain for gh-pages job

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -25,13 +25,13 @@ jobs:
     - name: Build Rust Docs
       uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.6
       with:
-        toolchain: nightly-2024-04-17
+        toolchain: nightly-2025-03-26
         components: rust-docs
     # Nightly is required, because index page generation is a nightly feature. Without it the index.html file will not be at the root of
     # The doc folder and gh-pages won't be able to find it.
     # --no-deps is required to prevent rustdoc from adding third party dependencies to our documentation, but that also brakes links to
     # local pages so that's fixed by adding --workspace.
-    - run: cargo +nightly-2024-04-17 doc --no-deps --workspace --document-private-items
+    - run: cargo +nightly-2025-03-26 doc --no-deps --workspace --document-private-items
 
     # Using @v1 of actions/upload-pages-artifact, because the later versions are buggy: https://github.com/actions/deploy-pages/issues/179
     - name: Upload Github pages artifact


### PR DESCRIPTION
### Problem
gh-pages job is still using rust v1.79 and we have packages which require higher versions. Version is adjusted here to match one defined in `build-docs-on-mac` job.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
