### PR TITLE
Bump trigger gitlab pipeline version

### DIFF
--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -18,7 +18,7 @@ jobs:
 
   trigger-gitlab-pipeline:
     needs: read-triggered-ref
-    uses: NordSecurity/trigger-gitlab-pipeline/.github/workflows/trigger-gitlab-pipeline.yml@22c73479b495367b1c8e6ee40145c75a3b4b6706
+    uses: NordSecurity/trigger-gitlab-pipeline/.github/workflows/trigger-gitlab-pipeline.yml@94a5d4a0ac0d6353948f0493c894dbd44b179bde
     secrets:
       ci-api-v4-url: ${{ secrets.CI_API_V4_URL }}
       access-token: ${{ secrets.GITLAB_API_TOKEN }}

--- a/.github/workflows/gitlab_schedule.yml
+++ b/.github/workflows/gitlab_schedule.yml
@@ -52,7 +52,7 @@ jobs:
 
   trigger-gitlab-pipeline:
     needs: [read-triggered-ref, prepare-sha]
-    uses: NordSecurity/trigger-gitlab-pipeline/.github/workflows/trigger-gitlab-pipeline.yml@22c73479b495367b1c8e6ee40145c75a3b4b6706
+    uses: NordSecurity/trigger-gitlab-pipeline/.github/workflows/trigger-gitlab-pipeline.yml@94a5d4a0ac0d6353948f0493c894dbd44b179bde
     secrets:
       ci-api-v4-url: ${{ secrets.CI_API_V4_URL }}
       access-token: ${{ secrets.GITLAB_API_TOKEN }}


### PR DESCRIPTION
### Problem
Sometimes `authorize-and-resolve-workflow-ref` workflow jobs [failing](https://github.com/NordSecurity/libtelio/actions/runs/16310405037/job/46064879188#step:3:68) with error:
`HTTPError: 403 Client Error: rate limit exceeded for url: ...`

Due to that some of the nightlies pipelines are not getting triggered.

### Solution
Make authenticated requests in get-workflow-action which increases the rate limit. 
Corresponding MR in trigger-gitlab-pipeline will be merged after the testing on nightlies for one week.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
