### PR TITLE
LLT-6138: Add VPN support to UCI

### DIFF
--- a/clis/teliod/src/daemon.rs
+++ b/clis/teliod/src/daemon.rs
@@ -201,6 +201,9 @@ fn telio_task(
                     _ = sys_config.cleanup_exit_routes().inspect_err(|e| {
                         error!("Failed to cleanup routes for exit routing with error '{e:?}'")
                     });
+                    _ = sys_config
+                        .cleanup_interface()
+                        .inspect_err(|e| error!("Failed to cleanup interface with error '{e:?}'"));
                     break;
                 }
             }


### PR DESCRIPTION
### Problem

OpenWRT platforms are using UCI commands to configure routes and firewall zones.

### Solution

Add UCI implementation for setting up VPN functionality. Disabling IPv6 and preserving LAN access between devices.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
