### PR TITLE
[LLT-5530] Add esp32 QEMU meshnet container to nat-lab

### DIFF
--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -24,4 +24,4 @@ jobs:
     with:
       schedule: ${{ github.event_name == 'schedule' }}
       cancel-outdated-pipelines: ${{ github.ref_name != 'main' }}
-      triggered-ref: v2.11.0  # REMEMBER to also update in .gitlab-ci.yml
+      triggered-ref: v0.0.0  # REMEMBER to also update in .gitlab-ci.yml

--- a/nat-lab/bin/esp32_qemu_entrypoint
+++ b/nat-lab/bin/esp32_qemu_entrypoint
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+sleep infinity

--- a/nat-lab/docker-compose.yml
+++ b/nat-lab/docker-compose.yml
@@ -706,6 +706,23 @@ services:
       - 10.0.80.82
       - 10.0.80.83
 
+  esp32-qemu:
+    hostname: esp32-qemu
+    build:
+      context: .
+      dockerfile: esp32_qemu.Dockerfile
+    entrypoint: /opt/bin/esp32_qemu_entrypoint
+    networks:
+      internet:
+        ipv4_address: 10.0.80.87
+        ipv6_address: 2001:db8:85a4::adda:edde:c
+    depends_on:
+      core-api:
+        condition: service_healthy
+    dns:
+      - 10.0.80.82
+      - 10.0.80.83
+
 networks:
   # Network representing public internet,
   # various services like DERP/STUN will be hosted

--- a/nat-lab/esp32_qemu.Dockerfile
+++ b/nat-lab/esp32_qemu.Dockerfile
@@ -1,0 +1,3 @@
+FROM ghcr.io/nordsecurity/qemu-esp32:v1.0.0
+
+COPY --chmod=0755 bin/ /opt/bin/

--- a/nat-lab/network.md
+++ b/nat-lab/network.md
@@ -49,6 +49,9 @@ graph LR
     core-api("core-api
         10.0.80.86
         2001:db8:85a4::adda:edde:b")
+    esp32-qemu("esp32-qemu
+        10.0.80.87
+        2001:db8:85a4::adda:edde:c")
   end
 
   %% Network cone-net-05


### PR DESCRIPTION
### Problem
To run nat-lab tests, we need a container in nat-lab that runs under ESP32 QEMU.

### Solution
Add a container to nat-lab that uses qemu-esp32 image. 


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
