### PR TITLE
Return http status CREATED in nat-lab register machine api

### DIFF
--- a/nat-lab/bin/core-api.py
+++ b/nat-lab/bin/core-api.py
@@ -303,7 +303,7 @@ class CoreApiHandler(BaseHTTPRequestHandler):
 
         req = MachineCreateRequest(**json_obj)
         node = self.add_node(req)
-        self._write_response(asdict(node))
+        self._write_response(asdict(node), HTTPStatus.CREATED)
 
     def add_node(self, req):
         uid = self.server.next_id()


### PR DESCRIPTION
### Problem
Currently in register machine api (in nat-lab core-api) the `HTTPStatus.OK` is returned instead of `HTTPStatus.CREATED`

### Solution
1. Return `HTTPStatus.CREATED` for `POST /v1/meshnet/machines` in nat-lab core-api




### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
