### PR TITLE
Fix QNAP missing import

### DIFF
--- a/clis/teliod/src/cgi/qnap.rs
+++ b/clis/teliod/src/cgi/qnap.rs
@@ -1,4 +1,4 @@
-use crate::Hidden;
+use crate::cgi::Hidden;
 use rust_cgi::{http::header::COOKIE, Request};
 use serde::Deserialize;
 


### PR DESCRIPTION
QNAP compilation is not exercised in CI/CD
which made it possible to merge changes that
resolved in unresolved import.

This commit fixes it

### Problem
*--describe problem being solved--*

### Solution
*--describe selected solution--*
