### PR TITLE
Persist teliod daemon state using a marker file

### DIFF
--- a/clis/teliod/src/cgi/constants.rs
+++ b/clis/teliod/src/cgi/constants.rs
@@ -21,3 +21,6 @@ pub const TELIOD_INIT_LOG: &str = "/var/log/teliod_init.log";
 
 #[cfg(debug_assertions)]
 pub const CGI_LOG: &str = concatcp!(APP_DIR, "/cgi.log");
+
+/// Path to the user intent file used to automatically turn meshnet on if found by NordSecurityMeshnet.sh
+pub const TELIOD_START_INTENT_FILE: &str = concatcp!(APP_DIR, "/.teliod_start_intent");

--- a/qnap/shared/NordSecurityMeshnet.sh
+++ b/qnap/shared/NordSecurityMeshnet.sh
@@ -8,6 +8,7 @@ QPKG_ROOT=`/sbin/getcfg $QPKG_NAME Install_Path -f ${CONF}`
 export QNAP_QPKG=$QPKG_NAME
 
 TELIOD_CFG_FILE=${QPKG_ROOT}/teliod.cfg
+TELIOD_START_INTENT_FILE=${QPKG_ROOT}/.teliod_start_intent
 TELIOD_INIT_LOG_FILE="/var/log/teliod_init.log"
 
 # Change the config file permissions. It contains the auth token so we should prohibit it being read by other users
@@ -44,6 +45,11 @@ case "$1" in
     fi
 
     ln -fs ${QPKG_ROOT}/teliod.cgi /home/httpd/cgi-bin/qpkg/teliod.cgi
+
+    if [ ! -e "$TELIOD_START_INTENT_FILE" ]; then
+        system_log INFO "Intent file not present, skipping daemon start"
+        exit 0
+    fi
 
     SOCKET_PATH=$(get_ipc_socket_path)
     if [ -e "$SOCKET_PATH" ]; then


### PR DESCRIPTION
### Problem
Meshnet is being started at the start of QNAP regardless if user has started it previously or not. This means that if user enters a valid token, starts meshnet and then stops it and machine restart happens - meshnet will automatically turn on even though it should stay off.

### Solution
In CGI handler we save user's intent by creating a file and then check for it in
NordSecurityMeshnet.sh when starting.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
