### PR TITLE
Loop log check in teliod test

### DIFF
--- a/nat-lab/tests/test_teliod.py
+++ b/nat-lab/tests/test_teliod.py
@@ -1,3 +1,4 @@
+import asyncio
 import pytest
 from config import PHOTO_ALBUM_IP, STUN_SERVER, WG_SERVER, WG_SERVER_2
 from contextlib import AsyncExitStack
@@ -47,11 +48,17 @@ async def test_teliod_logs() -> None:
         }
 
         # Check if log files exist and are not empty
-        for path, expected_string in expected_log_contents.items():
-            await connection.create_process(["test", "-s", path]).execute()
-            await connection.create_process(
-                ["grep", "-q", expected_string, path]
-            ).execute()
+        done = False
+        while not done:
+            try:
+                for path, expected_string in expected_log_contents.items():
+                    await connection.create_process(["test", "-s", path]).execute()
+                    await connection.create_process(
+                        ["grep", "-q", expected_string, path]
+                    ).execute()
+                    done = True
+            except ProcessExecError:
+                await asyncio.sleep(1)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Problem
With vagrantless natlab it seems like there's sometimes a small delay between teliod being started and logs being available. It happens in every nightly but only a couple of the pipelines there, so not super common

### Solution
Loop the log check until the expected logs are there, to account for any delays


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
