### PR TITLE
Fix teliod log path validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5204,6 +5204,7 @@ dependencies = [
  "smart-default",
  "telio",
  "temp-dir",
+ "temp-file",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -5217,6 +5218,12 @@ name = "temp-dir"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83176759e9416cf81ee66cb6508dbfe9c96f20b8b56265a39917551c23c70964"
+
+[[package]]
+name = "temp-file"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5ff282c3f91797f0acb021f3af7fffa8a78601f0f2fd0a9f79ee7dcf9a9af9e"
 
 [[package]]
 name = "tempfile"

--- a/clis/teliod/Cargo.toml
+++ b/clis/teliod/Cargo.toml
@@ -45,6 +45,7 @@ rust-cgi = { version = "0.7.2", optional = true }
 rand = "0.9.1"
 serial_test = "3.2.0"
 temp-dir = "0.1.16"
+temp-file = "0.1.9"
 
 [features]
 cgi = ["const_format", "rust-cgi", "lazy_static", "maud", "form_urlencoded"]

--- a/clis/teliod/src/main.rs
+++ b/clis/teliod/src/main.rs
@@ -120,6 +120,8 @@ enum TeliodError {
     LogAppenderError(#[from] InitError),
     #[error(transparent)]
     DaemonizeError(#[from] daemonize::Error),
+    #[error("Invalid log path {0}")]
+    InvalidLogPath(String),
 }
 
 /// Libtelio and meshnet status report


### PR DESCRIPTION
### Problem
When a relative path is given as `log_file_path`, the validation tries to convert it to an absolute path.

Since most likely the file does not yet exist, `canonicalize()` will fail with error `Error: Io(Os { code: 2, kind: NotFound, message: "No such file or directory" })`

### Solution
Properly convert the path to absolute, by splitting file name and directory parts, and canonicalize only the parent directory.
Add more descriptive error message.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
