### PR TITLE
build: Stop removing moose cargo feature from lana manifest

### DIFF
--- a/ci/moose_utils.py
+++ b/ci/moose_utils.py
@@ -192,14 +192,3 @@ def unset_cargo_dependencies():
             _write_file(
                 f"{PROJECT_ROOT}/crates/telio-lana/Cargo.toml", lana_cargo_contents
             )
-        if "moose" in lana_cargo_contents:
-            empty_features = re.search(r"\[features\]\nmo", lana_cargo_contents)
-            if empty_features:
-                lana_cargo_contents = re.sub(
-                    r"\n\[features\]\nmoose = \[\]\n", "", lana_cargo_contents
-                )
-            else:
-                lana_cargo_contents = re.sub(r"\nmoose.*\n", "\n", lana_cargo_contents)
-            _write_file(
-                f"{PROJECT_ROOT}/crates/telio-lana/Cargo.toml", lana_cargo_contents
-            )


### PR DESCRIPTION
In the past build scripts were manipulating manifest files when adding or removing the moose analytics libtelio feature.

Since https://github.com/NordSecurity/libtelio/pull/1165 `moose` cargo feature is required to always exist, therefore the scripts should not touch it anymore and actually keep it regardless of whether libmoose is included or not in the libtelio build.

This PR removes that feature from the scripts.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
