### PR TITLE
LLT-6138: Add UCI support to teliod

### DIFF
--- a/clis/teliod/README.md
+++ b/clis/teliod/README.md
@@ -60,8 +60,9 @@ needs be absolute, otherwise will be relative to `working-directory` when daemon
     - `manual` - do not configure interfaces automatically
     - `ifconfig` - systems using ifconfig command
     - `iproute` - systems using iproute2 command
+    - `uci` - OpenWRT systems using uci command
   - `vpn` - optional vpn config. If omitted, a VPN connection will not be established
-    - `server_endpoint` - The endpoint (ip:port) of the server/endpoint to connect to 
+    - `server_endpoint` - The endpoint (ip:port) of the server/endpoint to connect to
     - `server_pubkey` - The public key of the server/peer to connect to
 
 And following cli commands:


### PR DESCRIPTION
### Problem
For the OpenWRT there is a native command [UCI](https://openwrt.org/docs/techref/uci) (Unified Configuration Interface), which should be used to configure networks.

### Solution
Add `InterfaceConfigurationProvider` implementation for `UCI`
Rename `adapter_name` to `interface_name` for consistency.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
