### PR TITLE
LLT-6386: Censor feature config options from logs

### DIFF
--- a/crates/telio-utils/Cargo.toml
+++ b/crates/telio-utils/Cargo.toml
@@ -39,6 +39,7 @@ proptest.workspace = true
 proptest-derive.workspace = true
 rand.workspace = true
 rstest.workspace = true
+sn_fake_clock = { workspace = true }
 tokio = { workspace = true, features = ["time", "rt", "macros", "test-util"] }
 
 telio-test.workspace = true


### PR DESCRIPTION
### Problem
We have a couple of feature config options that are only there for us to use during development, like hide_user_info and hide_thread_id. These feature config options that are not active in production builds can give a bad impression to our users if they are spotted in the logs.

### Solution
Hide those options from the logs


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
