### PR TITLE
By default hide thread IDs in logs

### DIFF
--- a/.unreleased/LLT-6195-optional-thread-id-in-logs
+++ b/.unreleased/LLT-6195-optional-thread-id-in-logs
@@ -1,0 +1,1 @@
+Thread IDs are (by default) disabled in the logs

--- a/crates/telio-model/src/features.rs
+++ b/crates/telio-model/src/features.rs
@@ -32,10 +32,13 @@ pub struct Features {
     /// Test environment (natlab) requires binding feature disabled
     /// TODO: Remove it once mac integration tests support the binding mechanism
     pub is_test_env: Option<bool>,
-    /// Controll if IP addresses and domains should be hidden in logs
+    /// Control if IP addresses and domains should be hidden in logs
     #[serde(alias = "hide_ips")] // Old name
     #[default(true)]
     pub hide_user_data: bool,
+    /// Control if thread IDs should be shown in the logs
+    #[default(true)]
+    pub hide_thread_id: bool,
     /// Derp server specific configuration
     pub derp: Option<FeatureDerp>,
     /// Flag to specify if keys should be validated
@@ -564,6 +567,7 @@ mod tests {
             },
             "is_test_env": true,
             "hide_user_data": false,
+            "hide_thread_id": false,
             "derp": {
                 "tcp_keepalive": 13,
                 "derp_keepalive": 14,
@@ -661,6 +665,7 @@ mod tests {
                     }),
                     is_test_env: Some(true),
                     hide_user_data: false,
+                    hide_thread_id: false,
                     derp: Some(FeatureDerp {
                         tcp_keepalive: Some(13),
                         derp_keepalive: Some(14),

--- a/nat-lab/tests/utils/bindings.py
+++ b/nat-lab/tests/utils/bindings.py
@@ -55,6 +55,7 @@ def default_features(
     features = features_builder.build()
     features.is_test_env = True
     features.hide_user_data = False
+    features.hide_thread_id = False
     features.dns.exit_dns = FeatureExitDns(auto_switch_dns_ips=True)
     if enable_firewall_exclusion_range is not None:
         features.firewall.exclude_private_ip_range = enable_firewall_exclusion_range

--- a/src/device.rs
+++ b/src/device.rs
@@ -104,7 +104,10 @@ pub use wg::{
 #[cfg(test)]
 use wg::tests::AdapterExpectation;
 
-use crate::logging::{logs_dropped_since_last_checked, logs_dropped_until_now, LOG_CENSOR};
+use crate::{
+    hide_thread_id_in_logs,
+    logging::{logs_dropped_since_last_checked, logs_dropped_until_now, LOG_CENSOR},
+};
 
 #[derive(Debug, TError)]
 pub enum Error {
@@ -473,6 +476,7 @@ impl Device {
         protect: Option<Arc<dyn Protector>>,
     ) -> Result<Self> {
         LOG_CENSOR.set_enabled(features.hide_user_data);
+        hide_thread_id_in_logs(features.hide_thread_id);
 
         let version_tag = version_tag();
         let commit_sha = commit_sha();

--- a/src/device/wg_controller.rs
+++ b/src/device/wg_controller.rs
@@ -1853,6 +1853,7 @@ mod tests {
                         None
                     },
                     hide_user_data: false,
+                    hide_thread_id: false,
                     derp: None,
                     validate_keys: Default::default(),
                     ipv6: true,

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -20,7 +20,9 @@ use std::{
     time::Duration,
 };
 
-use self::{logging::LOGGER_STOPPER, logging::TIMESTAMPS_IN_LOGS, types::*};
+use self::{
+    logging::HIDE_THREAD_ID_IN_LOGS, logging::LOGGER_STOPPER, logging::TIMESTAMPS_IN_LOGS, types::*,
+};
 use crate::device::{Device, DeviceConfig, Result as DevResult};
 use telio_model::{
     config::{Config, ConfigParseError},
@@ -85,6 +87,11 @@ pub fn unset_global_logger() {
 /// When enabled host application doesn't need to add timestamps in the logging callback.
 pub fn add_timestamps_to_logs() {
     TIMESTAMPS_IN_LOGS.store(true, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// Control if thread IDs should be shown in the logs
+pub fn hide_thread_id_in_logs(hide: bool) {
+    HIDE_THREAD_ID_IN_LOGS.store(hide, std::sync::atomic::Ordering::Relaxed);
 }
 
 /// Get default recommended adapter type for platform.

--- a/src/ffi/defaults_builder.rs
+++ b/src/ffi/defaults_builder.rs
@@ -21,6 +21,7 @@ impl FeaturesDefaultsBuilder {
             direct: None,
             is_test_env: None,
             hide_user_data: true,
+            hide_thread_id: true,
             // All inner values of derp are None's or false's
             // and as it does not actualy control derp
             // builder part is not added

--- a/src/libtelio.udl
+++ b/src/libtelio.udl
@@ -545,8 +545,10 @@ dictionary Features {
     FeatureDirect? direct;
     /// Should only be set for macos sideload
     boolean? is_test_env;
-    /// Controll if IP addresses and domains should be hidden in logs
+    /// Control if IP addresses and domains should be hidden in logs
     boolean hide_user_data;
+    /// Control if thread IDs should be shown in the logs
+    boolean hide_thread_id;
     /// Derp server specific configuration
     FeatureDerp? derp;
     /// Flag to specify if keys should be validated

--- a/tests/logger.rs
+++ b/tests/logger.rs
@@ -16,8 +16,8 @@ mod test_module {
     #[test]
     fn test_logger() {
         // Line number of tracing::info! call in this fill, down below
-        const INFO_LINE1: u32 = 73;
-        const INFO_LINE2: u32 = 74;
+        const INFO_LINE1: u32 = 74;
+        const INFO_LINE2: u32 = 75;
 
         let call_count = Arc::new(AtomicUsize::new(0));
 
@@ -43,7 +43,7 @@ mod test_module {
                 if self.call_count.load(Ordering::Relaxed) == 0 {
                     assert_eq!(
                         format!(
-                            r#"{:?} "logger::test_module":{INFO_LINE1} test message"#,
+                            r#"{:?} logger::test_module:{INFO_LINE1} test message"#,
                             self.log_caller_tid
                         ),
                         payload
@@ -51,7 +51,7 @@ mod test_module {
                 } else {
                     assert_eq!(
                         format!(
-                            r#"{:?} "logger::test_module":{INFO_LINE2} test message"#,
+                            r#"{:?} logger::test_module:{INFO_LINE2} test message"#,
                             self.log_caller_tid
                         ),
                         payload
@@ -68,6 +68,7 @@ mod test_module {
         };
 
         telio::set_global_logger(telio::ffi_types::TelioLogLevel::Info, Box::new(logger));
+        telio::hide_thread_id_in_logs(false);
 
         tracing::debug!("this will be ignored since it's below info");
         tracing::info!("test message");


### PR DESCRIPTION
Additionaly, dropped `"` characters surrounding module path.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
