### PR TITLE
In QNAP open Meshnet in the same Window

### DIFF
--- a/clis/teliod/src/cgi/web.rs
+++ b/clis/teliod/src/cgi/web.rs
@@ -253,7 +253,7 @@ fn config_view(app: &AppState, error: Option<String>) -> Markup {
                     }
                     span class="text-primary body-md-medium" { "Nord Security Meshnet" }
                 }
-                a href="https://meshnet.nordvpn.com" class="text-accent body-xs-medium hover:text-blue-400 active:text-blue-700 dark:hover:text-blue-400 dark:active:text-blue-700" {
+                a href="https://meshnet.nordvpn.com" target="_blank" class="text-accent body-xs-medium hover:text-blue-400 active:text-blue-700 dark:hover:text-blue-400 dark:active:text-blue-700" {
                     "Docs"
                     span class="ml-2 inline-block" { "›" }
                 }
@@ -393,7 +393,7 @@ fn meshnet(app: &AppState) -> Markup {
             {
             div class="flex justify-between items-center" {
                 span class="text-primary body-md-medium" { ({meshnet_status_text}) }
-                a href="get-logs" class="body-xs-medium text-accent hover:text-blue-400 active:text-blue-700 dark:hover:text-blue-400 dark:active:text-blue-700" {"Logs"}
+                a href="get-logs" target="_blank" class="body-xs-medium text-accent hover:text-blue-400 active:text-blue-700 dark:hover:text-blue-400 dark:active:text-blue-700" {"Logs"}
             }
 
             div class="flex flex-col gap-4" {

--- a/qnap/qpkg.cfg
+++ b/qnap/qpkg.cfg
@@ -53,11 +53,11 @@ QPKG_USE_PROXY="1"
 
 #Desktop Application (since 4.1)
 # Set value to 1 means to open the QPKG's Web UI inside QTS desktop instead of new window.
-#QPKG_DESKTOP_APP="1"
+QPKG_DESKTOP_APP="1"
 # Desktop Application Window default inner width (since 4.1) (not over 1178)
 #QPKG_DESKTOP_APP_WIN_WIDTH=""
 # Desktop Application Window default inner height (since 4.1) (not over 600)
-#QPKG_DESKTOP_APP_WIN_HEIGHT=""
+QPKG_DESKTOP_APP_WIN_HEIGHT="600"
 
 # Minimum QTS version requirement
 QTS_MINI_VERSION="5.0.0"


### PR DESCRIPTION
### Problem
NordSecurityMeshnet is opened in another browser tab instead of the built-in QNAP desktop environment.

### Solution
QNAP has ability to open applications in an iframe which can be easily done by tweaking the configuration parameter.
![fla](https://github.com/user-attachments/assets/d6bcaa6d-9515-48b3-bd7e-c36217501e33)
![image](https://github.com/user-attachments/assets/3da1d7a5-1f5a-44f8-b5da-70c2e2cf1665)


It eventually lands in /etc/config/qpkg.conf
with `Desktop = 1` written to it.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
