### PR TITLE
LLT-6538: Ignore 'Connection reset by peer' during is-alive call during teliod test start

### DIFF
--- a/nat-lab/tests/teliod.py
+++ b/nat-lab/tests/teliod.py
@@ -206,6 +206,8 @@ class Teliod:
                 raise TeliodObtainingIdentity() from exc
             if "Error: DaemonIsNotRunning" in exc.stderr:
                 return False
+            if "Connection reset by peer" in exc.stderr:
+                return False
             raise exc
 
     async def get_status(self) -> str:


### PR DESCRIPTION
### Problem
We've had teliod tests fail because the `is-alive` call failed with error `Connection reset by peer`. We suspect this is a race condition that can be ignored. Ignored here meaning that since we are checking `is-alive` in a loop until we get `True`, the aforementioned error would mean `is-alive: False`

### Solution
Continue looping `is-alive` if getting error `Connection reset by peer`
