### PR TITLE
Increase commands channel size

### DIFF
--- a/clis/teliod/src/command_listener.rs
+++ b/clis/teliod/src/command_listener.rs
@@ -10,7 +10,7 @@ use crate::{
     daemon::{TelioStatusReport, TeliodError},
 };
 
-pub(crate) const TIMEOUT_SEC: u64 = 1;
+pub(crate) const TIMEOUT_SEC: u64 = 2;
 
 #[derive(Parser, Debug, PartialEq)]
 #[clap()]

--- a/clis/teliod/src/daemon.rs
+++ b/clis/teliod/src/daemon.rs
@@ -337,7 +337,7 @@ pub async fn daemon_event_loop(config: TeliodDaemonConfig) -> Result<(), TeliodE
 
     let mut signals = Signals::new([SIGHUP, SIGTERM, SIGINT, SIGQUIT])?;
 
-    let (telio_tx, telio_rx) = mpsc::channel(10);
+    let (telio_tx, telio_rx) = mpsc::channel(100);
 
     let socket = DaemonSocket::new(&DaemonSocket::get_ipc_socket_path()?)?;
     let mut cmd_listener = CommandListener::new(socket, telio_tx.clone());


### PR DESCRIPTION
### Problem
Occasionally teliod command replies time out.

### Solution
Increase command buffer size, in case we are spamming it with commands faster than it can process.
And increase the timeout to 2 seconds