### PR TITLE
[LLT-6404] natlab: Abstract teliod to its own module

### DIFF
--- a/nat-lab/pyproject.toml
+++ b/nat-lab/pyproject.toml
@@ -77,6 +77,7 @@ dependencies = [
     "virtualenv==20.26.2",
     "yarl==1.17.0",
     "pytest-shard>=0.1.2",
+    "aiofiles>=24.1.0",
 ]
 
 [tool.black]

--- a/nat-lab/tests/teliod.py
+++ b/nat-lab/tests/teliod.py
@@ -1,0 +1,279 @@
+import asyncio
+import json
+import os
+import re
+import time
+from config import LIBTELIO_BINARY_PATH_DOCKER
+from contextlib import AsyncExitStack, asynccontextmanager
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import AsyncIterator
+from utils.connection import Connection
+from utils.logger import log
+from utils.process import Process, ProcessExecError
+
+
+class TeliodObtainingIdentity(Exception):
+    pass
+
+
+class IfcConfigType(Enum):
+    DEFAULT = "config.json"
+    VPN_MANUAL = "config_with_vpn_manual_setup.json"
+    VPN_IPROUTE = "config_with_vpn_iproute_setup.json"
+
+
+@dataclass(frozen=True)
+class Paths:
+    exec_path: Path = Path(f"{LIBTELIO_BINARY_PATH_DOCKER}/teliod")
+    config_dir: Path = Path("/etc/teliod")
+    log_dir: Path = Path("/var/log")
+    run_dir: Path = Path("/run")
+
+    def __post_init__(self):
+        if os.environ.get("PYTEST_CURRENT_TEST"):
+            if not self.exec_path.exists():
+                raise FileNotFoundError(
+                    f"Teliod executable not found: {self.exec_path}"
+                )
+
+    @property
+    def socket_file(self) -> Path:
+        return self.run_dir / "teliod.sock"
+
+    @property
+    def daemon_log(self) -> Path:
+        return self.log_dir / "teliod.log"
+
+    @property
+    def lib_log(self) -> Path:
+        return self.log_dir / "teliod_natlab.log"
+
+    def config_path(self, config_type: IfcConfigType = IfcConfigType.DEFAULT) -> Path:
+        return self.config_dir / config_type.value
+
+
+class Command(list):
+    def __str__(self) -> str:
+        return " ".join(str(item) for item in self)
+
+    def __repr__(self) -> str:
+        return f"Command({super().__repr__()})"
+
+    @classmethod
+    def start(cls, config: "Config") -> "Command":
+        cmd = [str(Paths.exec_path), "start"]
+        if config.no_detach:
+            cmd.append("--no-detach")
+        cmd.append(str(config.path()))
+        return cls(cmd)
+
+    @classmethod
+    def is_alive(cls) -> "Command":
+        return cls([str(Paths.exec_path), "is-alive"])
+
+    @classmethod
+    def get_status(cls) -> "Command":
+        return cls([str(Paths.exec_path), "get-status"])
+
+    @classmethod
+    def quit_daemon(cls) -> "Command":
+        return cls([str(Paths.exec_path), "quit-daemon"])
+
+
+class Config:
+    def __init__(
+        self,
+        config_type: IfcConfigType = IfcConfigType.DEFAULT,
+        no_detach: bool = False,
+        paths=Paths(),
+    ):
+        self.paths: Paths = paths
+        self.config_type: IfcConfigType = config_type
+        self.no_detach: bool = no_detach
+
+    def path(self) -> Path:
+        return self.paths.config_path(self.config_type)
+
+    async def assert_match_daemon_start(self, stdout: str):
+        assert (
+            "Starting daemon" in stdout
+        ), f"Could not find 'Starting daemon' in: '{stdout}'"
+
+        config_match = re.search(r"Reading config from:\s*(.+.json)", stdout)
+        assert config_match, f"Could not find config path in: {stdout}"
+        config_path = Path(config_match.group(1).strip())
+        assert (
+            config_path == self.path()
+        ), f"Config path does not match: '{config_path}' != '{self.path()}'"
+
+        log_match = re.search(r"Saving logs to:\s*(.+\.log)", stdout)
+        assert log_match, f"Could not find log path in: {stdout}"
+        log_path = Path(log_match.group(1).strip())
+        assert (
+            log_path == self.paths.lib_log
+        ), f"Log path does not match: '{log_path}' != '{self.paths.lib_log}'"
+
+        return config_path, log_path
+
+
+class Teliod:
+    START_TIMEOUT_S = 3
+    SOCKET_CHECK_INTERVAL_S = 0.5
+    TELIOD_CMD_CHECK_INTERVAL_S = 1
+
+    def __init__(
+        self,
+        connection: Connection,
+        exit_stack: AsyncExitStack,
+        config: Config = Config(),
+    ) -> None:
+        self._connection: Connection = connection
+        self._exit_stack: AsyncExitStack = exit_stack
+        self.config: Config = config
+
+    async def execute_command(
+        self,
+        cmd: Command,
+    ) -> tuple[str, str]:
+        try:
+            proc = await self._connection.create_process(cmd).execute()
+            stdout, stderr = proc.get_stdout(), proc.get_stderr()
+            log.debug("'%s' stdout: '%s', stderr: '%s'", cmd, stdout, stderr)
+            return stdout, stderr
+        except ProcessExecError as exc:
+            log.debug("Exception occured while executing teliod command: %s", exc)
+            raise
+
+    async def run_command(
+        self,
+        cmd: Command,
+    ) -> Process:
+        proc = await self._exit_stack.enter_async_context(
+            self._connection.create_process(cmd).run()
+        )
+        return proc
+
+    @asynccontextmanager
+    async def start(self) -> AsyncIterator["Teliod"]:
+        try:
+            await self.remove_logs()
+
+            async def wait_for_teliod_start():
+                await self.wait_for_teliod_socket()
+                while True:
+                    try:
+                        if not await self.is_alive():
+                            raise RuntimeError(
+                                "socket exists but daemon's not running."
+                            )
+                        break
+                    except TeliodObtainingIdentity:
+                        await asyncio.sleep(self.TELIOD_CMD_CHECK_INTERVAL_S)
+                        continue
+
+            if not self.config.no_detach:
+                stdout, stderr = await self.execute_command(Command.start(self.config))
+                await wait_for_teliod_start()
+            else:
+                proc = await self.run_command(Command.start(self.config))
+                await wait_for_teliod_start()
+                stdout, stderr = proc.get_stdout(), proc.get_stderr()
+
+            assert len(stderr) == 0, f"Stderr is not empty: {stderr}"
+            await self.config.assert_match_daemon_start(stdout)
+            yield self
+        finally:
+            try:
+                await self.quit()
+            except ProcessExecError as exc:
+                if "Error: DaemonIsNotRunning" not in exc.stderr:
+                    log.error(exc)
+                    await self.kill()
+                    await self.remove_socket()
+                else:
+                    log.info("Tried to quit but daemon is already not running")
+
+    async def is_alive(self) -> bool:
+        try:
+            stdout, _ = await self.execute_command(Command.is_alive())
+            return "Command executed successfully" in stdout
+        except ProcessExecError as exc:
+            if "Obtaining identity, ignoring" in exc.stdout:
+                raise TeliodObtainingIdentity() from exc
+            if "Error: DaemonIsNotRunning" in exc.stderr:
+                return False
+            raise exc
+
+    async def get_status(self) -> str:
+        status, _ = await self.execute_command(Command.get_status())
+        return status
+
+    async def quit(self) -> None:
+        stdout, stderr = await self.execute_command(Command.quit_daemon())
+        assert (
+            "Command executed successfully" in stdout
+        ), f"Failed to execute quit-daemon command: {stderr}"
+
+        assert (
+            not await self.is_alive()
+        ), "Quit command was sent successfully but daemon's still running"
+        assert (
+            not await self.socket_exists()
+        ), "Daemon's not running but socket still exists"
+
+    async def kill(self) -> None:
+        try:
+            await self._connection.create_process(
+                ["killall", "-w", "-s", "SIGTERM", "teliod"]
+            ).execute()
+            assert (
+                not await self.is_alive()
+            ), "SIGTERM was sent but daemon's still running"
+        except ProcessExecError as exc:
+            if "teliod: no process found" not in exc.stderr:
+                raise
+
+    async def remove_logs(self) -> None:
+        for path in [self.config.paths.daemon_log, self.config.paths.lib_log]:
+            await self._connection.create_process(["rm", "-f", str(path)]).execute()
+            await self._connection.create_process(
+                ["test", "!", "-f", str(path)]
+            ).execute()
+
+    async def socket_exists(self) -> bool:
+        try:
+            await self._connection.create_process(
+                ["test", "-e", str(self.config.paths.socket_file)]
+            ).execute()
+            return True
+        except ProcessExecError as exc:
+            assert (exc.returncode, exc.stdout, exc.stderr) == (1, "", "")
+            return False
+
+    async def remove_socket(self):
+        await self._connection.create_process(
+            ["rm", "-f", str(self.config.paths.socket_file)]
+        ).execute()
+
+    async def wait_for_teliod_socket(self):
+        start_time = time.monotonic()
+        while time.monotonic() - start_time < self.START_TIMEOUT_S:
+            try:
+                if await asyncio.wait_for(
+                    self.socket_exists(), self.SOCKET_CHECK_INTERVAL_S
+                ):
+                    return
+            except TimeoutError:
+                pass
+            await asyncio.sleep(0.5)
+        raise TimeoutError("teliod did not start within timeout")
+
+    async def wait_for_vpn_connected_state(self):
+        while True:
+            status = json.loads(await self.get_status())
+            for ext_node in status["external_nodes"]:
+                if ext_node["is_vpn"] and ext_node["state"] == "connected":
+                    return
+            await asyncio.sleep(self.TELIOD_CMD_CHECK_INTERVAL_S)

--- a/nat-lab/tests/test_teliod.py
+++ b/nat-lab/tests/test_teliod.py
@@ -1,12 +1,9 @@
-import asyncio
 import base64
 import json
 import platform
 import pytest
-import time
 import uuid
 from config import (
-    LIBTELIO_BINARY_PATH_DOCKER,
     WG_SERVER,
     PHOTO_ALBUM_IP,
     STUN_SERVER,
@@ -16,9 +13,11 @@ from config import (
 )
 from contextlib import AsyncExitStack
 from helpers import setup_connections, send_https_request
-from mesh_api import API
+from mesh_api import API, Node
+from teliod import Teliod, Config, IfcConfigType
 from utils import stun
 from utils.connection import ConnectionTag
+from utils.logger import log
 from utils.ping import ping
 from utils.process.process import ProcessExecError
 from utils.router import IPStack
@@ -29,150 +28,30 @@ if platform.machine() != "x86_64":
 else:
     from python_wireguard import Key  # type: ignore
 
-TELIOD_EXEC_PATH = f"{LIBTELIO_BINARY_PATH_DOCKER}teliod"
-CONFIG_FILE_PATH = "/etc/teliod/config.json"
-CONFIG_FILE_PATH_WITH_VPN_MANUAL_SETUP = "/etc/teliod/config_with_vpn_manual_setup.json"
-CONFIG_FILE_PATH_WITH_VPN_IPROUTE_SETUP = (
-    "/etc/teliod/config_with_vpn_iproute_setup.json"
-)
-SOCKET_FILE_PATH = "/run/teliod.sock"
-STDOUT_FILE_PATH = "/var/log/teliod.log"
-LOG_FILE_PATH = "/var/log/teliod_natlab.log"
-
-TELIOD_START_PARAMS = [
-    TELIOD_EXEC_PATH,
-    "start",
-    CONFIG_FILE_PATH,
-]
-
-TELIOD_START_NODETACH_PARAMS = [
-    TELIOD_EXEC_PATH,
-    "start",
-    "--no-detach",
-    CONFIG_FILE_PATH,
-]
-
-TELIOD_STATUS_PARAMS = [TELIOD_EXEC_PATH, "get-status"]
-TELIOD_IS_ALIVE_PARAMS = [TELIOD_EXEC_PATH, "is-alive"]
-TELIOD_QUIT_DAEMON_PARAMS = [TELIOD_EXEC_PATH, "quit-daemon"]
-
-WAIT_FOR_TELIOD_TIMEOUT = 3.0
-
-
-async def is_teliod_running(connection):
-    try:
-        await connection.create_process(["test", "-e", SOCKET_FILE_PATH]).execute()
-        return True
-    except:
-        return False
-
-
-async def wait_for_is_teliod_running(connection):
-    start_time = time.monotonic()
-    while time.monotonic() - start_time < WAIT_FOR_TELIOD_TIMEOUT:
-        try:
-            if await asyncio.wait_for(is_teliod_running(connection), 0.5):
-                if (
-                    "Command executed successfully"
-                    in (
-                        await connection.create_process(
-                            TELIOD_IS_ALIVE_PARAMS
-                        ).execute()
-                    ).get_stdout()
-                ):
-                    return
-        except TimeoutError:
-            pass
-        await asyncio.sleep(0.1)
-    raise TimeoutError("teliod did not start within timeout")
-
-
-async def wait_for_teliod(connection):
-    # Let the daemon start
-    await wait_for_is_teliod_running(connection)
-
-    # Run the is-alive command
-    assert (
-        "Command executed successfully"
-        in (
-            await connection.create_process(TELIOD_IS_ALIVE_PARAMS).execute()
-        ).get_stdout()
-    )
-
-    # Run the get-status command
-    assert (
-        "telio_is_running"
-        in (
-            await connection.create_process(TELIOD_STATUS_PARAMS).execute()
-        ).get_stdout()
-    )
-
-
-async def start_teliod(exit_stack, connection, params):
-    # Run teliod
-    await exit_stack.enter_async_context(connection.create_process(params).run())
-
-    # wait for teliod to start and be available
-    await wait_for_teliod(connection)
-
-
-async def wait_for_teliod_stop(connection):
-    # wait for teliod to stop
-    assert not await is_teliod_running(connection)
-
-    # send get-status command, expected to fail
-    with pytest.raises(ProcessExecError) as err:
-        await connection.create_process(TELIOD_STATUS_PARAMS).execute()
-    assert err.value.stderr == "Error: DaemonIsNotRunning"
-
 
 @pytest.mark.parametrize(
-    "start_daemon_params",
-    [(TELIOD_START_PARAMS), (TELIOD_START_NODETACH_PARAMS)],
-    ids=["daemonized_mode", "no_detach_mode"],
+    "no_detach",
+    [True, False],
+    ids=["no_detach", "detach"],
 )
-async def test_teliod(start_daemon_params) -> None:
-    async with AsyncExitStack() as exit_stack:
-        connection = (
-            await setup_connections(exit_stack, [ConnectionTag.DOCKER_CONE_CLIENT_1])
-        )[0].connection
-        await start_teliod(exit_stack, connection, start_daemon_params)
-
-        # Send SIGTERM to the daemon
-        await connection.create_process(
-            ["killall", "-w", "-s", "SIGTERM", "teliod"]
-        ).execute()
-
-        await wait_for_teliod_stop(connection)
-
-
-@pytest.mark.parametrize(
-    "start_daemon_params",
-    [(TELIOD_START_PARAMS), (TELIOD_START_NODETACH_PARAMS)],
-    ids=["daemonized_mode", "no_detach_mode"],
-)
-async def test_teliod_quit(start_daemon_params) -> None:
+async def test_teliod_start(no_detach) -> None:
     async with AsyncExitStack() as exit_stack:
         connection = (
             await setup_connections(exit_stack, [ConnectionTag.DOCKER_CONE_CLIENT_1])
         )[0].connection
 
-        # Try to quit deamon that is not running
+        teliod = Teliod(connection, exit_stack, Config(no_detach=no_detach))
+
         with pytest.raises(ProcessExecError) as err:
-            await connection.create_process(TELIOD_QUIT_DAEMON_PARAMS).execute()
+            await teliod.quit()
         assert err.value.stderr == "Error: DaemonIsNotRunning"
 
-        await start_teliod(exit_stack, connection, start_daemon_params)
+        async with teliod.start() as teliod_client:
+            assert await teliod_client.is_alive()
 
-        # Send quit-daemon command
-        assert (
-            "Command executed successfully"
-            in (
-                await connection.create_process(TELIOD_QUIT_DAEMON_PARAMS).execute()
-            ).get_stdout()
-        )
-
-        await wait_for_teliod_stop(connection)
+        with pytest.raises(ProcessExecError) as err:
+            await teliod.quit()
+        assert err.value.stderr == "Error: DaemonIsNotRunning"
 
 
 async def test_teliod_logs() -> None:
@@ -181,31 +60,14 @@ async def test_teliod_logs() -> None:
             await setup_connections(exit_stack, [ConnectionTag.DOCKER_CONE_CLIENT_1])
         )[0].connection
 
-        # Delete any old logs
-        await connection.create_process(
-            ["rm", "-f", STDOUT_FILE_PATH, LOG_FILE_PATH]
-        ).execute()
+        teliod = Teliod(connection, exit_stack)
 
-        # Make sure they are indeed deleted
-        for path in [STDOUT_FILE_PATH, LOG_FILE_PATH]:
-            await connection.create_process(["test", "!", "-f", path]).execute()
+        async with teliod.start():
+            pass
 
-        await start_teliod(exit_stack, connection, TELIOD_START_PARAMS)
-
-        # Send quit-daemon command
-        assert (
-            "Command executed successfully"
-            in (
-                await connection.create_process(TELIOD_QUIT_DAEMON_PARAMS).execute()
-            ).get_stdout()
-        )
-
-        await wait_for_teliod_stop(connection)
-
-        # expected substrings for each log file
         expected_log_contents = {
-            STDOUT_FILE_PATH: "task started",
-            LOG_FILE_PATH: "telio::device",
+            str(teliod.config.paths.daemon_log): "task started",
+            str(teliod.config.paths.lib_log): "telio::device",
         }
 
         # Check if log files exist and are not empty
@@ -216,23 +78,12 @@ async def test_teliod_logs() -> None:
             ).execute()
 
 
-# TODO(LLT-6404): reduce boilerplate
 @pytest.mark.parametrize(
-    "use_manual_interface_setup",
-    [(True), (False)],
-    ids=["manual_interface_setup", "iproute_interface_setup"],
+    "config_type",
+    [(IfcConfigType.VPN_MANUAL), (IfcConfigType.VPN_IPROUTE)],
 )
-async def test_teliod_vpn_connection(use_manual_interface_setup: bool) -> None:
-    config_file_path = (
-        CONFIG_FILE_PATH_WITH_VPN_MANUAL_SETUP
-        if use_manual_interface_setup
-        else CONFIG_FILE_PATH_WITH_VPN_IPROUTE_SETUP
-    )
-    async with AsyncExitStack() as exit_stack:
-        connection = (
-            await setup_connections(exit_stack, [ConnectionTag.DOCKER_CONE_CLIENT_1])
-        )[0].connection
-
+async def test_teliod_vpn_connection(config_type: IfcConfigType) -> None:
+    async def register_new_device_on_api():
         (private_key, public_key) = Key.key_pair()
         hw_identifier = uuid.uuid4()
         payload = {
@@ -249,19 +100,22 @@ async def test_teliod_vpn_connection(use_manual_interface_setup: bool) -> None:
             data=str(payload).replace("'", '"'),
             authorization_header=CORE_API_BEARER_AUTHORIZATION_HEADER,
         )
-
         device_id = {
             "hw_identifier": str(hw_identifier),
             "private_key": list(base64.b64decode(str(private_key))),
             "machine_identifier": response_data["identifier"],
         }
+
+        device_id_json = json.dumps(device_id)
+        log.debug("Device ID: %s", device_id_json)
+
         await connection.create_process(["mkdir", "-p", "/etc/teliod"]).execute()
         await connection.create_process(
-            ["sh", "-c", f"echo '{json.dumps(device_id)}' > /etc/teliod/data.json"]
+            ["sh", "-c", f"echo '{device_id_json}' > /etc/teliod/data.json"]
         ).execute()
 
         api = API()
-        api.register(
+        node: Node = api.register(
             "teliod",
             "teliod",
             str(private_key),
@@ -272,62 +126,50 @@ async def test_teliod_vpn_connection(use_manual_interface_setup: bool) -> None:
         )
         api.prepare_all_vpn_servers()
 
-        # we only know the key of the VPN server at runtime but need it to be in the config before starting teliod
-        server_pubkey = WG_SERVER["public_key"]
+        return node
+
+    async with AsyncExitStack() as exit_stack:
+        connection = (
+            await setup_connections(exit_stack, [ConnectionTag.DOCKER_CONE_CLIENT_1])
+        )[0].connection
+
+        teliod = Teliod(connection, exit_stack, config=Config(config_type))
+
+        node: Node = await register_new_device_on_api()
+
+        # we only know the key of the VPN server at runtime and it needs to be in the config before starting teliod
         await connection.create_process([
             "sed",
             "-i",
-            f's#"server_pubkey": .*#"server_pubkey": "{server_pubkey}"#g',
-            config_file_path,
+            f's#"server_pubkey": .*#"server_pubkey": "{WG_SERVER["public_key"]}"#g',
+            str(teliod.config.path()),
         ]).execute()
 
-        # Run teliod
-        start_params = [
-            TELIOD_EXEC_PATH,
-            "start",
-            config_file_path,
-        ]
-        await start_teliod(exit_stack, connection, start_params)
+        async with teliod.start():
+            log.debug("Teliod started, waiting for connected vpn state...")
+            await teliod.wait_for_vpn_connected_state()
 
-        # Check that we are connected to the VPN server
-        while True:
-            status = (
-                await connection.create_process(TELIOD_STATUS_PARAMS).execute()
-            ).get_stdout()
-            status_dict = json.loads(status)
-            is_connected = False
-            for node in status_dict["external_nodes"]:
-                if node["is_vpn"] and node["state"] == "connected":
-                    is_connected = True
-            if is_connected:
-                break
+            router = LinuxRouter(connection, IPStack.IPv4)
+            if config_type == IfcConfigType.VPN_MANUAL:
+                router.set_interface_name("teliod")
+                await router.setup_interface(node.ip_addresses)
+                await router.create_meshnet_route()
+                await router.create_vpn_route()
 
-        router = LinuxRouter(connection, IPStack.IPv4)
-        if use_manual_interface_setup:
-            router.set_interface_name("teliod")
-            await router.setup_interface(response_data["ip_addresses"])
-            await router.create_meshnet_route()
-            await router.create_vpn_route()
+            await ping(connection, PHOTO_ALBUM_IP)
+            ip = await stun.get(connection, STUN_SERVER)
+            assert (
+                ip == WG_SERVER["ipv4"]
+            ), f"wrong public IP when connected to VPN {ip}"
 
-        await ping(connection, PHOTO_ALBUM_IP)
-        ip = await stun.get(connection, STUN_SERVER)
-        assert ip == WG_SERVER["ipv4"], f"wrong public IP when connected to VPN {ip}"
+            if config_type == ConfigType.VPN_MANUAL:
+                await router.delete_vpn_route()
+                await router.delete_exit_node_route()
+                await router.delete_interface()
 
-        # Send SIGTERM to the daemon
-        await connection.create_process(
-            ["killall", "-w", "-s", "SIGTERM", "teliod"]
-        ).execute()
-
-        if use_manual_interface_setup:
-            await router.delete_vpn_route()
-            await router.delete_exit_node_route()
-            await router.delete_interface()
-
-        await connection.create_process([
-            "sed",
-            "-i",
-            's#"server_pubkey": .*#"server_pubkey": "public-key-placeholder"#g',
-            config_file_path,
-        ]).execute()
-
-        await wait_for_teliod_stop(connection)
+            await connection.create_process([
+                "sed",
+                "-i",
+                's#"server_pubkey": .*#"server_pubkey": "public-key-placeholder"#g',
+                str(teliod.config.path()),
+            ]).execute()

--- a/nat-lab/tests/test_teliod.py
+++ b/nat-lab/tests/test_teliod.py
@@ -15,6 +15,7 @@ from contextlib import AsyncExitStack
 from helpers import setup_connections, send_https_request
 from mesh_api import API, Node
 from teliod import Teliod, Config, IfcConfigType
+from test_core_api import clean_up_machines as clean_up_registered_machines_on_api
 from utils import stun
 from utils.connection import ConnectionTag
 from utils.logger import log
@@ -135,6 +136,7 @@ async def test_teliod_vpn_connection(config_type: IfcConfigType) -> None:
 
         teliod = Teliod(connection, exit_stack, config=Config(config_type))
 
+        await clean_up_registered_machines_on_api(connection, CORE_API_URL)
         node: Node = await register_new_device_on_api()
 
         # we only know the key of the VPN server at runtime and it needs to be in the config before starting teliod

--- a/nat-lab/tests/utils/router/linux_router.py
+++ b/nat-lab/tests/utils/router/linux_router.py
@@ -298,6 +298,8 @@ class LinuxRouter(Router):
             except ProcessExecError as exception:
                 if exception.stderr.find("No chain/target/match by that name") < 0:
                     raise exception
+                else:
+                    log.warn(exception.stderr)
 
         if self.ip_stack in [IPStack.IPv6, IPStack.IPv4v6]:
             try:
@@ -326,6 +328,8 @@ class LinuxRouter(Router):
                     < 0
                 ):
                     raise exception
+                else:
+                    log.warn(exception.stderr)
 
     @asynccontextmanager
     async def disable_path(self, address: str) -> AsyncIterator:

--- a/nat-lab/tests/utils/router/linux_router.py
+++ b/nat-lab/tests/utils/router/linux_router.py
@@ -3,6 +3,7 @@ from .router import Router, IPStack, IPProto, get_ip_address_type
 from contextlib import asynccontextmanager
 from typing import AsyncIterator, List
 from utils.connection import Connection
+from utils.logger import log
 from utils.process import ProcessExecError
 
 # An arbitrary routing table id. Must be unique on the system.
@@ -138,6 +139,7 @@ class LinuxRouter(Router):
                 except ProcessExecError as exception:
                     if exception.stderr.find("File exists") < 0:
                         raise exception
+                    log.warning(exception.stderr)
 
             await self._connection.create_process([
                 "ip",
@@ -176,6 +178,7 @@ class LinuxRouter(Router):
                 except ProcessExecError as exception:
                     if exception.stderr.find("File exists") < 0:
                         raise exception
+                    log.warning(exception.stderr)
 
             await self._connection.create_process([
                 "ip",
@@ -204,6 +207,7 @@ class LinuxRouter(Router):
         except ProcessExecError as exception:
             if exception.stderr.find("Cannot find device") < 0:
                 raise exception
+            log.warning(exception.stderr)
 
     async def delete_vpn_route(self):
         if self.ip_stack in [IPStack.IPv4, IPStack.IPv4v6]:
@@ -220,6 +224,7 @@ class LinuxRouter(Router):
                     < 0
                 ):
                     raise exception
+                log.warning(exception.stderr)
 
         if self.ip_stack in [IPStack.IPv6, IPStack.IPv4v6]:
             try:
@@ -235,6 +240,7 @@ class LinuxRouter(Router):
                     < 0
                 ):
                     raise exception
+                log.warning(exception.stderr)
 
     async def create_exit_node_route(self) -> None:
         if self.ip_stack in [IPStack.IPv4, IPStack.IPv4v6]:
@@ -298,8 +304,7 @@ class LinuxRouter(Router):
             except ProcessExecError as exception:
                 if exception.stderr.find("No chain/target/match by that name") < 0:
                     raise exception
-                else:
-                    log.warn(exception.stderr)
+                log.warning(exception.stderr)
 
         if self.ip_stack in [IPStack.IPv6, IPStack.IPv4v6]:
             try:
@@ -328,8 +333,7 @@ class LinuxRouter(Router):
                     < 0
                 ):
                     raise exception
-                else:
-                    log.warn(exception.stderr)
+                log.warning(exception.stderr)
 
     @asynccontextmanager
     async def disable_path(self, address: str) -> AsyncIterator:

--- a/nat-lab/uv.lock
+++ b/nat-lab/uv.lock
@@ -19,6 +19,15 @@ wheels = [
 ]
 
 [[package]]
+name = "aiofiles"
+version = "24.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/03/a88171e277e8caa88a4c77808c20ebb04ba74cc4681bf1e9416c862de237/aiofiles-24.1.0.tar.gz", hash = "sha256:22a075c9e5a3810f0c2e48f3008c94d68c65d763b9b03857924c99e57355166c", size = 30247 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/45/30bb92d442636f570cb5651bc661f52b610e2eec3f891a5dc3a4c3667db0/aiofiles-24.1.0-py3-none-any.whl", hash = "sha256:b4ec55f4195e3eb5d7abd1bf7e061763e864dd4954231fb8539a0ef8bb8260e5", size = 15896 },
+]
+
+[[package]]
 name = "aiohappyeyeballs"
 version = "2.4.3"
 source = { registry = "https://pypi.org/simple" }
@@ -757,6 +766,7 @@ version = "0.1"
 source = { virtual = "." }
 dependencies = [
     { name = "aiodocker" },
+    { name = "aiofiles" },
     { name = "aiohappyeyeballs" },
     { name = "aiohttp" },
     { name = "aiosignal" },
@@ -835,6 +845,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "aiodocker", specifier = "==0.23.0" },
+    { name = "aiofiles", specifier = ">=24.1.0" },
     { name = "aiohappyeyeballs", specifier = "==2.4.3" },
     { name = "aiohttp", specifier = "==3.10.2" },
     { name = "aiosignal", specifier = "==1.3.1" },


### PR DESCRIPTION
### Problem:
Teliod natlab tests contains significant boilerplate and duplicated logic for starting, stopping, and interacting with the teliod daemon.

### Solution:
This PR refactors the teliod test suite by introducing a dedicated abstraction (Teliod, Config, and supporting classes) which encapsulates all process management, configuration, daemon lifecycle, log handling, and socket logic.

It centralizes teliod test logic, reducing boilerplate, improving maintainability and preparing the suite for easier future extension.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
