### PR TITLE
LLT-6571: Handle legacy boringtun_reset_conns feature config option

### DIFF
--- a/.unreleased/LLT-6571
+++ b/.unreleased/LLT-6571
@@ -1,0 +1,1 @@
+Fix bug where setting feature config boringtun_reset_conns did nothing

--- a/crates/telio-model/src/features.rs
+++ b/crates/telio-model/src/features.rs
@@ -478,6 +478,16 @@ pub struct FeatureFirewall {
     pub outgoing_blacklist: Vec<FirewallBlacklistTuple>,
 }
 
+impl FeatureFirewall {
+    /// For legacy reasons, this struct has two fields that have to coexist even though they mean the same thing
+    /// This function gives you the relevant value of those fields without having to check both
+    ///
+    /// Note: Use this function instead of direct field access
+    pub fn neptun_reset_conns(&self) -> bool {
+        self.neptun_reset_conns || self.boringtun_reset_conns
+    }
+}
+
 /// Turns on post quantum VPN tunnel
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, SmartDefault)]
 #[serde(default)]

--- a/src/device.rs
+++ b/src/device.rs
@@ -1044,7 +1044,7 @@ impl Runtime {
                 fw.process_outbound_packet(peer, packet, sink)
             }
         };
-        let firewall_reset_connections = if features.firewall.neptun_reset_conns {
+        let firewall_reset_connections = if features.firewall.neptun_reset_conns() {
             let fw = firewall.clone();
             let cb = move |exit_pubkey: &PublicKey, sink: &mut dyn io::Write| {
                 if let Err(err) = fw.reset_connections(exit_pubkey, sink) {


### PR DESCRIPTION
### Problem
We have "aliased" names for feature config option to handle legacy boringtun name and newer neptun name. Previously these were not handled properly so that using neptun_reset_conns actually did something and boringtun_reset_conns did nothing

### Solution
Introduce function that makes sure both options are taken into consideration and use that instead of directly referencing `neptun_reset_conns`, where relevant
