### PR TITLE
LLT-6125: Teliod size optimization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -188,7 +188,6 @@ telio-nat-detect = { version = "0.1.0", path = "./crates/telio-nat-detect" }
 telio-network-monitors = { version = "0.1.0", path = "./crates/telio-network-monitors" }
 telio-nurse = { version = "0.1.0", path = "./crates/telio-nurse" }
 telio-proto = { version = "0.1.0", path = "./crates/telio-proto" }
-telio-batcher = { version = "0.1.0", path = "./crates/telio-batcher" }
 telio-proxy = { version = "0.1.0", path = "./crates/telio-proxy" }
 telio-relay = { version = "0.1.0", path = "./crates/telio-relay" }
 telio-sockets = { version = "0.1.0", path = "./crates/telio-sockets" }
@@ -206,6 +205,13 @@ opt-level = "s"
 lto = true
 codegen-units = 1
 debug = "full"
+
+[profile.release-size-optimized]
+inherits = "release"
+opt-level = "z"      # Optimize for size.
+panic = "abort"      # Abort on panic
+strip = true         # Automatically strip symbols from the binary.
+debug = false        # No debug
 
 [profile.dev]
 debug = 0

--- a/clis/teliod/README.md
+++ b/clis/teliod/README.md
@@ -5,16 +5,33 @@ and embedded environments.
 
 ## Building Teliod
 
-For typical Linux environment it might be built using simply:
+For typical Linux environments, Teliod can be built using the following commands:
 
-```cargo build```
+```sh
+# Debug build from teliod directory
+cargo build
 
-For OpenWRT you might need a bit more complex command, including your router architecture
-and the fact the OpenWRT is MUSLE-based, for example:
+# Release build
+cargo build --package=teliod --release 
+```
 
-```CARGO_TARGET_ARMV7_UNKNOWN_LINUX_MUSLEABIHF_LINKER=rust-lld CC=/path/to/arm-linux-gnueabi-gcc cargo build --package teliod --target armv7-unknown-linux-musleabihf```
+For OpenWRT you might need to cross-compile, depending on the router architecture.
 
-You may need to download some sufficient MUSLE toolchains from `musle.cc`.
+OpenWRT does not ship with GNU libc and instead is MUSL based.
+And further needs to be compiled with MUSL tool-chains or statically linked.
+Which can be obtained from from [musle.cc](https://musl.cc/) or the `musl-dev` package
+
+```sh
+# Add MUSL target
+sudo apt install musl-dev
+rustup target add --toolchain <target_architecture>-linux-musl
+
+# Regular release build
+cargo build --package=teliod --target=<target_architecture>-linux-musl --release
+
+# Size optimized release build
+cargo build --package=teliod --target=<target_architecture>-linux-musl --profile=release-size-optimized
+```
 
 ## Using Teliod
 


### PR DESCRIPTION
### Problem
Binary size of `teliod` debug build is smaller than the release build.

### Solution
Introduce a custom release build profile that optimizes for size.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
