### PR TITLE
Align our proto definition with latest one from RFC

### DIFF
--- a/crates/telio-proto/protos/ens.proto
+++ b/crates/telio-proto/protos/ens.proto
@@ -10,21 +10,23 @@ enum Error {
     Superseded = 4;
 }
 
+message ConnectionErrorRequest {}
+
 message ConnectionError {
     Error code = 1;
     optional string additional_info = 2;
 }
 
-message Empty {}
+message ChallengeRequest {}
 
 message Challenge {
     string challenge = 1;
 }
 
 service Login {
-    rpc GetChallenge(Empty) returns (Challenge);
+    rpc GetChallenge(ChallengeRequest) returns (Challenge);
 }
 
 service ENS {
-    rpc ConnectionErrors(Empty) returns (stream ConnectionError);
+    rpc ConnectionErrors(ConnectionErrorRequest) returns (stream ConnectionError);
 }


### PR DESCRIPTION
Small changes have been made to the proto definition. Instead of using one common `Empty` type, distinct types are used to make it easy in the future to change them.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
