### PR TITLE
Replace raw fd with ownedfd for tunnel descriptor

### DIFF
--- a/clis/tcli/src/cli.rs
+++ b/clis/tcli/src/cli.rs
@@ -755,7 +755,7 @@ impl Cli {
                 ..Default::default()
             };
 
-            self.telio.start(&device_config)?;
+            self.telio.start(device_config)?;
 
             #[cfg(target_os = "linux")]
             self.telio.set_fwmark(FWMARK_VALUE)?;

--- a/clis/teliod/src/daemon.rs
+++ b/clis/teliod/src/daemon.rs
@@ -168,7 +168,7 @@ fn start_telio(
     interface_name: &str,
     adapter: AdapterType,
 ) -> Result<(), DeviceError> {
-    telio.start(&DeviceConfig {
+    telio.start(DeviceConfig {
         private_key,
         name: Some(interface_name.to_owned()),
         adapter,

--- a/crates/telio-dns/src/bind_tun.rs
+++ b/crates/telio-dns/src/bind_tun.rs
@@ -25,7 +25,6 @@ mod darwin {
     use nix::{setsockopt_impl, sockopt_impl};
     use std::os::fd::AsFd;
     use std::sync::atomic::{AtomicBool, Ordering};
-    use std::sync::Arc;
     use std::{io, sync::Mutex};
     use telio_utils::{telio_log_debug, telio_log_trace, telio_log_warn};
     use telio_wg::Tun;
@@ -42,7 +41,7 @@ mod darwin {
 
     static TUN_INDEX: Mutex<Option<u32>> = Mutex::new(None);
 
-    pub(crate) fn set_tun(tun: Option<&Arc<Tun>>) -> io::Result<()> {
+    pub(crate) fn set_tun(tun: Option<&Tun>) -> io::Result<()> {
         // For darwin bind socket to tun interface.
         if let Some(tun_fd) = tun {
             let name = getsockopt(&tun_fd, UtunIfname)?;

--- a/crates/telio-dns/src/bind_tun.rs
+++ b/crates/telio-dns/src/bind_tun.rs
@@ -25,8 +25,10 @@ mod darwin {
     use nix::{setsockopt_impl, sockopt_impl};
     use std::os::fd::AsFd;
     use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
     use std::{io, sync::Mutex};
     use telio_utils::{telio_log_debug, telio_log_trace, telio_log_warn};
+    use telio_wg::Tun;
 
     static SHOULD_BIND: AtomicBool = AtomicBool::new(false);
 
@@ -40,7 +42,7 @@ mod darwin {
 
     static TUN_INDEX: Mutex<Option<u32>> = Mutex::new(None);
 
-    pub(crate) fn set_tun(tun: Option<impl AsFd>) -> io::Result<()> {
+    pub(crate) fn set_tun(tun: Option<&Arc<Tun>>) -> io::Result<()> {
         // For darwin bind socket to tun interface.
         if let Some(tun_fd) = tun {
             let name = getsockopt(&tun_fd, UtunIfname)?;

--- a/crates/telio-dns/src/dns.rs
+++ b/crates/telio-dns/src/dns.rs
@@ -64,7 +64,7 @@ impl LocalDnsResolver {
     pub async fn new(
         public_key: &PublicKey,
         forward_ips: &[IpAddr],
-        tun: Option<&Arc<Tun>>,
+        tun: Option<&Tun>,
         exit_dns: Option<FeatureExitDns>,
     ) -> Result<Self, String> {
         let socket = UdpSocket::bind(SocketAddr::from(([127, 0, 0, 1], 0)))

--- a/crates/telio-dns/src/dns.rs
+++ b/crates/telio-dns/src/dns.rs
@@ -6,6 +6,7 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::{net::SocketAddr, sync::Arc};
 use telio_crypto::{PublicKey, SecretKey};
 use telio_wg::uapi::Peer;
+use telio_wg::Tun;
 use tokio::net::UdpSocket;
 use tokio::sync::{Mutex, RwLock};
 use x25519_dalek::{PublicKey as PublicKeyDalek, StaticSecret};
@@ -63,8 +64,7 @@ impl LocalDnsResolver {
     pub async fn new(
         public_key: &PublicKey,
         forward_ips: &[IpAddr],
-        #[cfg(not(target_os = "windows"))] tun: Option<impl std::os::fd::AsFd>,
-        #[cfg(target_os = "windows")] tun: Option<()>,
+        tun: Option<&Arc<Tun>>,
         exit_dns: Option<FeatureExitDns>,
     ) -> Result<Self, String> {
         let socket = UdpSocket::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
@@ -207,25 +207,14 @@ impl DnsResolver for LocalDnsResolver {
 
 #[cfg(test)]
 mod tests {
-
-    #[cfg(not(target_os = "windows"))]
-    use std::os::fd::OwnedFd;
-    #[cfg(target_os = "windows")]
-    type OwnedFd = ();
-
     use super::*;
     use telio_crypto::SecretKey;
 
     #[tokio::test]
     async fn test_get_default_dns_allowed_ips() {
-        let resolver = LocalDnsResolver::new(
-            &SecretKey::gen().public(),
-            &[],
-            None as Option<OwnedFd>,
-            None,
-        )
-        .await
-        .unwrap();
+        let resolver = LocalDnsResolver::new(&SecretKey::gen().public(), &[], None, None)
+            .await
+            .unwrap();
         assert_eq!(
             vec![
                 "100.64.0.2/32".parse::<IpNet>().unwrap(),
@@ -239,14 +228,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_exit_connected_dns_allowed_ips() {
-        let resolver = LocalDnsResolver::new(
-            &SecretKey::gen().public(),
-            &[],
-            None as Option<OwnedFd>,
-            None,
-        )
-        .await
-        .unwrap();
+        let resolver = LocalDnsResolver::new(&SecretKey::gen().public(), &[], None, None)
+            .await
+            .unwrap();
         assert_eq!(
             vec![
                 "100.64.0.2/32".parse::<IpNet>().unwrap(),
@@ -258,14 +242,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_default_dns_servers() {
-        let resolver = LocalDnsResolver::new(
-            &SecretKey::gen().public(),
-            &[],
-            None as Option<OwnedFd>,
-            None,
-        )
-        .await
-        .unwrap();
+        let resolver = LocalDnsResolver::new(&SecretKey::gen().public(), &[], None, None)
+            .await
+            .unwrap();
         assert_eq!(
             vec![
                 "100.64.0.3".parse::<IpAddr>().unwrap(),

--- a/crates/telio-wg/src/adapter/linux_native_wg.rs
+++ b/crates/telio-wg/src/adapter/linux_native_wg.rs
@@ -84,7 +84,7 @@ impl Adapter for LinuxNativeWg {
         let _ = self.rtsocket.lock().await.del_device(&self.ifname);
     }
 
-    async fn set_tun(&self, _tun: i32) -> Result<(), AdapterError> {
+    async fn set_tun(&self, _tun: super::Tun) -> Result<(), AdapterError> {
         Err(AdapterError::UnsupportedAdapter)
     }
 }

--- a/crates/telio-wg/src/adapter/neptun.rs
+++ b/crates/telio-wg/src/adapter/neptun.rs
@@ -4,7 +4,7 @@ use neptun::device::{tun::TunSocket, DeviceConfig, DeviceHandle};
 use slog::{o, Drain};
 use slog_stdlog::StdLog;
 use std::net::{IpAddr, Ipv4Addr};
-use std::os::fd::RawFd;
+use std::os::fd::{IntoRawFd, RawFd};
 use std::sync::Arc;
 use std::{io, ops::Deref};
 use telio_crypto::PublicKey;
@@ -120,8 +120,8 @@ impl Adapter for NepTUN {
         cb(exit_pubkey, exit_ipv4, &mut tun);
     }
 
-    async fn set_tun(&self, tun: i32) -> Result<(), AdapterError> {
-        let new_tun = TunSocket::new_from_fd(tun)?;
+    async fn set_tun(&self, tun: super::Tun) -> Result<(), AdapterError> {
+        let new_tun = TunSocket::new_from_fd(tun.into_raw_fd())?;
         self.device.write().await.set_iface(new_tun)?;
         Ok(())
     }

--- a/crates/telio-wg/src/adapter/neptun.rs
+++ b/crates/telio-wg/src/adapter/neptun.rs
@@ -4,6 +4,7 @@ use neptun::device::{tun::TunSocket, DeviceConfig, DeviceHandle};
 use slog::{o, Drain};
 use slog_stdlog::StdLog;
 use std::net::{IpAddr, Ipv4Addr};
+use std::os::fd::RawFd;
 use std::sync::Arc;
 use std::{io, ops::Deref};
 use telio_crypto::PublicKey;
@@ -29,13 +30,15 @@ impl NepTUN {
     #[cfg(not(any(test, feature = "test-adapter")))]
     pub fn start(
         name: &str,
-        tun: Option<NativeTun>,
+        tun: Option<RawFd>,
         socket_pool: Arc<SocketPool>,
         firewall_process_inbound_callback: FirewallInboundCb,
         firewall_process_outbound_callback: FirewallOutboundCb,
         firewall_reset_connections_callback: super::FirewallResetConnsCb,
         skt_buffer_size: Option<u32>,
     ) -> Result<Self, AdapterError> {
+        use std::os::fd::RawFd;
+
         let config = DeviceConfig {
             // Apple's NepTUN device runs most efficiently on a single perf-core
             n_threads: {

--- a/crates/telio-wg/src/adapter/windows_native_wg.rs
+++ b/crates/telio-wg/src/adapter/windows_native_wg.rs
@@ -428,7 +428,7 @@ impl Adapter for WindowsNativeWg {
         self.cleanup();
     }
 
-    async fn set_tun(&self, _tun: i32) -> Result<(), AdapterError> {
+    async fn set_tun(&self, _tun: super::Tun) -> Result<(), AdapterError> {
         Err(AdapterError::UnsupportedAdapter)
     }
 }

--- a/crates/telio-wg/src/wg.rs
+++ b/crates/telio-wg/src/wg.rs
@@ -100,7 +100,7 @@ pub struct Config {
     /// Name of network interface in readable string
     pub name: Option<String>,
     /// Tunnel file descriptor
-    pub tun: Option<Tun>,
+    pub tun: Option<Arc<Tun>>,
     /// Sockets to be protected, in order to avoid loopback
     pub socket_pool: Arc<SocketPool>,
     /// Callback of firewall to process incoming packets
@@ -176,6 +176,7 @@ impl DynamicWg {
     ///
     /// # Example
     /// ```
+    /// use std::os::fd::FromRawFd;
     /// use std::{sync::Arc, io, time::Duration};
     /// use telio_firewall::firewall::{StatefullFirewall, Firewall};
     /// use telio_model::features::FeatureFirewall;
@@ -221,7 +222,7 @@ impl DynamicWg {
     ///         Config {
     ///             adapter: AdapterType::default(),
     ///             name: Some("tun10".to_string()),
-    ///             tun: Some(Tun::default()),
+    ///             tun: Some(Arc::new(unsafe { std::os::fd::OwnedFd::from_raw_fd(0) })),
     ///             socket_pool: socket_pool,
     ///             firewall_process_inbound_callback:
     ///                 Some(Arc::new(firewall_filter_inbound_packets)),
@@ -509,14 +510,8 @@ impl WireGuard for DynamicWg {
 impl Config {
     fn try_clone(&self) -> Result<Self, io::Error> {
         #[cfg(unix)]
-        let tun = match self.tun {
-            Some(fd) => {
-                let dup_fd = unsafe { libc::dup(fd as libc::c_int) };
-                if dup_fd < 0 {
-                    return Err(io::Error::last_os_error());
-                }
-                Some(dup_fd)
-            }
+        let tun = match &self.tun {
+            Some(fd) => Some(Arc::new(fd.try_clone()?)),
             None => None,
         };
         #[cfg(windows)]
@@ -1038,9 +1033,7 @@ impl Runtime for State {
         #[cfg(unix)]
         use std::os::fd::AsRawFd;
         #[cfg(unix)]
-        self.cfg
-            .tun
-            .map(|tun| unsafe { libc::close(tun as libc::c_int) });
+        self.cfg.tun.map(|tun| nix::unistd::close(tun.as_raw_fd()));
     }
 }
 

--- a/src/device/wg_controller.rs
+++ b/src/device/wg_controller.rs
@@ -1342,7 +1342,7 @@ fn peer_state(
 mod tests {
     use super::*;
 
-    use crate::device::{DeviceConfig, DNS};
+    use crate::device::{RequestedDeviceConfig, DNS};
     use mockall::predicate::{self, eq};
     use rstest::*;
     use telio_nurse::config::AggregatorConfig;
@@ -1399,7 +1399,7 @@ mod tests {
         pq_mock.expect_keys().returning(|| None);
 
         let requested_state = RequestedState {
-            device_config: DeviceConfig {
+            device_config: RequestedDeviceConfig {
                 private_key: secret_key_b,
                 ..Default::default()
             },
@@ -1431,7 +1431,7 @@ mod tests {
         pq_mock.expect_is_rotating_keys().returning(|| false);
 
         let requested_state = RequestedState {
-            device_config: DeviceConfig {
+            device_config: RequestedDeviceConfig {
                 private_key: secret_key_a,
                 ..Default::default()
             },
@@ -1463,7 +1463,7 @@ mod tests {
             .returning(|_| Ok(()));
 
         let requested_state = RequestedState {
-            device_config: DeviceConfig {
+            device_config: RequestedDeviceConfig {
                 fwmark: Some(new),
                 ..Default::default()
             },
@@ -1489,7 +1489,7 @@ mod tests {
         });
 
         let requested_state = RequestedState {
-            device_config: DeviceConfig {
+            device_config: RequestedDeviceConfig {
                 fwmark: Some(old),
                 ..Default::default()
             },

--- a/src/doc/introduction.md
+++ b/src/doc/introduction.md
@@ -113,7 +113,7 @@ let config = telio::device::DeviceConfig {
     ..Default::default()
 };
 
-device.start(&config).unwrap();
+device.start(config).unwrap();
 ```
 
 To stop the device we can simply call the argumentless `Device::stop` method.

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -441,7 +441,10 @@ impl Telio {
         );
 
         #[cfg(not(target_os = "windows"))]
-        let tun = Some(_tun);
+        let tun = {
+            use std::os::fd::{FromRawFd, OwnedFd};
+            Some(Arc::new(unsafe { OwnedFd::from_raw_fd(_tun) }))
+        };
         #[cfg(target_os = "windows")]
         let tun = None;
         catch_ffi_panic(|| {
@@ -451,7 +454,7 @@ impl Telio {
                     adapter: adapter.into(),
                     fwmark: None,
                     name: None,
-                    tun,
+                    tun: tun.clone(),
                 })
                 .log_result("Telio::start_with_tun")
             })


### PR DESCRIPTION
### Problem
Before (#1273) a bug was introduced which caused nat-lab test start_with_tun to sometimes fail. This was later reverted (in #1287). The source of the problem was that the `OwnedFd` which was part of the `Config` was dropped after the underlying descriptor was passed to NepTUN - which meant the descriptor was closed.

### Solution
Instead of passing config by reference, and dropping it (and contained `tun`) afterwards, this PR changes the `start` (and `set_tun`) so that it consumes the `OwnedFd` using `IntoRawFd` and pass it to NepTUN for management.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
