### PR TITLE
Just web httpd accept any address

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -82,7 +82,7 @@ web:
 
     cd $(pwd)/contrib/http_root; \
     echo -n $(whoami) > cgi-bin/builder; \
-    sudo busybox httpd -f -p 127.0.0.1:8080 -vv -u root -h $(pwd)
+    sudo busybox httpd -f -p 0.0.0.0:8080 -vv -u root -h $(pwd)
 
 # Run the isort linter
 [working-directory: 'nat-lab']


### PR DESCRIPTION
### Problem
When developing on macOS, CGI server can only be run through a VM, but it only accepts connections from localhost. 

### Solution
CGI Server accepts connections from any address.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
