### PR TITLE
Add networking to OpenWrt qemu VM

### DIFF
--- a/nat-lab/bin/openwrt/50-set-ips.sh
+++ b/nat-lab/bin/openwrt/50-set-ips.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -ex
+# Assign IP 192.168.115.254/24 to LAN bridge (br-lan)
+uci set network.lan.ifname='br-lan'
+uci set network.lan.proto='static'
+uci set network.lan.ipaddr='192.168.115.254'
+uci set network.lan.netmask='255.255.255.0'
+
+# Assign IP 10.0.0.1/31 to WAN interface (eth1)
+uci set network.wan.ifname='eth1'
+uci set network.wan.proto='static'
+uci set network.wan.ipaddr='10.0.0.0'
+uci set network.wan.netmask='255.255.255.254'
+
+# Add defailt gateway via 10.0.0.1
+uci set network.wan.gateway='10.0.0.1'
+
+uci commit network
+/etc/init.d/network restart

--- a/nat-lab/bin/openwrt/container_net_setup.sh
+++ b/nat-lab/bin/openwrt/container_net_setup.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -Eeuox
+
+ETH_COUNT=$(ls /sys/class/net | grep -E '^eth[0-9]+$' | wc -l)
+ADD_ERR="Please add the following setting to your container:"
+
+tuntap="TUN device is missing. $ADD_ERR --device /dev/net/tun"
+WAN_IP="10.0.254.14/16"
+LAN_IP="192.168.115.254/24"
+
+if [ ! -c /dev/net/tun ]; then
+  error "$tuntap" && return 1
+fi
+
+for ((i = 0; i < ETH_COUNT; i++)); do
+  DOCKER_BRIDGE="dockerbridge$i"
+  NET_DEV="eth$i"
+  NET_TAP="qemu$i"
+  {
+    ip link add dev $DOCKER_BRIDGE type bridge
+    rc=$?
+  } || :
+
+  if ((rc != 0)); then
+    error "Failed to create bridge. $ADD_ERR --cap-add NET_ADMIN" && return 1
+  fi
+
+  # We need freshly created bridge to have IP address of the container
+  # For this reason we need to migrate IP from eth0 to dockerbridge.
+  for addr in $(ip --json addr show dev $NET_DEV | jq -c '.[0].addr_info[] | select(.family == "inet")'); do
+    cidr_addr=$(echo $addr | jq -r '[ .local, .prefixlen|tostring] | join("/")')
+    if ! ip addr add dev $DOCKER_BRIDGE $cidr_addr; then
+      error "Failed to add address for $DOCKER_BRIDGE interface"
+      exit 30
+    fi
+  done
+
+  if ! ip addr flush dev $NET_DEV; then
+    error "Failed to clear $NET_DEV interface addresses"
+    exit 30
+  fi
+
+  while ! ip link set $DOCKER_BRIDGE up; do
+    info "Waiting for IP address to become available..."
+    sleep 2
+  done
+
+  # QEMU Works with taps, set tap to the bridge created
+  if ! ip tuntap add dev "$NET_TAP" mode tap; then
+    error "$tuntap" && return 1
+  fi
+
+  while ! ip link set "$NET_TAP" up promisc on; do
+    info "Waiting for TAP to become available..."
+    sleep 2
+  done
+
+  if ! ip link set dev "$NET_TAP" master $DOCKER_BRIDGE; then
+    error "Failed to set IP link!" && return 1
+  fi
+
+  if ! ip link set dev "$NET_DEV" master $DOCKER_BRIDGE; then
+    error "Failed to attach docker interface to bridge"
+  fi
+done
+
+# deleting ips from the bridge to avoid ip conflicts
+# same ips will be assigned to VM interfaces
+ip addr del "$WAN_IP" dev dockerbridge0
+ip addr del "$LAN_IP" dev dockerbridge1
+
+ip link set dockerbridge0 down
+ip link set dockerbridge0 up
+ip link set dockerbridge1 down
+ip link set dockerbridge1 up

--- a/nat-lab/bin/openwrt/entrypoint.sh
+++ b/nat-lab/bin/openwrt/entrypoint.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -ex
+bash container_net_setup.sh
 if [ ! -f /var/lib/qemu/initialized ]; then
     timeout -s SIGINT "$QEMU_CONFIG_TIMEOUT" send-config-to-vm.sh || (echo "VM config error or time out."; exit 1)
     touch /var/lib/qemu/initialized

--- a/nat-lab/bin/openwrt/run-vm.sh
+++ b/nat-lab/bin/openwrt/run-vm.sh
@@ -5,8 +5,10 @@ exec /usr/bin/qemu-system-x86_64 \
     -display none \
     -m 256M \
     -smp 2 \
-    -nic "user,model=virtio,restrict=on,ipv6=off,net=192.168.1.0/24,host=192.168.1.2" \
-    -nic "user,model=virtio,net=172.16.0.0/24,hostfwd=tcp::30022-:22,hostfwd=tcp::30080-:80,hostfwd=tcp::30443-:443" \
+    -netdev tap,id=hostnet0,ifname=qemu1,script=no,downscript=no \
+    -netdev tap,id=hostnet1,ifname=qemu0,script=no,downscript=no \
+    -device virtio-net-pci,romfile=,netdev=hostnet0,mac=52:54:9B:96:1F:00,id=net0 \
+    -device virtio-net-pci,romfile=,netdev=hostnet1,mac=52:54:9B:96:1F:01,id=net1 \
     -chardev socket,id=chr0,path=/tmp/qemu-console.sock,mux=on,signal=off,server=on,wait=off \
     -serial chardev:chr0 \
     -monitor unix:/tmp/qemu-monitor.sock,server,nowait \

--- a/nat-lab/docker-compose.yml
+++ b/nat-lab/docker-compose.yml
@@ -490,8 +490,11 @@ services:
     cap_add:
       - NET_ADMIN
       - NET_RAW
+      - SYS_ADMIN
     security_opt:
       - no-new-privileges:true
+    devices:
+      - "/dev/net/tun"
     networks:
       internet:
         ipv4_address: 10.0.254.14

--- a/nat-lab/openwrt.Dockerfile
+++ b/nat-lab/openwrt.Dockerfile
@@ -30,14 +30,13 @@ RUN ln -s /opt/bin/openwrt/10-usbmount-initsh.sh    /usr/local/share/vmconfig/vm
     ln -s /opt/bin/openwrt/20-firewall.sh           /usr/local/share/vmconfig/vm.d/20-firewall.sh && \
     ln -s /opt/bin/openwrt/30-wait-for-network.sh   /usr/local/share/vmconfig/vm.d/30-wait-for-network.sh && \
     ln -s /opt/bin/openwrt/40-dns.sh                /usr/local/share/vmconfig/vm.d/40-dns.sh && \
+    ln -s /opt/bin/openwrt/50-set-ips.sh            /usr/local/share/vmconfig/vm.d/50-set-ips.sh && \
     ln -s /opt/bin/openwrt/99-install-ipks.sh       /usr/local/share/vmconfig/vm.d/99-install-ipks.sh && \
     ln -s /opt/bin/openwrt/serialize-vm-config.sh   /usr/local/bin/serialize-vm-config.sh && \
     ln -s /opt/bin/openwrt/send-config-to-vm.sh     /usr/local/bin/send-config-to-vm.sh && \
     ln -s /opt/bin/openwrt/run-vm.sh                /usr/local/bin/run-vm.sh && \
-    ln -s /opt/bin/openwrt/entrypoint.sh            /usr/local/bin/entrypoint.sh
-
-HEALTHCHECK --interval=30s --timeout=5s --retries=3 CMD \
-  ssh -o BatchMode=yes -o StrictHostKeyChecking=no -o ConnectTimeout=3 -p 30022 root@127.0.0.1 'exit' || exit 1
+    ln -s /opt/bin/openwrt/entrypoint.sh            /usr/local/bin/entrypoint.sh && \
+    ln -s /opt/bin/openwrt/container_net_setup.sh   /usr/local/bin/container_net_setup.sh
 
 WORKDIR /tmp
 


### PR DESCRIPTION
- Set up bridging networking in container to access qemu VM outside of the container
- Add necessary VM ip and routing set-up

**Problem:**
With VM’s default -nic user mode, the VM cannot be reached directly from LAN.
It cannot forward traffic between networks so it's not possible to properly test routing or VPN passthrough.

**Solution:**
Use TAP devices and Linux bridges to connect the QEMU VM to the host’s networks:
Bridge connects the TAP device to the host network, allowing the VM to appear as if it’s physically connected to that network.
With at least two interfaces (eth0 on LAN, eth1 on WAN), the QEMU VM can forward packets between networks and act as a router/gateway.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
