### PR TITLE
Optimize GitLab pipeline triggers

### DIFF
--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -3,6 +3,10 @@ on:
   pull_request_target:
     types: [labeled]
   push:
+    branches-ignore:
+      - 'gh-readonly-queue/**'
+    tags-ignore:
+      - '**'
   merge_group:
     types: [checks_requested]
   schedule:


### PR DESCRIPTION
### Problem
With current state there are 4 pipelines running for the same GITHUB_SHA which is to some extended is redundant:
1. When _Merge group checks requested_
2. On push event for temporary merge queue branch: _'gh-readonly-queue/**'_
3. On push event to _main_ branch
4. When tag is created

### Solution
*--describe selected solution--*
