### PR TITLE
Allow trailing close in mesh firewall test

### DIFF
--- a/nat-lab/tests/test_mesh_firewall.py
+++ b/nat-lab/tests/test_mesh_firewall.py
@@ -568,6 +568,7 @@ async def test_mesh_firewall_tcp_stuck_in_last_ack_state_conn_kill_from_server_s
                     "telio-firewall-server-side-kill",
                     FiveTuple(protocol="tcp", dst_ip=CLIENT_ALPHA_IP, dst_port=PORT),
                     [TcpState.LAST_ACK, TcpState.TIME_WAIT],
+                    trailing_state=TcpState.CLOSE,
                 )
             ],
         ).run() as conntrack:


### PR DESCRIPTION
### Problem
In some tests we are asserting that conntracker has the last few events in the regular TCP lifecycle, minus `CLOSE`. In most cases this works really well, but sometimes we get a `CLOSE` event too early, which is fine, as long as it's only ever `CLOSE` and it arrives at the end and in the right order. In this case, the test should not fail

### Solution
Allow trailing close in the test in question


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
