### PR TITLE
Increase the start of ephemeral port range in nat-lab

### DIFF
--- a/nat-lab/tests/utils/connection/connection.py
+++ b/nat-lab/tests/utils/connection/connection.py
@@ -130,7 +130,7 @@ async def setup_ephemeral_ports(connection: Connection):
     async def on_output(output: str) -> None:
         log.debug("[%s]: %s", connection.tag.name, output)
 
-    start_port = random.randint(5000, 55000)
+    start_port = random.randint(15000, 55000)
     num_ports = random.randint(2000, 5000)
 
     if connection.tag in [ConnectionTag.VM_WINDOWS_1, ConnectionTag.VM_WINDOWS_2]:


### PR DESCRIPTION
### Problem
When running nat-lab, sometimes wireguard got assigned a random port from the ephemeral port range that clashed with the port hardcoded for the starcast (13569). This is because we are overriding ephemeral port range in tests to avoid clashes between tests run on the same machine.

### Solution
Increase minimal ephemeral port range start so that it's greater than the starcast port.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
