### PR TITLE
Make QNAP package display name consistent with UI

### DIFF
--- a/qnap/qpkg.cfg
+++ b/qnap/qpkg.cfg
@@ -1,7 +1,7 @@
 # Name of the packaged application.
 QPKG_NAME="NordSecurityMeshnet"
 # Name of the display application.
-QPKG_DISPLAY_NAME="NordSecurityMeshnet"
+QPKG_DISPLAY_NAME="Nord Security Meshnet"
 # Version of the packaged application.
 QPKG_VER="1.0.0"
 # Author or maintainer of the package


### PR DESCRIPTION
### Problem
On QNAP the application is displayed as `NordSecurityMeshnet` but once open the UI shows the title `Nord Security Meshnet`.

### Solution
Make `QPKG_DISPLAY_NAME` consistent with UI.
