### PR TITLE
LLT-6394: Emit debug log when meshnet or feature config can't be deserialized

### DIFF
--- a/.unreleased/LLT-6394
+++ b/.unreleased/LLT-6394
@@ -1,0 +1,1 @@
+Emit debug log when deserializing meshnet or feature config fails

--- a/crates/telio-model/src/config.rs
+++ b/crates/telio-model/src/config.rs
@@ -4,7 +4,7 @@ use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use serde_json::{from_value, Error, Value};
 use smart_default::SmartDefault;
-use telio_utils::{telio_log_error, telio_log_warn, Hidden, Instant};
+use telio_utils::{telio_log_debug, telio_log_error, telio_log_warn, Hidden, Instant};
 
 use std::{
     io::ErrorKind,
@@ -273,8 +273,10 @@ impl Config {
             );
             return Err(ConfigParseError::TooLongString);
         }
-        let cfg: PartialConfig =
-            serde_json::from_str(value).map_err(|_| ConfigParseError::BadConfig)?;
+        let cfg: PartialConfig = serde_json::from_str(value).map_err(|err| {
+            telio_log_debug!("Failed to deserialize meshnet config with error: {err:?}");
+            ConfigParseError::BadConfig
+        })?;
         let (cfg, peer_deserialization_failures) = cfg.to_config();
         let res = (cfg, peer_deserialization_failures.len());
         for failure in peer_deserialization_failures {

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -130,7 +130,10 @@ pub fn deserialize_feature_config(fstr: String) -> FfiResult<Features> {
     if fstr.is_empty() {
         Ok(Features::default())
     } else {
-        serde_json::from_str(&fstr).map_err(|_| TelioError::InvalidString)
+        serde_json::from_str(&fstr).map_err(|err| {
+            telio_log_debug!("Failed to deserialize feature config with error: {err:?}");
+            TelioError::InvalidString
+        })
     }
 }
 


### PR DESCRIPTION
### Problem
Deserializing configs return very opaque errors upon failure, which makes it hard for apps to find the cause. 

### Solution
When the deserialization fails, emit debug log


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
