### PR TITLE
Exclude more files from markdown formatting

### DIFF
--- a/.gitlab/merge_request_templates/Default.md
+++ b/.gitlab/merge_request_templates/Default.md
@@ -1,9 +1,5 @@
-<!-- markdownlint-disable MD036 MD041 -->
-
 ### Description
-
 *--write your description here--*
 
 ### Conformity
-
 - [ ] [Changelog entry]

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -4,3 +4,6 @@ ignores:
 - "**/3rd-party/**"
 - "**/.venv/**"
 - "changelog.md"
+- ".gitlab/merge_request_templates/Default.md"
+- "PULL_REQUEST_TEMPLATE.md"
+- "nat-lab/network.md"

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,5 @@
-<!-- markdownlint-disable MD036 MD041 -->
-
 ### Problem
-
 *--describe problem being solved--*
 
 ### Solution
-
 *--describe selected solution--*

--- a/nat-lab/network.md
+++ b/nat-lab/network.md
@@ -1,5 +1,3 @@
-# Natlab network topology
-
 ```mermaid
 graph LR
 %% AUTO GENERATED DIAGRAM. To update run `./utils/generate_network_diagram.py docker-compose.yml network.md`


### PR DESCRIPTION
### Problem
Some files should not be included in markdown formatting/linting.
- `network.md` is autogenerated and just contains a mermaid graph
- Two different pull request templates look better in the pull request view the way they were before

### Solution
Exclude those files and restore them to how they were before adding the formatter/linter


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
