### PR TITLE
[LLT-6406] Teliod is not registering device on core api

### DIFF
--- a/clis/teliod/src/config.rs
+++ b/clis/teliod/src/config.rs
@@ -64,7 +64,7 @@ fn reconnect_after_expiry_default() -> Percentage {
     Percentage(90)
 }
 
-#[derive(PartialEq, Eq, Debug, Clone)]
+#[derive(Default, PartialEq, Eq, Debug, Clone)]
 pub struct NordToken(Arc<Hidden<String>>);
 
 impl NordToken {
@@ -81,13 +81,7 @@ impl NordToken {
     }
 
     fn validate(token: &str) -> bool {
-        token.is_empty() || (token.len() == 64 && token.chars().all(|c| c.is_ascii_hexdigit()))
-    }
-}
-
-impl Default for NordToken {
-    fn default() -> Self {
-        NordToken(Arc::new(Hidden("".to_owned())))
+        token.len() == 64 && token.chars().all(|c| c.is_ascii_hexdigit())
     }
 }
 

--- a/clis/teliod/src/daemon.rs
+++ b/clis/teliod/src/daemon.rs
@@ -2,7 +2,6 @@ use futures::pin_mut;
 use futures::stream::StreamExt;
 use nix::libc::{SIGHUP, SIGINT, SIGQUIT, SIGTERM};
 use nix::sys::signal::Signal;
-use reqwest::StatusCode;
 use signal_hook_tokio::Signals;
 use std::net::SocketAddr;
 use std::path::PathBuf;
@@ -26,10 +25,7 @@ use crate::{
     command_listener::CommandListener,
     comms::DaemonSocket,
     config::{NordToken, TeliodDaemonConfig, VpnConfig},
-    core_api::{
-        get_meshmap, init_with_api, DeviceIdentity,
-        Error as CoreApiError,
-    },
+    core_api::{get_meshmap, sync_device_identity, DeviceIdentity},
     nc::NotificationCenter,
     ClientCmd, ExitNodeStatus, TelioStatusReport, TeliodError,
 };
@@ -312,13 +308,7 @@ async fn daemon_init(
     // This is to not look for tokens in a test environment right now as the values
     // are dummy and program will not run as it expects real tokens.
     let identity = Arc::new(if *config.authentication_token != *EMPTY_TOKEN {
-        match Box::pin(init_with_api(&config)).await {
-            Err(CoreApiError::UpdateMachine(StatusCode::NOT_FOUND)) => {
-                debug!("Machine not found, removing cached identity file and trying again..");
-                DeviceIdentity::remove_file();
-
-                Box::pin(init_with_api(&config)).await?
-            }
+        match Box::pin(sync_device_identity(&config)).await {
             Ok(identity) => identity,
             Err(e) => return Err(e.into()),
         }

--- a/nat-lab/data/teliod/config.json
+++ b/nat-lab/data/teliod/config.json
@@ -2,8 +2,9 @@
     "log_level": "trace",
     "log_file_path": "/var/log/teliod_natlab.log",
     "log_file_count": 0,
-    "authentication_token": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "authentication_token": "48e9ef50178a68a716e38a9f9cd251e8be35e79a5c5f91464e92920425caa3d9",
     "adapter_type": "neptun",
+    "http_certificate_file_path": "/etc/ssl/server_certificate/test.pem",
     "interface": {
       "name": "teliod",
       "config_provider": "manual"

--- a/nat-lab/data/teliod/config_with_vpn_iproute_without_id_file.json
+++ b/nat-lab/data/teliod/config_with_vpn_iproute_without_id_file.json
@@ -1,0 +1,16 @@
+{
+  "log_level": "trace",
+  "log_file_path": "/var/log/teliod_natlab.log",
+  "log_file_count": 0,
+  "authentication_token": "48e9ef50178a68a716e38a9f9cd251e8be35e79a5c5f91464e92920425caa3d9",
+  "adapter_type": "neptun",
+  "http_certificate_file_path": "/etc/ssl/server_certificate/test.pem",
+  "interface": {
+    "name": "teliod",
+    "config_provider": "iproute"
+  },
+  "vpn": {
+    "server_endpoint": "10.0.100.1:1023",
+    "server_pubkey": "public-key-placeholder"
+  }
+}

--- a/nat-lab/tests/test_teliod.py
+++ b/nat-lab/tests/test_teliod.py
@@ -1,32 +1,13 @@
-import base64
-import json
-import platform
 import pytest
-import uuid
-from config import (
-    WG_SERVER,
-    PHOTO_ALBUM_IP,
-    STUN_SERVER,
-    CORE_API_URL,
-    CORE_API_CA_CERTIFICATE_PATH,
-    CORE_API_BEARER_AUTHORIZATION_HEADER,
-)
+from config import PHOTO_ALBUM_IP, STUN_SERVER, WG_SERVER
 from contextlib import AsyncExitStack
-from helpers import setup_connections, send_https_request
-from mesh_api import API, Node
+from helpers import setup_connections
 from teliod import Teliod, Config, IfcConfigType
-from test_core_api import clean_up_machines as clean_up_registered_machines_on_api
 from utils import stun
 from utils.connection import ConnectionTag
 from utils.logger import log
 from utils.ping import ping
 from utils.process.process import ProcessExecError
-from utils.router import IPStack
-
-if platform.machine() != "x86_64":
-    import pure_wg as Key
-else:
-    from python_wireguard import Key  # type: ignore
 
 
 @pytest.mark.parametrize(
@@ -83,68 +64,9 @@ async def test_teliod_logs() -> None:
     [(IfcConfigType.VPN_MANUAL), (IfcConfigType.VPN_IPROUTE)],
 )
 async def test_teliod_vpn_connection(config_type: IfcConfigType) -> None:
-    async def register_new_device_on_api():
-        (private_key, public_key) = Key.key_pair()
-        hw_identifier = uuid.uuid4()
-        payload = {
-            "public_key": str(public_key),
-            "hardware_identifier": str(hw_identifier),
-            "os": "linux",
-            "os_version": "teliod",
-        }
-        response_data = await send_https_request(
-            connection,
-            f"{CORE_API_URL}/v1/meshnet/machines",
-            "POST",
-            CORE_API_CA_CERTIFICATE_PATH,
-            data=str(payload).replace("'", '"'),
-            authorization_header=CORE_API_BEARER_AUTHORIZATION_HEADER,
-        )
-        device_id = {
-            "hw_identifier": str(hw_identifier),
-            "private_key": list(base64.b64decode(str(private_key))),
-            "machine_identifier": response_data["identifier"],
-        }
-
-        device_id_json = json.dumps(device_id)
-        log.debug("Device ID: %s", device_id_json)
-
-        await connection.create_process(["mkdir", "-p", "/etc/teliod"]).execute()
-        await connection.create_process(
-            ["sh", "-c", f"echo '{device_id_json}' > /etc/teliod/data.json"]
-        ).execute()
-
-        api = API()
-        node: Node = api.register(
-            "teliod",
-            "teliod",
-            str(private_key),
-            str(public_key),
-            True,
-            IPStack.IPv4,
-            response_data["ip_addresses"],
-        )
-        api.prepare_all_vpn_servers()
-
-        return node
-
     async with AsyncExitStack() as exit_stack:
-        connection = (
-            await setup_connections(exit_stack, [ConnectionTag.DOCKER_CONE_CLIENT_1])
-        )[0].connection
-
-        teliod = Teliod(connection, exit_stack, config=Config(config_type))
-
-        await clean_up_registered_machines_on_api(connection, CORE_API_URL)
-        node: Node = await register_new_device_on_api()
-
-        # we only know the key of the VPN server at runtime and it needs to be in the config before starting teliod
-        await connection.create_process([
-            "sed",
-            "-i",
-            f's#"server_pubkey": .*#"server_pubkey": "{WG_SERVER["public_key"]}"#g',
-            str(teliod.config.path()),
-        ]).execute()
+        teliod = await Teliod.new(exit_stack, config_type)
+        node, _ = await teliod.register_device_on_core()
 
         async with teliod.start():
             log.debug("Teliod started, waiting for connected vpn state...")
@@ -155,15 +77,8 @@ async def test_teliod_vpn_connection(config_type: IfcConfigType) -> None:
                     teliod.setup_interface(node.ip_addresses, vpn_routes=True)
                 )
 
-            await ping(connection, PHOTO_ALBUM_IP)
-            ip = await stun.get(connection, STUN_SERVER)
+            await ping(teliod.connection, PHOTO_ALBUM_IP)
+            ip = await stun.get(teliod.connection, STUN_SERVER)
             assert (
                 ip == WG_SERVER["ipv4"]
             ), f"wrong public IP when connected to VPN {ip}"
-
-            await connection.create_process([
-                "sed",
-                "-i",
-                's#"server_pubkey": .*#"server_pubkey": "public-key-placeholder"#g',
-                str(teliod.config.path()),
-            ]).execute()


### PR DESCRIPTION
### Problem
While writing tests for the teliod identity file management on https://github.com/NordSecurity/libtelio/pull/1322, there were a few issues found on the identity file logic:
1. Returned status code from API evaluation was checking for specific error instead of HTTP success codes (2xx).
2. According to the documentation, API HTTP errors should be handled with wether they are classified as terminal or not.
3. The identity file state machine from the teliod::core_api module was trivially fetching the machine attributes from the API right after generating new keys and hardware identifier.

Besides the issues mentioned above, tests were also non-existent for this identity file component of the core_api module.

### Solution
This PR adds integration tests for the identity file management functionality of the teliod::core_api module, and tackles the issues mentioned before by:
1. Checking for HTTP success codes
2. Add HTTP status code handling as described in the requirements of the documentation (LLT-5553)*.
3. Adds identity files specific functions to the core_api module that address the state machine and refactor the logic so it follows the documentation (LLT-5553*).

Tests are also added to cover https://github.com/NordSecurity/libtelio/pull/1322 and the identity file management logic that was touched in this PR.

*Besides LLT-5553, LLT-5410 can also be worthwhile taking a look.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
