### PR TITLE
add more debug logs for wireguard nt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2232,7 +2232,7 @@ dependencies = [
  "socket2",
  "widestring 1.2.0",
  "windows-sys 0.48.0",
- "winreg",
+ "winreg 0.50.0",
 ]
 
 [[package]]
@@ -5184,6 +5184,7 @@ dependencies = [
  "tracing",
  "winapi",
  "windows 0.60.0",
+ "winreg 0.55.0",
  "wireguard-nt",
  "wireguard-uapi",
 ]
@@ -6579,6 +6580,16 @@ checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "winreg"
+version = "0.55.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2232,7 +2232,7 @@ dependencies = [
  "socket2",
  "widestring 1.2.0",
  "windows-sys 0.48.0",
- "winreg 0.50.0",
+ "winreg",
 ]
 
 [[package]]
@@ -5184,7 +5184,7 @@ dependencies = [
  "tracing",
  "winapi",
  "windows 0.60.0",
- "winreg 0.55.0",
+ "winreg",
  "wireguard-nt",
  "wireguard-uapi",
 ]
@@ -6580,16 +6580,6 @@ checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "winreg"
-version = "0.55.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
-dependencies = [
- "cfg-if",
- "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,6 +170,7 @@ windows = { version = "0.60", features = [
     "Win32_Networking_WinSock",
     "Win32_NetworkManagement_IpHelper",
 ] }
+winreg = "0.55.0"
 
 neptun = { git = "https://github.com/NordSecurity/neptun.git", tag = "v1.0.7", features = ["device"] }
 x25519-dalek = { version = "2.0.1", features = ["reusable_secrets", "static_secrets"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,7 +170,7 @@ windows = { version = "0.60", features = [
     "Win32_Networking_WinSock",
     "Win32_NetworkManagement_IpHelper",
 ] }
-winreg = "0.55.0"
+winreg = "0.50.0"
 
 neptun = { git = "https://github.com/NordSecurity/neptun.git", tag = "v1.0.7", features = ["device"] }
 x25519-dalek = { version = "2.0.1", features = ["reusable_secrets", "static_secrets"] }

--- a/crates/telio-wg/Cargo.toml
+++ b/crates/telio-wg/Cargo.toml
@@ -57,6 +57,7 @@ cc.workspace = true
 [target.'cfg(windows)'.dependencies]
 sha2.workspace = true
 winapi = { workspace = true, features = ["nldef"] }
+winreg.workspace = true
 
 wireguard-nt = { git = "https://github.com/NordSecurity/wireguard-nt-rust-wrapper", tag = "v1.0.6" }
 


### PR DESCRIPTION
### Problem
wireguard-nt sometimes fails to start for unknown reason

### Solution
add some logs to list out registry where network driver lays


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
