### PR TITLE
Move copying of binaries to after connectivity checks

### DIFF
--- a/nat-lab/tests/conftest.py
+++ b/nat-lab/tests/conftest.py
@@ -373,13 +373,13 @@ async def collect_kernel_logs(items, suffix):
 
 def pytest_runtestloop(session):
     if not session.config.option.collectonly:
-        asyncio.run(_copy_vm_binaries_if_needed(session.items))
-
         if os.environ.get("NATLAB_SAVE_LOGS") is not None:
             asyncio.run(collect_kernel_logs(session.items, "before_tests"))
 
         if not asyncio.run(perform_setup_checks()):
             pytest.exit("Setup checks failed, exiting ...")
+
+        asyncio.run(_copy_vm_binaries_if_needed(session.items))
 
 
 def pytest_runtest_setup():


### PR DESCRIPTION
### Problem
We've seen some failures in natlab where binaries could not be copied to some VMs because the connection failed. 

### Solution
We already have precondition checks for connectivity between VMs and those have retries already set up. By moving the copying of binaries to after those connectivity checks have been done, we reduce the risk of the failed connection happening during the copying of binaries


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
