### PR TITLE
State reports connected when connected

### DIFF
--- a/.unreleased/LLT-6058
+++ b/.unreleased/LLT-6058
@@ -1,0 +1,1 @@
+Fix state reporting for Android TV

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2805,7 +2805,7 @@ dependencies = [
 [[package]]
 name = "neptun"
 version = "2.2.3"
-source = "git+https://github.com/NordSecurity/neptun.git?tag=v2.2.3#c362264f78d5fa5635fc318cc7bbb49740239e10"
+source = "git+https://github.com/NordSecurity/neptun.git?tag=v2.2.4#41c6bfc088ffd45623abf9642aa90e96cb839bcf"
 dependencies = [
  "aead",
  "base64 0.13.1",
@@ -2823,7 +2823,7 @@ dependencies = [
  "parking_lot",
  "rand_core 0.6.4",
  "ring",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "thiserror 1.0.69",
  "tracing",
  "untrusted 0.9.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,7 +177,7 @@ windows = { version = "0.61", features = [
 ] }
 winreg = "0.50.0"
 
-neptun = { git = "https://github.com/NordSecurity/neptun.git", tag = "v2.2.3", features = ["device"] }
+neptun = { git = "https://github.com/NordSecurity/neptun.git", tag = "v2.2.4", features = ["device"] }
 x25519-dalek = { version = "2.0.1", features = ["reusable_secrets", "static_secrets"] }
 
 


### PR DESCRIPTION
<!-- markdownlint-disable MD036 MD041 -->

### Problem

Libtelio was reporting state connecting even though it was connected. The bug was found to be coming from `rx_bytes` getting overflowed on 32-bit systems. `rx_bytes` was u64 on libtelio but was usize on neptun.

### Solution

Change rx and tx bytes on neptun from usize to u64 and add test for it. Update the neptun version in libtelio. PR for neptun has been merged already.

https://github.com/NordSecurity/NepTUN/pull/59
https://github.com/NordSecurity/NepTUN/pull/57


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
