### PR TITLE
Fix log typo

### DIFF
--- a/crates/telio-utils/src/tokio.rs
+++ b/crates/telio-utils/src/tokio.rs
@@ -43,7 +43,7 @@ impl ThreadTracker {
         {
             let delta = now - thread_last_status_change;
             if status == ThreadStatus::Parked && delta > UNPARKED_THRESHOLD {
-                telio_log_debug!("Thread {tid:?} was unparked for too long: {delta:?}");
+                telio_log_debug!("Thread {tid:?} was parked for too long: {delta:?}");
             }
         }
     }


### PR DESCRIPTION
### Problem
The log line prints unparked, whereas status above is checking whether thread was parked.

### Solution
Change logging from "unparked" to "parked"


### :ballot_box_with_check: Definition of Done checklist
- [ ] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [ ] README.md is updated
- [ ] Functionality is covered by unit or integration tests
