### PR TITLE
Fix teliod tunnel network mask

### DIFF
--- a/clis/teliod/src/interface.rs
+++ b/clis/teliod/src/interface.rs
@@ -139,7 +139,7 @@ impl ConfigureInterface for Ifconfig {
 
     fn set_ip(&mut self, ip_address: &IpAddr) -> Result<(), TeliodError> {
         let ip_string = ip_address.to_string();
-        let cidr_suffix = if ip_address.is_ipv4() { "/10" } else { "/64" };
+        let cidr_suffix = if ip_address.is_ipv4() { "/30" } else { "/64" };
         let cidr_string = format!("{ip_address}{cidr_suffix}");
         let ip_type = if ip_address.is_ipv4() {
             "inet"
@@ -162,7 +162,7 @@ impl ConfigureInterface for Ifconfig {
                 ]))?;
 
                 if ip_address.is_ipv4() {
-                    execute(Command::new("route").args(["-n", "add", "100.64/10", &ip_string]))?;
+                    execute(Command::new("route").args(["-n", "add", "10.5.0.0/30", &ip_string]))?;
                 } else {
                     execute(Command::new("route").args([
                         "add",
@@ -180,7 +180,7 @@ impl ConfigureInterface for Ifconfig {
                     "add",
                     ip_address.to_string().as_str(),
                     "netmask",
-                    "255.192.0.0",
+                    "255.255.255.252",
                 ]))?;
             }
         }
@@ -327,7 +327,7 @@ impl ConfigureInterface for Iproute {
     }
 
     fn set_ip(&mut self, ip_address: &IpAddr) -> Result<(), TeliodError> {
-        let cidr_suffix = if ip_address.is_ipv4() { "/10" } else { "/64" };
+        let cidr_suffix = if ip_address.is_ipv4() { "/30" } else { "/64" };
         let cidr_string = format!("{ip_address}{cidr_suffix}");
 
         info!(
@@ -637,7 +637,7 @@ impl ConfigureInterface for Uci {
         ]))?;
         execute(Command::new("uci").args(["set", "network.tun.proto=static"]))?;
         execute(Command::new("uci").args(["set", &format!("network.tun.ipaddr={ip_address}")]))?;
-        execute(Command::new("uci").args(["set", "network.tun.netmask=255.192.0.0"]))?;
+        execute(Command::new("uci").args(["set", "network.tun.netmask=255.255.255.252"]))?;
 
         // save and apply
         self.reload_network()?;


### PR DESCRIPTION
### Problem
After removal of meshnet, the tunnel interface address changed from the meshnet range `100.64.0.0/10` to a static `10.5.0.2` but the network mask is still set for the meshnet range.
This breaks connectivity in Class A `10.0.0.0` subnets, like our "public internet" in natlab tests.

### Solution
Change the tunnel interface network mask from `255.192.0.0` to `255.255.255.252`