### PR TITLE
Fix _get_artifacts usage

### DIFF
--- a/ci/fetch_artifacts.py
+++ b/ci/fetch_artifacts.py
@@ -173,7 +173,7 @@ class ArtifactsDownloader:
                 and self.target_arch is not None
                 and self.target_arch in job["name"]
             ):
-                self._get_artifacts(job, unzip=True)
+                self._get_artifacts(job)
                 job_found = True
 
         if not job_found:


### PR DESCRIPTION
### Problem
`unzip=False` was removed from `_get_artifacts ` hence `self._get_artifacts(job, unzip=True)` usage causing an error.

### Solution
*--describe selected solution--*


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
