### PR TITLE
Change teliod config file permissions to 0660 on qnap

### DIFF
--- a/qnap/shared/NordSecurityMeshnet.sh
+++ b/qnap/shared/NordSecurityMeshnet.sh
@@ -10,6 +10,9 @@ export QNAP_QPKG=$QPKG_NAME
 TELIOD_CFG_FILE=${QPKG_ROOT}/teliod.cfg
 TELIOD_LOG_FILE="/var/log/teliod.log"
 
+# Change the config file permissions. It contains the auth token so we should prohibit it being read by other users
+chmod 0660 $TELIOD_CFG_FILE
+
 system_log() {
     local log_level
     case "$1" in


### PR DESCRIPTION
### Problem

Config file after installing NordSecurityMeshnet
gets owned by `root` user with 0777 permissions and
`teliod` is later executed with `admin` user.

Changing the permissions is needed as 0777 is too lax,
but 0600 doesn't work since a different user accesses it.

As a resut 0660 is chosen
### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
