### PR TITLE
Accept LIBTELIO_VERSION env variable for version_tag

### DIFF
--- a/crates/telio-utils/src/git.rs
+++ b/crates/telio-utils/src/git.rs
@@ -9,12 +9,16 @@ pub fn commit_sha() -> &'static str {
 #[inline(never)]
 #[allow(index_access_check)]
 pub fn version_tag() -> &'static str {
-    const VER: [u8;129] = *b"VERSION_PLACEHOLDER@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@\0";
-    match VER.iter().position(|v| *v == 0) {
-        Some(i) => match std::str::from_utf8(&VER[..i]) {
-            Ok(s) => s,
-            Err(_) => "not_a_utf8_string",
-        },
-        None => "incorrect_version_string",
+    if let Some(ver) = option_env!("LIBTELIO_VERSION") {
+        ver
+    } else {
+        const VER: [u8;129] = *b"VERSION_PLACEHOLDER@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@\0";
+        match VER.iter().position(|v| *v == 0) {
+            Some(i) => match std::str::from_utf8(&VER[..i]) {
+                Ok(s) => s,
+                Err(_) => "not_a_utf8_string",
+            },
+            None => "incorrect_version_string",
+        }
     }
 }


### PR DESCRIPTION
Libtelio build process assumes build promotion.

However, for teliod, the build process might be different, for example OpenWRT uses it's own SDK and then produces a package file and it might not be very easy to tap into it to replace the intermediate binary before packing.

As a cheap solution, in order to support version placement in the binary for such cases, an environment option is read and if found then used.

### Problem
*--describe problem being solved--*

### Solution
*--describe selected solution--*


### :ballot_box_with_check: Definition of Done checklist
- [ ] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [ ] README.md is updated
- [ ] Functionality is covered by unit or integration tests
