### PR TITLE
Clippy and Tests for teliod cgi

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -56,6 +56,7 @@ jobs:
           with:
             just-version: '1.38.0'
         - run: just clippy teliod
+        - run: just clippy teliod cgi
   deny:
       runs-on: ubuntu-22.04
       steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,6 +37,17 @@ jobs:
       - name: Test replacement script
         run: python3 ci/test_replace_string.py
 
+  test-teliod:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+      - run: cargo test --package=teliod -- --nocapture
+        env:
+          RUST_BACKTRACE: full
+      - run: cargo test --package=teliod --features=cgi -- --nocapture
+        env:
+          RUST_BACKTRACE: full
+
   test-build-version-replacement:
     strategy:
       matrix:

--- a/Justfile
+++ b/Justfile
@@ -24,8 +24,8 @@ test:
     cargo test --all --quiet
 
 # Run clippy
-clippy package="": _clippy-install
-    cargo clippy {{ if package == "" {"--lib"} else {"--package=" + package} }} -- --deny warnings --allow unknown-lints -W clippy::expect_used -W clippy::panic -W clippy::unwrap_used
+clippy package="" features="": _clippy-install
+    cargo clippy {{ if package == "" {"--lib"} else {"--package=" + package} }} {{ if features == "" {""} else {"--features=" + features} }} -- --deny warnings --allow unknown-lints -W clippy::expect_used -W clippy::panic -W clippy::unwrap_used
 
 # Run udeps
 udeps: _udeps-install

--- a/clis/teliod/src/cgi/api.rs
+++ b/clis/teliod/src/cgi/api.rs
@@ -287,6 +287,7 @@ mod tests {
         cgi::constants::TELIOD_CFG,
         config::{InterfaceConfig, MqttConfig, Percentage},
         configure_interface::InterfaceConfigurationProvider,
+        Hidden,
     };
 
     #[test]
@@ -301,8 +302,9 @@ mod tests {
                 name: "eth0".to_owned(),
                 config_provider: InterfaceConfigurationProvider::Manual,
             },
-            authentication_token:
+            authentication_token: Hidden(
                 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_owned(),
+            ),
             http_certificate_file_path: Some(PathBuf::from("/http/certificate/path/")),
             mqtt: MqttConfig {
                 backoff_initial: NonZeroU64::new(5).unwrap(),
@@ -341,7 +343,7 @@ mod tests {
         expected_config.log_file_path = "/new/path/to/log".to_owned();
         expected_config.log_file_count = 8;
         expected_config.authentication_token =
-            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_owned();
+            Hidden("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_owned());
         expected_config.interface = InterfaceConfig {
             name: "eth1".to_owned(),
             config_provider: InterfaceConfigurationProvider::Ifconfig,
@@ -391,8 +393,9 @@ mod tests {
                 name: "eth0".to_owned(),
                 config_provider: InterfaceConfigurationProvider::Manual,
             },
-            authentication_token:
+            authentication_token: Hidden(
                 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_owned(),
+            ),
             http_certificate_file_path: Some(PathBuf::from("/http/certificate/path/")),
             mqtt: MqttConfig::default(),
         };
@@ -440,7 +443,7 @@ mod tests {
         assert_eq!(updated_config, expected_config);
 
         expected_config.authentication_token =
-            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_owned();
+            Hidden("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_owned());
         let update_body = r#"
         {
             "authentication_token": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"

--- a/clis/teliod/src/cgi/qnap.rs
+++ b/clis/teliod/src/cgi/qnap.rs
@@ -103,7 +103,7 @@ mod tests {
 
     #[test]
     fn test_sid_retrieval_with_cookie() {
-        let expected_sid = "nastestsid0%&)+";
+        let expected_sid = Hidden("nastestsid0%&)+".to_owned());
         let request = Request::builder()
             .uri("http://example.com/")
             .header("User-Agent", "test-agent/1.0")
@@ -119,7 +119,7 @@ mod tests {
 
         let parsed_sid = QnapUserAuthorization::retrieve_token(&request).unwrap();
 
-        assert!(parsed_sid.eq(expected_sid));
+        assert!(parsed_sid.eq(&expected_sid));
     }
 
     #[test]


### PR DESCRIPTION
### Problem
Some parts of teliod are under feature flags like `cgi` and `qnap`, and CI is not linting everything

### Solution
Add linting and tests to CI for `teliod` `cgi`


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
