### PR TITLE
Improve debuggability of connection tracking

### DIFF
--- a/nat-lab/tests/test_connection_tracker.py
+++ b/nat-lab/tests/test_connection_tracker.py
@@ -3,7 +3,8 @@ from utils.connection_tracker import parse_input, FiveTuple, EventType, TcpState
 
 def test_connection_tracker_parse_input():
     new_udp = parse_input(
-        "[NEW] udp      17 30 src=127.0.0.1 dst=127.0.0.53 sport=34348 dport=53 [UNREPLIED] src=127.0.0.53 dst=127.0.0.1 sport=53 dport=34348"
+        "[NEW] udp      17 30 src=127.0.0.1 dst=127.0.0.53 sport=34348 dport=53 [UNREPLIED] src=127.0.0.53 dst=127.0.0.1 sport=53 dport=34348",
+        0,
     )
     assert new_udp.five_tuple == FiveTuple(
         protocol="udp",
@@ -16,7 +17,8 @@ def test_connection_tracker_parse_input():
     assert new_udp.tcp_state is None
 
     updated_udp = parse_input(
-        "[UPDATE] udp      17 30 src=10.6.6.104 dst=8.8.8.8 sport=49922 dport=53 src=8.8.8.8 dst=10.6.6.104 sport=53 dport=49922"
+        "[UPDATE] udp      17 30 src=10.6.6.104 dst=8.8.8.8 sport=49922 dport=53 src=8.8.8.8 dst=10.6.6.104 sport=53 dport=49922",
+        0,
     )
     assert updated_udp.five_tuple == FiveTuple(
         protocol="udp",
@@ -29,7 +31,8 @@ def test_connection_tracker_parse_input():
     assert updated_udp.tcp_state is None
 
     new_icmp_type8 = parse_input(
-        "[NEW] icmp     1 30 src=10.6.6.104 dst=142.250.184.206 type=8 code=0 id=370 [UNREPLIED] src=142.250.184.206 dst=10.6.6.104 type=0 code=0 id=370"
+        "[NEW] icmp     1 30 src=10.6.6.104 dst=142.250.184.206 type=8 code=0 id=370 [UNREPLIED] src=142.250.184.206 dst=10.6.6.104 type=0 code=0 id=370",
+        0,
     )
     assert new_icmp_type8.five_tuple == FiveTuple(
         protocol="icmp",
@@ -42,7 +45,8 @@ def test_connection_tracker_parse_input():
     assert new_icmp_type8.tcp_state is None
 
     updated_icmp_type8 = parse_input(
-        "[UPDATE] icmp     1 30 src=10.6.6.104 dst=142.250.184.206 type=8 code=0 id=370 src=142.250.184.206 dst=10.6.6.104 type=0 code=0 id=370"
+        "[UPDATE] icmp     1 30 src=10.6.6.104 dst=142.250.184.206 type=8 code=0 id=370 src=142.250.184.206 dst=10.6.6.104 type=0 code=0 id=370",
+        0,
     )
     assert updated_icmp_type8.five_tuple == FiveTuple(
         protocol="icmp",
@@ -54,7 +58,8 @@ def test_connection_tracker_parse_input():
     assert new_icmp_type8.event_type == EventType.NEW
 
     new_icmp_type0 = parse_input(
-        "[NEW] icmp     1 30 src=10.6.6.104 dst=142.250.184.206 type=0 code=0 id=370 [UNREPLIED] src=142.250.184.206 dst=10.6.6.104 type=0 code=0 id=370"
+        "[NEW] icmp     1 30 src=10.6.6.104 dst=142.250.184.206 type=0 code=0 id=370 [UNREPLIED] src=142.250.184.206 dst=10.6.6.104 type=0 code=0 id=370",
+        0,
     )
     assert new_icmp_type0.five_tuple == FiveTuple(
         protocol="icmp",
@@ -66,7 +71,8 @@ def test_connection_tracker_parse_input():
     assert new_icmp_type0.event_type == EventType.NEW
 
     new_icmp_type13 = parse_input(
-        "[NEW] icmp     1 30 src=127.0.0.1 dst=127.0.0.1 type=13 code=0 id=44126 [UNREPLIED] src=127.0.0.1 dst=127.0.0.1 type=14 code=0 id=44126"
+        "[NEW] icmp     1 30 src=127.0.0.1 dst=127.0.0.1 type=13 code=0 id=44126 [UNREPLIED] src=127.0.0.1 dst=127.0.0.1 type=14 code=0 id=44126",
+        0,
     )
     assert new_icmp_type13.five_tuple == FiveTuple(
         protocol=None,
@@ -77,7 +83,8 @@ def test_connection_tracker_parse_input():
     )
 
     new_icmpv6_type128 = parse_input(
-        "[NEW] icmpv6   58 30 src=2600:1f1a:4d5e:c200:2787:af77:9c40:1365 dst=2a05:f480:2400:1e9a:5400:4ff:fe25:e8f4 type=128 code=0 id=2 [UNREPLIED] src=2a05:f480:2400:1e9a:5400:4ff:fe25:e8f4 dst=2600:1f1a:4d5e:c200:2787:af77:9c40:1365 type=666 code=0 id=2"
+        "[NEW] icmpv6   58 30 src=2600:1f1a:4d5e:c200:2787:af77:9c40:1365 dst=2a05:f480:2400:1e9a:5400:4ff:fe25:e8f4 type=128 code=0 id=2 [UNREPLIED] src=2a05:f480:2400:1e9a:5400:4ff:fe25:e8f4 dst=2600:1f1a:4d5e:c200:2787:af77:9c40:1365 type=666 code=0 id=2",
+        0,
     )
     assert new_icmpv6_type128.five_tuple == FiveTuple(
         protocol="icmpv6",
@@ -87,7 +94,8 @@ def test_connection_tracker_parse_input():
         dst_port=None,
     )
     new_icmpv6_type129 = parse_input(
-        "[NEW] icmpv6   58 30 src=2600:1f1a:4d5e:c200:2787:af77:9c40:1365 dst=2a05:f480:2400:1e9a:5400:4ff:fe25:e8f4 type=666 code=0 id=2 [UNREPLIED] src=2a05:f480:2400:1e9a:5400:4ff:fe25:e8f4 dst=2600:1f1a:4d5e:c200:2787:af77:9c40:1365 type=129 code=0 id=2"
+        "[NEW] icmpv6   58 30 src=2600:1f1a:4d5e:c200:2787:af77:9c40:1365 dst=2a05:f480:2400:1e9a:5400:4ff:fe25:e8f4 type=666 code=0 id=2 [UNREPLIED] src=2a05:f480:2400:1e9a:5400:4ff:fe25:e8f4 dst=2600:1f1a:4d5e:c200:2787:af77:9c40:1365 type=129 code=0 id=2",
+        0,
     )
     assert new_icmpv6_type129.five_tuple == FiveTuple(
         protocol="icmpv6",
@@ -97,7 +105,8 @@ def test_connection_tracker_parse_input():
         dst_port=None,
     )
     new_icmpv6_type130 = parse_input(
-        "[NEW] icmpv6   58 30 src=2600:1f1a:4d5e:c200:2787:af77:9c40:1365 dst=2a05:f480:2400:1e9a:5400:4ff:fe25:e8f4 type=130 code=0 id=2 [UNREPLIED] src=2a05:f480:2400:1e9a:5400:4ff:fe25:e8f4 dst=2600:1f1a:4d5e:c200:2787:af77:9c40:1365 type=131 code=0 id=2"
+        "[NEW] icmpv6   58 30 src=2600:1f1a:4d5e:c200:2787:af77:9c40:1365 dst=2a05:f480:2400:1e9a:5400:4ff:fe25:e8f4 type=130 code=0 id=2 [UNREPLIED] src=2a05:f480:2400:1e9a:5400:4ff:fe25:e8f4 dst=2600:1f1a:4d5e:c200:2787:af77:9c40:1365 type=131 code=0 id=2",
+        0,
     )
     assert new_icmpv6_type130.five_tuple == FiveTuple(
         protocol=None,
@@ -108,7 +117,8 @@ def test_connection_tracker_parse_input():
     )
 
     new_tcp = parse_input(
-        "    [NEW] tcp      6 120 SYN_SENT src=127.0.0.1 dst=127.0.0.1 sport=51222 dport=12345 [UNREPLIED] src=127.0.0.1 dst=127.0.0.1 sport=12345 dport=51222"
+        "    [NEW] tcp      6 120 SYN_SENT src=127.0.0.1 dst=127.0.0.1 sport=51222 dport=12345 [UNREPLIED] src=127.0.0.1 dst=127.0.0.1 sport=12345 dport=51222",
+        0,
     )
     assert new_tcp.five_tuple == FiveTuple(
         protocol="tcp",
@@ -121,7 +131,8 @@ def test_connection_tracker_parse_input():
     assert new_tcp.tcp_state == TcpState.SYN_SENT
 
     updated_tcp = parse_input(
-        "[UPDATE] tcp      6 60 SYN_RECV src=10.6.6.104 dst=8.8.8.8 sport=49922 dport=53 src=8.8.8.8 dst=10.6.6.104 sport=53 dport=49922"
+        "[UPDATE] tcp      6 60 SYN_RECV src=10.6.6.104 dst=8.8.8.8 sport=49922 dport=53 src=8.8.8.8 dst=10.6.6.104 sport=53 dport=49922",
+        0,
     )
     assert updated_tcp.five_tuple == FiveTuple(
         protocol="tcp",

--- a/nat-lab/tests/test_mesh_firewall.py
+++ b/nat-lab/tests/test_mesh_firewall.py
@@ -593,7 +593,7 @@ async def test_mesh_firewall_tcp_stuck_in_last_ack_state_conn_kill_from_server_s
             # kill server and check what is happening in conntrack events
             # if everything is correct -> conntrack should show LAST_ACK -> TIME_WAIT
             # if something goes wrong, it will be stuck at LAST_ACK state
-            await conntrack.wait()
+            await conntrack.wait_for_no_violations()
 
 
 @pytest.mark.asyncio
@@ -695,4 +695,4 @@ async def test_mesh_firewall_tcp_stuck_in_last_ack_state_conn_kill_from_client_s
                 # kill client and check what is happening in conntrack events
                 # if everything is correct -> conntrack should show LAST_ACK -> TIME_WAIT
                 # if something goes wrong, it will be stuck at LAST_ACK state
-                await conntrack.wait()
+                await conntrack.wait_for_no_violations()

--- a/nat-lab/tests/test_vpn.py
+++ b/nat-lab/tests/test_vpn.py
@@ -413,7 +413,7 @@ async def test_kill_external_tcp_conn_on_vpn_reconnect(
             # under normal circumstances -> conntrack should show FIN_WAIT -> CLOSE_WAIT
             # But our connection killing mechanism will reset connection resulting in CLOSE output.
             # Wait for close on both clients
-            await conntrack.wait()
+            await conntrack.wait_for_no_violations()
 
 
 @pytest.mark.asyncio
@@ -476,7 +476,7 @@ async def test_firewall_blacklist_tcp(ipv4: bool) -> None:
         ).run() as conntrack:
             serv_ip = serv_ip if ipv4 else "[" + serv_ip + "]"
             await alpha_connection.create_process(["curl", serv_ip]).execute()
-            await conntrack.wait()
+            await conntrack.wait_for_no_violations()
 
         async with ConnectionTracker(
             beta_connection,
@@ -492,7 +492,7 @@ async def test_firewall_blacklist_tcp(ipv4: bool) -> None:
             with pytest.raises(ProcessExecError):
                 await beta_connection.create_process(["curl", serv_ip]).execute()
 
-            await conntrack.wait()
+            await conntrack.wait_for_no_violations()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This PR implements action points from today's nat-lab meeting:
- prefix all conntacker logs with some unique id
- rename wait() funciton in conntracker, so it wouldn't be mixed up with asyncio.Event().wait() -> [code](https://github.com/NordSecurity/libtelio/blob/9095db6e8c657f4f267451da994e96141c451f8f/nat-lab/tests/utils/connection_tracker.py#L370)
- print what can be recover [here](https://github.com/NordSecurity/libtelio/blob/9095db6e8c657f4f267451da994e96141c451f8f/nat-lab/tests/utils/connection_tracker.py#L381)


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
