### PR TITLE
Fix sqlite timeout by splitting it

### DIFF
--- a/nat-lab/tests/utils/moose.py
+++ b/nat-lab/tests/utils/moose.py
@@ -1,1 +1,2 @@
 MOOSE_LOGS_DIR = "/moose_logs"
+MOOSE_DB_TIMEOUT_MS = 30000


### PR DESCRIPTION
### Problem
We caught an error, where `sqlite3` binary and `libmoose` accessed db file and caught a deadlock.

### Solution
Offloading some of `busy_timeout` to python-side retries.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
