### PR TITLE
Reduce log level of teliod client commands

### DIFF
--- a/clis/teliod/src/command_listener.rs
+++ b/clis/teliod/src/command_listener.rs
@@ -2,7 +2,7 @@ use crate::{daemon::TelioTaskCmd, ClientCmd, DaemonSocket, TelioStatusReport, Te
 use serde::{Deserialize, Serialize};
 use telio::telio_task::io::chan;
 use tokio::sync::oneshot;
-use tracing::{error, info};
+use tracing::{error, trace};
 
 /// Command response type used to communicate between `telio runner -> daemon -> client`
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
@@ -60,7 +60,7 @@ impl CommandListener {
     ) -> Result<CommandResponse, TeliodError> {
         match command {
             ClientCmd::GetStatus => {
-                info!("Reporting telio status");
+                trace!("Reporting telio status");
                 let (response_tx, response_rx) = oneshot::channel();
                 #[allow(mpsc_blocking_send)]
                 self.telio_task_tx

--- a/clis/teliod/src/daemon.rs
+++ b/clis/teliod/src/daemon.rs
@@ -85,7 +85,7 @@ fn telio_task(
         task_retrieve_meshmap(node_identity, auth_token, tx_channel.clone());
 
         while let Some(cmd) = rx_channel.blocking_recv() {
-            info!("Got command {:?}", cmd);
+            trace!("TelioTask got command {:?}", cmd);
             match cmd {
                 TelioTaskCmd::UpdateMeshmap(map) => {
                     let some_new_ip_address = map
@@ -175,7 +175,7 @@ fn start_telio(
         ..Default::default()
     })?;
 
-    debug!("started telio with {:?}...", adapter);
+    info!("started telio with {:?}...", adapter);
     Ok(())
 }
 
@@ -260,7 +260,7 @@ pub async fn daemon_event_loop(config: TeliodDaemonConfig) -> Result<(), TeliodE
             result = cmd_listener.handle_client_connection() => {
                 match result {
                     Ok(command) => {
-                        info!("Client command {:?} executed successfully", command);
+                        debug!("Client command {:?} executed successfully", command);
                         if command == ClientCmd::QuitDaemon {
                             break Ok(())
                         }


### PR DESCRIPTION
### Problem
Client commands like `get-status` and `is-alive` get constantly polled by the CGI, resulting in repeated log entries, potentially filling up space.

### Solution
Reduce the log level from `info` to `debug`

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
