### PR TITLE
[LLT-6515] Install openwrt vpn package during image creation process

### DIFF
--- a/nat-lab/bin/openwrt_docker_entrypoint.sh
+++ b/nat-lab/bin/openwrt_docker_entrypoint.sh
@@ -4,4 +4,6 @@ set -e
 opkg --version
 uname -a
 
+touch /ready
+
 exec sleep infinity

--- a/nat-lab/bin/openwrt_docker_entrypoint.sh
+++ b/nat-lab/bin/openwrt_docker_entrypoint.sh
@@ -4,6 +4,4 @@ set -e
 opkg --version
 uname -a
 
-opkg install /opt/bin/nordvpn_*_x86_64.ipk
-
 exec sleep infinity

--- a/nat-lab/docker-compose.yml
+++ b/nat-lab/docker-compose.yml
@@ -509,6 +509,8 @@ services:
       - 10.0.80.83
     volumes:
       - ./data/core_api/test.pem:/etc/ssl/certs/test.pem
+    healthcheck:
+      test: "ls /ready"
 
   ###########################################################
   #                       MISC SERVERS                      #

--- a/nat-lab/openwrt.Dockerfile
+++ b/nat-lab/openwrt.Dockerfile
@@ -1,5 +1,7 @@
 FROM openwrt/rootfs:x86-64-v24.10.2
 
-RUN mkdir -p /var/lock && opkg update && opkg install kmod-wireguard kmod-tun curl ca-bundle ca-certificates
+RUN mkdir -p /var/lock && opkg update && opkg install curl ca-bundle ca-certificates
 
 COPY --chmod=0755 bin/ /opt/bin/
+
+RUN opkg install /opt/bin/nordvpn_*_x86_64.ipk


### PR DESCRIPTION
### Problem
We must ensure that all dependencies specified in the Makefile are properly installed. Pre-installing them bypasses the standard installation process. 


### Solution
Install vpn package during image creation process so that all dependencies can be correctly downloaded (in docker entrypoint there is no access to public internet)


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
