### PR TITLE
Add tests for firewall that excercise previously untested configuration or state

### DIFF
--- a/crates/telio-firewall/src/conntrack.rs
+++ b/crates/telio-firewall/src/conntrack.rs
@@ -158,7 +158,7 @@ impl Conntracker {
         }
     }
 
-    #[cfg(feature = "test_utils")]
+    #[cfg(any(feature = "test_utils", test))]
     /// Return the size of conntrack entries for tcp and udp (for testing only).
     pub fn get_state(&self) -> (usize, usize) {
         let tcp = unwrap_lock_or_return!(self.tcp.lock(), (0, 0)).len();


### PR DESCRIPTION
### Problem
Previously there was very little actually testing of the conntracker state outside of the sanity checks in benchmarks - which turns out cough an issue: https://github.com/NordSecurity/libtelio/actions/runs/15852903485/job/44690771436?pr=1324#step:3:499

Also, there was no tests for the handling of vpn peer in the rust tests and also no test to check how the firewall behaves with different values for the `record_whitelisted` property.

### Solution
The state is checked using get_state in various tests that can impact it for both possible values of `record_whitelisted`. Also, a test for vpn peer handling has been added.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
