### PR TITLE
Prevent overflow in mtumonitor

### DIFF
--- a/crates/telio-wg/src/windows/tunnel/mtumonitor.rs
+++ b/crates/telio-wg/src/windows/tunnel/mtumonitor.rs
@@ -214,7 +214,7 @@ impl MtuMonitor {
             let own_luid = InterfaceLuid::new(self.own_luid);
             telio_log_trace!("+++ MtuMonitor::do_it: get_ip_interface");
             let mut own_iface = own_luid.get_ip_interface(self.family)?;
-            own_iface.NlMtu = mtu - 80;
+            own_iface.NlMtu = mtu.saturating_sub(80);
             if own_iface.NlMtu < self.min_mtu {
                 own_iface.NlMtu = self.min_mtu;
             }


### PR DESCRIPTION
### Problem
Previous code as a bare subtraction 'mtu - 80' which can overflow

### Solution
Instead, let's do a saturating subtraction


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
