### PR TITLE
Set android memory page size

### DIFF
--- a/.unreleased/android_memory_page_size
+++ b/.unreleased/android_memory_page_size
@@ -1,0 +1,1 @@
+Set Android memory page size to 16KiB

--- a/build.rs
+++ b/build.rs
@@ -109,7 +109,10 @@ fn main() -> Result<()> {
     if target_os == "android" {
         let pkg_name = env!("CARGO_PKG_NAME");
         let soname = format!("lib{}.so", pkg_name);
-        println!("cargo:rustc-cdylib-link-arg=-Wl,-soname,{}", soname);
+        println!(
+            "cargo:rustc-cdylib-link-arg=-Wl,-z,max-page-size=16384,-soname,{}",
+            soname
+        );
     }
 
     #[cfg(windows)]


### PR DESCRIPTION
### Problem
Android will [require](https://android-developers.googleblog.com/2025/05/prepare-play-apps-for-devices-with-16kb-page-size.html) 16KiB memory allignment.

### Solution
Allign memory to 16KiB for Android.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
