### PR TITLE
[LLT-6804] - Replace token placeholder in default nordvpnlite config

### DIFF
--- a/clis/nordvpnlite/openwrt/feed/net/nordvpnlite/files/config.json
+++ b/clis/nordvpnlite/openwrt/feed/net/nordvpnlite/files/config.json
@@ -1,5 +1,5 @@
 {
-  "authentication_token": "<REPLACE_WITH_YOUR_TOKEN>",
+  "authentication_token": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
   "vpn": "recommended",
   "log_level": "error",
   "log_file_path": "/var/log/nordvpnlite.log",


### PR DESCRIPTION
### Problem
There is inconsistency in the token placeholder between the example config and nordvpnlite service config. 

### Solution
Use 'aaa' format of placeholder in nordvpnlite service config


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
