### PR TITLE
Allow trailing conntracker close event in another test

### DIFF
--- a/nat-lab/tests/test_mesh_firewall.py
+++ b/nat-lab/tests/test_mesh_firewall.py
@@ -669,6 +669,7 @@ async def test_mesh_firewall_tcp_stuck_in_last_ack_state_conn_kill_from_client_s
                     "nc",
                     FiveTuple(protocol="tcp", dst_ip=CLIENT_ALPHA_IP, dst_port=PORT),
                     [TcpState.LAST_ACK, TcpState.TIME_WAIT],
+                    trailing_state=TcpState.CLOSE,
                 )
             ],
         ).run() as conntrack:


### PR DESCRIPTION
### Problem
`test_mesh_firewall_tcp_stuck_in_last_ack_state_conn_kill_from_client_side` failed in a recent nightly because we were expecting conntracker events LAST_ACK, TIME_WAIT but we got TIME_WAIT, CLOSE. We know from before that occasionally, probably due to multithreading in NepTUN, the final close event might arrive early which is fine and we should allow that to happen in our tests

### Solution
Allow trailing `CLOSE` in `test_mesh_firewall_tcp_stuck_in_last_ack_state_conn_kill_from_client_side`


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
