### PR TITLE
Move pre-test collection of kernel logs to after the setup checks

### DIFF
--- a/nat-lab/tests/conftest.py
+++ b/nat-lab/tests/conftest.py
@@ -373,11 +373,11 @@ async def collect_kernel_logs(items, suffix):
 
 def pytest_runtestloop(session):
     if not session.config.option.collectonly:
-        if os.environ.get("NATLAB_SAVE_LOGS") is not None:
-            asyncio.run(collect_kernel_logs(session.items, "before_tests"))
-
         if not asyncio.run(perform_setup_checks()):
             pytest.exit("Setup checks failed, exiting ...")
+
+        if os.environ.get("NATLAB_SAVE_LOGS") is not None:
+            asyncio.run(collect_kernel_logs(session.items, "before_tests"))
 
         asyncio.run(_copy_vm_binaries_if_needed(session.items))
 


### PR DESCRIPTION
### Problem
We saw an issue in natlab where kernel logs could not be collected from mac VM because the connection failed

### Solution
Move collecting kernel logs until after setup checks to hopefully avoid the problem since the setup checks do connection checks with retries
