### PR TITLE
LLT-6139: Implement VPN functionality for teliod

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ tcli.log
 /nat-lab/tests/uniffi/telio_bindings.py
 /nat-lab/tests/uniffi/libtelio.so
 /nat-lab/tests/uniffi/telio.dll
+/nat-lab/data/teliod/data.json
 /nat-lab/logs
 /nat-lab/coredumps
 /nat-lab/docker-compose.yml.bak

--- a/clis/tcli/src/cli.rs
+++ b/clis/tcli/src/cli.rs
@@ -9,6 +9,8 @@ use telio_model::config::{RelayState, Server};
 use telio_model::features::Features;
 use telio_model::{config::Config as MeshMap, event::Event as DevEvent, mesh::ExitNode};
 use telio_proto::CodecError;
+#[cfg(target_os = "linux")]
+use telio_utils::LIBTELIO_FWMARK;
 use telio_wg::AdapterType;
 use thiserror::Error;
 use tracing::error;
@@ -27,9 +29,6 @@ use std::{
         Arc,
     },
 };
-
-#[cfg(target_os = "linux")]
-const FWMARK_VALUE: u32 = 11673110;
 
 #[cfg(windows)]
 const DEFAULT_TUNNEL_NAME: &str = "NordLynx";
@@ -750,7 +749,7 @@ impl Cli {
             self.telio.start(device_config)?;
 
             #[cfg(target_os = "linux")]
-            self.telio.set_fwmark(FWMARK_VALUE)?;
+            self.telio.set_fwmark(LIBTELIO_FWMARK)?;
 
             cli_res!(res; (i "started telio with {:?}:{:?}...", adapter_type, private_key));
         }

--- a/clis/teliod/README.md
+++ b/clis/teliod/README.md
@@ -60,6 +60,9 @@ needs be absolute, otherwise will be relative to `working-directory` when daemon
     - `manual` - do not configure interfaces automatically
     - `ifconfig` - systems using ifconfig command
     - `iproute` - systems using iproute2 command
+  - `vpn` - optional vpn config. If omitted, a VPN connection will not be established
+    - `server_endpoint` - The endpoint (ip:port) of the server/endpoint to connect to 
+    - `server_pubkey` - The public key of the server/peer to connect to
 
 And following cli commands:
 

--- a/clis/teliod/src/cgi/api.rs
+++ b/clis/teliod/src/cgi/api.rs
@@ -387,7 +387,7 @@ fn get_logs(
 
 #[cfg(test)]
 mod tests {
-    use std::{fs, num::NonZeroU64, path::PathBuf};
+    use std::{fs, num::NonZeroU64, path::PathBuf, sync::Arc};
 
     use reqwest::StatusCode;
     use serial_test::serial;
@@ -415,11 +415,14 @@ mod tests {
                 name: "eth0".to_owned(),
                 config_provider: InterfaceConfigurationProvider::Manual,
             },
-            authentication_token:
+            vpn: None,
+            authentication_token: Arc::new(
                 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
                     .to_owned()
                     .into(),
+            ),
             http_certificate_file_path: Some(PathBuf::from("/http/certificate/path/")),
+            device_identity_file_path: None,
             mqtt: MqttConfig {
                 backoff_initial: NonZeroU64::new(5).unwrap(),
                 backoff_maximal: NonZeroU64::new(600).unwrap(),
@@ -456,10 +459,11 @@ mod tests {
         expected_config.log_level = LevelFilter::INFO;
         expected_config.log_file_path = "/new/path/to/log".to_owned();
         expected_config.log_file_count = 8;
-        expected_config.authentication_token =
+        expected_config.authentication_token = Arc::new(
             "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
                 .to_owned()
-                .into();
+                .into(),
+        );
         expected_config.interface = InterfaceConfig {
             name: "eth1".to_owned(),
             config_provider: InterfaceConfigurationProvider::Ifconfig,
@@ -509,11 +513,14 @@ mod tests {
                 name: "eth0".to_owned(),
                 config_provider: InterfaceConfigurationProvider::Manual,
             },
-            authentication_token:
+            vpn: None,
+            authentication_token: Arc::new(
                 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
                     .to_owned()
                     .into(),
+            ),
             http_certificate_file_path: Some(PathBuf::from("/http/certificate/path/")),
+            device_identity_file_path: None,
             mqtt: MqttConfig::default(),
         };
         let initial_config = r#"
@@ -559,10 +566,11 @@ mod tests {
                 .unwrap();
         assert_eq!(updated_config, expected_config);
 
-        expected_config.authentication_token =
+        expected_config.authentication_token = Arc::new(
             "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
                 .to_owned()
-                .into();
+                .into(),
+        );
         let update_body = r#"
         {
             "authentication_token": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"

--- a/clis/teliod/src/comms.rs
+++ b/clis/teliod/src/comms.rs
@@ -8,13 +8,15 @@ use std::{
 
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 
+#[cfg(not(test))]
+use interprocess::os::unix::local_socket::ListenerOptionsExt;
 use interprocess::{
     local_socket::{
         tokio::{Listener as LocalSocketListener, Stream as LocalSocketStream},
         traits::tokio::{Listener, Stream},
         ListenerOptions, ToFsName,
     },
-    os::unix::local_socket::{FilesystemUdSocket, ListenerOptionsExt},
+    os::unix::local_socket::FilesystemUdSocket,
 };
 
 /// Struct for handling connections of the daemon's side of the IPC communication with the API.

--- a/clis/teliod/src/configure_interface.rs
+++ b/clis/teliod/src/configure_interface.rs
@@ -1,22 +1,47 @@
 use crate::TeliodError;
+use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::net::IpAddr;
 use std::process::Command;
-use tracing::{error, info};
+use tracing::{debug, error, info};
 
 pub trait ConfigureInterface {
+    /// Initialize the interface
+    fn initialize(&mut self) -> Result<(), TeliodError>;
     /// Configure the IP address and routes for a given interface
-    fn set_ip(&self, _adapter_name: &str, _ip_address: &IpAddr) -> Result<(), TeliodError>;
+    fn set_ip(&mut self, ip_address: &IpAddr) -> Result<(), TeliodError>;
+    /// Configure routes for exit routing
+    fn set_exit_routes(&mut self, exit_node: &IpAddr) -> Result<(), TeliodError>;
+    /// Some of the configured routes are not cleared when the adapter is removed and must be removed manually
+    fn cleanup_exit_routes(&mut self) -> Result<(), TeliodError>;
 }
 
 /// Helper function to execute a system command
 fn execute(command: &mut Command) -> Result<(), TeliodError> {
+    debug!("Executing command '{command:?}'");
     let output = command
         .output()
         .map_err(|e| TeliodError::SystemCommandFailed(e.to_string()))?;
 
     if output.status.success() {
         Ok(())
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        error!("Error executing command {:?}: {:?}", command, stderr);
+        Err(TeliodError::SystemCommandFailed(stderr.into()))
+    }
+}
+
+/// Helper function to execute a system command with output
+fn execute_with_output(command: &mut Command) -> Result<String, TeliodError> {
+    debug!("Executing command with output '{command:?}'");
+    let output = command
+        .output()
+        .map_err(|e| TeliodError::SystemCommandFailed(e.to_string()))?;
+
+    if output.status.success() {
+        String::from_utf8(output.stdout)
+            .map_err(|e| TeliodError::SystemCommandFailed(e.to_string()))
     } else {
         let stderr = String::from_utf8_lossy(&output.stderr);
         error!("Error executing command {:?}: {:?}", command, stderr);
@@ -36,12 +61,12 @@ pub enum InterfaceConfigurationProvider {
 // TODO(tomasz-grz): Try using enum_dispatch instead of dynamic dyspatch
 impl InterfaceConfigurationProvider {
     /// Create a dynamic instance of a configuration provider
-    pub fn create(&self) -> Box<dyn ConfigureInterface> {
+    pub fn create(&self, adapter_name: String) -> Box<dyn ConfigureInterface> {
         info!("Creating interface config provider for {:?}", self);
         match self {
             Self::Manual => Box::new(Manual),
-            Self::Ifconfig => Box::new(Ifconfig),
-            Self::Iproute => Box::new(Iproute),
+            Self::Ifconfig => Box::new(Ifconfig::new(adapter_name)),
+            Self::Iproute => Box::new(Iproute::new(adapter_name)),
         }
     }
 }
@@ -51,17 +76,42 @@ impl InterfaceConfigurationProvider {
 pub struct Manual;
 
 impl ConfigureInterface for Manual {
-    fn set_ip(&self, _adapter_name: &str, _ip_address: &IpAddr) -> Result<(), TeliodError> {
+    fn initialize(&mut self) -> Result<(), TeliodError> {
+        Ok(()) // No-op implementaiton
+    }
+
+    fn set_ip(&mut self, _ip_address: &IpAddr) -> Result<(), TeliodError> {
+        Ok(()) // No-op implementation
+    }
+
+    fn set_exit_routes(&mut self, _exit_node: &IpAddr) -> Result<(), TeliodError> {
+        Ok(()) // No-op implementation
+    }
+
+    fn cleanup_exit_routes(&mut self) -> Result<(), TeliodError> {
         Ok(()) // No-op implementation
     }
 }
 
 /// Implementation using `ifconfig`
-#[derive(Debug, PartialEq, Eq)]
-pub struct Ifconfig;
+#[derive(Debug)]
+pub struct Ifconfig {
+    adapter_name: String,
+}
+
+impl Ifconfig {
+    fn new(adapter_name: String) -> Self {
+        Self { adapter_name }
+    }
+}
 
 impl ConfigureInterface for Ifconfig {
-    fn set_ip(&self, adapter_name: &str, ip_address: &IpAddr) -> Result<(), TeliodError> {
+    fn initialize(&mut self) -> Result<(), TeliodError> {
+        execute(Command::new("ifconfig").args([&self.adapter_name, "mtu", "1420"]))?;
+        execute(Command::new("ifconfig").args([&self.adapter_name, "up"]))
+    }
+
+    fn set_ip(&mut self, ip_address: &IpAddr) -> Result<(), TeliodError> {
         let ip_string = ip_address.to_string();
         let cidr_suffix = if ip_address.is_ipv4() { "/10" } else { "/64" };
         let cidr_string = format!("{}{}", ip_string, cidr_suffix);
@@ -73,23 +123,24 @@ impl ConfigureInterface for Ifconfig {
 
         info!(
             "Assigning IP address for {} to {}",
-            adapter_name, cidr_string
+            self.adapter_name, cidr_string
         );
 
         match std::env::consts::OS {
             "macos" => {
                 execute(Command::new("ifconfig").args([
-                    adapter_name,
+                    &self.adapter_name,
                     ip_type,
                     &cidr_string,
                     &ip_string,
                 ]))?;
 
                 if ip_address.is_ipv4() {
-                    execute(Command::new("route").args(["add", "100.64/10", &ip_string]))?;
+                    execute(Command::new("route").args(["-n", "add", "100.64/10", &ip_string]))?;
                 } else {
                     execute(Command::new("route").args([
                         "add",
+                        "-n",
                         "-inet6",
                         "fd74:656c:696f::/64",
                         &ip_string,
@@ -97,31 +148,292 @@ impl ConfigureInterface for Ifconfig {
                 }
             }
             _ => {
-                execute(Command::new("ifconfig").args([adapter_name, ip_type, &cidr_string]))?;
+                execute(Command::new("ifconfig").args([
+                    &self.adapter_name,
+                    "inet",
+                    "add",
+                    ip_address.to_string().as_str(),
+                    "netmask",
+                    "255.192.0.0",
+                ]))?;
             }
         }
+        Ok(())
+    }
 
-        execute(Command::new("ifconfig").args([adapter_name, "mtu", "1420"]))?;
-        execute(Command::new("ifconfig").args([adapter_name, "up"]))
+    fn set_exit_routes(&mut self, _exit_node: &IpAddr) -> Result<(), TeliodError> {
+        Ok(()) // No-op implementation
+    }
+
+    fn cleanup_exit_routes(&mut self) -> Result<(), TeliodError> {
+        Ok(()) // No-op implementation
     }
 }
 
 /// Implementation using `iproute2`
-#[derive(Debug, PartialEq, Eq)]
-pub struct Iproute;
+#[derive(Debug)]
+pub struct Iproute {
+    adapter_name: String,
+    default_gateway_ipv4: Option<String>,
+    exit_route_ip: Option<IpAddr>,
+    ipv6_support_manager: Ipv6SupportManager,
+}
+
+impl Iproute {
+    pub fn new(adapter_name: String) -> Self {
+        Self {
+            adapter_name,
+            default_gateway_ipv4: Self::get_default_gateway("-4"),
+            exit_route_ip: None,
+            ipv6_support_manager: Ipv6SupportManager::default(),
+        }
+    }
+
+    #[allow(clippy::expect_used)]
+    fn get_default_gateway(family: &str) -> Option<String> {
+        let metric_pattern = Regex::new("metric ([0-9]+)").expect("Failed to compile metric regex");
+        let via_pattern = Regex::new("via ([0-9\\.\\/]+)").expect("Failed to compile via regex");
+        let dev_pattern = Regex::new("dev ([A-Za-z0-9]+)").expect("Failed to compile dev regex");
+
+        let stdout =
+            execute_with_output(Command::new("ip").args([family, "route", "show", "default"]))
+                .ok()?;
+        stdout
+            .lines()
+            .filter_map(|line| {
+                let metric = metric_pattern
+                    .captures(line)
+                    .and_then(|c| c.get(1))
+                    .and_then(|m| m.as_str().parse::<u16>().ok())
+                    .unwrap_or(0);
+                let gateway = via_pattern
+                    .captures(line)
+                    .or(dev_pattern.captures(line))
+                    .and_then(|c| c.get(1))
+                    .map(|m| m.as_str());
+                gateway.map(|gateway| (metric, gateway.to_owned()))
+            })
+            .min_by_key(|(m, _)| *m)
+            .map(|(_, g)| g)
+    }
+
+    // Some ip commands will return "RNETLINK answers: File exists" which means that the command was already executed and we can ignore the error
+    fn ignore_file_exists_error(res: Result<(), TeliodError>) -> Result<(), TeliodError> {
+        match res {
+            Err(TeliodError::SystemCommandFailed(message)) if message.contains("File exists") => {
+                Ok(())
+            }
+            _ => res,
+        }
+    }
+}
 
 impl ConfigureInterface for Iproute {
-    fn set_ip(&self, adapter_name: &str, ip_address: &IpAddr) -> Result<(), TeliodError> {
+    fn initialize(&mut self) -> Result<(), TeliodError> {
+        execute(Command::new("ip").args([
+            "link",
+            "set",
+            "dev",
+            &self.adapter_name,
+            "mtu",
+            "1420",
+        ]))?;
+        execute(Command::new("ip").args(["link", "set", "dev", &self.adapter_name, "up"]))
+    }
+
+    fn set_ip(&mut self, ip_address: &IpAddr) -> Result<(), TeliodError> {
         let cidr_suffix = if ip_address.is_ipv4() { "/10" } else { "/64" };
         let cidr_string = format!("{}{}", ip_address, cidr_suffix);
 
         info!(
             "Assigning IP address for {} to {}",
-            adapter_name, cidr_string
+            self.adapter_name, cidr_string
         );
+        Self::ignore_file_exists_error(execute(Command::new("ip").args([
+            "addr",
+            "add",
+            &cidr_string,
+            "dev",
+            &self.adapter_name,
+        ])))
+    }
 
-        execute(Command::new("ip").args(["addr", "add", &cidr_string, "dev", adapter_name]))?;
-        execute(Command::new("ip").args(["link", "set", "dev", adapter_name, "mtu", "1420"]))?;
-        execute(Command::new("ip").args(["link", "set", "dev", adapter_name, "up"]))
+    fn set_exit_routes(&mut self, exit_node: &IpAddr) -> Result<(), TeliodError> {
+        if exit_node.is_ipv4() {
+            execute(Command::new("ip").args([
+                "route",
+                "add",
+                "0.0.0.0/0",
+                "dev",
+                &self.adapter_name,
+            ]))?;
+            if let Some(gateway) = &self.default_gateway_ipv4 {
+                Self::ignore_file_exists_error(execute(Command::new("ip").args([
+                    "route",
+                    "add",
+                    exit_node.to_string().as_str(),
+                    "via",
+                    gateway.as_str(),
+                ])))?;
+            }
+            self.exit_route_ip = Some(*exit_node);
+            self.ipv6_support_manager.disable(&self.adapter_name)?;
+            // We have already disabled IPv6 on all interfaces (except the tunnel interface)
+            // but interfaces that get added later could still have IPv6 enabled.
+            // As a backup solution we route all IPv6 packets into the tunnel
+            execute(Command::new("ip").args([
+                "-6",
+                "route",
+                "add",
+                "default",
+                "dev",
+                &self.adapter_name,
+            ]))?;
+        }
+        Ok(())
+    }
+
+    fn cleanup_exit_routes(&mut self) -> Result<(), TeliodError> {
+        if let Some(exit_node) = self.exit_route_ip {
+            if let Some(gateway) = &self.default_gateway_ipv4 {
+                execute(Command::new("ip").args([
+                    "route",
+                    "del",
+                    exit_node.to_string().as_str(),
+                    "via",
+                    gateway.as_str(),
+                ]))?;
+            }
+        }
+        self.ipv6_support_manager.reenable()
+    }
+}
+
+/// This hold the initial IPv6 state of the machine, so that we can accurately re-enable
+/// IPv6 support when disconnecting from VPN/exit node
+/// For macos it holds the names of the interfaces where IPv6 was enabled
+/// For linux we store the names of the interfaces along with if IPv6 was enabled. We need to store
+/// the initial state for each interface here because setting the all.disable_ipv6 option affects
+/// all interfaces and we need to know what value to set them to.
+#[derive(Debug)]
+enum InitialIpv6State {
+    Macos { interfaces: Vec<String> },
+    Linux { interfaces: Vec<(String, u8)> },
+}
+
+/// We don't have VPN servers that support IPv6 and IPv6 support in libtelio as a whole is not fully battle tested,
+/// so for now we need to disable IPv6 while connected to VPN/exit node to prevent leaks.
+///
+/// Disabling of IPv6 is done in two steps:
+/// 1. Disable IPv6 on all interfaces except the tunnel interface we create for libtelio.
+///    On linux this includes setting the all.disable_ipv6 and default.disable_ipv6 options.
+///    We leave IPv6 enabled on the tunnel interface so that we can do the next step.
+/// 2. Setting the tunnel interface as the default route for IPv6 traffic.
+///    Disabling IPv6 on all current interfaces doesn't help if a new interface is added with IPv6 enabled.
+///    To get around this, the tunnel interface is set as the default route for IPv6 so that any potential IPv6
+///    traffic goes into the tunnel and is then dropped there because we don't support it.
+///
+/// When disconnecting from VPN/exit node we need to restore IPv6 support to the state it was before.
+/// This struct handles both those tasks.
+#[derive(Debug, Default)]
+struct Ipv6SupportManager {
+    initial_state: Option<InitialIpv6State>,
+}
+
+impl Ipv6SupportManager {
+    fn disable(&mut self, skip_interface: &str) -> Result<(), TeliodError> {
+        let initial_state = match std::env::consts::OS {
+            "macos" => {
+                let interfaces = execute_with_output(
+                    Command::new("networksetup").args(["-listallnetworkservices"]),
+                )?;
+                let mut previously_enabled = Vec::new();
+                for interface in interfaces
+                    .lines()
+                    .skip(1)
+                    .filter(|i| !i.starts_with('*') && *i != skip_interface)
+                {
+                    let interface_info = execute_with_output(
+                        Command::new("networksetup").args(["-getinfo", interface]),
+                    )?;
+                    let ipv6_enabled = interface_info.contains("IPv6: Automatic")
+                        || interface_info.contains("IPv6: On");
+
+                    if ipv6_enabled {
+                        previously_enabled.push(interface.to_string());
+
+                        // Disable IPv6 for this service
+                        execute(Command::new("networksetup").args(["-setv6off", interface]))?;
+                    }
+                }
+
+                InitialIpv6State::Macos {
+                    interfaces: previously_enabled,
+                }
+            }
+            _ => {
+                #[allow(clippy::expect_used)]
+                let sysctl_regex =
+                    Regex::new("net\\.ipv6\\.conf\\.(\\S*)\\.disable_ipv6\\s*=\\s*(0|1)")
+                        .expect("Failed to compile sysctl regex");
+                let mut interfaces = execute_with_output(Command::new("sysctl").arg("--all"))?
+                    .lines()
+                    .filter_map(|l| {
+                        let vals = sysctl_regex.captures(l).map(|c| {
+                            (
+                                c.get(1).map(|m| m.as_str()),
+                                c.get(2).and_then(|m| m.as_str().parse::<u8>().ok()),
+                            )
+                        });
+                        match vals {
+                            Some((Some(interface), Some(value))) => {
+                                Some((interface.to_owned(), value))
+                            }
+                            _ => None,
+                        }
+                    })
+                    .collect::<Vec<_>>();
+
+                let ipv6_default_status = execute_with_output(
+                    Command::new("sysctl").args(["--values", "net.ipv6.conf.default.disable_ipv6"]),
+                )?;
+                let ipv6_default_status = ipv6_default_status.trim().parse::<u8>().unwrap_or(0);
+                interfaces.insert(0, ("default".to_owned(), ipv6_default_status));
+
+                for (interface, _) in &interfaces {
+                    let val = if interface.as_str() == skip_interface {
+                        0
+                    } else {
+                        1
+                    };
+                    let cmd = format!("net.ipv6.conf.{interface}.disable_ipv6={val}");
+                    execute(Command::new("sysctl").args(["--write", &cmd]))?;
+                }
+
+                InitialIpv6State::Linux { interfaces }
+            }
+        };
+        self.initial_state = Some(initial_state);
+        Ok(())
+    }
+
+    fn reenable(&mut self) -> Result<(), TeliodError> {
+        let initial_state = self.initial_state.take();
+        match initial_state {
+            Some(InitialIpv6State::Macos { interfaces }) => {
+                for interface in interfaces {
+                    let _ =
+                        execute(Command::new("networksetup").args(["-setv6automatic", &interface]));
+                }
+            }
+            Some(InitialIpv6State::Linux { interfaces }) => {
+                for (interface, value) in interfaces {
+                    let sysctl_cmd = format!("net.ipv6.conf.{interface}.disable_ipv6={value}");
+                    execute(Command::new("sysctl").args(["--write", &sysctl_cmd]))?;
+                }
+            }
+            _ => {}
+        }
+        Ok(())
     }
 }

--- a/crates/telio-model/src/config.rs
+++ b/crates/telio-model/src/config.rs
@@ -39,10 +39,13 @@ pub struct Peer {
     pub base: PeerBase,
     /// The peer is local, when the flag is set
     pub is_local: bool,
+    #[serde(default)]
     /// Flag to control whether the peer allows incoming connections
     pub allow_incoming_connections: bool,
+    #[serde(default)]
     /// Flag to control whether the Node allows routing through
     pub allow_peer_traffic_routing: bool,
+    #[serde(default)]
     /// Flag to control whether the Node allows incoming local area access
     pub allow_peer_local_network_access: bool,
     #[serde(default)]

--- a/crates/telio-sockets/src/protector/linux.rs
+++ b/crates/telio-sockets/src/protector/linux.rs
@@ -79,7 +79,7 @@ mod tests {
     #[case(IpAddr::V6(Ipv6Addr::UNSPECIFIED))]
     fn test_make_external(#[case] ip_addr: IpAddr) {
         let protector = NativeProtector::new().unwrap();
-        protector.set_fwmark(11673110);
+        protector.set_fwmark(telio_utils::LIBTELIO_FWMARK);
         let addr = SocketAddr::new(ip_addr, 0);
 
         let socket = match UdpSocket::bind(addr) {

--- a/crates/telio-utils/src/lib.rs
+++ b/crates/telio-utils/src/lib.rs
@@ -68,3 +68,7 @@ pub use bytes_and_timestamps::*;
 /// suspend-aware replacement for {std,tokio}::time::Instant
 pub mod instant;
 pub use instant::*;
+
+#[cfg(target_os = "linux")]
+/// Default FWMARK value for libtelio on linux
+pub const LIBTELIO_FWMARK: u32 = 11673110;

--- a/nat-lab/data/teliod/config_with_vpn.json
+++ b/nat-lab/data/teliod/config_with_vpn.json
@@ -1,0 +1,17 @@
+{
+  "log_level": "trace",
+  "log_file_path": "/var/log/teliod_natlab.log",
+  "log_file_count": 0,
+  "authentication_token": "48e9ef50178a68a716e38a9f9cd251e8be35e79a5c5f91464e92920425caa3d9",
+  "adapter_type": "neptun",
+  "http_certificate_file_path": "/etc/ssl/server_certificate/test.pem",
+  "device_identity_file_path": "/etc/teliod/data.json",
+  "interface": {
+    "name": "teliod",
+    "config_provider": "manual"
+  },
+  "vpn": {
+    "server_endpoint": "10.0.100.1:1023",
+    "server_pubkey": "public-key-placeholder"
+  }
+}

--- a/nat-lab/tests/config.py
+++ b/nat-lab/tests/config.py
@@ -246,3 +246,13 @@ CORE_API_URL = "https://api.nordvpn.com"
 MQTT_BROKER_HOST = "mqtt.nordvpn.com"
 MQTT_BROKER_IP = "10.0.80.85"
 CORE_API_CA_CERTIFICATE_PATH = "/etc/ssl/server_certificate/test.pem"
+
+# These credentials are only used in tests, never in production
+CORE_API_CREDENTIALS = {
+    "username": "token",
+    "password": "48e9ef50178a68a716e38a9f9cd251e8be35e79a5c5f91464e92920425caa3d9",
+}
+
+CORE_API_BEARER_AUTHORIZATION_HEADER = (
+    f"Bearer {CORE_API_CREDENTIALS['username']}:{CORE_API_CREDENTIALS['password']}"
+)

--- a/nat-lab/tests/mesh_api.py
+++ b/nat-lab/tests/mesh_api.py
@@ -213,7 +213,7 @@ class API:
     def __init__(self) -> None:
         self.nodes = {}
 
-    def register(
+    def register(  # pylint: disable=dangerous-default-value
         self,
         name: str,
         node_id: str,
@@ -221,6 +221,7 @@ class API:
         public_key: str,
         is_local=False,
         ip_stack: IPStack = IPStack.IPv4,
+        ip_addresses: Optional[List[str]] = None,
     ) -> Node:
         if node_id in self.nodes:
             raise DuplicateNodeError(node_id)
@@ -233,6 +234,8 @@ class API:
         node.is_local = is_local
         node.hostname = name + ".nord"
         node.ip_stack = ip_stack
+        if ip_addresses is not None:
+            node.ip_addresses = ip_addresses
 
         self.nodes[node_id] = node
         return node

--- a/nat-lab/tests/test_core_api.py
+++ b/nat-lab/tests/test_core_api.py
@@ -108,15 +108,19 @@ async def clean_up_machines(connection, api_url):
         )
 
 
+# this key is only used for testing
+linux_vm_public_key = "IMk1XXVnlPngn1qQ4Xp27oGMVj9rfqb7lvCvNYVDTCE="
 linux_vm = MachineData(
-    public_key="linux-vm-public-key",
+    public_key=linux_vm_public_key,
     hardware_identifier="linux-vm-hardware-identifier",
     os="linux",
     os_version="Ubuntu 22.04; kernel=5.15.0-78-generic",
 )
 
+# this key is only used for testing
+windows_vm_public_key = "5qTlXKYQUtlcOevUvb4+ldjZjnY0t6EZXJLM5iTx5gk="
 windows_vm = MachineData(
-    public_key="windows-vm-public-key",
+    public_key=windows_vm_public_key,
     hardware_identifier="linux-vm-hardware-identifier",
     os="windows",
     os_version="Windows 11; kernel=10.0.22621.2283",

--- a/nat-lab/tests/test_teliod.py
+++ b/nat-lab/tests/test_teliod.py
@@ -1,14 +1,37 @@
 import asyncio
+import base64
+import json
+import platform
 import pytest
 import time
-from config import LIBTELIO_BINARY_PATH_DOCKER
+import uuid
+from config import (
+    LIBTELIO_BINARY_PATH_DOCKER,
+    WG_SERVER,
+    PHOTO_ALBUM_IP,
+    STUN_SERVER,
+    CORE_API_URL,
+    CORE_API_CA_CERTIFICATE_PATH,
+    CORE_API_BEARER_AUTHORIZATION_HEADER,
+)
 from contextlib import AsyncExitStack
-from helpers import setup_connections
+from helpers import setup_connections, send_https_request
+from mesh_api import API
+from utils import stun
 from utils.connection import ConnectionTag
+from utils.ping import ping
 from utils.process.process import ProcessExecError
+from utils.router import IPStack
+from utils.router.linux_router import LinuxRouter
 
-TELIOD_EXEC_PATH = f"{LIBTELIO_BINARY_PATH_DOCKER}/teliod"
+if platform.machine() != "x86_64":
+    import pure_wg as Key
+else:
+    from python_wireguard import Key  # type: ignore
+
+TELIOD_EXEC_PATH = f"{LIBTELIO_BINARY_PATH_DOCKER}teliod"
 CONFIG_FILE_PATH = "/etc/teliod/config.json"
+CONFIG_FILE_PATH_WITH_VPN = "/etc/teliod/config_with_vpn.json"
 SOCKET_FILE_PATH = "/run/teliod.sock"
 STDOUT_FILE_PATH = "/var/log/teliod.log"
 LOG_FILE_PATH = "/var/log/teliod_natlab.log"
@@ -199,3 +222,112 @@ async def test_teliod_logs() -> None:
             await connection.create_process(
                 ["grep", "-q", expected_string, path]
             ).execute()
+
+
+# TODO(LLT-6404): reduce boilerplate
+async def test_teliod_vpn_connection_with_manual_interface_setup() -> None:
+    async with AsyncExitStack() as exit_stack:
+        connection = (
+            await setup_connections(exit_stack, [ConnectionTag.DOCKER_CONE_CLIENT_1])
+        )[0].connection
+
+        (private_key, public_key) = Key.key_pair()
+        hw_identifier = uuid.uuid4()
+        payload = {
+            "public_key": str(public_key),
+            "hardware_identifier": str(hw_identifier),
+            "os": "linux",
+            "os_version": "teliod",
+        }
+        response_data = await send_https_request(
+            connection,
+            f"{CORE_API_URL}/v1/meshnet/machines",
+            "POST",
+            CORE_API_CA_CERTIFICATE_PATH,
+            data=str(payload).replace("'", '"'),
+            authorization_header=CORE_API_BEARER_AUTHORIZATION_HEADER,
+        )
+
+        device_id = {
+            "hw_identifier": str(hw_identifier),
+            "private_key": list(base64.b64decode(str(private_key))),
+            "machine_identifier": response_data["identifier"],
+        }
+        await connection.create_process(["mkdir", "-p", "/etc/teliod"]).execute()
+        await connection.create_process(
+            ["sh", "-c", f"echo '{json.dumps(device_id)}' > /etc/teliod/data.json"]
+        ).execute()
+
+        api = API()
+        api.register(
+            "teliod",
+            "teliod",
+            str(private_key),
+            str(public_key),
+            True,
+            IPStack.IPv4,
+            response_data["ip_addresses"],
+        )
+        api.prepare_all_vpn_servers()
+
+        # we only know the key of the VPN server at runtime but need it to be in the config before starting teliod
+        server_pubkey = WG_SERVER["public_key"]
+        await connection.create_process([
+            "sed",
+            "-i",
+            f's#"server_pubkey": .*#"server_pubkey": "{server_pubkey}"#g',
+            CONFIG_FILE_PATH_WITH_VPN,
+        ]).execute()
+
+        # Run teliod
+        start_params = [
+            TELIOD_EXEC_PATH,
+            "start",
+            CONFIG_FILE_PATH_WITH_VPN,
+        ]
+        await exit_stack.enter_async_context(
+            connection.create_process(start_params).run()
+        )
+
+        # Let the daemon start
+        await wait_for_teliod(connection)
+
+        router = LinuxRouter(connection, IPStack.IPv4)
+        router.set_interface_name("teliod")
+        await router.setup_interface(response_data["ip_addresses"])
+        await router.create_meshnet_route()
+        await router.create_vpn_route()
+
+        with pytest.raises(ProcessExecError) as err:
+            await connection.create_process(TELIOD_START_PARAMS).execute()
+        assert err.value.stderr == "Error: DaemonIsRunning"
+
+        # Run the get-status command
+        assert (
+            "telio_is_running"
+            in (
+                await connection.create_process(TELIOD_STATUS_PARAMS).execute()
+            ).get_stdout()
+        )
+
+        await ping(connection, PHOTO_ALBUM_IP)
+        ip = await stun.get(connection, STUN_SERVER)
+        assert ip == WG_SERVER["ipv4"], f"wrong public IP when connected to VPN {ip}"
+
+        # Send SIGTERM to the daemon
+        await connection.create_process(
+            ["killall", "-w", "-s", "SIGTERM", "teliod"]
+        ).execute()
+
+        await router.delete_vpn_route()
+        await router.delete_exit_node_route()
+        await router.delete_interface()
+
+        await connection.create_process([
+            "sed",
+            "-i",
+            's#"server_pubkey": .*#"server_pubkey": "public-key-placeholder"#g',
+            CONFIG_FILE_PATH_WITH_VPN,
+        ]).execute()
+
+        assert not await is_teliod_running(connection)


### PR DESCRIPTION
`teliod` now needs to be able to connect to VPN and this is a first version.

The config is updated to allow passing the ip and public key of a server to connect to. Future updates would likely include more user-friendly options, but for this PR, this is how you connect to VPN.

Routing information is updated but only for the existing configuration options (`ip` and `ifconfig`). Basic routing is set up, along with disabling IPv6.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
