### PR TITLE
[LLT-6509] Add self-signed certificate to OpenWrt container

### DIFF
--- a/nat-lab/docker-compose.yml
+++ b/nat-lab/docker-compose.yml
@@ -507,6 +507,8 @@ services:
     dns:
       - 10.0.80.82
       - 10.0.80.83
+    volumes:
+      - ./data/core_api/test.pem:/etc/ssl/certs/test.pem
 
   ###########################################################
   #                       MISC SERVERS                      #

--- a/nat-lab/openwrt.Dockerfile
+++ b/nat-lab/openwrt.Dockerfile
@@ -1,5 +1,5 @@
 FROM openwrt/rootfs:x86-64-v24.10.2
 
-RUN mkdir -p /var/lock && opkg update && opkg install kmod-wireguard && opkg install kmod-tun
+RUN mkdir -p /var/lock && opkg update && opkg install kmod-wireguard kmod-tun curl ca-bundle ca-certificates
 
 COPY --chmod=0755 bin/ /opt/bin/


### PR DESCRIPTION
### Problem
To be able to make https requests to nat-lab's core api the self-signed certificate should be available in OpenWrt GW container

### Solution
1. Add core-api's `test.pem` certificate to OpenWrt container

Later on the daemon can be started with config which points to certificate location (tested and it works):
```
{
  "log_level": "trace",
   ....
  "http_certificate_file_path": "/etc/ssl/certs/test.pem",
   ....
}
```



### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
