### PR TITLE
LLT-6012: Add soname to libtelio.so on linux

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -109,7 +109,11 @@ fn main() -> Result<()> {
     if target_os == "android" {
         let pkg_name = env!("CARGO_PKG_NAME");
         let soname = format!("lib{pkg_name}.so");
-        println!("cargo:rustc-cdylib-link-arg=-Wl,-z,max-page-size=16384,-soname,{soname}",);
+        println!("cargo:rustc-cdylib-link-arg=-Wl,-z,max-page-size=16384,-soname,{soname}");
+    } else if target_os == "linux" {
+        let pkg_name = env!("CARGO_PKG_NAME");
+        let soname = format!("lib{pkg_name}.so");
+        println!("cargo:rustc-cdylib-link-arg=-Wl,-soname,{soname}");
     }
 
     #[cfg(windows)]


### PR DESCRIPTION
### Problem
Some platforms, like maybe kepler, need the .so libs it links to have it's `SONAME` section set. We were previously doing that for android builds but not linux builds

### Solution
Set the soname for linux too


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
