### PR TITLE
Add mkdir and cd to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,12 @@ cargo build -p tcli
 
 You will need a lightweight Linux docker image with the some networking utilities,
 which are missing from the basic Ubuntu image, so let's create a new one.
-Make a `docker` directory in `tcli-test` and put there the following simple Dockerfile:
+Make a `docker` directory in `tcli-test`:
+```shell
+mkdir -p tcli-test/docker
+cd tcli-test/docker
+```
+and put there the following simple Dockerfile:
 ```
 FROM ubuntu
 


### PR DESCRIPTION
### Problem
As a first time user while following README.md I was looking for a directory `tcli-test` in which I was supposed to create `docker` subfolder inside, but the `tcli-test` directory also has to be created.

### Solution
Make the README.md super clear about making both directories.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
