### PR TITLE
Rename OpenWRT config leftover to nordvpnlite

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-TRIGGERED_REF=lukasp/rename_openwrt_binary
+TRIGGERED_REF=v3.2.1

--- a/clis/nordvpnlite/openwrt/feed/net/nordvpnlite/files/config.json
+++ b/clis/nordvpnlite/openwrt/feed/net/nordvpnlite/files/config.json
@@ -1,11 +1,11 @@
 {
   "authentication_token": "<REPLACE_WITH_YOUR_TOKEN>",
   "log_level": "error",
-  "log_file_path": "/var/log/nordvpn.log",
+  "log_file_path": "/var/log/nordvpnlite.log",
   "log_file_count": 0,
   "adapter_type": "linux-native",
   "interface": {
-    "name": "nordvpn",
+    "name": "nordvpnlite",
     "config_provider": "uci"
   },
   "vpn": "recommended"


### PR DESCRIPTION
### Problem
Some leftovers of old name were present in OpenWRT config file(interface name, log file).

### Solution
Simply rename and also bump .env to latest libtelio-build reference.



### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
