### PR TITLE
ci: fix clippy for teliod

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -52,8 +52,10 @@ jobs:
       runs-on: ubuntu-22.04
       steps:
         - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
-        - run: cargo clippy --verbose --color always -- --deny warnings --allow unknown-lints -W clippy::expect_used -W clippy::panic -W clippy::unwrap_used
-          working-directory: clis/teliod
+        - uses: extractions/setup-just@dd310ad5a97d8e7b41793f8ef055398d51ad4de6 # v2.0.0
+          with:
+            just-version: '1.38.0'
+        - run: just clippy teliod
   deny:
       runs-on: ubuntu-22.04
       steps:

--- a/Justfile
+++ b/Justfile
@@ -24,8 +24,8 @@ test:
     cargo test --all --quiet
 
 # Run clippy
-clippy: _clippy-install
-    cargo clippy --lib -- --deny warnings --allow unknown-lints -W clippy::expect_used -W clippy::panic -W clippy::unwrap_used
+clippy package="": _clippy-install
+    cargo clippy {{ if package == "" {"--lib"} else {"--package=" + package} }} -- --deny warnings --allow unknown-lints -W clippy::expect_used -W clippy::panic -W clippy::unwrap_used
 
 # Run udeps
 udeps: _udeps-install


### PR DESCRIPTION
### Problem
Clippy for teliod started failing after some toolchain changes

### Solution
Changed the `just clippy` recipe to run for custom packages with an optional argument `just clippy teliod`


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
