### PR TITLE
Exclude gitlab pipeline running on libtelio main

### DIFF
--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -3,6 +3,8 @@ on:
   pull_request_target:
     types: [labeled]
   push:
+    branches-ignore:
+      - main
   merge_group:
     types: [checks_requested]
   schedule:


### PR DESCRIPTION
### Problem
With merge queue solution, duplicated Gitlab pipelines are getting triggered with the same commit SHA.
One pipeline runs on a branch with following pattern: `gh-readonly-queue/main/pr-\d+-[a-f0-9]{40}$`, and the other runs on the `main` branch. 
However, both pipelines are technically running for the same `GITHUB_SHA`.

Since the pipeline running on the `main` branch is redundant, it is unnecessary to execute it. 
Instead, we can optimize the process by creating a tag on the `gh-readonly-queue` pipeline.

### Solution
*--describe selected solution--*


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
