### PR TITLE
test(nat-lab): Use process.is_done() in run fail

### DIFF
--- a/nat-lab/tests/test_process.py
+++ b/nat-lab/tests/test_process.py
@@ -113,8 +113,8 @@ async def test_process_run_fail(connection_tag: ConnectionTag, command: list[str
             new_connection_by_tag(connection_tag)
         )
         with pytest.raises(ProcessExecError) as e:
-            async with connection.create_process(command).run():
-                await asyncio.sleep(1)
+            async with connection.create_process(command).run() as process:
+                await process.is_done()
         assert e.value.cmd == command
         assert e.value.returncode == 77
         assert " ".join(command) not in await _get_running_process_list(connection)


### PR DESCRIPTION
### Problem
Sleep makes test flaky

### Solution
Replace the arbitrary sleep with process.is_done() in the failing-run test to make it deterministic and avoid timing-related flakiness. This ensures ProcessExecError and the return code are captured reliably across supported OS targets.
