### PR TITLE
LLT-5601: Map more error types to FfiError

### DIFF
--- a/.unreleased/LLT-5601
+++ b/.unreleased/LLT-5601
@@ -1,0 +1,1 @@
+Some internal libtelio errors are now better mapped to error type exposed over FFI

--- a/src/ffi/types.rs
+++ b/src/ffi/types.rs
@@ -89,14 +89,7 @@ impl From<&serde_json::Error> for TelioError {
 
 impl From<DevError> for TelioError {
     fn from(err: DevError) -> Self {
-        // TODO: Map more error types.
-        match err {
-            DevError::AlreadyStarted => Self::AlreadyStarted,
-            DevError::BadPublicKey => Self::InvalidKey,
-            _ => Self::UnknownError {
-                inner: format!("{err:?}"),
-            },
-        }
+        (&err).into()
     }
 }
 
@@ -106,6 +99,8 @@ impl From<&DevError> for TelioError {
         match err {
             DevError::AlreadyStarted => Self::AlreadyStarted,
             DevError::BadPublicKey => Self::InvalidKey,
+            DevError::BadPrivateKey => Self::InvalidKey,
+            DevError::NotStarted => Self::NotStarted,
             _ => Self::UnknownError {
                 inner: format!("{err:?}"),
             },


### PR DESCRIPTION
### Problem
Most errors that are generated inside libtelio get mapped to `UnknownError` before being passed over the FFI layer. Some of the errors can be mapped to more appropriate error types

### Solution
Map the errors to better types where possible

Note: the list of errors that can be better mapped turned out to be surprisingly small
