### PR TITLE
Retry tcpdump startup and scope pcap cleanup

### DIFF
--- a/nat-lab/tests/utils/tcpdump.py
+++ b/nat-lab/tests/utils/tcpdump.py
@@ -18,6 +18,7 @@ PCAP_FILE_PATH = {
     TargetOS.Mac: "/var/root/dump.pcap",
     TargetOS.Windows: "C:\\workspace\\dump.pcap",
 }
+TCPDUMP_START_EVENT_TIMEOUT_S = 3
 
 
 class TcpDump:
@@ -99,7 +100,7 @@ class TcpDump:
     async def run(self) -> AsyncIterator["TcpDump"]:
         start_time = datetime.now()
         async with self.process.run(self.on_stdout, self.on_stderr, True):
-            await wait_for(self.start_event.wait(), 10)
+            await wait_for(self.start_event.wait(), TCPDUMP_START_EVENT_TIMEOUT_S)
             delta = datetime.now() - start_time
             log.info(
                 "[%s] '%s' time till ready: %s",


### PR DESCRIPTION
### Problem
Intermittent races can cause tcpdump to fail to start in NAT lab.

### Solution
Attempt to start the capture up to three times, logging a warning on each failure and rethrowing on the final attempt.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
