### PR TITLE
LLT-6211: Connect to VPN by country

### DIFF
--- a/clis/teliod/README.md
+++ b/clis/teliod/README.md
@@ -71,9 +71,11 @@ needs be absolute, otherwise will be relative to `working-directory` when daemon
     - `ifconfig` - systems using ifconfig command
     - `iproute` - systems using iproute2 command
     - `uci` - OpenWRT systems using uci command
-  - `vpn` - optional vpn config. If omitted, a VPN connection will not be established
-    - `server_endpoint` - The endpoint (ip:port) of the server/endpoint to connect to
-    - `server_pubkey` - The public key of the server/peer to connect to
+- `vpn` - VPN config type. If omitted, a VPN connection will not be established, please select only one. Possible options:
+  - `server` - manually specified endpoint:
+    - `address` - The IP address of the server/endpoint to connect to
+    - `public_key` - The public key of the server/peer to connect to
+  - `country` - Full country name or ISO A2 code, of the desired VPN server location.
 
 And following cli commands:
 

--- a/clis/teliod/example_teliod_config.json
+++ b/clis/teliod/example_teliod_config.json
@@ -7,5 +7,8 @@
     "interface": {
       "name": "utun10",
       "config_provider": "manual"
+    },
+    "vpn": {
+      "country": "de"
     }
 }

--- a/clis/teliod/src/cgi/api.rs
+++ b/clis/teliod/src/cgi/api.rs
@@ -430,6 +430,7 @@ mod tests {
                 config_provider: InterfaceConfigurationProvider::Manual,
             },
             vpn: None,
+            override_default_wg_port: None,
             authentication_token: NordToken::new(
                 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
             )
@@ -540,6 +541,7 @@ mod tests {
                 config_provider: InterfaceConfigurationProvider::Manual,
             },
             vpn: None,
+            override_default_wg_port: None,
             authentication_token: NordToken::new(
                 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
             )

--- a/clis/teliod/src/core_api.rs
+++ b/clis/teliod/src/core_api.rs
@@ -128,6 +128,7 @@ impl Country {
 #[derive(Debug, PartialEq, Deserialize)]
 pub struct Server {
     station: IpAddr,
+    hostname: Option<String>,
     technologies: Vec<Technology>,
 }
 
@@ -149,6 +150,11 @@ impl Server {
     /// Get IP address of server
     pub fn address(&self) -> IpAddr {
         self.station
+    }
+
+    /// Get hostname of VPN server
+    pub fn hostname(&self) -> Option<String> {
+        self.hostname.to_owned()
     }
 
     /// Get public_key of wireguard service
@@ -878,5 +884,6 @@ mod tests {
                 .parse()
                 .unwrap()
         );
+        assert_eq!(exit_node.hostname, Some("test100.domain.com".to_string()));
     }
 }

--- a/clis/teliod/src/daemon.rs
+++ b/clis/teliod/src/daemon.rs
@@ -25,10 +25,12 @@ use tracing::{debug, error, info, trace, warn};
 use crate::{
     command_listener::CommandListener,
     comms::DaemonSocket,
-    config::{NordToken, TeliodDaemonConfig, VpnConfig},
+    config::{DirectEndpointConfig, NordToken, TeliodDaemonConfig, VpnConfig},
     core_api::{
-        get_meshmap as get_meshmap_from_server, init_with_api, DeviceIdentity,
-        Error as CoreApiError,
+        get_countries_with_exp_backoff as get_countries_from_server,
+        get_meshmap as get_meshmap_from_server,
+        get_recommended_servers_with_exp_backoff as get_recommended_servers, init_with_api,
+        DeviceIdentity, Error as CoreApiError, Server as CoreApiServer,
     },
     nc::NotificationCenter,
     ClientCmd, ExitNodeStatus, TelioStatusReport, TeliodError,
@@ -36,14 +38,14 @@ use crate::{
 
 #[derive(Debug)]
 pub enum TelioTaskCmd {
-    // Command to set the downloaded meshmap to telio instance
+    /// Command to set the downloaded meshmap to telio instance
     UpdateMeshmap(MeshMap),
-    // Get telio status
+    /// Get telio status
     GetStatus(oneshot::Sender<TelioStatusReport>),
-    // Configure the system interface
+    /// Configure the system interface
     SetIp(IpAddr),
-    // Connect to exit node with IP and public key
-    ConnectToExitNode(SocketAddr, PublicKey),
+    /// Connect to exit node with IP and public key
+    ConnectToExitNode(ExitNodeConfig),
     /// Check if connected to VPN server and if so, setup device routing
     MaybeSetupVPNRoutes(IpAddr, PublicKey),
     // Break the receive loop to quit the daemon and exit gracefully
@@ -51,10 +53,43 @@ pub enum TelioTaskCmd {
 }
 
 const EMPTY_TOKEN: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const DEFAULT_WIREGUARD_PORT: u16 = 51820;
 
 #[derive(Debug, Default)]
 pub struct TelioTaskStates {
     interface_ip_address: Option<IpAddr>,
+}
+
+/// Endpoint configuration used for connection
+#[derive(PartialEq, Eq, Clone, Debug)]
+pub struct ExitNodeConfig {
+    /// IP of ExitNode server
+    pub address: IpAddr,
+    /// Public key of ExitNode
+    pub public_key: PublicKey,
+}
+
+impl ExitNodeConfig {
+    /// Convert Server from API response to ExitNode endpoint configuration
+    pub fn from_api(server: &CoreApiServer) -> Result<Self, TeliodError> {
+        Ok(Self {
+            address: server.address(),
+            public_key: server
+                .wg_public_key()
+                .and_then(|key| key.parse().ok())
+                .ok_or(TeliodError::EndpointNoPublicKey)?,
+        })
+    }
+}
+
+/// Convert DirectEndpointConfig specified manually to ExitNode configuration
+impl From<DirectEndpointConfig> for ExitNodeConfig {
+    fn from(server: DirectEndpointConfig) -> Self {
+        Self {
+            address: server.address,
+            public_key: server.public_key,
+        }
+    }
 }
 
 // From async context Telio needs to be run in separate task
@@ -78,17 +113,13 @@ fn telio_task(
         None,
     )?;
 
-    // Keep track of current meshnet states
+    // Keep track of current states
     let mut state = TelioTaskStates::default();
     let mut sys_config = config
         .interface
         .config_provider
         .create(config.interface.name.clone());
 
-    // TODO: This is temporary to be removed later on when we have proper integration
-    // tests with core API. This is to not look for tokens in a test environment
-    // right now as the values are dummy and program will not run as it expects
-    // real tokens.
     if !config.authentication_token.is_empty() {
         start_telio(
             &mut telio,
@@ -148,18 +179,33 @@ fn telio_task(
                     // update the interface only if the address is new
                     if state.interface_ip_address != Some(new_ip_address) {
                         state.interface_ip_address = Some(new_ip_address);
-                        _ = sys_config
-                            .set_ip(&new_ip_address)
-                            .inspect_err(|e| error!("Failed to set IP with error '{e:?}'"));
-                        task_connect_to_exit_node(config.vpn, tx_channel.clone());
+                        match sys_config.set_ip(&new_ip_address) {
+                            Ok(_) => {
+                                if let Some(vpn_config) = config.vpn.as_ref() {
+                                    handle_exit_node_connection(
+                                        vpn_config.clone(),
+                                        tx_channel.clone(),
+                                        config.http_certificate_file_path.clone(),
+                                        config.authentication_token.clone(),
+                                    );
+                                }
+                            }
+                            Err(e) => {
+                                error!("Failed to set IP with error '{e:?}'");
+                            }
+                        }
                     }
                 }
-                TelioTaskCmd::ConnectToExitNode(ip, pubkey) => {
+                TelioTaskCmd::ConnectToExitNode(server) => {
+                    let port = config
+                        .override_default_wg_port
+                        .unwrap_or(DEFAULT_WIREGUARD_PORT);
+
                     let node = ExitNode {
                         identifier: uuid::Uuid::new_v4().to_string(),
-                        public_key: pubkey,
+                        public_key: server.public_key,
                         allowed_ips: None,
-                        endpoint: Some(ip),
+                        endpoint: Some(SocketAddr::new(server.address, port)),
                     };
                     match telio.connect_exit_node(&node) {
                         Ok(_) => {
@@ -167,7 +213,11 @@ fn telio_task(
                             // which could take some amount of time, yet we don't want to block the event loop
                             // this task checks the connection status and if connected sets up routing information
                             // otherwise it sleeps and tries again
-                            task_maybe_setup_vpn_routes(tx_channel.clone(), ip.ip(), pubkey);
+                            task_maybe_setup_vpn_routes(
+                                tx_channel.clone(),
+                                server.address,
+                                server.public_key,
+                            );
                         }
                         Err(e) => {
                             error!("Failed to connect to VPN with error: {e:?}");
@@ -213,6 +263,79 @@ fn telio_task(
     Ok(())
 }
 
+/// Handles establishing a connection to a VPN exit node based on the given configuration.
+///
+/// If a specific server is provided, it uses that directly.
+/// If a country is provided, it queries the API to find a recommended server.
+/// Sends a `ConnectToExitNode` command via the provided channel on success.
+#[allow(mpsc_blocking_send)]
+fn handle_exit_node_connection(
+    vpn_config: VpnConfig,
+    tx_channel: mpsc::Sender<TelioTaskCmd>,
+    cert_path: Option<PathBuf>,
+    auth_token: NordToken,
+) {
+    tokio::spawn(async move {
+        let server = match vpn_config {
+            // Use the server directly if provided in the config
+            VpnConfig::Server(server) => Some(server.into()),
+            // Find VPN exit node based on country
+            VpnConfig::Country(target_country) => {
+                // Fetch the list of countries to find the matching country ID
+                let country_id = match get_countries_from_server(&auth_token, &cert_path).await {
+                    Ok(countries_list) => countries_list.iter().find_map(|country| {
+                        if country.matches(&target_country) {
+                            Some(country.id)
+                        } else {
+                            None
+                        }
+                    }),
+                    Err(e) => {
+                        error!("Getting countries failed due to: {e}");
+                        None
+                    }
+                };
+                if country_id.is_none() {
+                    warn!("country_id not found for: {target_country}");
+                }
+
+                // Fetch the list of recommended server from the API
+                // if no country_id is found, as a fallback the API will still return a
+                // recommended server based on other metrics
+                match get_recommended_servers(country_id, Some(1), &auth_token, &cert_path).await {
+                    Ok(servers) => {
+                        // TODO: LLT-6460 - We can store the recommended server list, just in case
+                        // one server fails to connect, try the next one.
+                        trace!("Servers {:#?}", servers);
+                        let server = servers
+                            .first()
+                            // Override the default wg port, since it's not fetched by the API
+                            .and_then(|server| ExitNodeConfig::from_api(server).ok());
+                        server
+                    }
+                    Err(e) => {
+                        error!("Getting recommended servers failed due to: {e}");
+                        None
+                    }
+                }
+            }
+        };
+
+        debug!("Selected exit node: {:#?}", server);
+        if let Some(server) = server {
+            // Send the command to initiate the VPN connection
+            if let Err(e) = tx_channel
+                .send(TelioTaskCmd::ConnectToExitNode(server))
+                .await
+            {
+                error!("Faild to send connect to exit node command: {e}");
+            }
+        } else {
+            warn!("No exit node found");
+        }
+    });
+}
+
 fn task_retrieve_meshmap(
     device_identity: Arc<DeviceIdentity>,
     cert_path: Option<PathBuf>,
@@ -239,28 +362,6 @@ fn task_set_ip(address: IpAddr, tx: mpsc::Sender<TelioTaskCmd>) {
         #[allow(mpsc_blocking_send)]
         if let Err(e) = tx.send(TelioTaskCmd::SetIp(address)).await {
             error!("Unable to send command due to {e}");
-        }
-    });
-}
-
-fn task_connect_to_exit_node(
-    vpn_config: Option<VpnConfig>,
-    tx_channel: mpsc::Sender<TelioTaskCmd>,
-) {
-    tokio::spawn(async move {
-        #[allow(mpsc_blocking_send)]
-        if let Some(VpnConfig {
-            server_endpoint,
-            server_pubkey,
-        }) = vpn_config
-        {
-            _ = tx_channel
-                .send(TelioTaskCmd::ConnectToExitNode(
-                    server_endpoint,
-                    server_pubkey,
-                ))
-                .await
-                .inspect_err(|e| error!("Failed to send connect to exit node event: {e:?}"));
         }
     });
 }

--- a/clis/teliod/src/main.rs
+++ b/clis/teliod/src/main.rs
@@ -133,6 +133,8 @@ enum TeliodError {
     IpRule,
     #[error("Could not configure IP routing")]
     IpRoute,
+    #[error("Endpoint has no PublicKey")]
+    EndpointNoPublicKey,
 }
 
 /// Libtelio and meshnet status report

--- a/clis/teliod/src/main.rs
+++ b/clis/teliod/src/main.rs
@@ -157,6 +157,8 @@ pub struct ExitNodeStatus {
     pub identifier: String,
     /// The public key of the exit node
     pub public_key: PublicKey,
+    /// Hostname of the node
+    pub hostname: Option<String>,
     /// Socket address of the Exit Node
     pub endpoint: Option<SocketAddr>,
     /// State of the node (Connecting, connected, or disconnected)
@@ -170,6 +172,7 @@ impl From<&Node> for ExitNodeStatus {
             public_key: value.public_key,
             state: value.state,
             endpoint: value.endpoint,
+            hostname: value.hostname.to_owned(),
         }
     }
 }

--- a/nat-lab/data/teliod/config_with_vpn_country_de.json
+++ b/nat-lab/data/teliod/config_with_vpn_country_de.json
@@ -1,0 +1,17 @@
+{
+  "log_level": "trace",
+  "log_file_path": "/var/log/teliod_natlab.log",
+  "log_file_count": 0,
+  "authentication_token": "48e9ef50178a68a716e38a9f9cd251e8be35e79a5c5f91464e92920425caa3d9",
+  "adapter_type": "neptun",
+  "http_certificate_file_path": "/etc/ssl/server_certificate/test.pem",
+  "device_identity_file_path": "/etc/teliod/data.json",
+  "interface": {
+    "name": "teliod",
+    "config_provider": "iproute"
+  },
+  "vpn": {
+    "country": "de"
+  },
+  "override_default_wg_port": 1023
+}

--- a/nat-lab/data/teliod/config_with_vpn_country_pl.json
+++ b/nat-lab/data/teliod/config_with_vpn_country_pl.json
@@ -1,0 +1,17 @@
+{
+  "log_level": "trace",
+  "log_file_path": "/var/log/teliod_natlab.log",
+  "log_file_count": 0,
+  "authentication_token": "48e9ef50178a68a716e38a9f9cd251e8be35e79a5c5f91464e92920425caa3d9",
+  "adapter_type": "neptun",
+  "http_certificate_file_path": "/etc/ssl/server_certificate/test.pem",
+  "device_identity_file_path": "/etc/teliod/data.json",
+  "interface": {
+    "name": "teliod",
+    "config_provider": "iproute"
+  },
+  "vpn": {
+    "country": "pl"
+  },
+  "override_default_wg_port": 1023
+}

--- a/nat-lab/data/teliod/config_with_vpn_iproute_setup.json
+++ b/nat-lab/data/teliod/config_with_vpn_iproute_setup.json
@@ -11,7 +11,10 @@
     "config_provider": "iproute"
   },
   "vpn": {
-    "server_endpoint": "10.0.100.1:1023",
-    "server_pubkey": "public-key-placeholder"
-  }
+    "server": {
+      "address": "10.0.100.1",
+      "public_key": "public-key-placeholder"
+    }
+  },
+  "override_default_wg_port": 1023
 }

--- a/nat-lab/data/teliod/config_with_vpn_manual_setup.json
+++ b/nat-lab/data/teliod/config_with_vpn_manual_setup.json
@@ -11,7 +11,10 @@
     "config_provider": "manual"
   },
   "vpn": {
-    "server_endpoint": "10.0.100.1:1023",
-    "server_pubkey": "public-key-placeholder"
-  }
+    "server": {
+      "address": "10.0.100.1",
+      "public_key": "public-key-placeholder"
+    }
+  },
+  "override_default_wg_port": 1023
 }

--- a/nat-lab/tests/teliod.py
+++ b/nat-lab/tests/teliod.py
@@ -24,6 +24,8 @@ class IfcConfigType(Enum):
     DEFAULT = "config.json"
     VPN_MANUAL = "config_with_vpn_manual_setup.json"
     VPN_IPROUTE = "config_with_vpn_iproute_setup.json"
+    VPN_COUNTRY_PL = "config_with_vpn_country_pl.json"
+    VPN_COUNTRY_DE = "config_with_vpn_country_de.json"
 
 
 @dataclass(frozen=True)

--- a/nat-lab/tests/test_core_api.py
+++ b/nat-lab/tests/test_core_api.py
@@ -5,7 +5,8 @@ from contextlib import AsyncExitStack
 from dataclasses import dataclass
 from enum import Enum
 from helpers import send_https_request, verify_uuid
-from utils.connection import ConnectionTag
+from typing import Optional
+from utils.connection import ConnectionTag, Connection
 from utils.connection_util import new_connection_by_tag
 
 
@@ -61,6 +62,10 @@ BEARER_AUTHORIZATION_HEADER = (
     f"Bearer {CORE_API_CREDENTIALS['username']}:{CORE_API_CREDENTIALS['password']}"
 )
 
+COUNTRY_ID_PL = 1
+COUNTRY_ID_DE = 2
+COUNTRY_ID_INVALID = 5
+
 
 def validate_dict_structure(data_to_validate, expected_data_structure) -> None:
     for key, expected_type in expected_data_structure.items():
@@ -88,10 +93,11 @@ def validate_dict_structure(data_to_validate, expected_data_structure) -> None:
             raise ValueError(f"Unexpected type for key '{key}': {expected_type}")
 
 
-async def clean_up_machines(connection, api_url):
+async def clean_up_machines(connection: Connection):
+    """Clear out all the registered machines from the mocked core API"""
     machines = await send_https_request(
         connection,
-        f"{api_url}/v1/meshnet/machines",
+        f"{CORE_API_URL}/v1/meshnet/machines",
         "GET",
         CORE_API_CA_CERTIFICATE_PATH,
         authorization_header=BEARER_AUTHORIZATION_HEADER,
@@ -100,12 +106,32 @@ async def clean_up_machines(connection, api_url):
     for machine in machines:
         await send_https_request(
             connection,
-            f"{api_url}/v1/meshnet/machines/{machine['identifier']}",
+            f"{CORE_API_URL}/v1/meshnet/machines/{machine['identifier']}",
             "DELETE",
             CORE_API_CA_CERTIFICATE_PATH,
             expect_response=False,
             authorization_header=BEARER_AUTHORIZATION_HEADER,
         )
+
+
+async def register_vpn_server_key(
+    connection: Connection, public_key: str, country_id: Optional[int]
+):
+    """Register a VPN server public_key for given country_id with the mocked core API"""
+    payload: dict[str, str | int] = {"public_key": public_key}
+    if country_id:
+        payload["country_id"] = country_id
+    payload_json = json.dumps(payload)
+
+    await send_https_request(
+        connection,
+        f"{CORE_API_URL}/test/public-key",
+        "POST",
+        CORE_API_CA_CERTIFICATE_PATH,
+        data=payload_json,
+        authorization_header=BEARER_AUTHORIZATION_HEADER,
+        expect_response=False,
+    )
 
 
 # this key is only used for testing
@@ -139,7 +165,7 @@ async def fixture_register_machine(machine_data):
             new_connection_by_tag(ConnectionTag.DOCKER_CONE_CLIENT_1)
         )
 
-        await clean_up_machines(connection, CORE_API_URL)
+        await clean_up_machines(connection)
 
         registered_machines = []
 
@@ -332,7 +358,7 @@ async def test_not_able_to_register_same_machine_twice():
         connection = await exit_stack.enter_async_context(
             new_connection_by_tag(ConnectionTag.DOCKER_CONE_CLIENT_1)
         )
-        await clean_up_machines(connection, CORE_API_URL)
+        await clean_up_machines(connection)
 
         payload = json.dumps(linux_vm.__dict__)
 
@@ -520,17 +546,7 @@ async def test_get_servers_no_filters():
             new_connection_by_tag(ConnectionTag.DOCKER_CONE_CLIENT_1)
         )
 
-        payload = json.dumps({"public_key": linux_vm_public_key})
-
-        await send_https_request(
-            connection,
-            f"{CORE_API_URL}/test/public-key",
-            "POST",
-            CORE_API_CA_CERTIFICATE_PATH,
-            data=payload,
-            authorization_header=BEARER_AUTHORIZATION_HEADER,
-            expect_response=False,
-        )
+        await register_vpn_server_key(connection, linux_vm_public_key, None)
 
         response_data = await send_https_request(
             connection,
@@ -559,21 +575,11 @@ async def test_get_servers_with_filters():
             new_connection_by_tag(ConnectionTag.DOCKER_CONE_CLIENT_1)
         )
 
-        payload = json.dumps({"public_key": linux_vm_public_key, "country_id": 2})
-
-        await send_https_request(
-            connection,
-            f"{CORE_API_URL}/test/public-key",
-            "POST",
-            CORE_API_CA_CERTIFICATE_PATH,
-            data=payload,
-            authorization_header=BEARER_AUTHORIZATION_HEADER,
-            expect_response=False,
-        )
+        await register_vpn_server_key(connection, linux_vm_public_key, COUNTRY_ID_DE)
 
         response_data = await send_https_request(
             connection,
-            f"{CORE_API_URL}/v1/servers/recommendations?filters%5Bcountry_id%5D=2",
+            f"{CORE_API_URL}/v1/servers/recommendations?filters%5Bcountry_id%5D={COUNTRY_ID_DE}",
             "GET",
             CORE_API_CA_CERTIFICATE_PATH,
             authorization_header=BEARER_AUTHORIZATION_HEADER,
@@ -598,21 +604,15 @@ async def test_get_nonexisting_servers():
             new_connection_by_tag(ConnectionTag.DOCKER_CONE_CLIENT_1)
         )
 
-        payload = json.dumps({"public_key": linux_vm_public_key, "country_id": 5})
-
-        await send_https_request(
-            connection,
-            f"{CORE_API_URL}/test/public-key",
-            "POST",
-            CORE_API_CA_CERTIFICATE_PATH,
-            data=payload,
-            authorization_header=BEARER_AUTHORIZATION_HEADER,
-            expect_response=False,
+        # note that there are only 2 country_id servers hardcoded,
+        # even if we register one for any other, this test will fail
+        await register_vpn_server_key(
+            connection, linux_vm_public_key, COUNTRY_ID_INVALID
         )
 
         response_data = await send_https_request(
             connection,
-            f"{CORE_API_URL}/v1/servers/recommendations?filters%5Bcountry_id%5D=5",
+            f"{CORE_API_URL}/v1/servers/recommendations?filters%5Bcountry_id%5D={COUNTRY_ID_INVALID}",
             "GET",
             CORE_API_CA_CERTIFICATE_PATH,
             authorization_header=BEARER_AUTHORIZATION_HEADER,


### PR DESCRIPTION
### Problem
Initial VPN supuport in Teliod is currently designed to use a direct endpoint (ip, port, public_key) provided from the config file. This approach is not user-friendly, as end users are unlikely to know valid IPs and public keys of NordVPN servers.

To improve usability, the goal is to allow users to specify a country code (e.g., "US" or "AR") in the VPN config. Teliod will then fetch a suitable VPN server automatically using the NordVPN Core API.

### Solution
####  Updated config file to support connection by country:
`config::VpnConfig` was converted into an enum with `Server` and `Country` variants.
This enables us to maintain the previous functionality.

Config changes from:
```json
  "vpn": {
    "server_endpoint": "10.0.100.1:1023",
    "server_pubkey": "public-key-placeholder"
  }
```
to
```json
  "vpn": {
    "server": {
      "address": "10.0.100.1",
      "public_key": "public-key-placeholder"
    }
  }
```

Connection by country is done with:
```json
  "vpn": {
    "country": "pl"
  }
```

#### Updated config file to support overriding WG endpoint port:
When fetching VPN server configurations from the Core API, no endpoint port is given, and the default WG port `51820` is assumed.
During natlab testing, we have a non standard port of `1023` for WG servers, therefore the default port needs to be overwritten. For this reason the "hidden" `override_default_wg_port` field was added to the config.

#### Added exit node `hostname` to status report:
To help verify the selected VPN server, the `hostname` field was added to status report.

This field is not present from the call `telio.external_nodes()` (in fact it is only present for meshnet peers fetched by the meshmap, but not peers added with `telio.connect_exit_node()` which is the case with VPN servers). 
Therefore a reply from the API is cached as `maybe_connected_vpn_server: Option<VpnServer>` to fill this data.

Example output of `get-status`:
```json
  "exit_node": {
    "identifier": "identifier-placeholder",
    "public_key": "public-key-placeholder",
    "hostname": "pl100.nordvpn.com",
    "endpoint": "10.0.100.1:1023",
    "state": "connected"
  }
```

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
