### PR TITLE
Backport: emit debug log when meshnet or feature config can't be deserialized

### DIFF
--- a/.unreleased/LLT-6394
+++ b/.unreleased/LLT-6394
@@ -1,0 +1,1 @@
+Emit debug log when deserializing meshnet or feature config fails

--- a/crates/telio-model/src/config.rs
+++ b/crates/telio-model/src/config.rs
@@ -4,7 +4,7 @@ use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use serde_json::{from_value, Error, Value};
 use smart_default::SmartDefault;
-use telio_utils::{telio_log_error, telio_log_warn, Hidden};
+use telio_utils::{telio_log_debug, telio_log_error, telio_log_warn, Hidden};
 use tokio::time::Instant;
 
 use std::{
@@ -274,8 +274,10 @@ impl Config {
             );
             return Err(ConfigParseError::TooLongString);
         }
-        let cfg: PartialConfig =
-            serde_json::from_str(value).map_err(|_| ConfigParseError::BadConfig)?;
+        let cfg: PartialConfig = serde_json::from_str(value).map_err(|err| {
+            telio_log_debug!("Failed to deserialize meshnet config with error: {err:?}");
+            ConfigParseError::BadConfig
+        })?;
         let (cfg, peer_deserialization_failures) = cfg.to_config();
         let res = (cfg, peer_deserialization_failures.len());
         for failure in peer_deserialization_failures {

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -123,7 +123,10 @@ pub fn deserialize_feature_config(fstr: String) -> FfiResult<Features> {
     if fstr.is_empty() {
         Ok(Features::default())
     } else {
-        serde_json::from_str(&fstr).map_err(|_| TelioError::InvalidString)
+        serde_json::from_str(&fstr).map_err(|err| {
+            telio_log_debug!("Failed to deserialize feature config with error: {err:?}");
+            TelioError::InvalidString
+        })
     }
 }
 


### PR DESCRIPTION
This is a backport of https://github.com/NordSecurity/libtelio/pull/1309


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
