### PR TITLE
allow trailing close in conntracker

### DIFF
--- a/nat-lab/tests/test_vpn.py
+++ b/nat-lab/tests/test_vpn.py
@@ -471,6 +471,7 @@ async def test_firewall_blacklist_tcp(ipv4: bool) -> None:
                     "telio-kill-blacklisted-connection",
                     FiveTuple(protocol="tcp", dst_ip=serv_ip, dst_port=serv_port),
                     [TcpState.FIN_WAIT, TcpState.LAST_ACK, TcpState.TIME_WAIT],
+                    trailing_state=TcpState.CLOSE,
                 )
             ],
         ).run() as conntrack:


### PR DESCRIPTION
### Problem
test_firewall_blacklist_tcp nat-lab test fails because TcpState CLOSE comes immediately after TIME_WAIT and we just check for last 3 events upto TIME_WAIT

### Solution
Add optional to check whether events above the last event match the event sequences.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
