### PR TITLE
Add backoff to the ENS task

### DIFF
--- a/.unreleased/LLT-6489
+++ b/.unreleased/LLT-6489
@@ -1,0 +1,1 @@
+Implement backoff strategy for ENS

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4935,6 +4935,7 @@ name = "telio-proto"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-channel 2.5.0",
  "aws-lc-rs",
  "base64 0.22.1",
  "blake3",

--- a/crates/telio-model/Cargo.toml
+++ b/crates/telio-model/Cargo.toml
@@ -31,6 +31,7 @@ once_cell.workspace = true
 pretty_assertions.workspace = true
 proptest.workspace = true
 proptest-derive.workspace = true
+telio-utils = { workspace = true, features = ["arbitrary"] }
 
 [profile.test.package.proptest]
 opt-level = 3

--- a/crates/telio-proto/Cargo.toml
+++ b/crates/telio-proto/Cargo.toml
@@ -44,7 +44,9 @@ protobuf-codegen.workspace = true
 tonic-prost-build = "0.14.0"
 
 [dev-dependencies]
+async-channel = "2.5.0"
 rcgen = "0.14.3"
+telio-utils = { workspace = true, features = ["mockall"] }
 test-log = { version = "0.2.18", features = ["trace"] }
 tokio = { workspace = true, features = ["sync"] }
 tonic = { version = "0.14.0", features = ["tls-aws-lc"] }

--- a/crates/telio-proto/src/ens.rs
+++ b/crates/telio-proto/src/ens.rs
@@ -22,7 +22,10 @@ use telio_task::io::{
     chan::{Rx, Tx},
     Chan,
 };
-use telio_utils::{telio_log_debug, telio_log_error, telio_log_info, telio_log_warn};
+use telio_utils::{
+    exponential_backoff::{self, Backoff},
+    telio_log_debug, telio_log_error, telio_log_info, telio_log_warn,
+};
 use tokio::{select, sync::watch, task::JoinHandle};
 use tokio_rustls::TlsConnector;
 use tonic::{
@@ -71,6 +74,9 @@ pub enum Error {
     /// GRPC status error
     #[error("GRPC status error: {0}")]
     StatusError(#[from] tonic::Status),
+    /// Exponential backoff creation error
+    #[error("Exponential backoff creation failed {0}")]
+    ExponentialBackoff(#[from] exponential_backoff::Error),
 }
 
 /// ErrorNotificationService manages tasks started and stopped to consume the ENS grpc error streams
@@ -112,8 +118,9 @@ impl ErrorNotificationService {
         vpn_ip: IpAddr,
         vpn_public_key: PublicKey,
         local_private_key: SecretKey,
+        backoff: impl Backoff,
     ) -> Result<(), Error> {
-        self.start_monitor_on_port(vpn_ip, ENS_PORT, vpn_public_key, local_private_key)
+        self.start_monitor_on_port(vpn_ip, ENS_PORT, vpn_public_key, local_private_key, backoff)
             .await
     }
 
@@ -123,6 +130,7 @@ impl ErrorNotificationService {
         ens_port: u16,
         vpn_public_key: PublicKey,
         local_private_key: SecretKey,
+        backoff: impl Backoff,
     ) -> Result<(), Error> {
         telio_log_info!("Will start ENS monitoring on {vpn_ip}:{ens_port} ({vpn_public_key:?})");
         self.stop().await;
@@ -141,13 +149,14 @@ impl ErrorNotificationService {
         let join_handle = tokio::spawn(async move {
             // This future is too big for keeping it on the stack
             if let Err(e) = Box::pin(task(
-                vpn_uri.clone(),
+                &vpn_uri,
                 vpn_public_key,
                 local_private_key,
                 pool.clone(),
                 tx,
                 quit_rx,
                 allow_only_mlkem,
+                backoff,
             ))
             .await
             {
@@ -187,35 +196,70 @@ impl ErrorNotificationService {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn task(
-    vpn_uri: String,
+    vpn_uri: &str,
     vpn_public_key: PublicKey,
     local_private_key: SecretKey,
     pool: Arc<SocketPool>,
     tx: Tx<(ConnectionError, PublicKey)>,
     mut quit_rx: watch::Receiver<bool>,
     allow_only_mlkem: bool,
+    mut backoff: impl Backoff,
 ) -> anyhow::Result<()> {
     'outer: loop {
-        let pool = pool.clone();
-        let external_channel =
-            Box::pin(create_external_channel(&vpn_uri, pool, allow_only_mlkem)).await?;
+        macro_rules! restart {
+            ($backoff: expr) => {
+                tokio::time::sleep(backoff.get_backoff()).await;
+                backoff.next_backoff();
+                continue 'outer;
+            };
+        }
+        /// If the Err is returned but ENS shouldn't quit yet, the outer loop will be restarted
+        /// and the task will reconnect. If we should quit, the task will terminate. In case of Ok
+        /// case, the macro will evaluete to the inner value of Ok.
+        macro_rules! handle_error {
+            ($value: expr, $backoff: expr) => {
+                match $value {
+                    Ok(v) => v,
+                    Err(e) => {
+                        telio_log_warn!("ENS task transient failure: {e}");
+                        if *quit_rx.borrow() == true {
+                            break 'outer;
+                        }
+                        restart!($backoff);
+                    }
+                }
+            };
+        }
 
-        let authenticated_challenge = get_login_challenge(
-            external_channel.clone(),
-            vpn_public_key,
-            local_private_key.clone(),
-        )
-        .await?;
+        let pool = pool.clone();
+        let external_channel = handle_error!(
+            Box::pin(create_external_channel(vpn_uri, pool, allow_only_mlkem)).await,
+            backoff
+        );
+
+        let authenticated_challenge = handle_error!(
+            get_login_challenge(
+                external_channel.clone(),
+                vpn_public_key,
+                local_private_key.clone(),
+            )
+            .await,
+            backoff
+        );
 
         let mut client = grpc::ens_client::EnsClient::with_interceptor(
             external_channel,
             authentication_interceptor(authenticated_challenge),
         );
 
-        let connection = client
-            .connection_errors(ConnectionErrorRequest::default())
-            .await?;
+        let connection = handle_error!(
+            client
+                .connection_errors(ConnectionErrorRequest::default())
+                .await,
+            backoff
+        );
         let mut stream = connection.into_inner();
         loop {
             select! {
@@ -227,6 +271,7 @@ async fn task(
                     telio_log_warn!("Received error notification for '{vpn_uri}': {error_notification:?}");
                     match error_notification {
                         Ok(Some(error_notification)) => {
+                            backoff.reset();
                             if let Err(e) = tx.try_send((error_notification, vpn_public_key)) {
                                 telio_log_warn!("Failed to publish newly received error notification: {e}");
                             }
@@ -236,14 +281,16 @@ async fn task(
                             break 'outer;
                         }
                         Err(e) => {
+                            // After the first error, the stream will never return any new value, which means
+                            // we need to reconnect. For details, see: https://github.com/hyperium/tonic/blob/c9cc210cb7c6f3f937786a3134c682761a26c65c/tonic/src/codec/decode.rs#L392-L394
                             telio_log_error!("GRPC error: {e}");
-                            // TODO(LLT-6489): we shouldn't reconnect immediately, instead we should have a backoff strategy
                             break;
                         }
                     }
                 }
             };
         }
+        restart!(&mut backoff);
     }
     telio_log_debug!("ENS monitor for '{vpn_uri}' terminates");
     Ok(())
@@ -441,7 +488,6 @@ pub fn install_default_crypto_provider() {
 
 #[cfg(test)]
 mod tests {
-
     use std::{
         collections::HashSet,
         net::Ipv4Addr,
@@ -449,6 +495,7 @@ mod tests {
         time::Duration,
     };
 
+    use async_channel::{self, unbounded, Receiver, Sender};
     use grpc::{
         ens_server::{self, EnsServer},
         login_server::{self, LoginServer},
@@ -457,7 +504,10 @@ mod tests {
     use rcgen::{generate_simple_self_signed, CertifiedKey};
     use telio_crypto::SecretKey;
     use telio_sockets::NativeProtector;
-    use tokio::sync::{mpsc, oneshot};
+    use telio_utils::exponential_backoff::{
+        ExponentialBackoff, ExponentialBackoffBounds, MockBackoff,
+    };
+    use tokio::sync::oneshot;
     use tokio_stream::wrappers::ReceiverStream;
     use tonic::{service::Interceptor, transport::Server};
 
@@ -466,18 +516,25 @@ mod tests {
     const SUBJECT_ALT_NAMES: LazyLock<Vec<String>> =
         LazyLock::new(|| vec!["localhost".to_string(), "127.0.0.1".to_string()]);
 
+    #[derive(Debug)]
+    enum Command {
+        Send(ConnectionError),
+        Error(tonic::Status),
+        End,
+    }
+
     struct GrpcStub {
-        errors: Vec<ConnectionError>,
+        command_rx: Receiver<Command>,
         challenges: Mutex<HashSet<Uuid>>,
         vpn_server_private_key: SecretKey,
     }
 
     impl GrpcStub {
-        fn new(errors: &[ConnectionError], vpn_server_private_key: SecretKey) -> Self {
+        fn new(command_rx: Receiver<Command>, vpn_server_private_key: SecretKey) -> Self {
             Self {
-                errors: errors.to_vec(),
                 challenges: Mutex::new(HashSet::default()),
                 vpn_server_private_key,
+                command_rx,
             }
         }
     }
@@ -490,11 +547,17 @@ mod tests {
             _request: tonic::Request<ConnectionErrorRequest>,
         ) -> std::result::Result<tonic::Response<Self::ConnectionErrorsStream>, tonic::Status>
         {
-            let (tx, rx) = mpsc::channel(1);
-            let errors = self.errors.clone();
+            let (tx, rx) = tokio::sync::mpsc::channel(1);
+
+            let command_rx = self.command_rx.clone();
             tokio::spawn(async move {
-                for error in errors {
-                    tx.send(Ok(error)).await.unwrap();
+                loop {
+                    println!("next loop iteration...");
+                    match command_rx.recv().await.unwrap() {
+                        Command::Send(e) => tx.send(Ok(e)).await.unwrap(),
+                        Command::Error(status) => tx.send(Err(status)).await.unwrap(),
+                        Command::End => break,
+                    }
                 }
             });
 
@@ -548,14 +611,12 @@ mod tests {
         }
     }
 
-    async fn spawn_server(errors_to_emit: &[ConnectionError]) -> (u16, PublicKey) {
+    async fn spawn_server() -> (u16, PublicKey, Sender<Command>) {
         install_default_crypto_provider();
         let server_private_key = SecretKey::gen();
 
-        let grpc_stub = Arc::new(GrpcStub::new(
-            &errors_to_emit.iter().cloned().collect::<Vec<_>>(),
-            server_private_key.clone(),
-        ));
+        let (command_tx, command_rx) = unbounded();
+        let grpc_stub = Arc::new(GrpcStub::new(command_rx, server_private_key.clone()));
         let ens_srv = EnsServer::with_interceptor(
             grpc_stub.clone(),
             CheckAuthenticationInterceptor(grpc_stub.clone()),
@@ -587,16 +648,26 @@ mod tests {
                 .await
                 .unwrap();
         });
-        (port_rx.await.unwrap(), server_private_key.public())
+        (
+            port_rx.await.unwrap(),
+            server_private_key.public(),
+            command_tx,
+        )
+    }
+
+    async fn send_errors(errors_to_emit: &[ConnectionError], errors_tx: Sender<Command>) {
+        let errors_to_emit = errors_to_emit.to_vec();
+        for e in errors_to_emit {
+            errors_tx.send(Command::Send(e)).await.unwrap();
+        }
+        errors_tx.send(Command::End).await.unwrap();
     }
 
     #[tokio::test]
     #[test_log::test]
     async fn test_ens() {
-        tokio_rustls::rustls::crypto::aws_lc_rs::default_provider()
-            .install_default()
-            .unwrap();
-
+        let bounds = ExponentialBackoffBounds::default();
+        let backoff = ExponentialBackoff::new(bounds).unwrap();
         let client_private_key = SecretKey::gen();
 
         let errors_to_emit = [
@@ -610,30 +681,36 @@ mod tests {
             },
         ];
 
-        let (port, server_public_key) = spawn_server(&errors_to_emit).await;
+        let (port, server_public_key, command_tx) = spawn_server().await;
 
-        let socket_pool = make_socket_pool();
         let allow_only_mlkem = true;
-        let (mut ens, mut rx) = ErrorNotificationService::new(10, socket_pool, allow_only_mlkem);
+        let (mut ens, mut rx) =
+            ErrorNotificationService::new(10, make_socket_pool(), allow_only_mlkem);
 
         ens.start_monitor_on_port(
             IpAddr::V4(Ipv4Addr::LOCALHOST),
             port,
             server_public_key,
             client_private_key.clone(),
+            backoff.clone(),
         )
         .await
         .unwrap();
+
+        send_errors(&errors_to_emit, command_tx.clone()).await;
         let _collected_errors = collect_errors(2, &mut rx).await;
+
         ens.start_monitor_on_port(
             IpAddr::V4(Ipv4Addr::LOCALHOST),
             port,
             server_public_key,
             client_private_key,
+            backoff,
         )
         .await
         .unwrap();
 
+        send_errors(&errors_to_emit, command_tx.clone()).await;
         let collected_errors = collect_errors(2, &mut rx).await;
 
         assert_eq!(
@@ -660,6 +737,61 @@ mod tests {
 
     #[tokio::test]
     #[test_log::test]
+    async fn test_ens_backoff() {
+        let client_private_key = SecretKey::gen();
+
+        let errors_to_emit = [
+            ConnectionError {
+                code: grpc::Error::Unknown as i32,
+                additional_info: None,
+            },
+            ConnectionError {
+                code: grpc::Error::ConnectionLimitReached as i32,
+                additional_info: Some("additional info".to_owned()),
+            },
+        ];
+
+        let (port, server_public_key, errors_tx) = spawn_server().await;
+
+        let allow_only_mlkem = true;
+        let (mut ens, mut rx) =
+            ErrorNotificationService::new(10, make_socket_pool(), allow_only_mlkem);
+
+        let mut backoff = MockBackoff::new();
+
+        backoff.expect_reset().times(4).return_const(());
+        backoff
+            .expect_get_backoff()
+            .times(1)
+            .return_const(Duration::from_secs(1));
+        backoff.expect_next_backoff().times(1).return_const(());
+
+        ens.start_monitor_on_port(
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            port,
+            server_public_key,
+            client_private_key.clone(),
+            backoff,
+        )
+        .await
+        .unwrap();
+
+        for e in errors_to_emit.clone() {
+            errors_tx.send(Command::Send(e)).await.unwrap();
+        }
+        errors_tx
+            .send(Command::Error(tonic::Status::unknown("some message")))
+            .await
+            .unwrap();
+        errors_tx.send(Command::End).await.unwrap();
+        for e in errors_to_emit {
+            errors_tx.send(Command::Send(e)).await.unwrap();
+        }
+        let _collected_errors = collect_errors(3, &mut rx).await;
+    }
+
+    #[tokio::test]
+    #[test_log::test]
     async fn test_ens_fails_without_x25519mlkem768_support() {
         let server_private_key = SecretKey::gen();
         let server_public_key = server_private_key.public();
@@ -676,9 +808,6 @@ mod tests {
 
             let CertifiedKey { cert, signing_key } =
                 generate_simple_self_signed(SUBJECT_ALT_NAMES.clone()).unwrap();
-
-            let _cert_pem = cert.pem();
-            let _key_pem = signing_key.serialize_pem();
 
             // Create a TLS server that explicitly does NOT support X25519MLKEM768
             // by using a provider that only supports traditional key exchange algorithms
@@ -729,17 +858,17 @@ mod tests {
             }
         });
 
-        let socket_pool = make_socket_pool();
         let allow_only_mlkem = true;
-        let (mut ens, mut rx) = ErrorNotificationService::new(10, socket_pool, allow_only_mlkem);
+        let (mut ens, mut rx) =
+            ErrorNotificationService::new(10, make_socket_pool(), allow_only_mlkem);
 
-        let port = port_rx.await.unwrap();
         let result = ens
             .start_monitor_on_port(
                 IpAddr::V4(Ipv4Addr::LOCALHOST),
-                port,
+                port_rx.await.unwrap(),
                 server_public_key,
                 client_private_key,
+                ExponentialBackoff::new(Default::default()).unwrap(),
             )
             .await;
 

--- a/crates/telio-utils/Cargo.toml
+++ b/crates/telio-utils/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 
 [features]
 sn_fake_clock = ["dep:sn_fake_clock"]
+arbitrary = ["dep:proptest-derive", "dep:proptest"]
 
 [dependencies]
 backtrace = "0.3.75"
@@ -18,6 +19,8 @@ hashlink.workspace = true
 ipnet.workspace = true
 mockall = { workspace = true, optional = true }
 parking_lot.workspace = true
+proptest = { version = "1.6", optional = true }
+proptest-derive = { version = "0.5", optional = true }
 rand.workspace = true
 rand_core.workspace = true
 regex.workspace = true

--- a/src/libtelio.udl
+++ b/src/libtelio.udl
@@ -803,6 +803,23 @@ dictionary FeatureErrorNotificationService {
 
     /// Allow only post-quantum safe key exchange algorithm for the ENS HTTPS connection
     boolean allow_only_pq;
+
+    /// Configuration of the backoff algorithm used by ENS
+    Backoff backoff;
+};
+
+/// Exponential backoff bounds
+dictionary Backoff {
+    /// Initial bound
+    ///
+    /// Used as the first backoff value after ExponentialBackoff creation or reset [default 2s]
+    u32 initial_s = 2;
+
+    /// Maximal bound
+    ///
+    /// A maximal backoff value which might be achieved during exponential backoff
+    /// - if set to None/null there will be no upper bound for the penalty duration [default 120s]
+    u32? maximal_s;
 };
 
 /// Rust representation of [meshnet map]


### PR DESCRIPTION
Since part of the ENS task logic is to retry connection, we need (exponential) backoff to avoid (d)dosing the VPN server.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
