### PR TITLE
Wrap token into Hidden<String>

### DIFF
--- a/clis/teliod/src/cgi/app.rs
+++ b/clis/teliod/src/cgi/app.rs
@@ -1,7 +1,5 @@
 //! App logic for web ui
 
-use std::collections::HashMap;
-
 use tracing::error;
 
 use crate::{config::TeliodDaemonConfig, TelioStatusReport};

--- a/clis/teliod/src/cgi/web.rs
+++ b/clis/teliod/src/cgi/web.rs
@@ -9,12 +9,12 @@ use rust_cgi::{
     Response,
 };
 use telio::telio_model::mesh::{Node, NodeState};
-use telio::telio_utils::telio_log_debug;
 use tracing::{level_filters::LevelFilter, warn, Level};
 
 use crate::{
     cgi::constants::TELIOD_CFG,
     config::{InterfaceConfig, TeliodDaemonConfigPartial},
+    Hidden,
 };
 
 use super::{
@@ -168,7 +168,9 @@ fn update_config(app: &mut AppState, request: &CgiRequest) {
     let values: HashMap<_, _> = form_urlencoded::parse(request.body()).collect();
 
     let partial = TeliodDaemonConfigPartial {
-        authentication_token: values.get(ACCESS_TOKEN).map(ToString::to_string),
+        authentication_token: values
+            .get(ACCESS_TOKEN)
+            .map(|n| Hidden(ToString::to_string(n))),
         log_level: values
             .get(LOG_LEVEL)
             .and_then(|v| LevelFilter::from_str(v).ok()),

--- a/clis/teliod/src/command_listener.rs
+++ b/clis/teliod/src/command_listener.rs
@@ -138,12 +138,9 @@ mod tests {
 
         // spawn a fake telio task
         task::spawn(async move {
-            match task_rx.recv().await.unwrap() {
-                TelioTaskCmd::GetStatus(response_tx_channel) => {
-                    let status_report = TelioStatusReport::default();
-                    response_tx_channel.send(status_report).unwrap();
-                }
-                _ => (),
+            if let TelioTaskCmd::GetStatus(response_tx_channel) = task_rx.recv().await.unwrap() {
+                let status_report = TelioStatusReport::default();
+                response_tx_channel.send(status_report).unwrap();
             }
         });
 
@@ -205,7 +202,7 @@ mod tests {
         let command = "garbage";
         let (cmd, _) = tokio::join!(
             listener.handle_client_connection(),
-            client_send_command(&path, &command)
+            client_send_command(&path, command)
         );
 
         assert!(matches!(cmd, Err(TeliodError::InvalidCommand(_))));
@@ -219,7 +216,7 @@ mod tests {
         let command = "garbage";
         let (cmd, _) = tokio::join!(
             listener.handle_client_connection(),
-            broken_client_send_command(&path, &command)
+            broken_client_send_command(&path, command)
         );
 
         assert!(matches!(cmd, Err(TeliodError::Io(_))));

--- a/clis/teliod/src/core_api.rs
+++ b/clis/teliod/src/core_api.rs
@@ -11,6 +11,7 @@ use telio::crypto::SecretKey;
 use telio::telio_utils::exponential_backoff::{
     Backoff, Error as BackoffError, ExponentialBackoff, ExponentialBackoffBounds,
 };
+use telio::telio_utils::Hidden;
 use telio::{crypto::PublicKey, telio_model::config::Config as MeshMap};
 use thiserror::Error;
 use tokio::time::Duration;
@@ -300,7 +301,7 @@ async fn update_machine(device_identity: &DeviceIdentity, auth_token: &str) -> R
 
 pub async fn get_meshmap(
     device_identity: Arc<DeviceIdentity>,
-    auth_token: Arc<String>,
+    auth_token: Arc<Hidden<String>>,
 ) -> Result<MeshMap, Error> {
     debug!("Getting meshmap");
     let client = Client::new();

--- a/clis/teliod/src/main.rs
+++ b/clis/teliod/src/main.rs
@@ -4,7 +4,7 @@ use clap::Parser;
 use serde::{Deserialize, Serialize};
 use serde_json::error::Error as SerdeJsonError;
 use std::{fs, net::IpAddr};
-use telio::{device::Error as DeviceError, telio_model::mesh::Node};
+use telio::{device::Error as DeviceError, telio_model::mesh::Node, telio_utils::Hidden};
 use thiserror::Error as ThisError;
 use tokio::{
     task::JoinError,
@@ -118,7 +118,7 @@ async fn main() -> Result<(), TeliodError> {
                 if let Ok(token) = std::env::var("NORD_TOKEN") {
                     debug!("Overriding token from env");
                     if token.len() == 64 && token.chars().all(|c| c.is_ascii_hexdigit()) {
-                        config.authentication_token = token;
+                        config.authentication_token = Hidden::<String>(token);
                     } else {
                         error!("Token from env not valid")
                     }

--- a/clis/teliod/src/nc.rs
+++ b/clis/teliod/src/nc.rs
@@ -78,7 +78,7 @@ pub struct NotificationCenter {
 }
 
 struct NCConfig {
-    authentication_token: String,
+    authentication_token: Hidden<String>,
     app_user_uid: Uuid,
     callbacks: Arc<Mutex<Vec<Callback>>>,
     http_certificate_file_path: Option<PathBuf>,
@@ -470,7 +470,7 @@ mod tests {
             expires_in: 86400,
         };
 
-        let credentials: NotificationCenterCredentials = serde_json::from_str(&input).unwrap();
+        let credentials: NotificationCenterCredentials = serde_json::from_str(input).unwrap();
         assert_eq!(expected, credentials);
     }
 
@@ -530,7 +530,7 @@ mod tests {
                 },
             },
         };
-        let notification: Notification = serde_json::from_str(&input).unwrap();
+        let notification: Notification = serde_json::from_str(input).unwrap();
         assert_eq!(expected, notification);
     }
 }


### PR DESCRIPTION

    Wrap token into Hidden<String>
    
    In teliod the auth token should never appear in a
    plaintext form exept for debug builds for security
    reasons so it wouldn't be emitted by accident or logged.
    
    Each place storing a token as String is replaced with
    Hidden<String> which prints itself as `****` unless it's in
    debug mode.
    
    Signed-off-by: Lukas Pukenis <lukas.pukenis@nordsec.com>

### Problem
*--describe problem being solved--*

### Solution
*--describe selected solution--*


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
