### PR TITLE
LLT-7043: pytest fixtures for helpers

### DIFF
--- a/nat-lab/tests/conftest.py
+++ b/nat-lab/tests/conftest.py
@@ -1,3 +1,7 @@
+# TODO (LLT-7084): Move fixtures to separate fixture files out of conftest.py
+# pylint: disable=too-many-lines
+# Register helpers_fixtures once here so individual test modules don't need to
+# repeat it (which caused PytestWarning: Plugin already registered).
 import asyncio
 import logging
 import os
@@ -29,6 +33,27 @@ from tests.utils.logger import log
 from tests.utils.router import IPStack
 from tests.utils.testing import get_current_test_log_path
 from typing import List
+
+pytest_plugins = ["tests.helpers_fixtures"]
+
+DERP_SERVER_1_ADDR = "http://10.0.10.1:8765"
+DERP_SERVER_2_ADDR = "http://10.0.10.2:8765"
+DERP_SERVER_3_ADDR = "http://10.0.10.3:8765"
+DERP_SERVER_1_SECRET_KEY = "yBTYHj8yPlG9VtMYMwJSRHdzNdyAlVXGc6X2xJkjfHQ="
+DERP_SERVER_2_SECRET_KEY = "2NgALOCSKJcDxwr8MtA+6lYbf7b98KSdAROGoUwZ1V0="
+
+SETUP_CHECK_TIMEOUT_S = 30
+SETUP_CHECK_RETRIES = 5
+SETUP_CHECK_CONNECTIVITY_TIMEOUT = 60
+SETUP_CHECK_CONNECTIVITY_RETRIES = 1
+GW_CHECK_CONNECTIVITY_TIMEOUT = 30
+GW_CHECK_CONNECTIVITY_RETRIES = 2
+SETUP_CHECK_MAC_COLLISION_TIMEOUT_S = 300
+SETUP_CHECK_MAC_COLLISION_RETRIES = 1
+SETUP_CHECK_ARP_CACHE_TIMEOUT_S = 300
+SETUP_CHECK_ARP_CACHE_RETRIES = 1
+SETUP_CHECK_DUPLICATE_IP_TIMEOUT_S = 60
+SETUP_CHECK_DUPLICATE_IP_RETRIES = 1
 
 RUNNER: asyncio.Runner | None = None
 SESSION_SCOPE_EXIT_STACK: AsyncExitStack | None = None

--- a/nat-lab/tests/helpers_fixtures.py
+++ b/nat-lab/tests/helpers_fixtures.py
@@ -1,0 +1,237 @@
+"""Pytest fixtures wrapping helpers.setup_environment / setup_connections."""
+
+from __future__ import annotations
+
+import asyncio
+import pytest
+import pytest_asyncio
+from contextlib import AsyncExitStack
+from tests.helpers import (
+    SetupParameters,
+    setup_connections as _setup_connections,
+    setup_environment as _setup_environment,
+    setup_mesh_nodes as _setup_mesh_nodes,
+    Environment,
+)
+from tests.helpers_vpn import VpnConfig
+from tests.mesh_api import API
+from tests.utils.connection import ConnectionTag
+from tests.utils.connection_util import ConnectionManager
+from typing import AsyncGenerator, Callable, Awaitable, List, Optional, Union, Tuple
+
+
+# ---------------------------------------------------------------------------
+# 1) Shared AsyncExitStack
+# ---------------------------------------------------------------------------
+@pytest_asyncio.fixture(name="exit_stack")
+async def _exit_stack() -> AsyncGenerator[AsyncExitStack, None]:
+    """Provide an AsyncExitStack whose lifetime spans the entire test."""
+    stack = AsyncExitStack()
+    yield stack
+    try:
+        await asyncio.wait_for(stack.aclose(), timeout=60)
+    except asyncio.TimeoutError:
+        raise RuntimeError(
+            "exit_stack fixture teardown timed out after 60s — "
+            "likely a context manager is stuck during cleanup"
+        ) from None
+
+
+# ---------------------------------------------------------------------------
+# 2) Factory fixture for setup_connections
+# ---------------------------------------------------------------------------
+@pytest.fixture(name="setup_connections_factory")
+def _setup_connections_factory(
+    exit_stack: AsyncExitStack,
+) -> Callable[..., Awaitable[List[ConnectionManager]]]:
+    """Return a callable that forwards to helpers.setup_connections
+    using the shared *exit_stack*.
+
+    Usage inside a test or another fixture::
+
+        managers = await setup_connections_factory([ConnectionTag.DOCKER_VPN_1])
+    """
+
+    async def _factory(
+        connection_parameters: List[
+            Union[
+                ConnectionTag,
+                Tuple[ConnectionTag, Optional[list]],
+            ]
+        ],
+    ) -> List[ConnectionManager]:
+        return await _setup_connections(exit_stack, connection_parameters)
+
+    return _factory
+
+
+# ---------------------------------------------------------------------------
+# 2b) Factory fixture for setup_mesh_nodes
+# ---------------------------------------------------------------------------
+@pytest.fixture(name="setup_mesh_nodes_factory")
+def _setup_mesh_nodes_factory(
+    exit_stack: AsyncExitStack,
+) -> Callable[..., Awaitable[Environment]]:
+    """Return a callable that forwards to helpers.setup_mesh_nodes
+    using the shared *exit_stack*."""
+
+    async def _factory(
+        instances: List[SetupParameters],
+        is_timeout_expected: bool = False,
+        provided_api=None,
+        vpn=None,
+    ) -> Environment:
+        return await _setup_mesh_nodes(
+            exit_stack,
+            instances,
+            is_timeout_expected=is_timeout_expected,
+            provided_api=provided_api,
+            vpn=vpn,
+        )
+
+    return _factory
+
+
+# ===========================================================================
+# VPN TAGS — composable VPN configuration
+# ===========================================================================
+
+
+@pytest.fixture(name="vpn_tags")
+def _vpn_tags() -> List[ConnectionTag]:
+    """Default: no VPN servers. Override in test module or conftest to add VPN."""
+    return []
+
+
+# ===========================================================================
+# ENVIRONMENT FIXTURES
+# ===========================================================================
+
+
+# --- Optional VPN-side connection (for ping-back) ---
+
+
+@pytest_asyncio.fixture(name="vpn_server_connection")
+async def _vpn_server_connection(
+    vpn_conf: VpnConfig,
+    setup_connections_factory: Callable[..., Awaitable[List[ConnectionManager]]],
+) -> Optional[ConnectionManager]:
+    """When *vpn_conf.should_ping_client* is True, establish a connection
+    to the VPN server container and return its ``ConnectionManager``.
+    Otherwise return ``None``.
+    """
+    if vpn_conf.should_ping_client:
+        managers = await setup_connections_factory([vpn_conf.conn_tag])
+        return managers[0]
+    return None
+
+
+@pytest_asyncio.fixture(name="dual_vpn_server_connections")
+async def _dual_vpn_server_connections(
+    setup_connections_factory: Callable[..., Awaitable[List[ConnectionManager]]],
+) -> Tuple[ConnectionManager, ConnectionManager]:
+    """Establish connections to both VPN server containers for reconnect tests."""
+    vpn_1, vpn_2 = await setup_connections_factory(
+        [ConnectionTag.DOCKER_VPN_1, ConnectionTag.DOCKER_VPN_2]
+    )
+    return vpn_1, vpn_2
+
+
+@pytest_asyncio.fixture(name="single_vpn_server_connection")
+async def _single_vpn_server_connection(
+    setup_connections_factory: Callable[..., Awaitable[List[ConnectionManager]]],
+) -> ConnectionManager:
+    """Establish a connection to the VPN server for key-change tests."""
+    managers = await setup_connections_factory([ConnectionTag.DOCKER_VPN_1])
+    return managers[0]
+
+
+# ---------------------------------------------------------------------------
+# Auto-detection of *_setup_params fixtures
+# ---------------------------------------------------------------------------
+
+_PARAM_NAMES = ["alpha_setup_params", "beta_setup_params", "gamma_setup_params"]
+
+
+def _resolve_setup_params(request: pytest.FixtureRequest) -> List[SetupParameters]:
+    """Dynamically resolve available *_setup_params fixtures.
+
+    Tries alpha, beta, gamma in order. Stops at the first missing fixture.
+    At least alpha_setup_params must be available.
+    """
+    instances: List[SetupParameters] = []
+    for name in _PARAM_NAMES:
+        try:
+            instances.append(request.getfixturevalue(name))
+        except pytest.FixtureLookupError:
+            break
+    if not instances:
+        raise ValueError(
+            "env_mesh/env fixture requires at least alpha_setup_params to be "
+            "parametrized on the test"
+        )
+    return instances
+
+
+# ---------------------------------------------------------------------------
+# env_mesh — dynamic mesh environment (auto-detects available *_setup_params)
+# ---------------------------------------------------------------------------
+@pytest_asyncio.fixture(name="env_mesh")
+async def _env_mesh(
+    request: pytest.FixtureRequest,
+    exit_stack: AsyncExitStack,
+    vpn_tags: List[ConnectionTag],
+) -> Environment:
+    """Dynamic mesh environment. Auto-detects available *_setup_params fixtures."""
+    instances = _resolve_setup_params(request)
+    return await _setup_mesh_nodes(
+        exit_stack,
+        instances,
+        vpn=vpn_tags or None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# env — dynamic non-mesh environment (auto-detects available *_setup_params)
+# ---------------------------------------------------------------------------
+@pytest_asyncio.fixture(name="env")
+async def _env(
+    request: pytest.FixtureRequest,
+    exit_stack: AsyncExitStack,
+    vpn_tags: List[ConnectionTag],
+) -> Environment:
+    """Dynamic non-mesh environment. Auto-detects available *_setup_params fixtures."""
+    instances = _resolve_setup_params(request)
+    return await exit_stack.enter_async_context(
+        _setup_environment(
+            exit_stack,
+            instances,
+            vpn=vpn_tags or None,
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# env_mesh_3node_ring_fw — 3-node mesh, ring firewall (no extractors)
+# ---------------------------------------------------------------------------
+@pytest_asyncio.fixture(name="env_mesh_3node_ring_fw")
+async def _env_mesh_3node_ring_fw(
+    exit_stack: AsyncExitStack,
+    alpha_setup_params: SetupParameters,
+    beta_setup_params: SetupParameters,
+    gamma_setup_params: SetupParameters,
+) -> Environment:
+    """Set up a 3-node mesh with default_config_three_nodes and ring-shaped
+    firewall restrictions (each node blocks incoming from one peer)."""
+    api = API()
+    alpha, beta, gamma = api.default_config_three_nodes()
+
+    alpha.set_peer_firewall_settings(beta.id, allow_incoming_connections=False)
+    beta.set_peer_firewall_settings(gamma.id, allow_incoming_connections=False)
+    gamma.set_peer_firewall_settings(alpha.id, allow_incoming_connections=False)
+
+    return await _setup_mesh_nodes(
+        exit_stack,
+        [alpha_setup_params, beta_setup_params, gamma_setup_params],
+        provided_api=api,
+    )

--- a/nat-lab/tests/helpers_fixtures.py
+++ b/nat-lab/tests/helpers_fixtures.py
@@ -156,7 +156,8 @@ _PARAM_NAMES = ["alpha_setup_params", "beta_setup_params", "gamma_setup_params"]
 def _resolve_setup_params(request: pytest.FixtureRequest) -> List[SetupParameters]:
     """Dynamically resolve available *_setup_params fixtures.
 
-    Tries alpha, beta, gamma in order. Stops at the first missing fixture.
+    Tries alpha, beta, gamma in order.  Skips any that are not defined so
+    that e.g. alpha + gamma (without beta) is supported.
     At least alpha_setup_params must be available.
     """
     instances: List[SetupParameters] = []
@@ -164,7 +165,7 @@ def _resolve_setup_params(request: pytest.FixtureRequest) -> List[SetupParameter
         try:
             instances.append(request.getfixturevalue(name))
         except pytest.FixtureLookupError:
-            break
+            continue
     if not instances:
         raise ValueError(
             "env_mesh/env fixture requires at least alpha_setup_params to be "

--- a/nat-lab/tests/helpers_fixtures.py
+++ b/nat-lab/tests/helpers_fixtures.py
@@ -30,11 +30,11 @@ async def _exit_stack() -> AsyncGenerator[AsyncExitStack, None]:
     yield stack
     try:
         await asyncio.wait_for(stack.aclose(), timeout=60)
-    except asyncio.TimeoutError:
+    except asyncio.TimeoutError as e:
         raise RuntimeError(
             "exit_stack fixture teardown timed out after 60s — "
             "likely a context manager is stuck during cleanup"
-        ) from None
+        ) from e
 
 
 # ---------------------------------------------------------------------------
@@ -119,6 +119,13 @@ async def _vpn_server_connection(
     """When *vpn_conf.should_ping_client* is True, establish a connection
     to the VPN server container and return its ``ConnectionManager``.
     Otherwise return ``None``.
+
+    .. note::
+        ``vpn_conf`` is **not** defined in this module.  The calling test
+        must supply it via ``@pytest.mark.parametrize("vpn_conf", [...])``
+        or by defining a ``vpn_conf`` fixture in its own module / conftest.
+        Requesting this fixture without a ``vpn_conf`` source will raise a
+        ``FixtureLookupError`` at collection time.
     """
     if vpn_conf.should_ping_client:
         managers = await setup_connections_factory([vpn_conf.conn_tag])
@@ -156,8 +163,10 @@ _PARAM_NAMES = ["alpha_setup_params", "beta_setup_params", "gamma_setup_params"]
 def _resolve_setup_params(request: pytest.FixtureRequest) -> List[SetupParameters]:
     """Dynamically resolve available *_setup_params fixtures.
 
-    Tries alpha, beta, gamma in order.  Skips any that are not defined so
-    that e.g. alpha + gamma (without beta) is supported.
+    Tries alpha, beta, gamma in order and stops at the first missing fixture.
+    This preserves positional semantics: index 0 is always alpha, index 1 is
+    always beta, etc.  Gaps (e.g. alpha + gamma without beta) are not
+    supported — define contiguous fixtures starting from alpha.
     At least alpha_setup_params must be available.
     """
     instances: List[SetupParameters] = []
@@ -165,7 +174,7 @@ def _resolve_setup_params(request: pytest.FixtureRequest) -> List[SetupParameter
         try:
             instances.append(request.getfixturevalue(name))
         except pytest.FixtureLookupError:
-            continue
+            break
     if not instances:
         raise ValueError(
             "env_mesh/env fixture requires at least alpha_setup_params to be "

--- a/nat-lab/tests/test_adapter.py
+++ b/nat-lab/tests/test_adapter.py
@@ -1,14 +1,8 @@
 import asyncio
 import pytest
-from contextlib import AsyncExitStack
 from enum import Enum
 from tests import config
-from tests.helpers import (
-    SetupParameters,
-    setup_environment,
-    setup_mesh_nodes,
-    setup_connections,
-)
+from tests.helpers import SetupParameters, Environment
 from tests.utils import asyncio_util
 from tests.utils.bindings import (
     ErrorEvent,
@@ -18,8 +12,14 @@ from tests.utils.bindings import (
     default_features,
 )
 from tests.utils.connection import TargetOS, ConnectionTag
-from tests.utils.connection_util import generate_connection_tracker_config
+from tests.utils.connection_util import (
+    generate_connection_tracker_config,
+    ConnectionManager,
+)
 from tests.utils.process import ProcessExecError
+from typing import Awaitable, Callable, List
+
+pytest_plugins = ["tests.helpers_fixtures"]
 
 
 class AdapterState(Enum):
@@ -70,47 +70,49 @@ async def get_interface_state(client_conn, client):
         ),
     ],
 )
-async def test_adapter_gone_event(alpha_setup_params: SetupParameters) -> None:
-    async with AsyncExitStack() as exit_stack:
-        env = await setup_mesh_nodes(exit_stack, [alpha_setup_params])
-        conn, *_ = [conn.connection for conn in env.connections]
-        client, *_ = env.clients
+async def test_adapter_gone_event(
+    alpha_setup_params: SetupParameters,  # pylint: disable=unused-argument
+    env_mesh: Environment,
+) -> None:
+    env = env_mesh
+    conn, *_ = [conn.connection for conn in env.connections]
+    client, *_ = env.clients
 
-        expected_event = ErrorEvent(
-            level=ErrorLevel.CRITICAL,
-            code=ErrorCode.UNKNOWN,
-            msg="Interface gone",
+    expected_event = ErrorEvent(
+        level=ErrorLevel.CRITICAL,
+        code=ErrorCode.UNKNOWN,
+        msg="Interface gone",
+    )
+
+    async def delete_adapter() -> None:
+        iface = client.get_router().get_interface_name()
+
+        if conn.target_os == TargetOS.Linux:
+            await conn.create_process(["ip", "link", "delete", iface]).execute()
+
+        elif conn.target_os == TargetOS.Windows:
+            try:
+                await conn.create_process(
+                    ["netsh", "interface", "set", "interface", iface, "disable"]
+                ).execute()
+            except ProcessExecError as e:
+                if e.returncode != 1:
+                    raise
+        else:
+            raise RuntimeError("unsupported os")
+
+    async with asyncio_util.run_async_context(
+        client.wait_for_event_error(expected_event)
+    ) as event:
+        await asyncio.gather(
+            delete_adapter(),
+            event,
         )
 
-        async def delete_adapter() -> None:
-            iface = client.get_router().get_interface_name()
-
-            if conn.target_os == TargetOS.Linux:
-                await conn.create_process(["ip", "link", "delete", iface]).execute()
-
-            elif conn.target_os == TargetOS.Windows:
-                try:
-                    await conn.create_process(
-                        ["netsh", "interface", "set", "interface", iface, "disable"]
-                    ).execute()
-                except ProcessExecError as e:
-                    if e.returncode != 1:
-                        raise
-            else:
-                raise RuntimeError("unsupported os")
-
-        async with asyncio_util.run_async_context(
-            client.wait_for_event_error(expected_event)
-        ) as event:
-            await asyncio.gather(
-                delete_adapter(),
-                event,
-            )
-
-        client.allow_errors([
-            "neptun::device.*Fatal read error on tun interface",
-            "telio_wg::adapter::linux_native_wg.*LinuxNativeWg: \\[GET01\\] Unable to get interface from WireGuard. Make sure it exists and you have permissions to access it.",
-        ])
+    client.allow_errors([
+        "neptun::device.*Fatal read error on tun interface",
+        "telio_wg::adapter::linux_native_wg.*LinuxNativeWg: \\[GET01\\] Unable to get interface from WireGuard. Make sure it exists and you have permissions to access it.",
+    ])
 
 
 @pytest.mark.parametrize(
@@ -136,81 +138,81 @@ async def test_adapter_gone_event(alpha_setup_params: SetupParameters) -> None:
     ],
 )
 async def test_adapter_service_loading(
-    alpha_setup_params: SetupParameters, beta_setup_params: SetupParameters
+    alpha_setup_params: SetupParameters,
+    beta_setup_params: SetupParameters,
+    setup_connections_factory: Callable[..., Awaitable[List[ConnectionManager]]],
+    setup_mesh_nodes_factory: Callable[..., Awaitable[Environment]],
 ) -> None:
     """
     Windows-only test that verifies that the adapter service can be loaded, even if it was un-loaded before.
     """
-    async with AsyncExitStack() as exit_stack:
-        connection = (
-            await setup_connections(exit_stack, [alpha_setup_params.connection_tag])
-        )[0].connection
+    managers = await setup_connections_factory([alpha_setup_params.connection_tag])
+    connection = managers[0].connection
 
-        try:
-            await connection.create_process([
-                "sc",
-                "delete",
-                "WireGuard",
-            ]).execute()
-        except ProcessExecError:
-            pass
+    try:
+        await connection.create_process([
+            "sc",
+            "delete",
+            "WireGuard",
+        ]).execute()
+    except ProcessExecError:
+        pass
 
-        try:
-            await connection.create_process([
-                "sc",
-                "delete",
-                "Wintun",
-            ]).execute()
-        except ProcessExecError:
-            pass
+    try:
+        await connection.create_process([
+            "sc",
+            "delete",
+            "Wintun",
+        ]).execute()
+    except ProcessExecError:
+        pass
 
-    async with AsyncExitStack() as exit_stack:
-        _ = await setup_mesh_nodes(exit_stack, [alpha_setup_params, beta_setup_params])
+    _ = await setup_mesh_nodes_factory([alpha_setup_params, beta_setup_params])
 
 
-@pytest.mark.parametrize(
-    "alpha_setup_params",
-    [
-        pytest.param(
-            SetupParameters(
-                connection_tag=ConnectionTag.VM_WINDOWS_1,
-                adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
-                connection_tracker_config=generate_connection_tracker_config(
+class TestAdapterStateForVpnAndDns:
+    """Tests requiring single VPN with 1-node non-mesh (env)."""
+
+    @pytest.fixture(name="vpn_tags")
+    def _vpn_tags(self) -> list:
+        return [ConnectionTag.DOCKER_VPN_1]
+
+    @pytest.mark.parametrize(
+        "alpha_setup_params",
+        [
+            pytest.param(
+                SetupParameters(
                     connection_tag=ConnectionTag.VM_WINDOWS_1,
-                    vpn_1_limits=(1, 1),
+                    adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
+                    connection_tracker_config=generate_connection_tracker_config(
+                        connection_tag=ConnectionTag.VM_WINDOWS_1,
+                        vpn_1_limits=(1, 1),
+                    ),
+                    is_meshnet=False,
+                    features=default_features(enable_dynamic_wg_nt_control=True),
                 ),
-                is_meshnet=False,
-                features=default_features(enable_dynamic_wg_nt_control=True),
+                marks=[pytest.mark.windows],
             ),
-            marks=[pytest.mark.windows],
-        ),
-        pytest.param(
-            SetupParameters(
-                connection_tag=ConnectionTag.VM_WINDOWS_1,
-                adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
-                connection_tracker_config=generate_connection_tracker_config(
+            pytest.param(
+                SetupParameters(
                     connection_tag=ConnectionTag.VM_WINDOWS_1,
-                    vpn_1_limits=(1, 1),
+                    adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
+                    connection_tracker_config=generate_connection_tracker_config(
+                        connection_tag=ConnectionTag.VM_WINDOWS_1,
+                        vpn_1_limits=(1, 1),
+                    ),
+                    is_meshnet=False,
+                    features=default_features(enable_dynamic_wg_nt_control=False),
                 ),
-                is_meshnet=False,
-                features=default_features(enable_dynamic_wg_nt_control=False),
+                marks=[pytest.mark.windows],
             ),
-            marks=[pytest.mark.windows],
-        ),
-    ],
-)
-async def test_adapter_state_for_vpn_and_dns(
-    alpha_setup_params: SetupParameters,
-) -> None:
-    async with AsyncExitStack() as exit_stack:
-        env = await exit_stack.enter_async_context(
-            setup_environment(
-                exit_stack,
-                [alpha_setup_params],
-                vpn=[ConnectionTag.DOCKER_VPN_1],
-            )
-        )
-
+        ],
+    )
+    async def test_adapter_state_for_vpn_and_dns(
+        self,
+        alpha_setup_params: SetupParameters,
+        env: Environment,
+    ) -> None:
         client_conn, *_ = [conn.connection for conn in env.connections]
         client_alpha, *_ = env.clients
 
@@ -282,37 +284,35 @@ async def test_adapter_state_for_vpn_and_dns(
         ),
     ],
 )
-async def test_adapter_state_for_meshnet(alpha_setup_params: SetupParameters) -> None:
-    async with AsyncExitStack() as exit_stack:
-        # Creates and enables meshnet without any nodes
-        env = await exit_stack.enter_async_context(
-            setup_environment(exit_stack, [alpha_setup_params])
-        )
+async def test_adapter_state_for_meshnet(
+    alpha_setup_params: SetupParameters,
+    env: Environment,
+) -> None:
+    # Creates and enables meshnet without any nodes
+    api = env.api
+    client_conn, *_ = [conn.connection for conn in env.connections]
+    client_alpha, *_ = env.clients
 
-        api = env.api
-        client_conn, *_ = [conn.connection for conn in env.connections]
-        client_alpha, *_ = env.clients
+    expected_idle_state = (
+        AdapterState.DOWN
+        if alpha_setup_params.features.wireguard.enable_dynamic_wg_nt_control
+        else AdapterState.UP
+    )
 
-        expected_idle_state = (
-            AdapterState.DOWN
-            if alpha_setup_params.features.wireguard.enable_dynamic_wg_nt_control
-            else AdapterState.UP
-        )
+    state = await get_interface_state(client_conn, client_alpha)
+    assert state == expected_idle_state
 
-        state = await get_interface_state(client_conn, client_alpha)
-        assert state == expected_idle_state
+    # Add node to meshnet
+    api.default_config_two_nodes()
+    first_node_id = next(iter(api.nodes))
+    await client_alpha.set_meshnet_config(
+        api.get_meshnet_config(first_node_id, derp_servers=[config.DERP_PRIMARY])
+    )
 
-        # Add node to meshnet
-        api.default_config_two_nodes()
-        first_node_id = next(iter(api.nodes))
-        await client_alpha.set_meshnet_config(
-            api.get_meshnet_config(first_node_id, derp_servers=[config.DERP_PRIMARY])
-        )
+    state = await get_interface_state(client_conn, client_alpha)
+    assert state == AdapterState.UP
 
-        state = await get_interface_state(client_conn, client_alpha)
-        assert state == AdapterState.UP
+    await client_alpha.set_mesh_off()
 
-        await client_alpha.set_mesh_off()
-
-        state = await get_interface_state(client_conn, client_alpha)
-        assert state == expected_idle_state
+    state = await get_interface_state(client_conn, client_alpha)
+    assert state == expected_idle_state

--- a/nat-lab/tests/test_adapter.py
+++ b/nat-lab/tests/test_adapter.py
@@ -19,8 +19,6 @@ from tests.utils.connection_util import (
 from tests.utils.process import ProcessExecError
 from typing import Awaitable, Callable, List
 
-pytest_plugins = ["tests.helpers_fixtures"]
-
 
 class AdapterState(Enum):
     DOWN = (0,)

--- a/nat-lab/tests/test_connection_states.py
+++ b/nat-lab/tests/test_connection_states.py
@@ -1,10 +1,11 @@
 import pytest
-from contextlib import AsyncExitStack
-from tests.helpers import SetupParameters, setup_mesh_nodes
+from tests.helpers import SetupParameters, Environment
 from tests.utils.bindings import TelioAdapterType
 from tests.utils.connection import ConnectionTag
 from tests.utils.connection_util import generate_connection_tracker_config
 from tests.utils.ping import ping
+
+pytest_plugins = ["tests.helpers_fixtures"]
 
 
 @pytest.mark.asyncio
@@ -71,25 +72,24 @@ from tests.utils.ping import ping
     ],
 )
 async def test_connected_state_after_routing(
-    alpha_setup_params: SetupParameters, beta_setup_params: SetupParameters
+    alpha_setup_params: SetupParameters,  # pylint: disable=unused-argument
+    beta_setup_params: SetupParameters,  # pylint: disable=unused-argument
+    env_mesh: Environment,
 ) -> None:
-    async with AsyncExitStack() as exit_stack:
-        env = await setup_mesh_nodes(
-            exit_stack, [alpha_setup_params, beta_setup_params]
-        )
+    env = env_mesh
 
-        _, beta = env.nodes
-        client_alpha, client_beta = env.clients
-        conn_alpha, _ = env.connections
+    _, beta = env.nodes
+    client_alpha, client_beta = env.clients
+    conn_alpha, _ = env.connections
 
-        await client_beta.get_router().create_exit_node_route()
+    await client_beta.get_router().create_exit_node_route()
 
-        await client_alpha.connect_to_exit_node(beta.public_key)
-        await client_alpha.disconnect_from_exit_node(beta.public_key)
+    await client_alpha.connect_to_exit_node(beta.public_key)
+    await client_alpha.disconnect_from_exit_node(beta.public_key)
 
-        await ping(conn_alpha.connection, beta.ip_addresses[0])
+    await ping(conn_alpha.connection, beta.ip_addresses[0])
 
-        # LLT-5532: To be cleaned up...
-        client_beta.allow_errors([
-            "neptun::device.*Decapsulate error error=UnexpectedPacket public_key=.*",
-        ])
+    # LLT-5532: To be cleaned up...
+    client_beta.allow_errors([
+        "neptun::device.*Decapsulate error error=UnexpectedPacket public_key=.*",
+    ])

--- a/nat-lab/tests/test_connection_states.py
+++ b/nat-lab/tests/test_connection_states.py
@@ -5,8 +5,6 @@ from tests.utils.connection import ConnectionTag
 from tests.utils.connection_util import generate_connection_tracker_config
 from tests.utils.ping import ping
 
-pytest_plugins = ["tests.helpers_fixtures"]
-
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(

--- a/nat-lab/tests/test_direct_feature.py
+++ b/nat-lab/tests/test_direct_feature.py
@@ -1,8 +1,9 @@
 import pytest
-from contextlib import AsyncExitStack
-from tests.helpers import setup_mesh_nodes, SetupParameters
+from tests.helpers import SetupParameters, Environment
 from tests.utils.bindings import features_with_endpoint_providers, EndpointProvider
 from typing import List
+
+pytest_plugins = ["tests.helpers_fixtures"]
 
 ALL_DIRECT_FEATURES = [
     EndpointProvider.UPNP,
@@ -12,48 +13,66 @@ ALL_DIRECT_FEATURES = [
 EMPTY_PROVIDER: List[EndpointProvider] = []
 
 
+@pytest.mark.parametrize(
+    "alpha_setup_params",
+    [
+        pytest.param(
+            SetupParameters(features=features_with_endpoint_providers(None)),
+        ),
+    ],
+)
 @pytest.mark.asyncio
-async def test_default_direct_features() -> None:
-    async with AsyncExitStack() as exit_stack:
-        env = await setup_mesh_nodes(
-            exit_stack,
-            [SetupParameters(features=features_with_endpoint_providers(None))],
-        )
-        started_tasks = env.clients[0].get_runtime().get_started_tasks()
-        assert "UpnpEndpointProvider" not in started_tasks
-        assert "LocalInterfacesEndpointProvider" in started_tasks
-        assert "StunEndpointProvider" in started_tasks
+async def test_default_direct_features(
+    alpha_setup_params: SetupParameters,  # pylint: disable=unused-argument
+    env_mesh: Environment,
+) -> None:
+    alpha_client = env_mesh.clients[0]
+
+    started_tasks = alpha_client.get_runtime().get_started_tasks()
+    assert "UpnpEndpointProvider" not in started_tasks
+    assert "LocalInterfacesEndpointProvider" in started_tasks
+    assert "StunEndpointProvider" in started_tasks
 
 
+@pytest.mark.parametrize(
+    "alpha_setup_params",
+    [
+        pytest.param(
+            SetupParameters(
+                features=features_with_endpoint_providers(ALL_DIRECT_FEATURES)
+            ),
+        ),
+    ],
+)
 @pytest.mark.asyncio
-async def test_enable_all_direct_features() -> None:
-    async with AsyncExitStack() as exit_stack:
-        env = await setup_mesh_nodes(
-            exit_stack,
-            [
-                SetupParameters(
-                    features=features_with_endpoint_providers(ALL_DIRECT_FEATURES)
-                )
-            ],
-        )
-        started_tasks = env.clients[0].get_runtime().get_started_tasks()
-        assert "UpnpEndpointProvider" in started_tasks
-        assert "LocalInterfacesEndpointProvider" in started_tasks
-        assert "StunEndpointProvider" in started_tasks
+async def test_enable_all_direct_features(
+    alpha_setup_params: SetupParameters,  # pylint: disable=unused-argument
+    env_mesh: Environment,
+) -> None:
+    alpha_client = env_mesh.clients[0]
+
+    started_tasks = alpha_client.get_runtime().get_started_tasks()
+    assert "UpnpEndpointProvider" in started_tasks
+    assert "LocalInterfacesEndpointProvider" in started_tasks
+    assert "StunEndpointProvider" in started_tasks
 
 
+@pytest.mark.parametrize(
+    "alpha_setup_params",
+    [
+        pytest.param(
+            SetupParameters(features=features_with_endpoint_providers(EMPTY_PROVIDER)),
+        ),
+    ],
+)
 @pytest.mark.asyncio
-async def test_check_features_with_empty_direct_providers() -> None:
-    async with AsyncExitStack() as exit_stack:
-        env = await setup_mesh_nodes(
-            exit_stack,
-            [
-                SetupParameters(
-                    features=features_with_endpoint_providers(EMPTY_PROVIDER)
-                )
-            ],
-        )
-        started_tasks = env.clients[0].get_runtime().get_started_tasks()
-        assert "UpnpEndpointProvider" not in started_tasks
-        assert "LocalInterfacesEndpointProvider" not in started_tasks
-        assert "StunEndpointProvider" not in started_tasks
+async def test_check_features_with_empty_direct_providers(
+    alpha_setup_params: SetupParameters,  # pylint: disable=unused-argument
+    env_mesh: Environment,
+) -> None:
+    alpha_client = env_mesh.clients[0]
+
+    started_tasks = alpha_client.get_runtime().get_started_tasks()
+    assert "UpnpEndpointProvider" not in started_tasks
+    assert "LocalInterfacesEndpointProvider" not in started_tasks
+    assert "StunEndpointProvider" not in started_tasks

--- a/nat-lab/tests/test_direct_feature.py
+++ b/nat-lab/tests/test_direct_feature.py
@@ -3,8 +3,6 @@ from tests.helpers import SetupParameters, Environment
 from tests.utils.bindings import features_with_endpoint_providers, EndpointProvider
 from typing import List
 
-pytest_plugins = ["tests.helpers_fixtures"]
-
 ALL_DIRECT_FEATURES = [
     EndpointProvider.UPNP,
     EndpointProvider.LOCAL,

--- a/nat-lab/tests/test_dns_through_exit.py
+++ b/nat-lab/tests/test_dns_through_exit.py
@@ -2,14 +2,16 @@ import asyncio
 import pytest
 from contextlib import AsyncExitStack
 from tests import config
-from tests.helpers import setup_api, setup_mesh_nodes, SetupParameters
+from tests.helpers import SetupParameters, setup_api, Environment
 from tests.test_dns import _dns_features, DNS_FORWARDER_PARAMS
 from tests.utils.bindings import TelioAdapterType
 from tests.utils.connection import ConnectionTag
 from tests.utils.connection_util import generate_connection_tracker_config
 from tests.utils.dns import query_dns
 from tests.utils.router import IPStack
-from typing import List, Tuple
+from typing import List, Tuple, Callable, Awaitable
+
+pytest_plugins = ["tests.helpers_fixtures"]
 
 
 # IPv6 tests are failing because we do not have IPV6 internet connection
@@ -111,104 +113,102 @@ from typing import List, Tuple
     ],
 )
 async def test_dns_through_exit(
+    exit_stack: AsyncExitStack,
+    setup_mesh_nodes_factory: Callable[..., Awaitable[Environment]],
     alpha_setup_params: SetupParameters,
     beta_setup_params: SetupParameters,
     alpha_info: Tuple[IPStack, List[str]],
     exit_info: Tuple[IPStack, List[str]],
     use_raw_forwarder: bool,
 ) -> None:
-    async with AsyncExitStack() as exit_stack:
-        if (alpha_info[0] == IPStack.IPv4 and exit_info[0] == IPStack.IPv6) or (
-            alpha_info[0] == IPStack.IPv6 and exit_info[0] == IPStack.IPv4
-        ):
-            # Incompatible configurations
-            pytest.skip()
+    if (alpha_info[0] == IPStack.IPv4 and exit_info[0] == IPStack.IPv6) or (
+        alpha_info[0] == IPStack.IPv6 and exit_info[0] == IPStack.IPv4
+    ):
+        # Incompatible configurations
+        pytest.skip()
 
-        dns_server_address_exit = (
-            config.LIBTELIO_DNS_IPV4
-            if exit_info[0] in [IPStack.IPv4, IPStack.IPv4v6]
-            else config.LIBTELIO_DNS_IPV6
-        )
-        dns_server_address_local = (
-            config.LIBTELIO_DNS_IPV4
-            if alpha_info[0] in [IPStack.IPv4, IPStack.IPv4v6]
-            else config.LIBTELIO_DNS_IPV6
-        )
+    dns_server_address_exit = (
+        config.LIBTELIO_DNS_IPV4
+        if exit_info[0] in [IPStack.IPv4, IPStack.IPv4v6]
+        else config.LIBTELIO_DNS_IPV6
+    )
+    dns_server_address_local = (
+        config.LIBTELIO_DNS_IPV4
+        if alpha_info[0] in [IPStack.IPv4, IPStack.IPv4v6]
+        else config.LIBTELIO_DNS_IPV6
+    )
 
-        api, (alpha, beta) = setup_api(
-            [(False, alpha_setup_params.ip_stack), (False, beta_setup_params.ip_stack)]
-        )
-        beta.set_peer_firewall_settings(
-            alpha.id, allow_incoming_connections=True, allow_peer_traffic_routing=True
-        )
+    api, (alpha, beta) = setup_api(
+        [(False, alpha_setup_params.ip_stack), (False, beta_setup_params.ip_stack)]
+    )
+    beta.set_peer_firewall_settings(
+        alpha.id, allow_incoming_connections=True, allow_peer_traffic_routing=True
+    )
 
-        alpha_setup_params.features = _dns_features(use_raw_forwarder)
-        beta_setup_params.features = _dns_features(
-            use_raw_forwarder, enable_firewall_exclusion_range="10.0.0.0/8"
-        )
+    alpha_setup_params.features = _dns_features(use_raw_forwarder)
+    beta_setup_params.features = _dns_features(
+        use_raw_forwarder, enable_firewall_exclusion_range="10.0.0.0/8"
+    )
 
-        env = await setup_mesh_nodes(
-            exit_stack,
-            [alpha_setup_params, beta_setup_params],
-            provided_api=api,
-        )
+    env = await setup_mesh_nodes_factory(
+        [alpha_setup_params, beta_setup_params],
+        provided_api=api,
+    )
 
-        _, exit_node = env.nodes
-        client_alpha, client_exit = env.clients
-        connection_alpha, _ = [conn.connection for conn in env.connections]
+    _, exit_node = env.nodes
+    client_alpha, client_exit = env.clients
+    connection_alpha, _ = [conn.connection for conn in env.connections]
 
-        # entry connects to exit
-        await client_exit.get_router().create_exit_node_route()
+    # entry connects to exit
+    await client_exit.get_router().create_exit_node_route()
 
-        await client_alpha.connect_to_exit_node(exit_node.public_key)
+    await client_alpha.connect_to_exit_node(exit_node.public_key)
 
-        await client_exit.enable_magic_dns(exit_info[1])
+    await client_exit.enable_magic_dns(exit_info[1])
 
-        # if this times out dns forwarder failed to start
-        await query_dns(
-            connection_alpha, "google.com", dns_server=dns_server_address_exit
-        )
+    # if this times out dns forwarder failed to start
+    await query_dns(connection_alpha, "google.com", dns_server=dns_server_address_exit)
 
-        # sending dns straight to exit peer's dns forwarder(as will be done on linux/windows)
-        await query_dns(
-            connection_alpha,
-            "google.com",
-            dns_server=dns_server_address_exit,
-            expected_output=["Name:.*google.com.*Address"],
-        )
+    # sending dns straight to exit peer's dns forwarder(as will be done on linux/windows)
+    await query_dns(
+        connection_alpha,
+        "google.com",
+        dns_server=dns_server_address_exit,
+        expected_output=["Name:.*google.com.*Address"],
+    )
 
-        await client_alpha.enable_magic_dns(alpha_info[1])
+    await client_alpha.enable_magic_dns(alpha_info[1])
 
-        async def disable_path(addr):
-            await exit_stack.enter_async_context(
-                client_exit.get_router().disable_path(addr)
-            )
-
-        # blocking dns-server-1 and its ipv6 counterpart, to make sure requests go to dns-server-2
-        await asyncio.gather(*[disable_path(addr) for addr in alpha_info[1]])
-
-        # sending dns to local forwarder, which should forward it to exit dns forwarder(apple/android way)
-        await query_dns(
-            connection_alpha,
-            "google.com",
-            dns_server=dns_server_address_local,
-            expected_output=["Name:.*google.com.*Address"],
-            options=["-timeout=5"],
-        )
-        await client_alpha.disconnect_from_exit_node(exit_node.public_key)
-
-        # local forwarder should resolve this, checking if forward ips are changed back correctly
-        await query_dns(
-            connection_alpha,
-            "google.com",
-            dns_server=dns_server_address_local,
-            expected_output=["Name:.*google.com.*Address"],
+    async def disable_path(addr):
+        await exit_stack.enter_async_context(
+            client_exit.get_router().disable_path(addr)
         )
 
-        # LLT-5532: To be cleaned up...
-        client_alpha.allow_errors(
-            ["telio_dns::nameserver.*Invalid protocol for DNS request"]
-        )
-        client_exit.allow_errors(
-            ["telio_dns::nameserver.*Invalid protocol for DNS request"]
-        )
+    # blocking dns-server-1 and its ipv6 counterpart, to make sure requests go to dns-server-2
+    await asyncio.gather(*[disable_path(addr) for addr in alpha_info[1]])
+
+    # sending dns to local forwarder, which should forward it to exit dns forwarder(apple/android way)
+    await query_dns(
+        connection_alpha,
+        "google.com",
+        dns_server=dns_server_address_local,
+        expected_output=["Name:.*google.com.*Address"],
+        options=["-timeout=5"],
+    )
+    await client_alpha.disconnect_from_exit_node(exit_node.public_key)
+
+    # local forwarder should resolve this, checking if forward ips are changed back correctly
+    await query_dns(
+        connection_alpha,
+        "google.com",
+        dns_server=dns_server_address_local,
+        expected_output=["Name:.*google.com.*Address"],
+    )
+
+    # LLT-5532: To be cleaned up...
+    client_alpha.allow_errors(
+        ["telio_dns::nameserver.*Invalid protocol for DNS request"]
+    )
+    client_exit.allow_errors(
+        ["telio_dns::nameserver.*Invalid protocol for DNS request"]
+    )

--- a/nat-lab/tests/test_dns_through_exit.py
+++ b/nat-lab/tests/test_dns_through_exit.py
@@ -11,8 +11,6 @@ from tests.utils.dns import query_dns
 from tests.utils.router import IPStack
 from typing import List, Tuple, Callable, Awaitable
 
-pytest_plugins = ["tests.helpers_fixtures"]
-
 
 # IPv6 tests are failing because we do not have IPV6 internet connection
 @pytest.mark.asyncio

--- a/nat-lab/tests/test_fire_connecting_event.py
+++ b/nat-lab/tests/test_fire_connecting_event.py
@@ -1,12 +1,13 @@
 import asyncio
 import pytest
-from contextlib import AsyncExitStack
 from tests import timeouts
-from tests.helpers import SetupParameters, setup_mesh_nodes
+from tests.helpers import SetupParameters, Environment
 from tests.utils.bindings import NodeState, TelioAdapterType
 from tests.utils.connection import ConnectionTag
 from tests.utils.connection_util import generate_connection_tracker_config
 from tests.utils.ping import ping
+
+pytest_plugins = ["tests.helpers_fixtures"]
 
 
 @pytest.mark.asyncio
@@ -36,21 +37,20 @@ from tests.utils.ping import ping
     ],
 )
 async def test_fire_connecting_event(
-    alpha_setup_params: SetupParameters, beta_setup_params: SetupParameters
+    alpha_setup_params: SetupParameters,  # pylint: disable=unused-argument
+    beta_setup_params: SetupParameters,  # pylint: disable=unused-argument
+    env_mesh: Environment,
 ) -> None:
-    async with AsyncExitStack() as exit_stack:
-        env = await setup_mesh_nodes(
-            exit_stack, [alpha_setup_params, beta_setup_params]
-        )
-        _, beta = env.nodes
-        connection_alpha, _ = [conn.connection for conn in env.connections]
-        client_alpha, client_beta = env.clients
+    env = env_mesh
+    _, beta = env.nodes
+    connection_alpha, _ = [conn.connection for conn in env.connections]
+    client_alpha, client_beta = env.clients
 
-        await ping(connection_alpha, beta.ip_addresses[0])
+    await ping(connection_alpha, beta.ip_addresses[0])
 
-        await client_beta.stop_device()
+    await client_beta.stop_device()
 
-        with pytest.raises(asyncio.TimeoutError):
-            await ping(connection_alpha, beta.ip_addresses[0], 15)
+    with pytest.raises(asyncio.TimeoutError):
+        await ping(connection_alpha, beta.ip_addresses[0], 15)
 
-        await client_alpha.wait_for_event_peer(beta.public_key, [NodeState.CONNECTING])
+    await client_alpha.wait_for_event_peer(beta.public_key, [NodeState.CONNECTING])

--- a/nat-lab/tests/test_fire_connecting_event.py
+++ b/nat-lab/tests/test_fire_connecting_event.py
@@ -7,8 +7,6 @@ from tests.utils.connection import ConnectionTag
 from tests.utils.connection_util import generate_connection_tracker_config
 from tests.utils.ping import ping
 
-pytest_plugins = ["tests.helpers_fixtures"]
-
 
 @pytest.mark.asyncio
 @pytest.mark.long

--- a/nat-lab/tests/test_flame_graph_chart.py
+++ b/nat-lab/tests/test_flame_graph_chart.py
@@ -1,18 +1,23 @@
 import pytest
-from contextlib import AsyncExitStack
 from tests import config
-from tests.helpers import SetupParameters, setup_environment
+from tests.helpers import SetupParameters, Environment
 from tests.helpers_vpn import VpnConfig
 from tests.utils.bindings import TelioAdapterType
 from tests.utils.connection import ConnectionTag
 from tests.utils.logger import log
 from tests.utils.ping import ping
 
+pytest_plugins = ["tests.helpers_fixtures"]
 
-@pytest.mark.perf_profiling
-@pytest.mark.asyncio
+
+# Module-level override — all tests in this file get VPN_1
+@pytest.fixture(name="vpn_tags")
+def _vpn_tags() -> list:
+    return [ConnectionTag.DOCKER_VPN_1]
+
+
 @pytest.mark.parametrize(
-    "setup_params",
+    "alpha_setup_params",
     [
         pytest.param(
             SetupParameters(
@@ -37,8 +42,11 @@ from tests.utils.ping import ping
         ),
     ],
 )
+@pytest.mark.perf_profiling
+@pytest.mark.asyncio
 async def test_connect_node_flame_graph_chart(
-    setup_params: SetupParameters,
+    alpha_setup_params: SetupParameters,  # pylint: disable=unused-argument
+    env: Environment,
 ) -> None:
     """
     Collect flame graph chart of connect_to_exit_node command
@@ -50,19 +58,15 @@ async def test_connect_node_flame_graph_chart(
         4. Generate flame graph chart
         5. Save results to logs
     """
-    async with AsyncExitStack() as exit_stack:
-        vpn_conf = VpnConfig(config.WG_SERVER, ConnectionTag.DOCKER_VPN_1, True)
-        log.info("Creating connection to nodes")
-        env = await exit_stack.enter_async_context(
-            setup_environment(exit_stack, [setup_params], vpn=[vpn_conf.conn_tag])
-        )
+    alpha_client, alpha_conn = env.clients[0], env.connections[0].connection
 
-        client_conn, *_ = [conn.connection for conn in env.connections]
-        client_alpha, *_ = env.clients
-        log.info("Connecting to vpn server")
-        await client_alpha.connect_to_vpn(
-            str(vpn_conf.server_conf["ipv4"]),
-            int(vpn_conf.server_conf["port"]),
-            str(vpn_conf.server_conf["public_key"]),
-        )
-        await ping(client_conn, config.PHOTO_ALBUM_IP)
+    vpn_conf = VpnConfig(config.WG_SERVER, ConnectionTag.DOCKER_VPN_1, True)
+    client_conn = alpha_conn
+    client_alpha = alpha_client
+    log.info("Connecting to vpn server")
+    await client_alpha.connect_to_vpn(
+        str(vpn_conf.server_conf["ipv4"]),
+        int(vpn_conf.server_conf["port"]),
+        str(vpn_conf.server_conf["public_key"]),
+    )
+    await ping(client_conn, config.PHOTO_ALBUM_IP)

--- a/nat-lab/tests/test_flame_graph_chart.py
+++ b/nat-lab/tests/test_flame_graph_chart.py
@@ -7,8 +7,6 @@ from tests.utils.connection import ConnectionTag
 from tests.utils.logger import log
 from tests.utils.ping import ping
 
-pytest_plugins = ["tests.helpers_fixtures"]
-
 
 # Module-level override — all tests in this file get VPN_1
 @pytest.fixture(name="vpn_tags")

--- a/nat-lab/tests/test_mesh_firewall.py
+++ b/nat-lab/tests/test_mesh_firewall.py
@@ -2,9 +2,8 @@
 
 import asyncio
 import pytest
-from contextlib import AsyncExitStack
 from tests import config
-from tests.helpers import SetupParameters, setup_mesh_nodes, setup_api
+from tests.helpers import SetupParameters, setup_api, Environment
 from tests.mesh_api import Node
 from tests.utils import testing, stun
 from tests.utils.bindings import default_features, Features, TelioAdapterType
@@ -20,7 +19,9 @@ from tests.utils.logger import log
 from tests.utils.netcat import NetCatServer, NetCatClient
 from tests.utils.ping import ping
 from tests.utils.router import IPProto, IPStack
-from typing import Tuple, Optional
+from typing import Tuple, Optional, Callable, Awaitable
+
+pytest_plugins = ["tests.helpers_fixtures"]
 
 
 def get_ips_and_stack(alpha: Node, beta: Node) -> Tuple[IPProto, str, str]:
@@ -90,72 +91,66 @@ def _setup_params(
 )
 @pytest.mark.asyncio
 async def test_mesh_firewall_successful_passthrough(
-    alpha_ip_stack: IPStack, beta_ip_stack: IPStack
+    setup_mesh_nodes_factory: Callable[..., Awaitable[Environment]],
+    alpha_ip_stack: IPStack,
+    beta_ip_stack: IPStack,
 ) -> None:
-    async with AsyncExitStack() as exit_stack:
-        api, (alpha, beta) = setup_api(
-            [(False, alpha_ip_stack), (False, beta_ip_stack)]
-        )
-        beta.set_peer_firewall_settings(alpha.id, allow_incoming_connections=False)
-        env = await setup_mesh_nodes(
-            exit_stack,
-            [
-                _setup_params(
-                    ConnectionTag.DOCKER_CONE_CLIENT_1, TelioAdapterType.NEP_TUN
-                ),
-                _setup_params(ConnectionTag.DOCKER_CONE_CLIENT_2),
-            ],
-            provided_api=api,
-        )
-        connection_alpha, connection_beta = [
-            conn.connection for conn in env.connections
-        ]
+    api, (alpha, beta) = setup_api([(False, alpha_ip_stack), (False, beta_ip_stack)])
+    beta.set_peer_firewall_settings(alpha.id, allow_incoming_connections=False)
+    env = await setup_mesh_nodes_factory(
+        [
+            _setup_params(ConnectionTag.DOCKER_CONE_CLIENT_1, TelioAdapterType.NEP_TUN),
+            _setup_params(ConnectionTag.DOCKER_CONE_CLIENT_2),
+        ],
+        provided_api=api,
+    )
+    connection_alpha, connection_beta = [conn.connection for conn in env.connections]
 
-        if alpha_ip_stack in [IPStack.IPv4, IPStack.IPv4v6] and beta_ip_stack in [
-            IPStack.IPv4,
-            IPStack.IPv4v6,
-        ]:
-            with pytest.raises(asyncio.TimeoutError):
-                await ping(
-                    connection_alpha,
-                    testing.unpack_optional(beta.get_ip_address(IPProto.IPv4)),
-                    15,
-                )
+    if alpha_ip_stack in [IPStack.IPv4, IPStack.IPv4v6] and beta_ip_stack in [
+        IPStack.IPv4,
+        IPStack.IPv4v6,
+    ]:
+        with pytest.raises(asyncio.TimeoutError):
             await ping(
-                connection_beta,
-                testing.unpack_optional(alpha.get_ip_address(IPProto.IPv4)),
+                connection_alpha,
+                testing.unpack_optional(beta.get_ip_address(IPProto.IPv4)),
+                15,
+            )
+        await ping(
+            connection_beta,
+            testing.unpack_optional(alpha.get_ip_address(IPProto.IPv4)),
+        )
+
+        # this should still block
+        with pytest.raises(asyncio.TimeoutError):
+            await ping(
+                connection_alpha,
+                testing.unpack_optional(beta.get_ip_address(IPProto.IPv4)),
+                15,
+            )
+    if alpha_ip_stack in [IPStack.IPv6, IPStack.IPv4v6] and beta_ip_stack in [
+        IPStack.IPv6,
+        IPStack.IPv4v6,
+    ]:
+        with pytest.raises(asyncio.TimeoutError):
+            await ping(
+                connection_alpha,
+                testing.unpack_optional(beta.get_ip_address(IPProto.IPv6)),
+                15,
             )
 
-            # this should still block
-            with pytest.raises(asyncio.TimeoutError):
-                await ping(
-                    connection_alpha,
-                    testing.unpack_optional(beta.get_ip_address(IPProto.IPv4)),
-                    15,
-                )
-        if alpha_ip_stack in [IPStack.IPv6, IPStack.IPv4v6] and beta_ip_stack in [
-            IPStack.IPv6,
-            IPStack.IPv4v6,
-        ]:
-            with pytest.raises(asyncio.TimeoutError):
-                await ping(
-                    connection_alpha,
-                    testing.unpack_optional(beta.get_ip_address(IPProto.IPv6)),
-                    15,
-                )
+        await ping(
+            connection_beta,
+            testing.unpack_optional(alpha.get_ip_address(IPProto.IPv6)),
+        )
 
+        # this should still block
+        with pytest.raises(asyncio.TimeoutError):
             await ping(
-                connection_beta,
-                testing.unpack_optional(alpha.get_ip_address(IPProto.IPv6)),
+                connection_alpha,
+                testing.unpack_optional(beta.get_ip_address(IPProto.IPv6)),
+                15,
             )
-
-            # this should still block
-            with pytest.raises(asyncio.TimeoutError):
-                await ping(
-                    connection_alpha,
-                    testing.unpack_optional(beta.get_ip_address(IPProto.IPv6)),
-                    15,
-                )
 
 
 @pytest.mark.parametrize(
@@ -190,174 +185,164 @@ async def test_mesh_firewall_successful_passthrough(
 )
 @pytest.mark.asyncio
 async def test_mesh_firewall_reject_packet(
-    alpha_ip_stack: IPStack, beta_ip_stack: IPStack
+    setup_mesh_nodes_factory: Callable[..., Awaitable[Environment]],
+    alpha_ip_stack: IPStack,
+    beta_ip_stack: IPStack,
 ) -> None:
-    async with AsyncExitStack() as exit_stack:
-        api, (alpha, beta) = setup_api(
-            [(False, alpha_ip_stack), (False, beta_ip_stack)]
-        )
-        beta.set_peer_firewall_settings(alpha.id, allow_incoming_connections=False)
-        alpha.set_peer_firewall_settings(beta.id, allow_incoming_connections=False)
-        env = await setup_mesh_nodes(
-            exit_stack,
-            [
-                _setup_params(
-                    ConnectionTag.DOCKER_CONE_CLIENT_1, TelioAdapterType.NEP_TUN
-                ),
-                _setup_params(ConnectionTag.DOCKER_CONE_CLIENT_2),
-            ],
-            provided_api=api,
-        )
-        connection_alpha, connection_beta = [
-            conn.connection for conn in env.connections
-        ]
+    api, (alpha, beta) = setup_api([(False, alpha_ip_stack), (False, beta_ip_stack)])
+    beta.set_peer_firewall_settings(alpha.id, allow_incoming_connections=False)
+    alpha.set_peer_firewall_settings(beta.id, allow_incoming_connections=False)
+    env = await setup_mesh_nodes_factory(
+        [
+            _setup_params(ConnectionTag.DOCKER_CONE_CLIENT_1, TelioAdapterType.NEP_TUN),
+            _setup_params(ConnectionTag.DOCKER_CONE_CLIENT_2),
+        ],
+        provided_api=api,
+    )
+    connection_alpha, connection_beta = [conn.connection for conn in env.connections]
 
-        if alpha_ip_stack in [IPStack.IPv4, IPStack.IPv4v6] and beta_ip_stack in [
-            IPStack.IPv4,
-            IPStack.IPv4v6,
-        ]:
-            with pytest.raises(asyncio.TimeoutError):
-                await ping(
-                    connection_alpha,
-                    testing.unpack_optional(beta.get_ip_address(IPProto.IPv4)),
-                    15,
-                )
+    if alpha_ip_stack in [IPStack.IPv4, IPStack.IPv4v6] and beta_ip_stack in [
+        IPStack.IPv4,
+        IPStack.IPv4v6,
+    ]:
+        with pytest.raises(asyncio.TimeoutError):
+            await ping(
+                connection_alpha,
+                testing.unpack_optional(beta.get_ip_address(IPProto.IPv4)),
+                15,
+            )
 
-            with pytest.raises(asyncio.TimeoutError):
-                await ping(
-                    connection_beta,
-                    testing.unpack_optional(alpha.get_ip_address(IPProto.IPv4)),
-                    15,
-                )
+        with pytest.raises(asyncio.TimeoutError):
+            await ping(
+                connection_beta,
+                testing.unpack_optional(alpha.get_ip_address(IPProto.IPv4)),
+                15,
+            )
 
-        if alpha_ip_stack in [IPStack.IPv6, IPStack.IPv4v6] and beta_ip_stack in [
-            IPStack.IPv6,
-            IPStack.IPv4v6,
-        ]:
-            with pytest.raises(asyncio.TimeoutError):
-                await ping(
-                    connection_alpha,
-                    testing.unpack_optional(beta.get_ip_address(IPProto.IPv6)),
-                    15,
-                )
+    if alpha_ip_stack in [IPStack.IPv6, IPStack.IPv4v6] and beta_ip_stack in [
+        IPStack.IPv6,
+        IPStack.IPv4v6,
+    ]:
+        with pytest.raises(asyncio.TimeoutError):
+            await ping(
+                connection_alpha,
+                testing.unpack_optional(beta.get_ip_address(IPProto.IPv6)),
+                15,
+            )
 
-            with pytest.raises(asyncio.TimeoutError):
-                await ping(
-                    connection_beta,
-                    testing.unpack_optional(alpha.get_ip_address(IPProto.IPv6)),
-                    15,
-                )
+        with pytest.raises(asyncio.TimeoutError):
+            await ping(
+                connection_beta,
+                testing.unpack_optional(alpha.get_ip_address(IPProto.IPv6)),
+                15,
+            )
 
 
 # This test uses 'stun' and our stun client does not IPv6
 @pytest.mark.asyncio
-async def test_blocking_incoming_connections_from_exit_node() -> None:
+async def test_blocking_incoming_connections_from_exit_node(
+    setup_mesh_nodes_factory: Callable[..., Awaitable[Environment]],
+) -> None:
     # This tests recreates LLT-3449
-    async with AsyncExitStack() as exit_stack:
-        env = await setup_mesh_nodes(
-            exit_stack,
-            [
-                _setup_params(
-                    ConnectionTag.DOCKER_CONE_CLIENT_1,
-                    TelioAdapterType.NEP_TUN,
-                    stun_limits=(1, 1),
-                    features=default_features(
-                        enable_firewall_exclusion_range="10.0.0.0/8"
-                    ),
-                ),
-                _setup_params(
-                    ConnectionTag.DOCKER_CONE_CLIENT_2,
-                    stun_limits=(1, 5),
-                    features=default_features(
-                        enable_firewall_exclusion_range="10.0.0.0/8"
-                    ),
-                ),
-            ],
-        )
-        api = env.api
-        alpha, exit_node = env.nodes
-        connection_alpha, connection_exit_node = [
-            conn.connection for conn in env.connections
-        ]
-        client_alpha, client_exit_node = env.clients
+    env = await setup_mesh_nodes_factory(
+        [
+            _setup_params(
+                ConnectionTag.DOCKER_CONE_CLIENT_1,
+                TelioAdapterType.NEP_TUN,
+                stun_limits=(1, 1),
+                features=default_features(enable_firewall_exclusion_range="10.0.0.0/8"),
+            ),
+            _setup_params(
+                ConnectionTag.DOCKER_CONE_CLIENT_2,
+                stun_limits=(1, 5),
+                features=default_features(enable_firewall_exclusion_range="10.0.0.0/8"),
+            ),
+        ],
+    )
+    api = env.api
+    alpha, exit_node = env.nodes
+    connection_alpha, connection_exit_node = [
+        conn.connection for conn in env.connections
+    ]
+    client_alpha, client_exit_node = env.clients
 
-        async def ping_should_work_both_ways():
-            await ping(connection_alpha, exit_node.ip_addresses[0])
-
-            await ping(connection_exit_node, alpha.ip_addresses[0])
-
-        async def get_external_ips():
-            ip_alpha = await stun.get(connection_alpha, config.STUN_SERVER)
-            ip_exit_node = await stun.get(connection_exit_node, config.STUN_SERVER)
-            return (ip_alpha, ip_exit_node)
-
-        await ping_should_work_both_ways()
-
-        # Block traffic both ways
-
-        alpha.set_peer_firewall_settings(exit_node.id, allow_incoming_connections=False)
-        await client_alpha.set_meshnet_config(api.get_meshnet_config(alpha.id))
-
-        exit_node.set_peer_firewall_settings(alpha.id, allow_incoming_connections=False)
-        await client_exit_node.set_meshnet_config(api.get_meshnet_config(exit_node.id))
-
-        # Ping should fail both ways
-        with pytest.raises(asyncio.TimeoutError):
-            await ping(connection_alpha, exit_node.ip_addresses[0], 15)
-
-        with pytest.raises(asyncio.TimeoutError):
-            await ping(connection_exit_node, alpha.ip_addresses[0], 15)
-
-        # Allow traffic both ways
-
-        alpha.set_peer_firewall_settings(exit_node.id, allow_incoming_connections=True)
-        await client_alpha.set_meshnet_config(api.get_meshnet_config(alpha.id))
-
-        exit_node.set_peer_firewall_settings(
-            alpha.id, allow_incoming_connections=True, allow_peer_traffic_routing=True
-        )
-        await client_exit_node.set_meshnet_config(api.get_meshnet_config(exit_node.id))
-
-        # Ping should again work both ways
-
-        await ping_should_work_both_ways()
-
-        # Both nodes should have unique ips
-
-        (ip_alpha, ip_exit_node) = await get_external_ips()
-        assert ip_alpha != ip_exit_node
-
-        # Start routing traffic via the exit node
-
-        await client_exit_node.get_router().create_exit_node_route()
-
-        await client_alpha.connect_to_exit_node(exit_node.public_key)
-
-        # Both nodes should have the same external ip
-
-        (ip_alpha, ip_exit_node) = await get_external_ips()
-        assert ip_alpha == ip_exit_node
-
-        # Ping should still work
-
-        await ping_should_work_both_ways()
-
-        # Block traffic from exit node
-
-        alpha.set_peer_firewall_settings(exit_node.id, allow_incoming_connections=False)
-        await client_alpha.set_meshnet_config(api.get_meshnet_config(alpha.id))
-
-        # Ping should only work in one direction
-
+    async def ping_should_work_both_ways():
         await ping(connection_alpha, exit_node.ip_addresses[0])
 
-        with pytest.raises(asyncio.TimeoutError):
-            await ping(connection_exit_node, alpha.ip_addresses[0], 15)
+        await ping(connection_exit_node, alpha.ip_addresses[0])
 
-        # Check that connecting to external services still works
+    async def get_external_ips():
+        ip_alpha = await stun.get(connection_alpha, config.STUN_SERVER)
+        ip_exit_node = await stun.get(connection_exit_node, config.STUN_SERVER)
+        return (ip_alpha, ip_exit_node)
 
-        (ip_alpha, ip_exit_node) = await get_external_ips()
-        assert ip_alpha == ip_exit_node
+    await ping_should_work_both_ways()
+
+    # Block traffic both ways
+
+    alpha.set_peer_firewall_settings(exit_node.id, allow_incoming_connections=False)
+    await client_alpha.set_meshnet_config(api.get_meshnet_config(alpha.id))
+
+    exit_node.set_peer_firewall_settings(alpha.id, allow_incoming_connections=False)
+    await client_exit_node.set_meshnet_config(api.get_meshnet_config(exit_node.id))
+
+    # Ping should fail both ways
+    with pytest.raises(asyncio.TimeoutError):
+        await ping(connection_alpha, exit_node.ip_addresses[0], 15)
+
+    with pytest.raises(asyncio.TimeoutError):
+        await ping(connection_exit_node, alpha.ip_addresses[0], 15)
+
+    # Allow traffic both ways
+
+    alpha.set_peer_firewall_settings(exit_node.id, allow_incoming_connections=True)
+    await client_alpha.set_meshnet_config(api.get_meshnet_config(alpha.id))
+
+    exit_node.set_peer_firewall_settings(
+        alpha.id, allow_incoming_connections=True, allow_peer_traffic_routing=True
+    )
+    await client_exit_node.set_meshnet_config(api.get_meshnet_config(exit_node.id))
+
+    # Ping should again work both ways
+
+    await ping_should_work_both_ways()
+
+    # Both nodes should have unique ips
+
+    (ip_alpha, ip_exit_node) = await get_external_ips()
+    assert ip_alpha != ip_exit_node
+
+    # Start routing traffic via the exit node
+
+    await client_exit_node.get_router().create_exit_node_route()
+
+    await client_alpha.connect_to_exit_node(exit_node.public_key)
+
+    # Both nodes should have the same external ip
+
+    (ip_alpha, ip_exit_node) = await get_external_ips()
+    assert ip_alpha == ip_exit_node
+
+    # Ping should still work
+
+    await ping_should_work_both_ways()
+
+    # Block traffic from exit node
+
+    alpha.set_peer_firewall_settings(exit_node.id, allow_incoming_connections=False)
+    await client_alpha.set_meshnet_config(api.get_meshnet_config(alpha.id))
+
+    # Ping should only work in one direction
+
+    await ping(connection_alpha, exit_node.ip_addresses[0])
+
+    with pytest.raises(asyncio.TimeoutError):
+        await ping(connection_exit_node, alpha.ip_addresses[0], 15)
+
+    # Check that connecting to external services still works
+
+    (ip_alpha, ip_exit_node) = await get_external_ips()
+    assert ip_alpha == ip_exit_node
 
 
 @pytest.mark.asyncio
@@ -405,6 +390,7 @@ async def test_blocking_incoming_connections_from_exit_node() -> None:
     ],
 )
 async def test_mesh_firewall_file_share_port(
+    setup_mesh_nodes_factory: Callable[..., Awaitable[Environment]],
     allow_incoming_connections: bool,
     allow_peer_send_file: bool,
     port: int,
@@ -412,87 +398,79 @@ async def test_mesh_firewall_file_share_port(
     alpha_ip_stack: IPStack,
     beta_ip_stack: IPStack,
 ) -> None:
-    async with AsyncExitStack() as exit_stack:
-        PORT = port
+    PORT = port
 
-        api, (alpha, beta) = setup_api(
-            [(False, alpha_ip_stack), (False, beta_ip_stack)]
-        )
-        alpha.set_peer_firewall_settings(
-            beta.id,
-            allow_incoming_connections=allow_incoming_connections,
-            allow_peer_send_files=allow_peer_send_file,
-        )
-        beta.set_peer_firewall_settings(
-            alpha.id,
-            allow_incoming_connections=allow_incoming_connections,
-            allow_peer_send_files=allow_peer_send_file,
-        )
+    api, (alpha, beta) = setup_api([(False, alpha_ip_stack), (False, beta_ip_stack)])
+    alpha.set_peer_firewall_settings(
+        beta.id,
+        allow_incoming_connections=allow_incoming_connections,
+        allow_peer_send_files=allow_peer_send_file,
+    )
+    beta.set_peer_firewall_settings(
+        alpha.id,
+        allow_incoming_connections=allow_incoming_connections,
+        allow_peer_send_files=allow_peer_send_file,
+    )
 
-        (CLIENT_PROTO, CLIENT_ALPHA_IP, CLIENT_BETA_IP) = get_ips_and_stack(alpha, beta)
+    (CLIENT_PROTO, CLIENT_ALPHA_IP, CLIENT_BETA_IP) = get_ips_and_stack(alpha, beta)
 
-        env = await setup_mesh_nodes(
-            exit_stack,
-            [
-                _setup_params(
-                    ConnectionTag.DOCKER_CONE_CLIENT_1, TelioAdapterType.NEP_TUN
-                ),
-                _setup_params(ConnectionTag.DOCKER_CONE_CLIENT_2),
-            ],
-            provided_api=api,
-        )
-        connection_alpha, connection_beta = [
-            conn.connection for conn in env.connections
-        ]
+    env = await setup_mesh_nodes_factory(
+        [
+            _setup_params(ConnectionTag.DOCKER_CONE_CLIENT_1, TelioAdapterType.NEP_TUN),
+            _setup_params(ConnectionTag.DOCKER_CONE_CLIENT_2),
+        ],
+        provided_api=api,
+    )
+    connection_alpha, connection_beta = [conn.connection for conn in env.connections]
 
-        if allow_incoming_connections:
-            await ping(connection_alpha, CLIENT_BETA_IP)
-        else:
-            with pytest.raises(asyncio.TimeoutError):
-                await ping(connection_alpha, CLIENT_BETA_IP, 15)
+    if allow_incoming_connections:
+        await ping(connection_alpha, CLIENT_BETA_IP)
+    else:
+        with pytest.raises(asyncio.TimeoutError):
+            await ping(connection_alpha, CLIENT_BETA_IP, 15)
 
-        if allow_incoming_connections:
-            await ping(connection_beta, CLIENT_ALPHA_IP)
-        else:
-            with pytest.raises(asyncio.TimeoutError):
-                await ping(connection_beta, CLIENT_ALPHA_IP, 15)
+    if allow_incoming_connections:
+        await ping(connection_beta, CLIENT_ALPHA_IP)
+    else:
+        with pytest.raises(asyncio.TimeoutError):
+            await ping(connection_beta, CLIENT_ALPHA_IP, 15)
 
-        log.info("Start NetCat server")
-        async with NetCatServer(
-            connection_alpha,
+    log.info("Start NetCat server")
+    async with NetCatServer(
+        connection_alpha,
+        PORT,
+        udp=True,
+        ipv6=CLIENT_PROTO == IPProto.IPv6,
+        bind_ip=CLIENT_ALPHA_IP,
+    ).run() as listener:
+        # wait for listening to start
+        log.info("Wait for listening to start")
+        await listener.listening_started()
+
+        log.info("Start NetCat client")
+        async with NetCatClient(
+            connection_beta,
+            CLIENT_ALPHA_IP,
             PORT,
             udp=True,
             ipv6=CLIENT_PROTO == IPProto.IPv6,
-            bind_ip=CLIENT_ALPHA_IP,
-        ).run() as listener:
-            # wait for listening to start
-            log.info("Wait for listening to start")
-            await listener.listening_started()
+            port_scan=True,
+            source_ip=CLIENT_BETA_IP,
+        ).run() as client:
+            # wait for client to connect
+            log.info("Wait for client to connect")
+            await client.connection_succeeded()
 
-            log.info("Start NetCat client")
-            async with NetCatClient(
-                connection_beta,
-                CLIENT_ALPHA_IP,
-                PORT,
-                udp=True,
-                ipv6=CLIENT_PROTO == IPProto.IPv6,
-                port_scan=True,
-                source_ip=CLIENT_BETA_IP,
-            ).run() as client:
-                # wait for client to connect
-                log.info("Wait for client to connect")
-                await client.connection_succeeded()
-
-                # check for connection status according to parameter provided
-                if successful:
-                    log.info("Wait for connection received event")
-                    await listener.connection_received()
-                else:
-                    log.info("Wait for connection received event to timeout")
-                    with pytest.raises(asyncio.TimeoutError):
-                        await asyncio.wait_for(listener.connection_received(), 5)
-            log.info("Teardown client")
-        log.info("Teardown server")
+            # check for connection status according to parameter provided
+            if successful:
+                log.info("Wait for connection received event")
+                await listener.connection_received()
+            else:
+                log.info("Wait for connection received event to timeout")
+                with pytest.raises(asyncio.TimeoutError):
+                    await asyncio.wait_for(listener.connection_received(), 5)
+        log.info("Teardown client")
+    log.info("Teardown server")
 
 
 @pytest.mark.asyncio
@@ -535,66 +513,61 @@ async def test_mesh_firewall_file_share_port(
     ],
 )
 async def test_mesh_firewall_tcp_stuck_in_last_ack_state_conn_kill_from_server_side(
+    setup_mesh_nodes_factory: Callable[..., Awaitable[Environment]],
     alpha_adapter_type: Optional[TelioAdapterType],
     beta_adapter_type: Optional[TelioAdapterType],
     alpha_ip_stack: IPStack,
     beta_ip_stack: IPStack,
 ) -> None:
-    async with AsyncExitStack() as exit_stack:
-        api, (alpha, beta) = setup_api(
-            [(False, alpha_ip_stack), (False, beta_ip_stack)]
-        )
-        beta.set_peer_firewall_settings(alpha.id, allow_incoming_connections=False)
+    api, (alpha, beta) = setup_api([(False, alpha_ip_stack), (False, beta_ip_stack)])
+    beta.set_peer_firewall_settings(alpha.id, allow_incoming_connections=False)
 
-        PORT = 12345
-        (CLIENT_PROTO, CLIENT_ALPHA_IP, CLIENT_BETA_IP) = get_ips_and_stack(alpha, beta)
+    PORT = 12345
+    (CLIENT_PROTO, CLIENT_ALPHA_IP, CLIENT_BETA_IP) = get_ips_and_stack(alpha, beta)
 
-        env = await setup_mesh_nodes(
-            exit_stack,
-            [
-                _setup_params(ConnectionTag.DOCKER_CONE_CLIENT_1, alpha_adapter_type),
-                _setup_params(ConnectionTag.DOCKER_CONE_CLIENT_2, beta_adapter_type),
-            ],
-            provided_api=api,
-        )
-        connection_alpha, connection_beta = [
-            conn.connection for conn in env.connections
-        ]
+    env = await setup_mesh_nodes_factory(
+        [
+            _setup_params(ConnectionTag.DOCKER_CONE_CLIENT_1, alpha_adapter_type),
+            _setup_params(ConnectionTag.DOCKER_CONE_CLIENT_2, beta_adapter_type),
+        ],
+        provided_api=api,
+    )
+    connection_alpha, connection_beta = [conn.connection for conn in env.connections]
 
-        async with ConnectionTracker(
-            connection_beta,
-            [
-                TCPStateSequence(
-                    "telio-firewall-server-side-kill",
-                    FiveTuple(protocol="tcp", dst_ip=CLIENT_ALPHA_IP, dst_port=PORT),
-                    [TcpState.LAST_ACK, TcpState.TIME_WAIT],
-                    trailing_state=TcpState.CLOSE,
-                )
-            ],
-        ).run() as conntrack:
-            async with NetCatServer(
-                connection_alpha,
+    async with ConnectionTracker(
+        connection_beta,
+        [
+            TCPStateSequence(
+                "telio-firewall-server-side-kill",
+                FiveTuple(protocol="tcp", dst_ip=CLIENT_ALPHA_IP, dst_port=PORT),
+                [TcpState.LAST_ACK, TcpState.TIME_WAIT],
+                trailing_state=TcpState.CLOSE,
+            )
+        ],
+    ).run() as conntrack:
+        async with NetCatServer(
+            connection_alpha,
+            PORT,
+            ipv6=CLIENT_PROTO == IPProto.IPv6,
+            bind_ip=CLIENT_ALPHA_IP,
+        ).run() as listener:
+            await listener.listening_started()
+
+            async with NetCatClient(
+                connection_beta,
+                CLIENT_ALPHA_IP,
                 PORT,
                 ipv6=CLIENT_PROTO == IPProto.IPv6,
-                bind_ip=CLIENT_ALPHA_IP,
-            ).run() as listener:
-                await listener.listening_started()
+                source_ip=CLIENT_BETA_IP,
+            ).run() as client:
+                await asyncio.gather(
+                    listener.connection_received(), client.connection_succeeded()
+                )
 
-                async with NetCatClient(
-                    connection_beta,
-                    CLIENT_ALPHA_IP,
-                    PORT,
-                    ipv6=CLIENT_PROTO == IPProto.IPv6,
-                    source_ip=CLIENT_BETA_IP,
-                ).run() as client:
-                    await asyncio.gather(
-                        listener.connection_received(), client.connection_succeeded()
-                    )
-
-            # kill server and check what is happening in conntrack events
-            # if everything is correct -> conntrack should show LAST_ACK -> TIME_WAIT
-            # if something goes wrong, it will be stuck at LAST_ACK state
-            await conntrack.wait_for_no_violations()
+        # kill server and check what is happening in conntrack events
+        # if everything is correct -> conntrack should show LAST_ACK -> TIME_WAIT
+        # if something goes wrong, it will be stuck at LAST_ACK state
+        await conntrack.wait_for_no_violations()
 
 
 @pytest.mark.asyncio
@@ -637,64 +610,59 @@ async def test_mesh_firewall_tcp_stuck_in_last_ack_state_conn_kill_from_server_s
     ],
 )
 async def test_mesh_firewall_tcp_stuck_in_last_ack_state_conn_kill_from_client_side(
+    setup_mesh_nodes_factory: Callable[..., Awaitable[Environment]],
     alpha_adapter_type: Optional[TelioAdapterType],
     beta_adapter_type: Optional[TelioAdapterType],
     alpha_ip_stack: IPStack,
     beta_ip_stack: IPStack,
 ) -> None:
-    async with AsyncExitStack() as exit_stack:
-        api, (alpha, beta) = setup_api(
-            [(False, alpha_ip_stack), (False, beta_ip_stack)]
-        )
-        beta.set_peer_firewall_settings(alpha.id, allow_incoming_connections=False)
+    api, (alpha, beta) = setup_api([(False, alpha_ip_stack), (False, beta_ip_stack)])
+    beta.set_peer_firewall_settings(alpha.id, allow_incoming_connections=False)
 
-        PORT = 12345
-        (CLIENT_PROTO, CLIENT_ALPHA_IP, CLIENT_BETA_IP) = get_ips_and_stack(alpha, beta)
+    PORT = 12345
+    (CLIENT_PROTO, CLIENT_ALPHA_IP, CLIENT_BETA_IP) = get_ips_and_stack(alpha, beta)
 
-        env = await setup_mesh_nodes(
-            exit_stack,
-            [
-                _setup_params(ConnectionTag.DOCKER_CONE_CLIENT_1, alpha_adapter_type),
-                _setup_params(ConnectionTag.DOCKER_CONE_CLIENT_2, beta_adapter_type),
-            ],
-            provided_api=api,
-        )
-        connection_alpha, connection_beta = [
-            conn.connection for conn in env.connections
-        ]
+    env = await setup_mesh_nodes_factory(
+        [
+            _setup_params(ConnectionTag.DOCKER_CONE_CLIENT_1, alpha_adapter_type),
+            _setup_params(ConnectionTag.DOCKER_CONE_CLIENT_2, beta_adapter_type),
+        ],
+        provided_api=api,
+    )
+    connection_alpha, connection_beta = [conn.connection for conn in env.connections]
 
-        async with ConnectionTracker(
-            connection_beta,
-            [
-                TCPStateSequence(
-                    "nc",
-                    FiveTuple(protocol="tcp", dst_ip=CLIENT_ALPHA_IP, dst_port=PORT),
-                    [TcpState.LAST_ACK, TcpState.TIME_WAIT],
-                    trailing_state=TcpState.CLOSE,
-                )
-            ],
-        ).run() as conntrack:
-            async with NetCatServer(
-                connection_alpha,
+    async with ConnectionTracker(
+        connection_beta,
+        [
+            TCPStateSequence(
+                "nc",
+                FiveTuple(protocol="tcp", dst_ip=CLIENT_ALPHA_IP, dst_port=PORT),
+                [TcpState.LAST_ACK, TcpState.TIME_WAIT],
+                trailing_state=TcpState.CLOSE,
+            )
+        ],
+    ).run() as conntrack:
+        async with NetCatServer(
+            connection_alpha,
+            PORT,
+            ipv6=CLIENT_PROTO == IPProto.IPv6,
+            bind_ip=CLIENT_ALPHA_IP,
+        ).run() as listener:
+            await listener.listening_started()
+
+            async with NetCatClient(
+                connection_beta,
+                CLIENT_ALPHA_IP,
                 PORT,
+                detached=True,
                 ipv6=CLIENT_PROTO == IPProto.IPv6,
-                bind_ip=CLIENT_ALPHA_IP,
-            ).run() as listener:
-                await listener.listening_started()
+                source_ip=CLIENT_BETA_IP,
+            ).run() as client:
+                await asyncio.gather(
+                    listener.connection_received(), client.connection_succeeded()
+                )
 
-                async with NetCatClient(
-                    connection_beta,
-                    CLIENT_ALPHA_IP,
-                    PORT,
-                    detached=True,
-                    ipv6=CLIENT_PROTO == IPProto.IPv6,
-                    source_ip=CLIENT_BETA_IP,
-                ).run() as client:
-                    await asyncio.gather(
-                        listener.connection_received(), client.connection_succeeded()
-                    )
-
-                # kill client and check what is happening in conntrack events
-                # if everything is correct -> conntrack should show LAST_ACK -> TIME_WAIT
-                # if something goes wrong, it will be stuck at LAST_ACK state
-                await conntrack.wait_for_no_violations()
+            # kill client and check what is happening in conntrack events
+            # if everything is correct -> conntrack should show LAST_ACK -> TIME_WAIT
+            # if something goes wrong, it will be stuck at LAST_ACK state
+            await conntrack.wait_for_no_violations()

--- a/nat-lab/tests/test_mesh_firewall.py
+++ b/nat-lab/tests/test_mesh_firewall.py
@@ -21,8 +21,6 @@ from tests.utils.ping import ping
 from tests.utils.router import IPProto, IPStack
 from typing import Tuple, Optional, Callable, Awaitable
 
-pytest_plugins = ["tests.helpers_fixtures"]
-
 
 def get_ips_and_stack(alpha: Node, beta: Node) -> Tuple[IPProto, str, str]:
     if alpha.ip_stack in [IPStack.IPv4, IPStack.IPv4v6]:

--- a/nat-lab/tests/test_mesh_plus_vpn.py
+++ b/nat-lab/tests/test_mesh_plus_vpn.py
@@ -1,10 +1,7 @@
 import asyncio
 import pytest
-from contextlib import AsyncExitStack
 from tests import config, timeouts
-from tests.helpers import SetupParameters, setup_mesh_nodes
-from tests.mesh_api import API
-from tests.telio import Client
+from tests.helpers import SetupParameters
 from tests.utils import stun, asyncio_util
 from tests.utils.bindings import (
     features_with_endpoint_providers,
@@ -15,11 +12,16 @@ from tests.utils.bindings import (
     NodeState,
 )
 from tests.utils.connection import ConnectionTag
-from tests.utils.connection_util import (
-    generate_connection_tracker_config,
-    new_connection_with_conn_tracker,
-)
+from tests.utils.connection_util import generate_connection_tracker_config
 from tests.utils.ping import ping
+
+pytest_plugins = ["tests.helpers_fixtures"]
+
+
+# Module-level override — all tests in this file get VPN_1
+@pytest.fixture(name="vpn_tags")
+def _vpn_tags() -> list:
+    return [ConnectionTag.DOCKER_VPN_1]
 
 
 # Marks in-tunnel stack only, exiting only through IPv4
@@ -91,35 +93,31 @@ from tests.utils.ping import ping
     ],
 )
 async def test_mesh_plus_vpn_one_peer(
-    alpha_setup_params: SetupParameters, beta_setup_params: SetupParameters
+    alpha_setup_params: SetupParameters,  # pylint: disable=unused-argument
+    beta_setup_params: SetupParameters,  # pylint: disable=unused-argument
+    env_mesh,
 ) -> None:
-    async with AsyncExitStack() as exit_stack:
-        env = await setup_mesh_nodes(
-            exit_stack,
-            [alpha_setup_params, beta_setup_params],
-            vpn=[ConnectionTag.DOCKER_VPN_1],
-        )
+    beta_node, alpha_client, alpha_conn = (
+        env_mesh.nodes[1],
+        env_mesh.clients[0],
+        env_mesh.connections[0].connection,
+    )
 
-        _, beta = env.nodes
-        client_alpha, _ = env.clients
-        connection_alpha, _ = [conn.connection for conn in env.connections]
+    await ping(alpha_conn, beta_node.ip_addresses[0])
 
-        await ping(connection_alpha, beta.ip_addresses[0])
+    wg_server = config.WG_SERVER
 
-        wg_server = config.WG_SERVER
+    await alpha_client.connect_to_vpn(
+        str(wg_server["ipv4"]), int(wg_server["port"]), str(wg_server["public_key"])
+    )
 
-        await client_alpha.connect_to_vpn(
-            str(wg_server["ipv4"]), int(wg_server["port"]), str(wg_server["public_key"])
-        )
+    await ping(alpha_conn, beta_node.ip_addresses[0])
+    await ping(alpha_conn, config.STUN_SERVER)
 
-        await ping(connection_alpha, beta.ip_addresses[0])
-
-        await ping(connection_alpha, config.STUN_SERVER)
-
-        public_ip = await stun.get(connection_alpha, config.STUN_SERVER)
-        assert (
-            public_ip == wg_server["ipv4"]
-        ), f"wrong public IP when connected to VPN {public_ip}"
+    public_ip = await stun.get(alpha_conn, config.STUN_SERVER)
+    assert (
+        public_ip == wg_server["ipv4"]
+    ), f"wrong public IP when connected to VPN {public_ip}"
 
 
 @pytest.mark.asyncio
@@ -191,161 +189,175 @@ async def test_mesh_plus_vpn_one_peer(
     ],
 )
 async def test_mesh_plus_vpn_both_peers(
-    alpha_setup_params: SetupParameters, beta_setup_params: SetupParameters
+    alpha_setup_params: SetupParameters,  # pylint: disable=unused-argument
+    beta_setup_params: SetupParameters,  # pylint: disable=unused-argument
+    env_mesh,
 ) -> None:
-    async with AsyncExitStack() as exit_stack:
-        env = await setup_mesh_nodes(
-            exit_stack,
-            [alpha_setup_params, beta_setup_params],
-            vpn=[ConnectionTag.DOCKER_VPN_1],
-        )
+    alpha_node, beta_node = env_mesh.nodes[0], env_mesh.nodes[1]
+    alpha_client, beta_client = env_mesh.clients[0], env_mesh.clients[1]
+    alpha_conn, beta_conn = (
+        env_mesh.connections[0].connection,
+        env_mesh.connections[1].connection,
+    )
 
-        alpha, beta = env.nodes
-        client_alpha, client_beta = env.clients
-        connection_alpha, connection_beta = [
-            conn.connection for conn in env.connections
-        ]
+    await ping(alpha_conn, beta_node.ip_addresses[0])
 
-        await ping(connection_alpha, beta.ip_addresses[0])
+    wg_server = config.WG_SERVER
 
-        wg_server = config.WG_SERVER
+    await asyncio.gather(
+        alpha_client.connect_to_vpn(
+            str(wg_server["ipv4"]),
+            int(wg_server["port"]),
+            str(wg_server["public_key"]),
+        ),
+        beta_client.connect_to_vpn(
+            str(wg_server["ipv4"]),
+            int(wg_server["port"]),
+            str(wg_server["public_key"]),
+        ),
+    )
 
-        await asyncio.gather(
-            client_alpha.connect_to_vpn(
-                str(wg_server["ipv4"]),
-                int(wg_server["port"]),
-                str(wg_server["public_key"]),
-            ),
-            client_beta.connect_to_vpn(
-                str(wg_server["ipv4"]),
-                int(wg_server["port"]),
-                str(wg_server["public_key"]),
-            ),
-        )
+    await ping(alpha_conn, beta_node.ip_addresses[0])
+    await ping(alpha_conn, config.STUN_SERVER)
 
-        await ping(connection_alpha, beta.ip_addresses[0])
-        await ping(connection_alpha, config.STUN_SERVER)
+    await ping(beta_conn, alpha_node.ip_addresses[0])
+    await ping(beta_conn, config.STUN_SERVER)
 
-        await ping(connection_beta, alpha.ip_addresses[0])
-        await ping(connection_beta, config.STUN_SERVER)
-
-        for connection in [connection_alpha, connection_beta]:
-            public_ip = await stun.get(connection, config.STUN_SERVER)
-            assert (
-                public_ip == wg_server["ipv4"]
-            ), f"wrong public IP when connected to VPN {public_ip}"
+    for connection in [alpha_conn, beta_conn]:
+        public_ip = await stun.get(connection, config.STUN_SERVER)
+        assert (
+            public_ip == wg_server["ipv4"]
+        ), f"wrong public IP when connected to VPN {public_ip}"
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "alpha_connection_tag,adapter_type,public_ip",
+    "alpha_setup_params, public_ip",
     [
         pytest.param(
-            ConnectionTag.DOCKER_CONE_CLIENT_1,
-            TelioAdapterType.NEP_TUN,
+            SetupParameters(
+                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
+                adapter_type_override=TelioAdapterType.NEP_TUN,
+                connection_tracker_config=generate_connection_tracker_config(
+                    ConnectionTag.DOCKER_CONE_CLIENT_1,
+                    derp_1_limits=(1, 1),
+                    vpn_1_limits=(1, 1),
+                    stun_limits=(1, 1),
+                ),
+                is_meshnet=False,
+            ),
             "10.0.254.1",
         ),
         pytest.param(
-            ConnectionTag.DOCKER_CONE_CLIENT_1,
-            TelioAdapterType.LINUX_NATIVE_TUN,
+            SetupParameters(
+                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
+                adapter_type_override=TelioAdapterType.LINUX_NATIVE_TUN,
+                connection_tracker_config=generate_connection_tracker_config(
+                    ConnectionTag.DOCKER_CONE_CLIENT_1,
+                    derp_1_limits=(1, 1),
+                    vpn_1_limits=(1, 1),
+                    stun_limits=(1, 1),
+                ),
+                is_meshnet=False,
+            ),
             "10.0.254.1",
             marks=pytest.mark.linux_native,
         ),
         pytest.param(
-            ConnectionTag.VM_WINDOWS_1,
-            TelioAdapterType.WINDOWS_NATIVE_TUN,
+            SetupParameters(
+                connection_tag=ConnectionTag.VM_WINDOWS_1,
+                adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
+                connection_tracker_config=generate_connection_tracker_config(
+                    ConnectionTag.VM_WINDOWS_1,
+                    derp_1_limits=(1, 1),
+                    vpn_1_limits=(1, 1),
+                    stun_limits=(1, 1),
+                ),
+                is_meshnet=False,
+            ),
             "10.0.254.15",
             marks=pytest.mark.windows,
         ),
         pytest.param(
-            ConnectionTag.VM_MAC,
-            TelioAdapterType.NEP_TUN,
+            SetupParameters(
+                connection_tag=ConnectionTag.VM_MAC,
+                adapter_type_override=TelioAdapterType.NEP_TUN,
+                connection_tracker_config=generate_connection_tracker_config(
+                    ConnectionTag.VM_MAC,
+                    derp_1_limits=(1, 1),
+                    vpn_1_limits=(1, 1),
+                    stun_limits=(1, 1),
+                ),
+                is_meshnet=False,
+            ),
             "10.0.254.19",
             marks=pytest.mark.mac,
         ),
     ],
 )
-async def test_vpn_plus_mesh(
-    alpha_connection_tag: ConnectionTag,
-    adapter_type: TelioAdapterType,
-    public_ip: str,
-) -> None:
-    async with AsyncExitStack() as exit_stack:
-        api = API()
-
-        (alpha, beta) = api.default_config_two_nodes()
-        (connection_alpha, alpha_conn_tracker) = await exit_stack.enter_async_context(
-            new_connection_with_conn_tracker(
-                alpha_connection_tag,
-                generate_connection_tracker_config(
-                    alpha_connection_tag,
-                    derp_1_limits=(1, 1),
-                    vpn_1_limits=(1, 1),
-                    stun_limits=(1, 1),
-                ),
-            )
-        )
-        (connection_beta, beta_conn_tracker) = await exit_stack.enter_async_context(
-            new_connection_with_conn_tracker(
-                ConnectionTag.DOCKER_CONE_CLIENT_2,
-                generate_connection_tracker_config(
+@pytest.mark.parametrize(
+    "beta_setup_params",
+    [
+        pytest.param(
+            SetupParameters(
+                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2,
+                connection_tracker_config=generate_connection_tracker_config(
                     ConnectionTag.DOCKER_CONE_CLIENT_2,
                     derp_1_limits=(1, 1),
                 ),
             )
         )
+    ],
+)
+async def test_vpn_plus_mesh(
+    alpha_setup_params: SetupParameters,  # pylint: disable=unused-argument
+    beta_setup_params: SetupParameters,  # pylint: disable=unused-argument
+    public_ip: str,
+    env,
+) -> None:
+    alpha_node, beta_node = env.nodes
+    client_alpha, client_beta = env.clients
+    connection_alpha = env.connections[0].connection
+    api = env.api
 
-        await api.prepare_vpn_servers()
+    ip = await stun.get(connection_alpha, config.STUN_SERVER)
+    assert ip == public_ip, f"wrong public IP before connecting to VPN {ip}"
 
-        ip = await stun.get(connection_alpha, config.STUN_SERVER)
-        assert ip == public_ip, f"wrong public IP before connecting to VPN {ip}"
+    wg_server = config.WG_SERVER
 
-        client_alpha = await exit_stack.enter_async_context(
-            Client(connection_alpha, alpha, adapter_type).run()
+    await client_alpha.connect_to_vpn(
+        str(wg_server["ipv4"]), int(wg_server["port"]), str(wg_server["public_key"])
+    )
+
+    await ping(connection_alpha, config.PHOTO_ALBUM_IP)
+
+    ip = await stun.get(connection_alpha, config.STUN_SERVER)
+    assert ip == wg_server["ipv4"], f"wrong public IP when connected to VPN {ip}"
+
+    await client_alpha.set_meshnet_config(api.get_meshnet_config(alpha_node.id))
+
+    await asyncio.gather(
+        client_alpha.wait_for_state_on_any_derp([RelayState.CONNECTED]),
+        client_beta.wait_for_state_on_any_derp([RelayState.CONNECTED]),
+    )
+    await asyncio.gather(
+        client_alpha.wait_for_state_peer(beta_node.public_key, [NodeState.CONNECTED]),
+        client_beta.wait_for_state_peer(alpha_node.public_key, [NodeState.CONNECTED]),
+    )
+
+    await ping(connection_alpha, beta_node.ip_addresses[0])
+
+    # Testing if the VPN node is not cleared after disabling meshnet. See LLT-4266 for more details.
+    async with asyncio_util.run_async_context(
+        client_alpha.wait_for_event_peer(
+            beta_node.public_key, [NodeState.DISCONNECTED], list(PathType)
         )
+    ) as event:
+        await client_alpha.set_mesh_off()
+        await event
 
-        wg_server = config.WG_SERVER
-
-        await client_alpha.connect_to_vpn(
-            str(wg_server["ipv4"]), int(wg_server["port"]), str(wg_server["public_key"])
-        )
-
-        await ping(connection_alpha, config.PHOTO_ALBUM_IP)
-
-        ip = await stun.get(connection_alpha, config.STUN_SERVER)
-        assert ip == wg_server["ipv4"], f"wrong public IP when connected to VPN {ip}"
-
-        await client_alpha.set_meshnet_config(api.get_meshnet_config(alpha.id))
-
-        client_beta = await exit_stack.enter_async_context(
-            Client(connection_beta, beta).run(api.get_meshnet_config(beta.id))
-        )
-
-        await asyncio.gather(
-            client_alpha.wait_for_state_on_any_derp([RelayState.CONNECTED]),
-            client_beta.wait_for_state_on_any_derp([RelayState.CONNECTED]),
-        )
-        await asyncio.gather(
-            client_alpha.wait_for_state_peer(beta.public_key, [NodeState.CONNECTED]),
-            client_beta.wait_for_state_peer(alpha.public_key, [NodeState.CONNECTED]),
-        )
-
-        await ping(connection_alpha, beta.ip_addresses[0])
-
-        # Testing if the VPN node is not cleared after disabling meshnet. See LLT-4266 for more details.
-        async with asyncio_util.run_async_context(
-            client_alpha.wait_for_event_peer(
-                beta.public_key, [NodeState.DISCONNECTED], list(PathType)
-            )
-        ) as event:
-            await client_alpha.set_mesh_off()
-            await event
-
-        ip = await stun.get(connection_alpha, config.STUN_SERVER)
-        assert ip == wg_server["ipv4"], f"wrong public IP when connected to VPN {ip}"
-
-        assert await alpha_conn_tracker.find_conntracker_violations() is None
-        assert await beta_conn_tracker.find_conntracker_violations() is None
+    ip = await stun.get(connection_alpha, config.STUN_SERVER)
+    assert ip == wg_server["ipv4"], f"wrong public IP when connected to VPN {ip}"
 
 
 @pytest.mark.asyncio
@@ -380,9 +392,7 @@ async def test_vpn_plus_mesh(
                     [EndpointProvider.LOCAL, EndpointProvider.STUN]
                 ),
             ),
-            marks=[
-                pytest.mark.linux_native,
-            ],
+            marks=[pytest.mark.linux_native],
         ),
         pytest.param(
             SetupParameters(
@@ -397,9 +407,7 @@ async def test_vpn_plus_mesh(
                     [EndpointProvider.LOCAL, EndpointProvider.STUN]
                 ),
             ),
-            marks=[
-                pytest.mark.windows,
-            ],
+            marks=[pytest.mark.windows],
         ),
         pytest.param(
             SetupParameters(
@@ -414,9 +422,7 @@ async def test_vpn_plus_mesh(
                     [EndpointProvider.LOCAL, EndpointProvider.STUN]
                 ),
             ),
-            marks=[
-                pytest.mark.mac,
-            ],
+            marks=[pytest.mark.mac],
         ),
     ],
 )
@@ -439,183 +445,173 @@ async def test_vpn_plus_mesh(
     ],
 )
 async def test_vpn_plus_mesh_over_direct(
-    alpha_setup_params: SetupParameters, beta_setup_params: SetupParameters
+    alpha_setup_params: SetupParameters,  # pylint: disable=unused-argument
+    beta_setup_params: SetupParameters,  # pylint: disable=unused-argument
+    env_mesh,
 ) -> None:
-    async with AsyncExitStack() as exit_stack:
-        env = await setup_mesh_nodes(
-            exit_stack,
-            [alpha_setup_params, beta_setup_params],
-            vpn=[ConnectionTag.DOCKER_VPN_1],
-        )
+    alpha_node, beta_node = env_mesh.nodes[0], env_mesh.nodes[1]
+    alpha_client, beta_client = env_mesh.clients[0], env_mesh.clients[1]
+    alpha_conn, beta_conn = (
+        env_mesh.connections[0].connection,
+        env_mesh.connections[1].connection,
+    )
 
-        alpha, beta = env.nodes
-        client_alpha, client_beta = env.clients
-        connection_alpha, connection_beta = [
-            conn.connection for conn in env.connections
-        ]
+    await ping(alpha_conn, beta_node.ip_addresses[0])
+    await ping(beta_conn, alpha_node.ip_addresses[0])
 
-        await ping(connection_alpha, beta.ip_addresses[0])
-        await ping(connection_beta, alpha.ip_addresses[0])
+    wg_server = config.WG_SERVER
 
-        wg_server = config.WG_SERVER
+    await asyncio.gather(
+        alpha_client.connect_to_vpn(
+            str(wg_server["ipv4"]),
+            int(wg_server["port"]),
+            str(wg_server["public_key"]),
+        ),
+        beta_client.connect_to_vpn(
+            str(wg_server["ipv4"]),
+            int(wg_server["port"]),
+            str(wg_server["public_key"]),
+        ),
+    )
 
-        await asyncio.gather(
-            client_alpha.connect_to_vpn(
-                str(wg_server["ipv4"]),
-                int(wg_server["port"]),
-                str(wg_server["public_key"]),
+    await ping(alpha_conn, beta_node.ip_addresses[0])
+    await ping(alpha_conn, config.STUN_SERVER)
+
+    await ping(beta_conn, alpha_node.ip_addresses[0])
+    await ping(beta_conn, config.STUN_SERVER)
+
+    for connection in [alpha_conn, beta_conn]:
+        public_ip = await stun.get(connection, config.STUN_SERVER)
+        assert (
+            public_ip == wg_server["ipv4"]
+        ), f"wrong public IP when connected to VPN {public_ip}"
+
+    # LLT-5532: To be cleaned up...
+    alpha_client.allow_errors(
+        ["telio_proxy::proxy.*Unable to send. WG Address not available"]
+    )
+    beta_client.allow_errors(
+        ["telio_proxy::proxy.*Unable to send. WG Address not available"]
+    )
+
+
+class TestThreeNode:
+    @pytest.mark.asyncio
+    @pytest.mark.timeout(
+        timeouts.TEST_VPN_PLUS_MESH_OVER_DIFFERENT_CONNECTION_TYPES_TIMEOUT
+    )
+    @pytest.mark.parametrize(
+        "alpha_setup_params",
+        [
+            pytest.param(
+                SetupParameters(
+                    connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
+                    adapter_type_override=TelioAdapterType.NEP_TUN,
+                    connection_tracker_config=generate_connection_tracker_config(
+                        ConnectionTag.DOCKER_CONE_CLIENT_1,
+                        derp_1_limits=(1, 1),
+                        vpn_1_limits=(1, 1),
+                    ),
+                    features=features_with_endpoint_providers(
+                        [EndpointProvider.LOCAL, EndpointProvider.STUN]
+                    ),
+                )
             ),
-            client_beta.connect_to_vpn(
-                str(wg_server["ipv4"]),
-                int(wg_server["port"]),
-                str(wg_server["public_key"]),
+            pytest.param(
+                SetupParameters(
+                    connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
+                    adapter_type_override=TelioAdapterType.LINUX_NATIVE_TUN,
+                    connection_tracker_config=generate_connection_tracker_config(
+                        ConnectionTag.DOCKER_CONE_CLIENT_1,
+                        derp_1_limits=(1, 1),
+                        vpn_1_limits=(1, 1),
+                    ),
+                    features=features_with_endpoint_providers(
+                        [EndpointProvider.LOCAL, EndpointProvider.STUN]
+                    ),
+                ),
+                marks=pytest.mark.linux_native,
             ),
-        )
-
-        await ping(connection_alpha, beta.ip_addresses[0])
-        await ping(connection_alpha, config.STUN_SERVER)
-
-        await ping(connection_beta, alpha.ip_addresses[0])
-        await ping(connection_beta, config.STUN_SERVER)
-
-        for connection in [connection_alpha, connection_beta]:
-            public_ip = await stun.get(connection, config.STUN_SERVER)
-            assert (
-                public_ip == wg_server["ipv4"]
-            ), f"wrong public IP when connected to VPN {public_ip}"
-
-        # LLT-5532: To be cleaned up...
-        client_alpha.allow_errors(
-            ["telio_proxy::proxy.*Unable to send. WG Address not available"]
-        )
-        client_beta.allow_errors(
-            ["telio_proxy::proxy.*Unable to send. WG Address not available"]
-        )
-
-
-@pytest.mark.asyncio
-@pytest.mark.timeout(
-    timeouts.TEST_VPN_PLUS_MESH_OVER_DIFFERENT_CONNECTION_TYPES_TIMEOUT
-)
-@pytest.mark.parametrize(
-    "alpha_setup_params",
-    [
-        pytest.param(
-            SetupParameters(
-                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                adapter_type_override=TelioAdapterType.NEP_TUN,
-                connection_tracker_config=generate_connection_tracker_config(
-                    ConnectionTag.DOCKER_CONE_CLIENT_1,
-                    derp_1_limits=(1, 1),
-                    vpn_1_limits=(1, 1),
+            pytest.param(
+                SetupParameters(
+                    connection_tag=ConnectionTag.VM_WINDOWS_1,
+                    adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
+                    connection_tracker_config=generate_connection_tracker_config(
+                        ConnectionTag.VM_WINDOWS_1,
+                        derp_1_limits=(1, 1),
+                        vpn_1_limits=(1, 1),
+                    ),
+                    features=features_with_endpoint_providers(
+                        [EndpointProvider.LOCAL, EndpointProvider.STUN]
+                    ),
                 ),
-                features=features_with_endpoint_providers(
-                    [EndpointProvider.LOCAL, EndpointProvider.STUN]
+                marks=pytest.mark.windows,
+            ),
+            pytest.param(
+                SetupParameters(
+                    connection_tag=ConnectionTag.VM_MAC,
+                    adapter_type_override=TelioAdapterType.NEP_TUN,
+                    connection_tracker_config=generate_connection_tracker_config(
+                        ConnectionTag.VM_MAC,
+                        derp_1_limits=(1, 1),
+                        vpn_1_limits=(1, 1),
+                    ),
+                    features=features_with_endpoint_providers(
+                        [EndpointProvider.LOCAL, EndpointProvider.STUN]
+                    ),
                 ),
+                marks=[pytest.mark.mac],
+            ),
+        ],
+    )
+    @pytest.mark.parametrize(
+        "beta_setup_params",
+        [
+            pytest.param(
+                SetupParameters(
+                    connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2,
+                    connection_tracker_config=generate_connection_tracker_config(
+                        ConnectionTag.DOCKER_CONE_CLIENT_2,
+                        derp_1_limits=(1, 1),
+                        vpn_1_limits=(1, 1),
+                    ),
+                    features=features_with_endpoint_providers(
+                        [EndpointProvider.LOCAL, EndpointProvider.STUN]
+                    ),
+                )
             )
-        ),
-        pytest.param(
-            SetupParameters(
-                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                adapter_type_override=TelioAdapterType.LINUX_NATIVE_TUN,
-                connection_tracker_config=generate_connection_tracker_config(
-                    ConnectionTag.DOCKER_CONE_CLIENT_1,
-                    derp_1_limits=(1, 1),
-                    vpn_1_limits=(1, 1),
-                ),
-                features=features_with_endpoint_providers(
-                    [EndpointProvider.LOCAL, EndpointProvider.STUN]
-                ),
-            ),
-            marks=pytest.mark.linux_native,
-        ),
-        pytest.param(
-            SetupParameters(
-                connection_tag=ConnectionTag.VM_WINDOWS_1,
-                adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
-                connection_tracker_config=generate_connection_tracker_config(
-                    ConnectionTag.VM_WINDOWS_1,
-                    derp_1_limits=(1, 1),
-                    vpn_1_limits=(1, 1),
-                ),
-                features=features_with_endpoint_providers(
-                    [EndpointProvider.LOCAL, EndpointProvider.STUN]
-                ),
-            ),
-            marks=pytest.mark.windows,
-        ),
-        pytest.param(
-            SetupParameters(
-                connection_tag=ConnectionTag.VM_MAC,
-                adapter_type_override=TelioAdapterType.NEP_TUN,
-                connection_tracker_config=generate_connection_tracker_config(
-                    ConnectionTag.VM_MAC,
-                    derp_1_limits=(1, 1),
-                    vpn_1_limits=(1, 1),
-                ),
-                features=features_with_endpoint_providers(
-                    [EndpointProvider.LOCAL, EndpointProvider.STUN]
-                ),
-            ),
-            marks=[
-                pytest.mark.mac,
-            ],
-        ),
-    ],
-)
-@pytest.mark.parametrize(
-    "beta_setup_params",
-    [
-        pytest.param(
-            SetupParameters(
-                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2,
-                connection_tracker_config=generate_connection_tracker_config(
-                    ConnectionTag.DOCKER_CONE_CLIENT_2,
-                    derp_1_limits=(1, 1),
-                    vpn_1_limits=(1, 1),
-                ),
-                features=features_with_endpoint_providers(
-                    [EndpointProvider.LOCAL, EndpointProvider.STUN]
-                ),
+        ],
+    )
+    @pytest.mark.parametrize(
+        "gamma_setup_params",
+        [
+            pytest.param(
+                SetupParameters(
+                    connection_tag=ConnectionTag.DOCKER_SYMMETRIC_CLIENT_1,
+                    connection_tracker_config=generate_connection_tracker_config(
+                        ConnectionTag.DOCKER_SYMMETRIC_CLIENT_1,
+                        derp_1_limits=(1, 1),
+                        vpn_1_limits=(1, 1),
+                    ),
+                )
             )
-        )
-    ],
-)
-@pytest.mark.parametrize(
-    "gamma_setup_params",
-    [
-        pytest.param(
-            SetupParameters(
-                connection_tag=ConnectionTag.DOCKER_SYMMETRIC_CLIENT_1,
-                connection_tracker_config=generate_connection_tracker_config(
-                    ConnectionTag.DOCKER_SYMMETRIC_CLIENT_1,
-                    derp_1_limits=(1, 1),
-                    vpn_1_limits=(1, 1),
-                ),
-            )
-        )
-    ],
-)
-async def test_vpn_plus_mesh_over_different_connection_types(
-    alpha_setup_params: SetupParameters,
-    beta_setup_params: SetupParameters,
-    gamma_setup_params: SetupParameters,
-) -> None:
-    async with AsyncExitStack() as exit_stack:
-        env = await setup_mesh_nodes(
-            exit_stack,
-            [alpha_setup_params, beta_setup_params, gamma_setup_params],
-            vpn=[ConnectionTag.DOCKER_VPN_1],
-        )
-
+        ],
+    )
+    async def test_vpn_plus_mesh_over_different_connection_types(
+        self,
+        alpha_setup_params: SetupParameters,  # pylint: disable=unused-argument
+        beta_setup_params: SetupParameters,  # pylint: disable=unused-argument
+        gamma_setup_params: SetupParameters,  # pylint: disable=unused-argument
+        env_mesh,
+    ) -> None:
+        alpha_node, beta_node, gamma_node = env_mesh.nodes
+        client_alpha, client_beta, client_gamma = env_mesh.clients
         connection_alpha, connection_beta, connection_gamma = [
-            conn.connection for conn in env.connections
+            conn.connection for conn in env_mesh.connections
         ]
-        client_alpha, client_beta, client_gamma = env.clients
-        alpha, beta, gamma = env.nodes
 
-        await ping(connection_alpha, beta.ip_addresses[0])
-        await ping(connection_alpha, gamma.ip_addresses[0])
+        await ping(connection_alpha, beta_node.ip_addresses[0])
+        await ping(connection_alpha, gamma_node.ip_addresses[0])
 
         wg_server = config.WG_SERVER
 
@@ -637,14 +633,14 @@ async def test_vpn_plus_mesh_over_different_connection_types(
             ),
         )
 
-        await ping(connection_alpha, beta.ip_addresses[0])
-        await ping(connection_alpha, gamma.ip_addresses[0])
+        await ping(connection_alpha, beta_node.ip_addresses[0])
+        await ping(connection_alpha, gamma_node.ip_addresses[0])
         await ping(connection_alpha, config.STUN_SERVER)
 
-        await ping(connection_beta, alpha.ip_addresses[0])
+        await ping(connection_beta, alpha_node.ip_addresses[0])
         await ping(connection_beta, config.STUN_SERVER)
 
-        await ping(connection_gamma, alpha.ip_addresses[0])
+        await ping(connection_gamma, alpha_node.ip_addresses[0])
         await ping(connection_gamma, config.STUN_SERVER)
 
         for connection in [connection_alpha, connection_beta, connection_gamma]:

--- a/nat-lab/tests/test_mesh_plus_vpn.py
+++ b/nat-lab/tests/test_mesh_plus_vpn.py
@@ -15,8 +15,6 @@ from tests.utils.connection import ConnectionTag
 from tests.utils.connection_util import generate_connection_tracker_config
 from tests.utils.ping import ping
 
-pytest_plugins = ["tests.helpers_fixtures"]
-
 
 # Module-level override — all tests in this file get VPN_1
 @pytest.fixture(name="vpn_tags")

--- a/nat-lab/tests/test_mesh_remove_node.py
+++ b/nat-lab/tests/test_mesh_remove_node.py
@@ -1,12 +1,12 @@
 import asyncio
 import pytest
-from contextlib import AsyncExitStack
-from tests.helpers import SetupParameters, setup_mesh_nodes
-from tests.mesh_api import API
+from tests.helpers import SetupParameters, Environment
 from tests.utils.bindings import TelioAdapterType
 from tests.utils.connection import ConnectionTag
 from tests.utils.connection_util import generate_connection_tracker_config
 from tests.utils.ping import ping
+
+pytest_plugins = ["tests.helpers_fixtures"]
 
 
 @pytest.mark.asyncio
@@ -91,41 +91,28 @@ from tests.utils.ping import ping
     ],
 )
 async def test_mesh_remove_node(
-    alpha_setup_params: SetupParameters,
-    beta_setup_params: SetupParameters,
-    gamma_setup_params: SetupParameters,
+    env_mesh_3node_ring_fw: Environment,
 ) -> None:
-    async with AsyncExitStack() as exit_stack:
-        api = API()
+    env = env_mesh_3node_ring_fw
+    api = env.api
+    alpha, beta, gamma = env.nodes
 
-        (alpha, beta, gamma) = api.default_config_three_nodes()
+    connection_alpha, connection_beta, connection_gamma = [
+        conn.connection for conn in env.connections
+    ]
+    client_alpha, client_beta, _ = env.clients
 
-        alpha.set_peer_firewall_settings(beta.id, allow_incoming_connections=False)
-        beta.set_peer_firewall_settings(gamma.id, allow_incoming_connections=False)
-        gamma.set_peer_firewall_settings(alpha.id, allow_incoming_connections=False)
+    await ping(connection_alpha, beta.ip_addresses[0])
+    await ping(connection_beta, gamma.ip_addresses[0])
+    await ping(connection_gamma, alpha.ip_addresses[0])
 
-        env = await setup_mesh_nodes(
-            exit_stack,
-            [alpha_setup_params, beta_setup_params, gamma_setup_params],
-            provided_api=api,
-        )
+    api.remove(gamma.id)
 
-        connection_alpha, connection_beta, connection_gamma = [
-            conn.connection for conn in env.connections
-        ]
-        client_alpha, client_beta, _ = env.clients
+    await client_alpha.set_meshnet_config(api.get_meshnet_config(alpha.id))
+    await client_beta.set_meshnet_config(api.get_meshnet_config(beta.id))
 
-        await ping(connection_alpha, beta.ip_addresses[0])
-        await ping(connection_beta, gamma.ip_addresses[0])
-        await ping(connection_gamma, alpha.ip_addresses[0])
-
-        api.remove(gamma.id)
-
-        await client_alpha.set_meshnet_config(api.get_meshnet_config(alpha.id))
-        await client_beta.set_meshnet_config(api.get_meshnet_config(beta.id))
-
-        await ping(connection_alpha, beta.ip_addresses[0])
-        with pytest.raises(asyncio.TimeoutError):
-            await ping(connection_beta, gamma.ip_addresses[0], 5)
-        with pytest.raises(asyncio.TimeoutError):
-            await ping(connection_gamma, alpha.ip_addresses[0], 5)
+    await ping(connection_alpha, beta.ip_addresses[0])
+    with pytest.raises(asyncio.TimeoutError):
+        await ping(connection_beta, gamma.ip_addresses[0], 5)
+    with pytest.raises(asyncio.TimeoutError):
+        await ping(connection_gamma, alpha.ip_addresses[0], 5)

--- a/nat-lab/tests/test_mesh_remove_node.py
+++ b/nat-lab/tests/test_mesh_remove_node.py
@@ -6,8 +6,6 @@ from tests.utils.connection import ConnectionTag
 from tests.utils.connection_util import generate_connection_tracker_config
 from tests.utils.ping import ping
 
-pytest_plugins = ["tests.helpers_fixtures"]
-
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(

--- a/nat-lab/tests/test_meshnet_id.py
+++ b/nat-lab/tests/test_meshnet_id.py
@@ -1,46 +1,48 @@
 import pytest
 import re
-from contextlib import AsyncExitStack
-from tests.helpers import SetupParameters, setup_environment
+from tests.helpers import SetupParameters, Environment
 from tests.utils.bindings import default_features, TelioAdapterType
 from tests.utils.connection import ConnectionTag
 
+pytest_plugins = ["tests.helpers_fixtures"]
 
-@pytest.mark.asyncio
-async def test_meshnet_id_generated_only_when_meshnet_starts() -> None:
-    async with AsyncExitStack() as exit_stack:
-        alpha_setup_params = SetupParameters(
-            connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-            adapter_type_override=TelioAdapterType.NEP_TUN,
-            features=default_features(
-                enable_nurse=True,
-                enable_lana=("path.db", False),
+
+@pytest.mark.parametrize(
+    "alpha_setup_params",
+    [
+        pytest.param(
+            SetupParameters(
+                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
+                adapter_type_override=TelioAdapterType.NEP_TUN,
+                features=default_features(
+                    enable_nurse=True,
+                    enable_lana=("path.db", False),
+                ),
+                is_meshnet=False,
             ),
-            is_meshnet=False,
-        )
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_meshnet_id_generated_only_when_meshnet_starts(
+    alpha_setup_params: SetupParameters,  # pylint: disable=unused-argument
+    env: Environment,
+) -> None:
+    client_alpha = env.clients[0]
+    # Wait for everything to get set up
+    await client_alpha.wait_for_log("Telio::start_named: Ok(())")
 
-        env = await exit_stack.enter_async_context(
-            setup_environment(
-                exit_stack,
-                [alpha_setup_params],
-            )
-        )
+    logs = await client_alpha.get_log()
+    # There should be no meshnet ID generation
+    assert logs.count("Meshnet ID:") == 0
 
-        [client_alpha] = env.clients
-        # Wait for everything to get set up
-        await client_alpha.wait_for_log("Telio::start_named: Ok(())")
+    config = env.api.get_meshnet_config(env.nodes[0].id)
+    await client_alpha.set_meshnet_config(config)
 
-        logs = await client_alpha.get_log()
-        # There should be no meshnet ID generation
-        assert logs.count("Meshnet ID:") == 0
+    await client_alpha.wait_for_log("Meshnet ID:")
 
-        config = env.api.get_meshnet_config(env.nodes[0].id)
-        await client_alpha.set_meshnet_config(config)
-
-        await client_alpha.wait_for_log("Meshnet ID:")
-
-        logs = await client_alpha.get_log()
-        assert re.search(
-            r"Meshnet ID: Some\(([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\)",
-            logs,
-        )
+    logs = await client_alpha.get_log()
+    assert re.search(
+        r"Meshnet ID: Some\(([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\)",
+        logs,
+    )

--- a/nat-lab/tests/test_meshnet_id.py
+++ b/nat-lab/tests/test_meshnet_id.py
@@ -4,8 +4,6 @@ from tests.helpers import SetupParameters, Environment
 from tests.utils.bindings import default_features, TelioAdapterType
 from tests.utils.connection import ConnectionTag
 
-pytest_plugins = ["tests.helpers_fixtures"]
-
 
 @pytest.mark.parametrize(
     "alpha_setup_params",

--- a/nat-lab/tests/test_neptun.py
+++ b/nat-lab/tests/test_neptun.py
@@ -1,32 +1,37 @@
 import pytest
-from contextlib import AsyncExitStack
-from tests.helpers import setup_mesh_nodes, SetupParameters, ping_between_all_nodes
+from tests.helpers import SetupParameters, Environment, ping_between_all_nodes
 from tests.utils.bindings import default_features, TelioAdapterType
 from tests.utils.connection import ConnectionTag
+
+pytest_plugins = ["tests.helpers_fixtures"]
 
 BUFFER_SIZE = 1310720
 
 
+@pytest.mark.parametrize(
+    "alpha_setup_params, beta_setup_params",
+    [
+        pytest.param(
+            SetupParameters(
+                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
+                adapter_type_override=TelioAdapterType.NEP_TUN,
+                features=default_features(custom_skt_buffer_size=BUFFER_SIZE),
+            ),
+            SetupParameters(
+                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2,
+            ),
+        ),
+    ],
+)
 @pytest.mark.asyncio
-async def test_custom_socket_buffers_on_neptun() -> None:
-    async with AsyncExitStack() as exit_stack:
-        env = await setup_mesh_nodes(
-            exit_stack,
-            [
-                SetupParameters(
-                    connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                    adapter_type_override=TelioAdapterType.NEP_TUN,
-                    features=default_features(custom_skt_buffer_size=BUFFER_SIZE),
-                ),
-                SetupParameters(
-                    connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2,
-                ),
-            ],
-        )
-
-        [client_alpha, _] = env.clients
-        await client_alpha.wait_for_log(
-            'Socket buffer "RcvBuf" set with value ' + str(BUFFER_SIZE)
-        )
-        # Ping to check connection works both ways
-        await ping_between_all_nodes(env)
+async def test_custom_socket_buffers_on_neptun(
+    alpha_setup_params: SetupParameters,  # pylint: disable=unused-argument
+    beta_setup_params: SetupParameters,  # pylint: disable=unused-argument
+    env_mesh: Environment,
+) -> None:
+    client_alpha = env_mesh.clients[0]
+    await client_alpha.wait_for_log(
+        'Socket buffer "RcvBuf" set with value ' + str(BUFFER_SIZE)
+    )
+    # Ping to check connection works both ways
+    await ping_between_all_nodes(env_mesh)

--- a/nat-lab/tests/test_neptun.py
+++ b/nat-lab/tests/test_neptun.py
@@ -3,8 +3,6 @@ from tests.helpers import SetupParameters, Environment, ping_between_all_nodes
 from tests.utils.bindings import default_features, TelioAdapterType
 from tests.utils.connection import ConnectionTag
 
-pytest_plugins = ["tests.helpers_fixtures"]
-
 BUFFER_SIZE = 1310720
 
 

--- a/nat-lab/tests/test_network_monitor.py
+++ b/nat-lab/tests/test_network_monitor.py
@@ -1,9 +1,10 @@
 import asyncio
 import pytest
-from contextlib import AsyncExitStack
-from tests.helpers import setup_mesh_nodes, SetupParameters
+from tests.helpers import SetupParameters, Environment
 from tests.utils.bindings import TelioAdapterType
 from tests.utils.connection import ConnectionTag, TargetOS
+
+pytest_plugins = ["tests.helpers_fixtures"]
 
 DEFAULT_WAITING_TIME = 2
 
@@ -37,43 +38,43 @@ DEFAULT_WAITING_TIME = 2
     ],
 )
 async def test_network_monitor(
-    alpha_setup_params: SetupParameters,
+    alpha_setup_params: SetupParameters,  # pylint: disable=unused-argument
+    env_mesh: Environment,
 ) -> None:
     # 1 [interface creation] + 1 [set IP] + 1 [remove IP] + 1 [set IP] -> interface initialization + restart
-    async with AsyncExitStack() as exit_stack:
-        env = await setup_mesh_nodes(exit_stack, [alpha_setup_params])
-        [client_alpha] = env.clients
+    env = env_mesh
+    [client_alpha] = env.clients
 
-        target_os = client_alpha.get_connection().target_os
-        if target_os == TargetOS.Linux:
-            NR_OF_NOTIFICATIONS = 12
-            NOT_GREATER = True
-        elif target_os == TargetOS.Windows:
-            NR_OF_NOTIFICATIONS = 10
-            NOT_GREATER = False
-        else:
-            NR_OF_NOTIFICATIONS = 4
-            NOT_GREATER = True
+    target_os = client_alpha.get_connection().target_os
+    if target_os == TargetOS.Linux:
+        NR_OF_NOTIFICATIONS = 12
+        NOT_GREATER = True
+    elif target_os == TargetOS.Windows:
+        NR_OF_NOTIFICATIONS = 10
+        NOT_GREATER = False
+    else:
+        NR_OF_NOTIFICATIONS = 4
+        NOT_GREATER = True
 
-        PLATFORM_AGNOSTIC_MESSAGE = "Detected network interface modification"
+    PLATFORM_AGNOSTIC_MESSAGE = "Detected network interface modification"
 
-        await asyncio.sleep(DEFAULT_WAITING_TIME)
-        await client_alpha.restart_interface()
+    await asyncio.sleep(DEFAULT_WAITING_TIME)
+    await client_alpha.restart_interface()
 
-        async def check_logs(msg, count):
-            await client_alpha.wait_for_log(msg, count=count, not_greater=NOT_GREATER)
+    async def check_logs(msg, count):
+        await client_alpha.wait_for_log(msg, count=count, not_greater=NOT_GREATER)
 
-        await check_logs(PLATFORM_AGNOSTIC_MESSAGE, NR_OF_NOTIFICATIONS)
+    await check_logs(PLATFORM_AGNOSTIC_MESSAGE, NR_OF_NOTIFICATIONS)
 
-        if client_alpha.get_connection().target_os == TargetOS.Linux:
-            PREFIX = "Received netfilter message: "
-            LINK_NEW = f"{PREFIX}NewLink(LinkMessage "
-            IPV4_IFADDR_NEW = f"{PREFIX}NewAddress(AddressMessage "
-            IPV4_IFADDR_DEL = f"{PREFIX}DelAddress(AddressMessage "
-            IPV4_ROUTE_NEW = f"{PREFIX}NewRoute(RouteMessage "
-            IPV4_ROUTE_DEL = f"{PREFIX}DelRoute(RouteMessage "
-            await check_logs(LINK_NEW, 4)
-            await check_logs(IPV4_IFADDR_NEW, 2)
-            await check_logs(IPV4_ROUTE_NEW, 4)
-            await check_logs(IPV4_ROUTE_DEL, 1)
-            await check_logs(IPV4_IFADDR_DEL, 1)
+    if client_alpha.get_connection().target_os == TargetOS.Linux:
+        PREFIX = "Received netfilter message: "
+        LINK_NEW = f"{PREFIX}NewLink(LinkMessage "
+        IPV4_IFADDR_NEW = f"{PREFIX}NewAddress(AddressMessage "
+        IPV4_IFADDR_DEL = f"{PREFIX}DelAddress(AddressMessage "
+        IPV4_ROUTE_NEW = f"{PREFIX}NewRoute(RouteMessage "
+        IPV4_ROUTE_DEL = f"{PREFIX}DelRoute(RouteMessage "
+        await check_logs(LINK_NEW, 4)
+        await check_logs(IPV4_IFADDR_NEW, 2)
+        await check_logs(IPV4_ROUTE_NEW, 4)
+        await check_logs(IPV4_ROUTE_DEL, 1)
+        await check_logs(IPV4_IFADDR_DEL, 1)

--- a/nat-lab/tests/test_network_monitor.py
+++ b/nat-lab/tests/test_network_monitor.py
@@ -4,8 +4,6 @@ from tests.helpers import SetupParameters, Environment
 from tests.utils.bindings import TelioAdapterType
 from tests.utils.connection import ConnectionTag, TargetOS
 
-pytest_plugins = ["tests.helpers_fixtures"]
-
 DEFAULT_WAITING_TIME = 2
 
 

--- a/nat-lab/tests/test_node_state_flickering.py
+++ b/nat-lab/tests/test_node_state_flickering.py
@@ -3,7 +3,7 @@ import itertools
 import pytest
 from contextlib import AsyncExitStack
 from tests import timeouts
-from tests.helpers import SetupParameters, setup_mesh_nodes
+from tests.helpers import SetupParameters, setup_mesh_nodes, Environment
 from tests.utils.bindings import (
     features_with_endpoint_providers,
     EndpointProvider,
@@ -14,6 +14,8 @@ from tests.utils.bindings import (
 )
 from tests.utils.connection import ConnectionTag
 from tests.utils.connection_util import generate_connection_tracker_config
+
+pytest_plugins = ["tests.helpers_fixtures"]
 
 
 @pytest.mark.asyncio
@@ -82,26 +84,25 @@ from tests.utils.connection_util import generate_connection_tracker_config
     ],
 )
 async def test_node_state_flickering_relay(
-    alpha_setup_params: SetupParameters, beta_setup_params: SetupParameters
+    alpha_setup_params: SetupParameters,  # pylint: disable=unused-argument
+    beta_setup_params: SetupParameters,  # pylint: disable=unused-argument
+    env_mesh: Environment,
 ) -> None:
-    async with AsyncExitStack() as exit_stack:
-        env = await setup_mesh_nodes(
-            exit_stack, [alpha_setup_params, beta_setup_params]
-        )
-        alpha, beta = env.nodes
-        client_alpha, client_beta = env.clients
+    env = env_mesh
+    alpha, beta = env.nodes
+    client_alpha, client_beta = env.clients
 
-        with pytest.raises(asyncio.TimeoutError):
-            await asyncio.gather(
-                client_alpha.wait_for_event_peer(
-                    beta.public_key, list(NodeState), timeout=120
-                ),
-                client_beta.wait_for_event_peer(
-                    alpha.public_key, list(NodeState), timeout=120
-                ),
-                client_alpha.wait_for_event_on_any_derp(list(RelayState), timeout=120),
-                client_beta.wait_for_event_on_any_derp(list(RelayState), timeout=120),
-            )
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.gather(
+            client_alpha.wait_for_event_peer(
+                beta.public_key, list(NodeState), timeout=120
+            ),
+            client_beta.wait_for_event_peer(
+                alpha.public_key, list(NodeState), timeout=120
+            ),
+            client_alpha.wait_for_event_on_any_derp(list(RelayState), timeout=120),
+            client_beta.wait_for_event_on_any_derp(list(RelayState), timeout=120),
+        )
 
 
 CFG = [

--- a/nat-lab/tests/test_node_state_flickering.py
+++ b/nat-lab/tests/test_node_state_flickering.py
@@ -15,8 +15,6 @@ from tests.utils.bindings import (
 from tests.utils.connection import ConnectionTag
 from tests.utils.connection_util import generate_connection_tracker_config
 
-pytest_plugins = ["tests.helpers_fixtures"]
-
 
 @pytest.mark.asyncio
 @pytest.mark.timeout(timeouts.TEST_NODE_STATE_FLICKERING_RELAY_TIMEOUT)

--- a/nat-lab/tests/test_pinging.py
+++ b/nat-lab/tests/test_pinging.py
@@ -1,7 +1,7 @@
 import asyncio
 import pytest
 from contextlib import AsyncExitStack
-from tests.helpers import setup_mesh_nodes, SetupParameters, connectivity_stack
+from tests.helpers import SetupParameters, Environment, connectivity_stack
 from tests.utils.bindings import (
     Features,
     default_features,
@@ -20,7 +20,7 @@ from tests.utils.connection_util import (
 )
 from tests.utils.logger import log
 from tests.utils.router import IPStack
-from typing import Tuple
+from typing import Awaitable, Callable, Tuple
 
 IP_STACKS = [
     pytest.param(
@@ -149,56 +149,55 @@ async def test_session_keeper(
     alpha_setup_params: SetupParameters,
     alpha_ip_stack: IPStack,
     beta_setup_params: SetupParameters,
+    exit_stack: AsyncExitStack,
+    setup_mesh_nodes_factory: Callable[..., Awaitable[Environment]],
 ) -> None:
-    async with AsyncExitStack() as exit_stack:
-        alpha_setup_params.ip_stack = alpha_ip_stack
+    alpha_setup_params.ip_stack = alpha_ip_stack
 
-        # Initialize node conntracker before starting nodes
-        _, alpha_conntrack = await build_conntracker(
-            exit_stack,
-            alpha_setup_params.connection_tag,
-            alpha_ip_stack,
-            beta_setup_params.ip_stack,
-            for_session_keeper=True,
-        )
-        _, beta_conntrack = await build_conntracker(
-            exit_stack,
-            beta_setup_params.connection_tag,
-            alpha_ip_stack,
-            beta_setup_params.ip_stack,
-            for_session_keeper=True,
-        )
+    # Initialize node conntracker before starting nodes
+    _, alpha_conntrack = await build_conntracker(
+        exit_stack,
+        alpha_setup_params.connection_tag,
+        alpha_ip_stack,
+        beta_setup_params.ip_stack,
+        for_session_keeper=True,
+    )
+    _, beta_conntrack = await build_conntracker(
+        exit_stack,
+        beta_setup_params.connection_tag,
+        alpha_ip_stack,
+        beta_setup_params.ip_stack,
+        for_session_keeper=True,
+    )
 
-        # Startup meshnet
-        env = await setup_mesh_nodes(
-            exit_stack, [alpha_setup_params, beta_setup_params]
-        )
+    # Startup meshnet
+    env = await setup_mesh_nodes_factory([alpha_setup_params, beta_setup_params])
 
-        alpha, beta = env.nodes
-        alpha_client, beta_client = env.clients
+    alpha, beta = env.nodes
+    alpha_client, beta_client = env.clients
 
-        async def wait_for_conntracker() -> None:
-            while True:
-                alpha_limits = await alpha_conntrack.find_conntracker_violations()
-                beta_limits = await beta_conntrack.find_conntracker_violations()
-                log.info("Conntracker state: %s %s", alpha_limits, beta_limits)
-                if alpha_limits is None and beta_limits is None:
-                    return
-                await asyncio.sleep(1)
+    async def wait_for_conntracker() -> None:
+        while True:
+            alpha_limits = await alpha_conntrack.find_conntracker_violations()
+            beta_limits = await beta_conntrack.find_conntracker_violations()
+            log.info("Conntracker state: %s %s", alpha_limits, beta_limits)
+            if alpha_limits is None and beta_limits is None:
+                return
+            await asyncio.sleep(1)
 
-        await asyncio.gather(
-            alpha_client.wait_for_state_peer(
-                beta.public_key,
-                [NodeState.CONNECTED],
-                [PathType.DIRECT],
-            ),
-            beta_client.wait_for_state_peer(
-                alpha.public_key,
-                [NodeState.CONNECTED],
-                [PathType.DIRECT],
-            ),
-            wait_for_conntracker(),
-        )
+    await asyncio.gather(
+        alpha_client.wait_for_state_peer(
+            beta.public_key,
+            [NodeState.CONNECTED],
+            [PathType.DIRECT],
+        ),
+        beta_client.wait_for_state_peer(
+            alpha.public_key,
+            [NodeState.CONNECTED],
+            [PathType.DIRECT],
+        ),
+        wait_for_conntracker(),
+    )
 
 
 @pytest.mark.asyncio
@@ -256,41 +255,40 @@ async def test_qos(
     alpha_setup_params: SetupParameters,
     alpha_ip_stack: IPStack,
     beta_setup_params: SetupParameters,
+    exit_stack: AsyncExitStack,
+    setup_mesh_nodes_factory: Callable[..., Awaitable[Environment]],
 ) -> None:
-    async with AsyncExitStack() as exit_stack:
-        alpha_setup_params.ip_stack = alpha_ip_stack
+    alpha_setup_params.ip_stack = alpha_ip_stack
 
-        # Setup conntracking before mesh startup
-        _, alpha_conntrack = await build_conntracker(
-            exit_stack,
-            alpha_setup_params.connection_tag,
-            alpha_setup_params.ip_stack,
-            beta_setup_params.ip_stack,
-        )
+    # Setup conntracking before mesh startup
+    _, alpha_conntrack = await build_conntracker(
+        exit_stack,
+        alpha_setup_params.connection_tag,
+        alpha_setup_params.ip_stack,
+        beta_setup_params.ip_stack,
+    )
 
-        env = await setup_mesh_nodes(
-            exit_stack, [alpha_setup_params, beta_setup_params]
-        )
+    env = await setup_mesh_nodes_factory([alpha_setup_params, beta_setup_params])
 
-        alpha, beta = env.nodes
-        alpha_client, beta_client = env.clients
+    alpha, beta = env.nodes
+    alpha_client, beta_client = env.clients
 
-        async def wait_for_conntracker() -> None:
-            while True:
-                alpha_limits = await alpha_conntrack.find_conntracker_violations()
-                log.info("wait_for_conntracker(): %s", alpha_limits)
-                if alpha_limits is None:
-                    return
-                await asyncio.sleep(1.0)
+    async def wait_for_conntracker() -> None:
+        while True:
+            alpha_limits = await alpha_conntrack.find_conntracker_violations()
+            log.info("wait_for_conntracker(): %s", alpha_limits)
+            if alpha_limits is None:
+                return
+            await asyncio.sleep(1.0)
 
-        await asyncio.gather(
-            alpha_client.wait_for_state_peer(
-                beta.public_key,
-                [NodeState.CONNECTED],
-            ),
-            beta_client.wait_for_state_peer(
-                alpha.public_key,
-                [NodeState.CONNECTED],
-            ),
-            wait_for_conntracker(),
-        )
+    await asyncio.gather(
+        alpha_client.wait_for_state_peer(
+            beta.public_key,
+            [NodeState.CONNECTED],
+        ),
+        beta_client.wait_for_state_peer(
+            alpha.public_key,
+            [NodeState.CONNECTED],
+        ),
+        wait_for_conntracker(),
+    )

--- a/nat-lab/tests/test_pq.py
+++ b/nat-lab/tests/test_pq.py
@@ -249,10 +249,10 @@ class TestPqVpnRekey:
         )
 
         async with new_connection_by_tag(ConnectionTag.VM_LINUX_NLX_1) as nlx_conn:
-            preshared_before = inspect_preshared_key(nlx_conn)
+            preshared_before = await inspect_preshared_key(nlx_conn)
             await client_alpha.wait_for_log("Successful PQ REKEY")
 
-            preshared_after = inspect_preshared_key(nlx_conn)
+            preshared_after = await inspect_preshared_key(nlx_conn)
             assert (
                 preshared_after != preshared_before
             ), "Preshared key not changed on the nlx server"

--- a/nat-lab/tests/test_pq.py
+++ b/nat-lab/tests/test_pq.py
@@ -1,9 +1,8 @@
 import asyncio
 import pytest
-from contextlib import AsyncExitStack
 from datetime import datetime, timedelta
 from tests import config
-from tests.helpers import SetupParameters, setup_environment
+from tests.helpers import SetupParameters, Environment
 from tests.telio import Client
 from tests.utils import stun
 from tests.utils.bindings import TelioAdapterType, NodeState, PathType
@@ -15,7 +14,15 @@ from tests.utils.connection_util import (
 from tests.utils.dns import query_dns
 from tests.utils.ping import ping
 
+pytest_plugins = ["tests.helpers_fixtures"]
+
 EMPTY_PRESHARED_KEY_SLOT = "(none)"
+
+
+# Module-level override — all standalone PQ tests use NLX VPN
+@pytest.fixture(name="vpn_tags")
+def _vpn_tags() -> list:
+    return [ConnectionTag.VM_LINUX_NLX_1]
 
 
 # Returns the time at which the connection to the VPN server was established
@@ -55,89 +62,87 @@ async def inspect_preshared_key(nlx_conn: Connection) -> str:
     return preshared
 
 
-@pytest.mark.nlx
-@pytest.mark.parametrize(
-    "alpha_setup_params, public_ip",
-    [
-        pytest.param(
-            SetupParameters(
-                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                adapter_type_override=TelioAdapterType.NEP_TUN,
-                connection_tracker_config=generate_connection_tracker_config(
-                    ConnectionTag.DOCKER_CONE_CLIENT_1,
-                    stun_limits=(1, 1),
-                    nlx_1_limits=(2, 2),
-                ),
-                is_meshnet=False,
-            ),
-            "10.0.254.1",
-        ),
-        pytest.param(
-            SetupParameters(
-                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                adapter_type_override=TelioAdapterType.LINUX_NATIVE_TUN,
-                connection_tracker_config=generate_connection_tracker_config(
-                    ConnectionTag.DOCKER_CONE_CLIENT_1,
-                    stun_limits=(1, 1),
-                    nlx_1_limits=(2, 2),
-                ),
-                is_meshnet=False,
-            ),
-            "10.0.254.1",
-            marks=pytest.mark.linux_native,
-        ),
-        pytest.param(
-            SetupParameters(
-                connection_tag=ConnectionTag.VM_WINDOWS_1,
-                adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
-                connection_tracker_config=generate_connection_tracker_config(
-                    ConnectionTag.VM_WINDOWS_1,
-                    stun_limits=(1, 1),
-                    nlx_1_limits=(2, 2),
-                ),
-                is_meshnet=False,
-            ),
-            "10.0.254.15",
-            marks=[
-                pytest.mark.windows,
-            ],
-        ),
-        pytest.param(
-            SetupParameters(
-                connection_tag=ConnectionTag.VM_MAC,
-                adapter_type_override=TelioAdapterType.NEP_TUN,
-                connection_tracker_config=generate_connection_tracker_config(
-                    ConnectionTag.VM_MAC,
-                    stun_limits=(1, 1),
-                    nlx_1_limits=(2, 2),
-                ),
-                is_meshnet=False,
-            ),
-            "10.0.254.19",
-            marks=pytest.mark.mac,
-        ),
-    ],
-)
-@pytest.mark.parametrize(
-    "pq_version",
-    [pytest.param(1), pytest.param(2)],
-)
-async def test_pq_vpn_connection(
-    alpha_setup_params: SetupParameters,
-    public_ip: str,
-    pq_version: int,
-) -> None:
-    alpha_setup_params.features.post_quantum_vpn.version = pq_version
+class TestPqVpnConnection:
+    """Tests using PQ VPN with version mutation."""
 
-    async with AsyncExitStack() as exit_stack:
-        env = await exit_stack.enter_async_context(
-            setup_environment(
-                exit_stack,
-                [alpha_setup_params],
-                vpn=[ConnectionTag.VM_LINUX_NLX_1],
-            )
-        )
+    @pytest.fixture(autouse=True)
+    def _mutate_pq_version(self, alpha_setup_params: SetupParameters, pq_version: int):
+        alpha_setup_params.features.post_quantum_vpn.version = pq_version
 
+    @pytest.mark.nlx
+    @pytest.mark.parametrize(
+        "alpha_setup_params, public_ip",
+        [
+            pytest.param(
+                SetupParameters(
+                    connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
+                    adapter_type_override=TelioAdapterType.NEP_TUN,
+                    connection_tracker_config=generate_connection_tracker_config(
+                        ConnectionTag.DOCKER_CONE_CLIENT_1,
+                        stun_limits=(1, 1),
+                        nlx_1_limits=(2, 2),
+                    ),
+                    is_meshnet=False,
+                ),
+                "10.0.254.1",
+            ),
+            pytest.param(
+                SetupParameters(
+                    connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
+                    adapter_type_override=TelioAdapterType.LINUX_NATIVE_TUN,
+                    connection_tracker_config=generate_connection_tracker_config(
+                        ConnectionTag.DOCKER_CONE_CLIENT_1,
+                        stun_limits=(1, 1),
+                        nlx_1_limits=(2, 2),
+                    ),
+                    is_meshnet=False,
+                ),
+                "10.0.254.1",
+                marks=pytest.mark.linux_native,
+            ),
+            pytest.param(
+                SetupParameters(
+                    connection_tag=ConnectionTag.VM_WINDOWS_1,
+                    adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
+                    connection_tracker_config=generate_connection_tracker_config(
+                        ConnectionTag.VM_WINDOWS_1,
+                        stun_limits=(1, 1),
+                        nlx_1_limits=(2, 2),
+                    ),
+                    is_meshnet=False,
+                ),
+                "10.0.254.15",
+                marks=[
+                    pytest.mark.windows,
+                ],
+            ),
+            pytest.param(
+                SetupParameters(
+                    connection_tag=ConnectionTag.VM_MAC,
+                    adapter_type_override=TelioAdapterType.NEP_TUN,
+                    connection_tracker_config=generate_connection_tracker_config(
+                        ConnectionTag.VM_MAC,
+                        stun_limits=(1, 1),
+                        nlx_1_limits=(2, 2),
+                    ),
+                    is_meshnet=False,
+                ),
+                "10.0.254.19",
+                marks=pytest.mark.mac,
+            ),
+        ],
+    )
+    @pytest.mark.parametrize(
+        "pq_version",
+        [pytest.param(1), pytest.param(2)],
+    )
+    async def test_pq_vpn_connection(
+        self,
+        alpha_setup_params: SetupParameters,  # pylint: disable=unused-argument
+        public_ip: str,
+        pq_version: int,  # pylint: disable=unused-argument
+        env: Environment,
+    ) -> None:
         client_conn, *_ = [conn.connection for conn in env.connections]
         client_alpha, *_ = env.clients
 
@@ -150,91 +155,88 @@ async def test_pq_vpn_connection(
         )
 
 
-@pytest.mark.nlx
-@pytest.mark.parametrize(
-    "alpha_setup_params, public_ip",
-    [
-        pytest.param(
-            SetupParameters(
-                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                adapter_type_override=TelioAdapterType.NEP_TUN,
-                connection_tracker_config=generate_connection_tracker_config(
-                    ConnectionTag.DOCKER_CONE_CLIENT_1,
-                    stun_limits=(1, 1),
-                    nlx_1_limits=(2, 2),
-                ),
-                is_meshnet=False,
-            ),
-            "10.0.254.1",
-        ),
-        pytest.param(
-            SetupParameters(
-                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                adapter_type_override=TelioAdapterType.LINUX_NATIVE_TUN,
-                connection_tracker_config=generate_connection_tracker_config(
-                    ConnectionTag.DOCKER_CONE_CLIENT_1,
-                    stun_limits=(1, 1),
-                    nlx_1_limits=(2, 2),
-                ),
-                is_meshnet=False,
-            ),
-            "10.0.254.1",
-            marks=pytest.mark.linux_native,
-        ),
-        pytest.param(
-            SetupParameters(
-                connection_tag=ConnectionTag.VM_WINDOWS_1,
-                adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
-                connection_tracker_config=generate_connection_tracker_config(
-                    ConnectionTag.VM_WINDOWS_1,
-                    stun_limits=(1, 1),
-                    nlx_1_limits=(2, 2),
-                ),
-                is_meshnet=False,
-            ),
-            "10.0.254.15",
-            marks=[
-                pytest.mark.windows,
-            ],
-        ),
-        pytest.param(
-            SetupParameters(
-                connection_tag=ConnectionTag.VM_MAC,
-                adapter_type_override=TelioAdapterType.NEP_TUN,
-                connection_tracker_config=generate_connection_tracker_config(
-                    ConnectionTag.VM_MAC,
-                    stun_limits=(1, 1),
-                    nlx_1_limits=(2, 2),
-                ),
-                is_meshnet=False,
-            ),
-            "10.0.254.19",
-            marks=pytest.mark.mac,
-        ),
-    ],
-)
-@pytest.mark.parametrize(
-    "pq_version",
-    [pytest.param(1), pytest.param(2)],
-)
-async def test_pq_vpn_rekey(
-    alpha_setup_params: SetupParameters,
-    public_ip: str,
-    pq_version: int,
-) -> None:
-    # Set rekey interval to some small value
-    alpha_setup_params.features.post_quantum_vpn.rekey_interval_s = 2
-    alpha_setup_params.features.post_quantum_vpn.version = pq_version
+class TestPqVpnRekey:
+    """Tests using PQ VPN with version + rekey mutation."""
 
-    async with AsyncExitStack() as exit_stack:
-        env = await exit_stack.enter_async_context(
-            setup_environment(
-                exit_stack,
-                [alpha_setup_params],
-                vpn=[ConnectionTag.VM_LINUX_NLX_1],
-            )
-        )
+    @pytest.fixture(autouse=True)
+    def _mutate_pq_rekey(self, alpha_setup_params: SetupParameters, pq_version: int):
+        alpha_setup_params.features.post_quantum_vpn.rekey_interval_s = 2
+        alpha_setup_params.features.post_quantum_vpn.version = pq_version
 
+    @pytest.mark.nlx
+    @pytest.mark.parametrize(
+        "alpha_setup_params, public_ip",
+        [
+            pytest.param(
+                SetupParameters(
+                    connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
+                    adapter_type_override=TelioAdapterType.NEP_TUN,
+                    connection_tracker_config=generate_connection_tracker_config(
+                        ConnectionTag.DOCKER_CONE_CLIENT_1,
+                        stun_limits=(1, 1),
+                        nlx_1_limits=(2, 2),
+                    ),
+                    is_meshnet=False,
+                ),
+                "10.0.254.1",
+            ),
+            pytest.param(
+                SetupParameters(
+                    connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
+                    adapter_type_override=TelioAdapterType.LINUX_NATIVE_TUN,
+                    connection_tracker_config=generate_connection_tracker_config(
+                        ConnectionTag.DOCKER_CONE_CLIENT_1,
+                        stun_limits=(1, 1),
+                        nlx_1_limits=(2, 2),
+                    ),
+                    is_meshnet=False,
+                ),
+                "10.0.254.1",
+                marks=pytest.mark.linux_native,
+            ),
+            pytest.param(
+                SetupParameters(
+                    connection_tag=ConnectionTag.VM_WINDOWS_1,
+                    adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
+                    connection_tracker_config=generate_connection_tracker_config(
+                        ConnectionTag.VM_WINDOWS_1,
+                        stun_limits=(1, 1),
+                        nlx_1_limits=(2, 2),
+                    ),
+                    is_meshnet=False,
+                ),
+                "10.0.254.15",
+                marks=[
+                    pytest.mark.windows,
+                ],
+            ),
+            pytest.param(
+                SetupParameters(
+                    connection_tag=ConnectionTag.VM_MAC,
+                    adapter_type_override=TelioAdapterType.NEP_TUN,
+                    connection_tracker_config=generate_connection_tracker_config(
+                        ConnectionTag.VM_MAC,
+                        stun_limits=(1, 1),
+                        nlx_1_limits=(2, 2),
+                    ),
+                    is_meshnet=False,
+                ),
+                "10.0.254.19",
+                marks=pytest.mark.mac,
+            ),
+        ],
+    )
+    @pytest.mark.parametrize(
+        "pq_version",
+        [pytest.param(1), pytest.param(2)],
+    )
+    async def test_pq_vpn_rekey(
+        self,
+        alpha_setup_params: SetupParameters,  # pylint: disable=unused-argument
+        public_ip: str,
+        pq_version: int,  # pylint: disable=unused-argument
+        env: Environment,
+    ) -> None:
         client_conn, *_ = [conn.connection for conn in env.connections]
         client_alpha, *_ = env.clients
 
@@ -246,17 +248,14 @@ async def test_pq_vpn_rekey(
             client_alpha,
         )
 
-        nlx_conn = await exit_stack.enter_async_context(
-            new_connection_by_tag(ConnectionTag.VM_LINUX_NLX_1)
-        )
+        async with new_connection_by_tag(ConnectionTag.VM_LINUX_NLX_1) as nlx_conn:
+            preshared_before = inspect_preshared_key(nlx_conn)
+            await client_alpha.wait_for_log("Successful PQ REKEY")
 
-        preshared_before = inspect_preshared_key(nlx_conn)
-        await client_alpha.wait_for_log("Successful PQ REKEY")
-
-        preshared_after = inspect_preshared_key(nlx_conn)
-        assert (
-            preshared_after != preshared_before
-        ), "Preshared key not changed on the nlx server"
+            preshared_after = inspect_preshared_key(nlx_conn)
+            assert (
+                preshared_after != preshared_before
+            ), "Preshared key not changed on the nlx server"
 
         ip = await stun.get(client_conn, config.STUN_SERVER)
         assert (
@@ -265,81 +264,71 @@ async def test_pq_vpn_rekey(
 
         await ping(client_conn, config.PHOTO_ALBUM_IP)
 
-
-@pytest.mark.nlx
-@pytest.mark.parametrize(
-    "alpha_setup_params",
-    [
-        pytest.param(
-            SetupParameters(
-                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                adapter_type_override=TelioAdapterType.NEP_TUN,
-                connection_tracker_config=generate_connection_tracker_config(
-                    ConnectionTag.DOCKER_CONE_CLIENT_1,
-                    nlx_1_limits=(2, 2),
+    @pytest.mark.nlx
+    @pytest.mark.parametrize(
+        "alpha_setup_params",
+        [
+            pytest.param(
+                SetupParameters(
+                    connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
+                    adapter_type_override=TelioAdapterType.NEP_TUN,
+                    connection_tracker_config=generate_connection_tracker_config(
+                        ConnectionTag.DOCKER_CONE_CLIENT_1,
+                        nlx_1_limits=(2, 2),
+                    ),
+                    is_meshnet=False,
                 ),
-                is_meshnet=False,
             ),
-        ),
-        pytest.param(
-            SetupParameters(
-                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                adapter_type_override=TelioAdapterType.LINUX_NATIVE_TUN,
-                connection_tracker_config=generate_connection_tracker_config(
-                    ConnectionTag.DOCKER_CONE_CLIENT_1,
-                    nlx_1_limits=(2, 2),
+            pytest.param(
+                SetupParameters(
+                    connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
+                    adapter_type_override=TelioAdapterType.LINUX_NATIVE_TUN,
+                    connection_tracker_config=generate_connection_tracker_config(
+                        ConnectionTag.DOCKER_CONE_CLIENT_1,
+                        nlx_1_limits=(2, 2),
+                    ),
+                    is_meshnet=False,
                 ),
-                is_meshnet=False,
+                marks=pytest.mark.linux_native,
             ),
-            marks=pytest.mark.linux_native,
-        ),
-        pytest.param(
-            SetupParameters(
-                connection_tag=ConnectionTag.VM_WINDOWS_1,
-                adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
-                connection_tracker_config=generate_connection_tracker_config(
-                    ConnectionTag.VM_WINDOWS_1,
-                    nlx_1_limits=(2, 2),
+            pytest.param(
+                SetupParameters(
+                    connection_tag=ConnectionTag.VM_WINDOWS_1,
+                    adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
+                    connection_tracker_config=generate_connection_tracker_config(
+                        ConnectionTag.VM_WINDOWS_1,
+                        nlx_1_limits=(2, 2),
+                    ),
+                    is_meshnet=False,
                 ),
-                is_meshnet=False,
+                marks=[
+                    pytest.mark.windows,
+                ],
             ),
-            marks=[
-                pytest.mark.windows,
-            ],
-        ),
-        pytest.param(
-            SetupParameters(
-                connection_tag=ConnectionTag.VM_MAC,
-                adapter_type_override=TelioAdapterType.NEP_TUN,
-                connection_tracker_config=generate_connection_tracker_config(
-                    ConnectionTag.VM_MAC,
-                    nlx_1_limits=(2, 2),
+            pytest.param(
+                SetupParameters(
+                    connection_tag=ConnectionTag.VM_MAC,
+                    adapter_type_override=TelioAdapterType.NEP_TUN,
+                    connection_tracker_config=generate_connection_tracker_config(
+                        ConnectionTag.VM_MAC,
+                        nlx_1_limits=(2, 2),
+                    ),
+                    is_meshnet=False,
                 ),
-                is_meshnet=False,
+                marks=pytest.mark.mac,
             ),
-            marks=pytest.mark.mac,
-        ),
-    ],
-)
-@pytest.mark.parametrize(
-    "pq_version",
-    [pytest.param(1), pytest.param(2)],
-)
-async def test_dns_with_pq(
-    alpha_setup_params: SetupParameters,
-    pq_version: int,
-) -> None:
-    alpha_setup_params.features.post_quantum_vpn.version = pq_version
-
-    async with AsyncExitStack() as exit_stack:
-        env = await exit_stack.enter_async_context(
-            setup_environment(
-                exit_stack,
-                [alpha_setup_params],
-                vpn=[ConnectionTag.VM_LINUX_NLX_1],
-            )
-        )
-
+        ],
+    )
+    @pytest.mark.parametrize(
+        "pq_version",
+        [pytest.param(1), pytest.param(2)],
+    )
+    async def test_dns_with_pq(
+        self,
+        alpha_setup_params: SetupParameters,  # pylint: disable=unused-argument
+        pq_version: int,  # pylint: disable=unused-argument
+        env: Environment,
+    ) -> None:
         client_conn, *_ = [conn.connection for conn in env.connections]
         client, *_ = env.clients
 
@@ -372,40 +361,44 @@ async def test_dns_with_pq(
         await query_dns(client_conn, "google.com")
 
 
-@pytest.mark.nlx
-@pytest.mark.parametrize(
-    "setup",
-    [
-        pytest.param(
-            SetupParameters(
-                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                adapter_type_override=TelioAdapterType.NEP_TUN,
-                connection_tracker_config=generate_connection_tracker_config(
-                    ConnectionTag.DOCKER_CONE_CLIENT_1,
-                    vpn_1_limits=(1, None),
-                    nlx_1_limits=(2, 2),
+class TestPqVpnHandshake:
+    """Tests using PQ VPN with version + handshake_retry_interval mutation."""
+
+    @pytest.fixture(autouse=True)
+    def _mutate_pq_handshake(
+        self, alpha_setup_params: SetupParameters, pq_version: int
+    ):
+        alpha_setup_params.features.post_quantum_vpn.handshake_retry_interval_s = 1
+        alpha_setup_params.features.post_quantum_vpn.version = pq_version
+
+    @pytest.mark.nlx
+    @pytest.mark.parametrize(
+        "alpha_setup_params",
+        [
+            pytest.param(
+                SetupParameters(
+                    connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
+                    adapter_type_override=TelioAdapterType.NEP_TUN,
+                    connection_tracker_config=generate_connection_tracker_config(
+                        ConnectionTag.DOCKER_CONE_CLIENT_1,
+                        vpn_1_limits=(1, None),
+                        nlx_1_limits=(2, 2),
+                    ),
+                    is_meshnet=False,
                 ),
-                is_meshnet=False,
             ),
-        ),
-    ],
-)
-@pytest.mark.parametrize(
-    "pq_version",
-    [pytest.param(1), pytest.param(2)],
-)
-async def test_pq_vpn_silent_pq_upgrader(
-    setup: SetupParameters,
-    pq_version: int,
-) -> None:
-    setup.features.post_quantum_vpn.version = pq_version
-    async with AsyncExitStack() as exit_stack:
-        setup.features.post_quantum_vpn.handshake_retry_interval_s = 1
-
-        env = await exit_stack.enter_async_context(
-            setup_environment(exit_stack, [setup], vpn=[ConnectionTag.VM_LINUX_NLX_1])
-        )
-
+        ],
+    )
+    @pytest.mark.parametrize(
+        "pq_version",
+        [pytest.param(1), pytest.param(2)],
+    )
+    async def test_pq_vpn_silent_pq_upgrader(
+        self,
+        alpha_setup_params: SetupParameters,  # pylint: disable=unused-argument
+        pq_version: int,  # pylint: disable=unused-argument
+        env: Environment,
+    ) -> None:
         client_conn, *_ = [conn.connection for conn in env.connections]
         client, *_ = env.clients
 
@@ -454,137 +447,123 @@ async def test_pq_vpn_silent_pq_upgrader(
         await _connect_vpn_pq(client_conn, client)
         await ping(client_conn, config.PHOTO_ALBUM_IP)
 
-
-@pytest.mark.nlx
-@pytest.mark.parametrize(
-    "alpha_setup_params",
-    [
-        pytest.param(
-            SetupParameters(
-                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                adapter_type_override=TelioAdapterType.NEP_TUN,
-                connection_tracker_config=generate_connection_tracker_config(
-                    ConnectionTag.DOCKER_CONE_CLIENT_1,
-                    nlx_1_limits=(2, 2),
+    @pytest.mark.nlx
+    @pytest.mark.parametrize(
+        "alpha_setup_params",
+        [
+            pytest.param(
+                SetupParameters(
+                    connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
+                    adapter_type_override=TelioAdapterType.NEP_TUN,
+                    connection_tracker_config=generate_connection_tracker_config(
+                        ConnectionTag.DOCKER_CONE_CLIENT_1,
+                        nlx_1_limits=(2, 2),
+                    ),
+                    is_meshnet=False,
                 ),
-                is_meshnet=False,
             ),
-        ),
-    ],
-)
-@pytest.mark.parametrize(
-    "pq_version",
-    [pytest.param(1), pytest.param(2)],
-)
-async def test_pq_vpn_upgrade_from_non_pq(
-    alpha_setup_params: SetupParameters,
-    pq_version: int,
-) -> None:
-    async with AsyncExitStack() as exit_stack:
-        alpha_setup_params.features.post_quantum_vpn.handshake_retry_interval_s = 1
-        alpha_setup_params.features.post_quantum_vpn.version = pq_version
-
-        env = await exit_stack.enter_async_context(
-            setup_environment(
-                exit_stack,
-                [alpha_setup_params],
-                vpn=[ConnectionTag.VM_LINUX_NLX_1],
-            )
-        )
-
+        ],
+    )
+    @pytest.mark.parametrize(
+        "pq_version",
+        [pytest.param(1), pytest.param(2)],
+    )
+    async def test_pq_vpn_upgrade_from_non_pq(
+        self,
+        alpha_setup_params: SetupParameters,  # pylint: disable=unused-argument
+        pq_version: int,  # pylint: disable=unused-argument
+        env: Environment,
+    ) -> None:
         client_conn, *_ = [conn.connection for conn in env.connections]
         client, *_ = env.clients
 
-        nlx_conn = await exit_stack.enter_async_context(
-            new_connection_by_tag(ConnectionTag.VM_LINUX_NLX_1)
-        )
+        async with new_connection_by_tag(ConnectionTag.VM_LINUX_NLX_1) as nlx_conn:
+            wg_server = config.NLX_SERVER
 
-        wg_server = config.NLX_SERVER
-
-        # non-PQ connection
-        await client.connect_to_vpn(
-            str(wg_server["ipv4"]),
-            int(wg_server["port"]),
-            str(wg_server["public_key"]),
-            pq=False,
-        )
-        await ping(client_conn, config.PHOTO_ALBUM_IP)
-
-        preshared = await read_preshared_key_slot(nlx_conn)
-        assert preshared == EMPTY_PRESHARED_KEY_SLOT
-
-        # upgrade to PQ
-        await client.disconnect_from_vpn(str(wg_server["public_key"]))
-        await _connect_vpn_pq(client_conn, client)
-        await ping(client_conn, config.PHOTO_ALBUM_IP)
-
-        preshared = await read_preshared_key_slot(nlx_conn)
-        assert preshared != EMPTY_PRESHARED_KEY_SLOT
-
-
-# Regression test for LLT-5884
-@pytest.mark.nlx
-@pytest.mark.timeout(240)
-@pytest.mark.parametrize(
-    "setup_params, public_ip",
-    [
-        pytest.param(
-            SetupParameters(
-                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                adapter_type_override=TelioAdapterType.NEP_TUN,
-                connection_tracker_config=generate_connection_tracker_config(
-                    ConnectionTag.DOCKER_CONE_CLIENT_1,
-                    stun_limits=(1, 1),
-                    nlx_1_limits=(4, 4),
-                ),
-                is_meshnet=False,
-            ),
-            "10.0.254.1",
-        ),
-        pytest.param(
-            SetupParameters(
-                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                adapter_type_override=TelioAdapterType.LINUX_NATIVE_TUN,
-                connection_tracker_config=generate_connection_tracker_config(
-                    ConnectionTag.DOCKER_CONE_CLIENT_1,
-                    stun_limits=(1, 1),
-                    nlx_1_limits=(4, 4),
-                ),
-                is_meshnet=False,
-            ),
-            "10.0.254.1",
-            marks=pytest.mark.linux_native,
-        ),
-        # TODO(LLT-6000)
-        # pytest.param(
-        #     SetupParameters(
-        #         connection_tag=ConnectionTag.VM_WINDOWS_1,
-        #         adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
-        #         connection_tracker_config=generate_connection_tracker_config(
-        #             ConnectionTag.VM_WINDOWS_1,
-        #             stun_limits=(1, 1),
-        #             nlx_1_limits=(1, 4),
-        #         ),
-        #         is_meshnet=False,
-        #     ),
-        #     "10.0.254.15",
-        #     marks=pytest.mark.windows,
-        # ),
-    ],
-)
-async def test_pq_vpn_handshake_after_nonet(
-    setup_params: SetupParameters,
-    public_ip: str,
-) -> None:
-    async with AsyncExitStack() as exit_stack:
-        env = await exit_stack.enter_async_context(
-            setup_environment(
-                exit_stack,
-                [setup_params],
-                vpn=[ConnectionTag.VM_LINUX_NLX_1],
+            # non-PQ connection
+            await client.connect_to_vpn(
+                str(wg_server["ipv4"]),
+                int(wg_server["port"]),
+                str(wg_server["public_key"]),
+                pq=False,
             )
-        )
+            await ping(client_conn, config.PHOTO_ALBUM_IP)
 
+            preshared = await read_preshared_key_slot(nlx_conn)
+            assert preshared == EMPTY_PRESHARED_KEY_SLOT
+
+            # upgrade to PQ
+            await client.disconnect_from_vpn(str(wg_server["public_key"]))
+            await _connect_vpn_pq(client_conn, client)
+            await ping(client_conn, config.PHOTO_ALBUM_IP)
+
+            preshared = await read_preshared_key_slot(nlx_conn)
+            assert preshared != EMPTY_PRESHARED_KEY_SLOT
+
+
+class TestNlxVpn:
+    """Tests requiring NLX VPN with 1-node non-mesh (env)."""
+
+    @pytest.fixture(name="vpn_tags")
+    def _vpn_tags(self) -> list:
+        return [ConnectionTag.VM_LINUX_NLX_1]
+
+    # Regression test for LLT-5884
+    @pytest.mark.nlx
+    @pytest.mark.timeout(240)
+    @pytest.mark.parametrize(
+        "alpha_setup_params, public_ip",
+        [
+            pytest.param(
+                SetupParameters(
+                    connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
+                    adapter_type_override=TelioAdapterType.NEP_TUN,
+                    connection_tracker_config=generate_connection_tracker_config(
+                        ConnectionTag.DOCKER_CONE_CLIENT_1,
+                        stun_limits=(1, 1),
+                        nlx_1_limits=(4, 4),
+                    ),
+                    is_meshnet=False,
+                ),
+                "10.0.254.1",
+            ),
+            pytest.param(
+                SetupParameters(
+                    connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
+                    adapter_type_override=TelioAdapterType.LINUX_NATIVE_TUN,
+                    connection_tracker_config=generate_connection_tracker_config(
+                        ConnectionTag.DOCKER_CONE_CLIENT_1,
+                        stun_limits=(1, 1),
+                        nlx_1_limits=(4, 4),
+                    ),
+                    is_meshnet=False,
+                ),
+                "10.0.254.1",
+                marks=pytest.mark.linux_native,
+            ),
+            # TODO(LLT-6000)
+            # pytest.param(
+            #     SetupParameters(
+            #         connection_tag=ConnectionTag.VM_WINDOWS_1,
+            #         adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
+            #         connection_tracker_config=generate_connection_tracker_config(
+            #             ConnectionTag.VM_WINDOWS_1,
+            #             stun_limits=(1, 1),
+            #             nlx_1_limits=(1, 4),
+            #         ),
+            #         is_meshnet=False,
+            #     ),
+            #     "10.0.254.15",
+            #     marks=pytest.mark.windows,
+            # ),
+        ],
+    )
+    async def test_pq_vpn_handshake_after_nonet(
+        self,
+        alpha_setup_params: SetupParameters,  # pylint: disable=unused-argument
+        public_ip: str,
+        env: Environment,
+    ) -> None:
         client_conn, *_ = [conn.connection for conn in env.connections]
         client_alpha, *_ = env.clients
 
@@ -623,40 +602,32 @@ async def test_pq_vpn_handshake_after_nonet(
 
         await ping(client_conn, config.PHOTO_ALBUM_IP)
 
-
-@pytest.mark.nlx
-@pytest.mark.timeout(240)
-@pytest.mark.parametrize(
-    "setup_params, public_ip",
-    [
-        pytest.param(
-            SetupParameters(
-                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                adapter_type_override=TelioAdapterType.NEP_TUN,
-                connection_tracker_config=generate_connection_tracker_config(
-                    ConnectionTag.DOCKER_CONE_CLIENT_1,
-                    stun_limits=(1, 1),
-                    nlx_1_limits=(2, 4),
+    @pytest.mark.nlx
+    @pytest.mark.timeout(240)
+    @pytest.mark.parametrize(
+        "alpha_setup_params, public_ip",
+        [
+            pytest.param(
+                SetupParameters(
+                    connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
+                    adapter_type_override=TelioAdapterType.NEP_TUN,
+                    connection_tracker_config=generate_connection_tracker_config(
+                        ConnectionTag.DOCKER_CONE_CLIENT_1,
+                        stun_limits=(1, 1),
+                        nlx_1_limits=(2, 4),
+                    ),
+                    is_meshnet=False,
                 ),
-                is_meshnet=False,
+                "10.0.254.1",
             ),
-            "10.0.254.1",
-        ),
-    ],
-)
-async def test_pq_no_false_restart(
-    setup_params: SetupParameters,
-    public_ip: str,
-) -> None:
-    async with AsyncExitStack() as exit_stack:
-        env = await exit_stack.enter_async_context(
-            setup_environment(
-                exit_stack,
-                [setup_params],
-                vpn=[ConnectionTag.VM_LINUX_NLX_1],
-            )
-        )
-
+        ],
+    )
+    async def test_pq_no_false_restart(
+        self,
+        alpha_setup_params: SetupParameters,  # pylint: disable=unused-argument
+        public_ip: str,
+        env: Environment,
+    ) -> None:
         client_conn, *_ = [conn.connection for conn in env.connections]
         client_alpha, *_ = env.clients
 

--- a/nat-lab/tests/test_pq.py
+++ b/nat-lab/tests/test_pq.py
@@ -14,8 +14,6 @@ from tests.utils.connection_util import (
 from tests.utils.dns import query_dns
 from tests.utils.ping import ping
 
-pytest_plugins = ["tests.helpers_fixtures"]
-
 EMPTY_PRESHARED_KEY_SLOT = "(none)"
 
 

--- a/nat-lab/tests/test_pq.py
+++ b/nat-lab/tests/test_pq.py
@@ -248,7 +248,7 @@ class TestPqVpnRekey:
 
         async with new_connection_by_tag(ConnectionTag.VM_LINUX_NLX_1) as nlx_conn:
             preshared_before = await inspect_preshared_key(nlx_conn)
-            await client_alpha.wait_for_log("Successful PQ REKEY")
+            await client_alpha.wait_for_log("Successful PQ REKEY", incremental=True)
 
             preshared_after = await inspect_preshared_key(nlx_conn)
             assert (

--- a/nat-lab/tests/test_proxy.py
+++ b/nat-lab/tests/test_proxy.py
@@ -1,49 +1,62 @@
 import asyncio
 import pytest
 from contextlib import AsyncExitStack
-from tests.helpers import SetupParameters, setup_mesh_nodes
+from tests.helpers import SetupParameters, Environment
 from tests.utils.bindings import TelioNode
 from tests.utils.connection import ConnectionTag
 from tests.utils.ping import ping
 from typing import Optional
 
+pytest_plugins = ["tests.helpers_fixtures"]
 
+
+@pytest.mark.parametrize(
+    "alpha_setup_params, beta_setup_params",
+    [
+        pytest.param(
+            SetupParameters(connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1),
+            SetupParameters(connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2),
+        ),
+    ],
+)
 @pytest.mark.asyncio
-async def test_proxy_endpoint_map_update() -> None:
-    setup_params = [
-        SetupParameters(connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1),
-        SetupParameters(connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2),
-    ]
+async def test_proxy_endpoint_map_update(
+    alpha_setup_params: SetupParameters,  # pylint: disable=unused-argument
+    beta_setup_params: SetupParameters,  # pylint: disable=unused-argument
+    exit_stack: AsyncExitStack,
+    env_mesh: Environment,
+) -> None:
+    alpha_node, beta_node = env_mesh.nodes[0], env_mesh.nodes[1]
+    alpha_client = env_mesh.clients[0]
+    alpha_conn, beta_conn = (
+        env_mesh.connections[0].connection,
+        env_mesh.connections[1].connection,
+    )
 
-    async with AsyncExitStack() as exit_stack:
-        env = await setup_mesh_nodes(exit_stack, setup_params)
-        alpha, beta = env.nodes
-        alpha_connection, beta_connection = [
-            conn.connection for conn in env.connections
-        ]
-        alpha_client, _ = env.clients
+    alpha = alpha_node
+    beta = beta_node
+    alpha_connection = alpha_conn
+    beta_connection = beta_conn
 
-        port = node_port(alpha_client.get_node_state(beta.public_key))
+    port = node_port(alpha_client.get_node_state(beta.public_key))
 
-        await exit_stack.enter_async_context(
-            alpha_client.get_router().block_udp_port(port)
-        )
+    await exit_stack.enter_async_context(alpha_client.get_router().block_udp_port(port))
 
-        await ping(alpha_connection, beta.ip_addresses[0])
-        await ping(beta_connection, alpha.ip_addresses[0])
+    await ping(alpha_connection, beta.ip_addresses[0])
+    await ping(beta_connection, alpha.ip_addresses[0])
 
-        for _ in range(0, 5):
-            new_port = node_port(alpha_client.get_node_state(beta.public_key))
-            if port != new_port:
-                break
-            await asyncio.sleep(1)
-        else:
-            assert False, "Endpoint wasn't successfully updated"
+    for _ in range(0, 5):
+        new_port = node_port(alpha_client.get_node_state(beta.public_key))
+        if port != new_port:
+            break
+        await asyncio.sleep(1)
+    else:
+        assert False, "Endpoint wasn't successfully updated"
 
-        # LLT-5532: To be cleaned up...
-        alpha_client.allow_errors(
-            ["telio_proxy::proxy.*Unable to send. Operation not permitted"]
-        )
+    # LLT-5532: To be cleaned up...
+    alpha_client.allow_errors(
+        ["telio_proxy::proxy.*Unable to send. Operation not permitted"]
+    )
 
 
 def node_port(peer_info: Optional[TelioNode]) -> int:

--- a/nat-lab/tests/test_proxy.py
+++ b/nat-lab/tests/test_proxy.py
@@ -7,8 +7,6 @@ from tests.utils.connection import ConnectionTag
 from tests.utils.ping import ping
 from typing import Optional
 
-pytest_plugins = ["tests.helpers_fixtures"]
-
 
 @pytest.mark.parametrize(
     "alpha_setup_params, beta_setup_params",

--- a/nat-lab/tests/test_reconnections.py
+++ b/nat-lab/tests/test_reconnections.py
@@ -1,12 +1,13 @@
 import asyncio
 import pytest
-from contextlib import AsyncExitStack
-from tests.helpers import setup_mesh_nodes, SetupParameters
+from tests.helpers import SetupParameters, Environment
 from tests.utils import asyncio_util
 from tests.utils.bindings import NodeState, RelayState, TelioAdapterType
 from tests.utils.connection import ConnectionTag
 from tests.utils.connection_util import generate_connection_tracker_config
 from tests.utils.ping import ping
+
+pytest_plugins = ["tests.helpers_fixtures"]
 
 
 @pytest.mark.asyncio
@@ -75,44 +76,39 @@ from tests.utils.ping import ping
     ],
 )
 async def test_mesh_reconnect(
-    alpha_setup_params: SetupParameters, beta_setup_params: SetupParameters
+    alpha_setup_params: SetupParameters,  # pylint: disable=unused-argument
+    beta_setup_params: SetupParameters,  # pylint: disable=unused-argument
+    env_mesh: Environment,
 ) -> None:
-    async with AsyncExitStack() as exit_stack:
-        env = await setup_mesh_nodes(
-            exit_stack, [alpha_setup_params, beta_setup_params]
-        )
-        api = env.api
-        alpha, beta = env.nodes
-        alpha_connection, beta_connection = [
-            conn.connection for conn in env.connections
-        ]
-        client_alpha, client_beta = env.clients
+    env = env_mesh
+    api = env.api
+    alpha, beta = env.nodes
+    alpha_connection, beta_connection = [conn.connection for conn in env.connections]
+    client_alpha, client_beta = env.clients
 
-        await ping(alpha_connection, beta.ip_addresses[0])
-        await ping(beta_connection, alpha.ip_addresses[0])
+    await ping(alpha_connection, beta.ip_addresses[0])
+    await ping(beta_connection, alpha.ip_addresses[0])
 
-        await client_alpha.stop_device()
+    await client_alpha.stop_device()
 
-        with pytest.raises(asyncio.TimeoutError):
-            await ping(beta_connection, alpha.ip_addresses[0], 15)
+    with pytest.raises(asyncio.TimeoutError):
+        await ping(beta_connection, alpha.ip_addresses[0], 15)
 
-        await client_alpha.simple_start()
+    await client_alpha.simple_start()
 
-        async with asyncio_util.run_async_context(
-            asyncio.gather(
-                client_alpha.wait_for_event_peer(
-                    beta.public_key, [NodeState.CONNECTED]
-                ),
-                client_alpha.wait_for_event_on_any_derp([RelayState.CONNECTED]),
-            ),
-        ) as event:
-            await client_alpha.set_meshnet_config(api.get_meshnet_config(alpha.id))
-            await event
+    async with asyncio_util.run_async_context(
+        asyncio.gather(
+            client_alpha.wait_for_event_peer(beta.public_key, [NodeState.CONNECTED]),
+            client_alpha.wait_for_event_on_any_derp([RelayState.CONNECTED]),
+        ),
+    ) as event:
+        await client_alpha.set_meshnet_config(api.get_meshnet_config(alpha.id))
+        await event
 
-        await asyncio.gather(
-            client_alpha.wait_for_state_peer(beta.public_key, [NodeState.CONNECTED]),
-            client_beta.wait_for_state_peer(alpha.public_key, [NodeState.CONNECTED]),
-        )
+    await asyncio.gather(
+        client_alpha.wait_for_state_peer(beta.public_key, [NodeState.CONNECTED]),
+        client_beta.wait_for_state_peer(alpha.public_key, [NodeState.CONNECTED]),
+    )
 
-        await ping(alpha_connection, beta.ip_addresses[0])
-        await ping(beta_connection, alpha.ip_addresses[0])
+    await ping(alpha_connection, beta.ip_addresses[0])
+    await ping(beta_connection, alpha.ip_addresses[0])

--- a/nat-lab/tests/test_reconnections.py
+++ b/nat-lab/tests/test_reconnections.py
@@ -7,8 +7,6 @@ from tests.utils.connection import ConnectionTag
 from tests.utils.connection_util import generate_connection_tracker_config
 from tests.utils.ping import ping
 
-pytest_plugins = ["tests.helpers_fixtures"]
-
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(

--- a/nat-lab/tests/test_telio_tasks.py
+++ b/nat-lab/tests/test_telio_tasks.py
@@ -1,7 +1,6 @@
 import asyncio
 import pytest
-from contextlib import AsyncExitStack
-from tests.helpers import setup_mesh_nodes, SetupParameters
+from tests.helpers import SetupParameters, Environment
 from tests.utils.bindings import (
     FeatureQoS,
     FeatureExitDns,
@@ -13,41 +12,50 @@ from tests.utils.bindings import (
 )
 from tests.utils.connection import ConnectionTag
 
+pytest_plugins = ["tests.helpers_fixtures"]
 
+_FEATURES = default_features(
+    enable_direct=True, enable_lana=("/some_path", False), enable_nurse=True
+)
+assert _FEATURES.direct
+_FEATURES.direct.providers = [EndpointProvider.STUN, EndpointProvider.LOCAL]
+_FEATURES.direct.skip_unresponsive_peers = FeatureSkipUnresponsivePeers(
+    no_rx_threshold_secs=150
+)
+assert _FEATURES.nurse
+_FEATURES.nurse.initial_heartbeat_interval = 10
+_FEATURES.nurse.qos = FeatureQoS(
+    rtt_interval=5,
+    rtt_tries=3,
+    rtt_types=[RttType.PING],
+    buckets=5,
+)
+_FEATURES.dns = FeatureDns(
+    exit_dns=FeatureExitDns(auto_switch_dns_ips=True),
+    ttl_value=60,
+    use_raw_forwarder=True,
+)
+
+
+@pytest.mark.parametrize(
+    "alpha_setup_params",
+    [
+        pytest.param(
+            SetupParameters(
+                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
+                features=_FEATURES,
+                fingerprint="alpha",
+            ),
+        ),
+    ],
+)
 @pytest.mark.asyncio
-async def test_telio_tasks_with_all_features() -> None:
-    async with AsyncExitStack() as exit_stack:
-        features = default_features(
-            enable_direct=True, enable_lana=("/some_path", False), enable_nurse=True
-        )
-        assert features.direct
-        features.direct.providers = [EndpointProvider.STUN, EndpointProvider.LOCAL]
-        features.direct.skip_unresponsive_peers = FeatureSkipUnresponsivePeers(
-            no_rx_threshold_secs=150
-        )
-        assert features.nurse
-        features.nurse.initial_heartbeat_interval = 10
-        features.nurse.qos = FeatureQoS(
-            rtt_interval=5,
-            rtt_tries=3,
-            rtt_types=[RttType.PING],
-            buckets=5,
-        )
-        features.dns = FeatureDns(
-            exit_dns=FeatureExitDns(auto_switch_dns_ips=True),
-            ttl_value=60,
-            use_raw_forwarder=True,
-        )
-        env = await setup_mesh_nodes(
-            exit_stack,
-            [
-                SetupParameters(
-                    connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                    features=features,
-                    fingerprint="alpha",
-                )
-            ],
-        )
-        # let's wait some seconds for everything to start
-        await asyncio.sleep(5)
-        await env.clients[0].stop_device()
+async def test_telio_tasks_with_all_features(
+    alpha_setup_params: SetupParameters,  # pylint: disable=unused-argument
+    env_mesh: Environment,
+) -> None:
+    alpha_client = env_mesh.clients[0]
+
+    # let's wait some seconds for everything to start
+    await asyncio.sleep(5)
+    await alpha_client.stop_device()

--- a/nat-lab/tests/test_telio_tasks.py
+++ b/nat-lab/tests/test_telio_tasks.py
@@ -12,8 +12,6 @@ from tests.utils.bindings import (
 )
 from tests.utils.connection import ConnectionTag
 
-pytest_plugins = ["tests.helpers_fixtures"]
-
 _FEATURES = default_features(
     enable_direct=True, enable_lana=("/some_path", False), enable_nurse=True
 )

--- a/nat-lab/tests/test_tp_lite_stats.py
+++ b/nat-lab/tests/test_tp_lite_stats.py
@@ -1,8 +1,7 @@
 import asyncio
 import pytest
-from contextlib import AsyncExitStack
 from tests import config
-from tests.helpers import SetupParameters, setup_environment, Connection
+from tests.helpers import SetupParameters, Environment, Connection
 from tests.helpers_vpn import connect_vpn
 from tests.utils.bindings import (
     default_features,
@@ -65,22 +64,39 @@ async def _trigger_stats_collection(
     )
 
 
-@pytest.mark.asyncio
-async def test_tp_lite_stats_basic() -> None:
-    async with AsyncExitStack() as exit_stack:
-        env = await exit_stack.enter_async_context(
-            setup_environment(
-                exit_stack,
-                [
-                    SetupParameters(
-                        connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                        adapter_type_override=TelioAdapterType.NEP_TUN,
-                        features=_features_with_firewall(),
-                    )
-                ],
-                vpn=[ConnectionTag.DOCKER_VPN_1],
-            )
-        )
+def _alpha_setup_params_with_firewall() -> SetupParameters:
+    return SetupParameters(
+        connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
+        adapter_type_override=TelioAdapterType.NEP_TUN,
+        features=_features_with_firewall(),
+    )
+
+
+def _alpha_setup_params_default() -> SetupParameters:
+    return SetupParameters(
+        connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
+        adapter_type_override=TelioAdapterType.NEP_TUN,
+        features=default_features(),
+    )
+
+
+class TestTpLiteStats:
+    """TP-Lite stats collection — all tests share a single-node + VPN_1 setup."""
+
+    @pytest.fixture(name="vpn_tags")
+    def _vpn_tags(self) -> list:
+        return [ConnectionTag.DOCKER_VPN_1]
+
+    @pytest.mark.parametrize(
+        "alpha_setup_params",
+        [pytest.param(_alpha_setup_params_with_firewall())],
+    )
+    @pytest.mark.asyncio
+    async def test_tp_lite_stats_basic(
+        self,
+        alpha_setup_params: SetupParameters,  # pylint: disable=unused-argument
+        env: Environment,
+    ) -> None:
         [alpha] = env.nodes
         [client] = env.clients
         [connection] = [c.connection for c in env.connections]
@@ -168,23 +184,16 @@ async def test_tp_lite_stats_basic() -> None:
         (num_calls, _, _) = await client.get_tp_lite_stats()
         assert num_calls == 0
 
-
-@pytest.mark.asyncio
-async def test_tp_lite_stats_re_enable_with_new_callback() -> None:
-    async with AsyncExitStack() as exit_stack:
-        env = await exit_stack.enter_async_context(
-            setup_environment(
-                exit_stack,
-                [
-                    SetupParameters(
-                        connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                        adapter_type_override=TelioAdapterType.NEP_TUN,
-                        features=_features_with_firewall(),
-                    )
-                ],
-                vpn=[ConnectionTag.DOCKER_VPN_1],
-            )
-        )
+    @pytest.mark.parametrize(
+        "alpha_setup_params",
+        [pytest.param(_alpha_setup_params_with_firewall())],
+    )
+    @pytest.mark.asyncio
+    async def test_tp_lite_stats_re_enable_with_new_callback(
+        self,
+        alpha_setup_params: SetupParameters,  # pylint: disable=unused-argument
+        env: Environment,
+    ) -> None:
         [alpha] = env.nodes
         [client] = env.clients
         [connection] = [c.connection for c in env.connections]
@@ -221,23 +230,16 @@ async def test_tp_lite_stats_re_enable_with_new_callback() -> None:
             assert metrics.num_requests == 1
             assert metrics.num_responses == 1
 
-
-@pytest.mark.asyncio
-async def test_tp_lite_stats_empty_dns_server_ips_disables() -> None:
-    async with AsyncExitStack() as exit_stack:
-        env = await exit_stack.enter_async_context(
-            setup_environment(
-                exit_stack,
-                [
-                    SetupParameters(
-                        connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                        adapter_type_override=TelioAdapterType.NEP_TUN,
-                        features=_features_with_firewall(),
-                    )
-                ],
-                vpn=[ConnectionTag.DOCKER_VPN_1],
-            )
-        )
+    @pytest.mark.parametrize(
+        "alpha_setup_params",
+        [pytest.param(_alpha_setup_params_with_firewall())],
+    )
+    @pytest.mark.asyncio
+    async def test_tp_lite_stats_empty_dns_server_ips_disables(
+        self,
+        alpha_setup_params: SetupParameters,  # pylint: disable=unused-argument
+        env: Environment,
+    ) -> None:
         [alpha] = env.nodes
         [client] = env.clients
         [connection] = [c.connection for c in env.connections]
@@ -256,23 +258,16 @@ async def test_tp_lite_stats_empty_dns_server_ips_disables() -> None:
                 _tp_lite_config(dns_server_ips=[])
             )
 
-
-@pytest.mark.asyncio
-async def test_tp_lite_stats_requires_firewall_feature() -> None:
-    async with AsyncExitStack() as exit_stack:
-        env = await exit_stack.enter_async_context(
-            setup_environment(
-                exit_stack,
-                [
-                    SetupParameters(
-                        connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                        adapter_type_override=TelioAdapterType.NEP_TUN,
-                        features=default_features(),
-                    )
-                ],
-                vpn=[ConnectionTag.DOCKER_VPN_1],
-            )
-        )
+    @pytest.mark.parametrize(
+        "alpha_setup_params",
+        [pytest.param(_alpha_setup_params_default())],
+    )
+    @pytest.mark.asyncio
+    async def test_tp_lite_stats_requires_firewall_feature(
+        self,
+        alpha_setup_params: SetupParameters,  # pylint: disable=unused-argument
+        env: Environment,
+    ) -> None:
         [alpha] = env.nodes
         [client] = env.clients
         [connection] = [c.connection for c in env.connections]

--- a/nat-lab/tests/test_vpn.py
+++ b/nat-lab/tests/test_vpn.py
@@ -1,13 +1,13 @@
 import asyncio
 import pytest
-from contextlib import AsyncExitStack
 from tests import config
-from tests.helpers import SetupParameters, setup_environment, setup_connections
+from tests.helpers import SetupParameters
 from tests.helpers_vpn import connect_vpn, VpnConfig
 from tests.uniffi import FeatureFirewall, FirewallBlacklistTuple, IpProtocol
 from tests.utils import testing, stun
 from tests.utils.bindings import (
     default_features,
+    Features,
     TelioAdapterType,
     generate_secret_key,
     generate_public_key,
@@ -25,69 +25,20 @@ from tests.utils.ping import ping
 from tests.utils.process import ProcessExecError
 from tests.utils.router import IPProto, IPStack
 
+pytest_plugins = ["tests.helpers_fixtures"]
 
-@pytest.mark.parametrize(
-    "alpha_setup_params, public_ip",
-    [
-        pytest.param(
-            SetupParameters(
-                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                adapter_type_override=TelioAdapterType.NEP_TUN,
-                is_meshnet=False,
-            ),
-            "10.0.254.1",
-        ),
-        pytest.param(
-            SetupParameters(
-                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                adapter_type_override=TelioAdapterType.LINUX_NATIVE_TUN,
-                is_meshnet=False,
-            ),
-            "10.0.254.1",
-            marks=pytest.mark.linux_native,
-        ),
-        pytest.param(
-            SetupParameters(
-                connection_tag=ConnectionTag.VM_WINDOWS_1,
-                adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
-                is_meshnet=False,
-            ),
-            "10.0.254.15",
-            marks=[
-                pytest.mark.windows,
-            ],
-        ),
-        pytest.param(
-            SetupParameters(
-                connection_tag=ConnectionTag.VM_MAC,
-                adapter_type_override=TelioAdapterType.NEP_TUN,
-                is_meshnet=False,
-            ),
-            "10.0.254.19",
-            marks=pytest.mark.mac,
-        ),
-    ],
-)
-@pytest.mark.parametrize(
-    "vpn_conf",
-    [
-        pytest.param(
-            VpnConfig(config.WG_SERVER, ConnectionTag.DOCKER_VPN_1, True),
-            id="wg_server",
-        ),
-        pytest.param(
-            VpnConfig(config.NLX_SERVER, ConnectionTag.VM_LINUX_NLX_1, False),
-            id="nlx_server",
-            marks=pytest.mark.nlx,
-        ),
-    ],
-)
-async def test_vpn_connection(
-    alpha_setup_params: SetupParameters,
-    vpn_conf: VpnConfig,
-    public_ip: str,
-) -> None:
-    async with AsyncExitStack() as exit_stack:
+
+class TestVpnConnection:
+    """Tests for basic VPN connection (previously test_vpn_connection)."""
+
+    @pytest.fixture(name="vpn_tags")
+    def _vpn_tags(self, vpn_conf: VpnConfig) -> list:
+        return [vpn_conf.conn_tag]
+
+    @pytest.fixture(autouse=True)
+    def _mutate_conntracker(
+        self, alpha_setup_params: SetupParameters, vpn_conf: VpnConfig
+    ):
         alpha_setup_params.connection_tracker_config = (
             generate_connection_tracker_config(
                 alpha_setup_params.connection_tag,
@@ -104,124 +55,196 @@ async def test_vpn_connection(
                 ),
             )
         )
-        env = await exit_stack.enter_async_context(
-            setup_environment(exit_stack, [alpha_setup_params], vpn=[vpn_conf.conn_tag])
+
+    @pytest.mark.parametrize(
+        "alpha_setup_params, public_ip",
+        [
+            pytest.param(
+                SetupParameters(
+                    connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
+                    adapter_type_override=TelioAdapterType.NEP_TUN,
+                    is_meshnet=False,
+                ),
+                "10.0.254.1",
+            ),
+            pytest.param(
+                SetupParameters(
+                    connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
+                    adapter_type_override=TelioAdapterType.LINUX_NATIVE_TUN,
+                    is_meshnet=False,
+                ),
+                "10.0.254.1",
+                marks=pytest.mark.linux_native,
+            ),
+            pytest.param(
+                SetupParameters(
+                    connection_tag=ConnectionTag.VM_WINDOWS_1,
+                    adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
+                    is_meshnet=False,
+                ),
+                "10.0.254.15",
+                marks=[
+                    pytest.mark.windows,
+                ],
+            ),
+            pytest.param(
+                SetupParameters(
+                    connection_tag=ConnectionTag.VM_MAC,
+                    adapter_type_override=TelioAdapterType.NEP_TUN,
+                    is_meshnet=False,
+                ),
+                "10.0.254.19",
+                marks=pytest.mark.mac,
+            ),
+        ],
+    )
+    @pytest.mark.parametrize(
+        "vpn_conf",
+        [
+            pytest.param(
+                VpnConfig(config.WG_SERVER, ConnectionTag.DOCKER_VPN_1, True),
+                id="wg_server",
+            ),
+            pytest.param(
+                VpnConfig(config.NLX_SERVER, ConnectionTag.VM_LINUX_NLX_1, False),
+                id="nlx_server",
+                marks=pytest.mark.nlx,
+            ),
+        ],
+    )
+    async def test_vpn_connection(
+        self,
+        vpn_conf: VpnConfig,
+        public_ip: str,
+        env,
+        vpn_server_connection,
+    ) -> None:
+        alpha_node, alpha_conn, alpha_client = (
+            env.nodes[0],
+            env.connections[0].connection,
+            env.clients[0],
         )
 
-        alpha, *_ = env.nodes
-        client_conn, *_ = [conn.connection for conn in env.connections]
-        client_alpha, *_ = env.clients
-
-        ip = await stun.get(client_conn, config.STUN_SERVER)
+        ip = await stun.get(alpha_conn, config.STUN_SERVER)
         assert ip == public_ip, f"wrong public IP before connecting to VPN {ip}"
 
-        if vpn_conf.should_ping_client:
-            vpn_connection, *_ = await setup_connections(
-                exit_stack, [vpn_conf.conn_tag]
-            )
-            await connect_vpn(
-                client_conn,
-                vpn_connection.connection,
-                client_alpha,
-                alpha.ip_addresses[0],
-                vpn_conf.server_conf,
-            )
-        else:
-            await connect_vpn(
-                client_conn,
-                None,
-                client_alpha,
-                alpha.ip_addresses[0],
-                vpn_conf.server_conf,
-            )
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "alpha_setup_params, public_ip",
-    [
-        pytest.param(
-            SetupParameters(
-                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                adapter_type_override=TelioAdapterType.NEP_TUN,
-                connection_tracker_config=generate_connection_tracker_config(
-                    ConnectionTag.DOCKER_CONE_CLIENT_1,
-                    vpn_1_limits=(1, 1),
-                    vpn_2_limits=(1, 1),
-                    stun_limits=(1, 2),
-                ),
-                is_meshnet=False,
+        await connect_vpn(
+            alpha_conn,
+            (
+                vpn_server_connection.connection
+                if vpn_server_connection is not None
+                else None
             ),
-            "10.0.254.1",
-        ),
-        pytest.param(
-            SetupParameters(
-                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                adapter_type_override=TelioAdapterType.LINUX_NATIVE_TUN,
-                connection_tracker_config=generate_connection_tracker_config(
-                    ConnectionTag.DOCKER_CONE_CLIENT_1,
-                    vpn_1_limits=(1, 1),
-                    vpn_2_limits=(1, 1),
-                    stun_limits=(1, 2),
-                ),
-                is_meshnet=False,
-            ),
-            "10.0.254.1",
-            marks=pytest.mark.linux_native,
-        ),
-        pytest.param(
-            SetupParameters(
-                connection_tag=ConnectionTag.VM_WINDOWS_1,
-                adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
-                connection_tracker_config=generate_connection_tracker_config(
-                    ConnectionTag.VM_WINDOWS_1,
-                    vpn_1_limits=(1, 1),
-                    vpn_2_limits=(1, 1),
-                    stun_limits=(1, 2),
-                ),
-                is_meshnet=False,
-            ),
-            "10.0.254.15",
-            marks=[
-                pytest.mark.windows,
-            ],
-        ),
-        pytest.param(
-            SetupParameters(
-                connection_tag=ConnectionTag.VM_MAC,
-                adapter_type_override=TelioAdapterType.NEP_TUN,
-                connection_tracker_config=generate_connection_tracker_config(
-                    ConnectionTag.VM_MAC,
-                    vpn_1_limits=(1, 1),
-                    vpn_2_limits=(1, 1),
-                    stun_limits=(1, 2),
-                ),
-                is_meshnet=False,
-            ),
-            "10.0.254.19",
-            marks=pytest.mark.mac,
-        ),
-    ],
-)
-async def test_vpn_reconnect(
-    alpha_setup_params: SetupParameters, public_ip: str
-) -> None:
-    async with AsyncExitStack() as exit_stack:
-        env = await exit_stack.enter_async_context(
-            setup_environment(
-                exit_stack,
-                [alpha_setup_params],
-                vpn=[ConnectionTag.DOCKER_VPN_1, ConnectionTag.DOCKER_VPN_2],
-            )
+            alpha_client,
+            alpha_node.ip_addresses[0],
+            vpn_conf.server_conf,
         )
 
-        alpha, *_ = env.nodes
-        connection, *_ = [conn.connection for conn in env.connections]
-        client_alpha, *_ = env.clients
 
-        vpn_1_connection, vpn_2_connection = await setup_connections(
-            exit_stack, [ConnectionTag.DOCKER_VPN_1, ConnectionTag.DOCKER_VPN_2]
+def _make_blacklist_features(protocol: IpProtocol, ip: str, port: int) -> Features:
+    """Build default features with a firewall outgoing blacklist entry."""
+    features = default_features()
+    features.firewall = FeatureFirewall(
+        neptun_reset_conns=False,
+        boringtun_reset_conns=False,
+        exclude_private_ip_range=None,
+        outgoing_blacklist=[
+            FirewallBlacklistTuple(protocol=protocol, ip=ip, port=port)
+        ],
+    )
+    return features
+
+
+class TestDualVpn:
+    """Tests requiring dual VPN servers (DOCKER_VPN_1 + DOCKER_VPN_2)."""
+
+    @pytest.fixture(name="vpn_tags")
+    def _vpn_tags(self) -> list:
+        return [ConnectionTag.DOCKER_VPN_1, ConnectionTag.DOCKER_VPN_2]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "alpha_setup_params, public_ip",
+        [
+            pytest.param(
+                SetupParameters(
+                    connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
+                    adapter_type_override=TelioAdapterType.NEP_TUN,
+                    connection_tracker_config=generate_connection_tracker_config(
+                        ConnectionTag.DOCKER_CONE_CLIENT_1,
+                        vpn_1_limits=(1, 1),
+                        vpn_2_limits=(1, 1),
+                        stun_limits=(1, 2),
+                    ),
+                    is_meshnet=False,
+                ),
+                "10.0.254.1",
+            ),
+            pytest.param(
+                SetupParameters(
+                    connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
+                    adapter_type_override=TelioAdapterType.LINUX_NATIVE_TUN,
+                    connection_tracker_config=generate_connection_tracker_config(
+                        ConnectionTag.DOCKER_CONE_CLIENT_1,
+                        vpn_1_limits=(1, 1),
+                        vpn_2_limits=(1, 1),
+                        stun_limits=(1, 2),
+                    ),
+                    is_meshnet=False,
+                ),
+                "10.0.254.1",
+                marks=pytest.mark.linux_native,
+            ),
+            pytest.param(
+                SetupParameters(
+                    connection_tag=ConnectionTag.VM_WINDOWS_1,
+                    adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
+                    connection_tracker_config=generate_connection_tracker_config(
+                        ConnectionTag.VM_WINDOWS_1,
+                        vpn_1_limits=(1, 1),
+                        vpn_2_limits=(1, 1),
+                        stun_limits=(1, 2),
+                    ),
+                    is_meshnet=False,
+                ),
+                "10.0.254.15",
+                marks=[
+                    pytest.mark.windows,
+                ],
+            ),
+            pytest.param(
+                SetupParameters(
+                    connection_tag=ConnectionTag.VM_MAC,
+                    adapter_type_override=TelioAdapterType.NEP_TUN,
+                    connection_tracker_config=generate_connection_tracker_config(
+                        ConnectionTag.VM_MAC,
+                        vpn_1_limits=(1, 1),
+                        vpn_2_limits=(1, 1),
+                        stun_limits=(1, 2),
+                    ),
+                    is_meshnet=False,
+                ),
+                "10.0.254.19",
+                marks=pytest.mark.mac,
+            ),
+        ],
+    )
+    async def test_vpn_reconnect(
+        self,
+        alpha_setup_params: SetupParameters,  # pylint: disable=unused-argument
+        public_ip: str,
+        env,
+        dual_vpn_server_connections,
+    ) -> None:
+        alpha_node, alpha_conn, alpha_client = (
+            env.nodes[0],
+            env.connections[0].connection,
+            env.clients[0],
         )
+        alpha = alpha_node
+        connection = alpha_conn
+        client_alpha = alpha_client
+        vpn_1_connection, vpn_2_connection = dual_vpn_server_connections
 
         ip = await stun.get(connection, config.STUN_SERVER)
         assert ip == public_ip, f"wrong public IP before connecting to VPN {ip}"
@@ -247,70 +270,63 @@ async def test_vpn_reconnect(
             config.WG_SERVER_2,
         )
 
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "setup_params",
-    [
-        # IPv4 public server
-        pytest.param(
-            SetupParameters(
-                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                adapter_type_override=TelioAdapterType.NEP_TUN,
-                ip_stack=IPStack.IPv4,
-                features=default_features(
-                    enable_firewall_connection_reset=True,
-                    enable_firewall_exclusion_range="10.0.0.0/8",
-                ),
-            )
-        ),
-        pytest.param(
-            SetupParameters(
-                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                adapter_type_override=TelioAdapterType.NEP_TUN,
-                ip_stack=IPStack.IPv6,
-                features=default_features(
-                    enable_firewall_connection_reset=True,
-                    enable_firewall_exclusion_range="10.0.0.0/8",
-                ),
-            )
-        ),
-    ],
-)
-async def test_kill_external_tcp_conn_on_vpn_reconnect(
-    setup_params: SetupParameters,
-) -> None:
-    serv_ip = (
-        config.PHOTO_ALBUM_IPV6
-        if setup_params.ip_stack == IPStack.IPv6
-        else config.PHOTO_ALBUM_IP
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "alpha_setup_params",
+        [
+            # IPv4 public server
+            pytest.param(
+                SetupParameters(
+                    connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
+                    adapter_type_override=TelioAdapterType.NEP_TUN,
+                    ip_stack=IPStack.IPv4,
+                    features=default_features(
+                        enable_firewall_connection_reset=True,
+                        enable_firewall_exclusion_range="10.0.0.0/8",
+                    ),
+                )
+            ),
+            pytest.param(
+                SetupParameters(
+                    connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
+                    adapter_type_override=TelioAdapterType.NEP_TUN,
+                    ip_stack=IPStack.IPv6,
+                    features=default_features(
+                        enable_firewall_connection_reset=True,
+                        enable_firewall_exclusion_range="10.0.0.0/8",
+                    ),
+                )
+            ),
+        ],
     )
-
-    async with AsyncExitStack() as exit_stack:
-        env = await exit_stack.enter_async_context(
-            setup_environment(
-                exit_stack,
-                [setup_params],
-                vpn=[ConnectionTag.DOCKER_VPN_1, ConnectionTag.DOCKER_VPN_2],
-            )
+    async def test_kill_external_tcp_conn_on_vpn_reconnect(
+        self,
+        alpha_setup_params: SetupParameters,
+        env,
+    ) -> None:
+        alpha_node, alpha_conn, alpha_client = (
+            env.nodes[0],
+            env.connections[0].connection,
+            env.clients[0],
         )
 
-        alpha, *_ = env.nodes
-        connection, *_ = [conn.connection for conn in env.connections]
-        client, *_ = env.clients
+        serv_ip = (
+            config.PHOTO_ALBUM_IPV6
+            if alpha_setup_params.ip_stack == IPStack.IPv6
+            else config.PHOTO_ALBUM_IP
+        )
 
-        async def connect(
-            wg_server: dict,
-        ):
+        alpha = alpha_node
+        connection = alpha_conn
+        client = alpha_client
+
+        async def connect(wg_server: dict):
             await client.connect_to_vpn(
                 wg_server["ipv4"], wg_server["port"], wg_server["public_key"]
             )
-
             await ping(connection, serv_ip)
 
-        await connect(
-            config.WG_SERVER,
-        )
+        await connect(config.WG_SERVER)
 
         async with ConnectionTracker(
             connection,
@@ -323,98 +339,192 @@ async def test_kill_external_tcp_conn_on_vpn_reconnect(
             ],
         ).run() as conntrack:
             ip_proto = (
-                IPProto.IPv6 if setup_params.ip_stack == IPStack.IPv6 else IPProto.IPv4
+                IPProto.IPv6
+                if alpha_setup_params.ip_stack == IPStack.IPv6
+                else IPProto.IPv4
             )
-            alpha_ip = testing.unpack_optional(alpha.get_ip_address(ip_proto))
+            alpha_ip: str = testing.unpack_optional(alpha.get_ip_address(ip_proto))
 
-            nc_client_1 = await exit_stack.enter_async_context(
-                NetCatClient(
+            async with NetCatClient(
+                connection,
+                serv_ip,
+                80,
+                ipv6=ip_proto == IPProto.IPv6,
+                source_ip=alpha_ip,
+            ).run() as nc_client_1:
+                async with NetCatClient(
                     connection,
                     serv_ip,
                     80,
                     ipv6=ip_proto == IPProto.IPv6,
                     source_ip=alpha_ip,
-                ).run()
-            )
+                ).run() as nc_client_2:
+                    await asyncio.gather(
+                        nc_client_1.connection_succeeded(),
+                        nc_client_2.connection_succeeded(),
+                    )
 
-            # Second client, this time sending some data to check proper TCP sequence number generation
-            nc_client_2 = await exit_stack.enter_async_context(
-                NetCatClient(
-                    connection,
-                    serv_ip,
-                    80,
-                    ipv6=ip_proto == IPProto.IPv6,
-                    source_ip=alpha_ip,
-                ).run()
-            )
+                    await nc_client_2.send_data("GET")
 
-            # Wait for both netcat processes
-            await asyncio.gather(
-                nc_client_1.connection_succeeded(), nc_client_2.connection_succeeded()
-            )
+                    await client.disconnect_from_vpn(
+                        str(config.WG_SERVER["public_key"])
+                    )
 
-            # exchange some data
-            await nc_client_2.send_data("GET")
+                    await connect(config.WG_SERVER_2)
 
-            # the key is generated uniquely each time natlab runs
-            await client.disconnect_from_vpn(str(config.WG_SERVER["public_key"]))
+                    await conntrack.wait_for_no_violations()
 
-            await connect(
-                config.WG_SERVER_2,
-            )
-
-            # under normal circumstances -> conntrack should show FIN_WAIT -> CLOSE_WAIT
-            # But our connection killing mechanism will reset connection resulting in CLOSE output.
-            # Wait for close on both clients
-            await conntrack.wait_for_no_violations()
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "ipv4",
-    [
-        pytest.param(True),
-        pytest.param(False),
-    ],
-)
-async def test_firewall_blacklist_tcp(ipv4: bool) -> None:
-    serv_ip = config.PHOTO_ALBUM_IP if ipv4 else config.PHOTO_ALBUM_IPV6
-    serv_port = 80
-    wg_server: dict = config.WG_SERVER
-
-    setup_params = [
-        SetupParameters(
-            connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-            adapter_type_override=TelioAdapterType.NEP_TUN,
-            ip_stack=IPStack.IPv4 if ipv4 else IPStack.IPv6,
-        ),
-        SetupParameters(
-            connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2,
-            adapter_type_override=TelioAdapterType.NEP_TUN,
-            ip_stack=IPStack.IPv4 if ipv4 else IPStack.IPv6,
-        ),
-    ]
-
-    setup_params[1].features.firewall = FeatureFirewall(
-        neptun_reset_conns=False,
-        boringtun_reset_conns=False,
-        exclude_private_ip_range=None,
-        outgoing_blacklist=[
-            FirewallBlacklistTuple(protocol=IpProtocol.TCP, ip=serv_ip, port=serv_port)
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "alpha_setup_params",
+        [
+            # IPv4 public server
+            pytest.param(
+                SetupParameters(
+                    connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
+                    adapter_type_override=TelioAdapterType.NEP_TUN,
+                    ip_stack=IPStack.IPv4,
+                    features=default_features(
+                        enable_firewall_connection_reset=True,
+                        enable_firewall_exclusion_range="10.0.0.0/8",
+                    ),
+                )
+            ),
+            pytest.param(
+                SetupParameters(
+                    connection_tag=ConnectionTag.VM_MAC,
+                    adapter_type_override=TelioAdapterType.NEP_TUN,
+                    ip_stack=IPStack.IPv4,
+                    features=default_features(
+                        enable_firewall_connection_reset=True,
+                        enable_firewall_exclusion_range="10.0.0.0/8",
+                    ),
+                ),
+                marks=pytest.mark.mac,
+            ),
+            pytest.param(
+                SetupParameters(
+                    connection_tag=ConnectionTag.DOCKER_OPEN_INTERNET_CLIENT_DUAL_STACK,
+                    adapter_type_override=TelioAdapterType.NEP_TUN,
+                    ip_stack=IPStack.IPv6,
+                    features=default_features(enable_firewall_connection_reset=True),
+                )
+            ),
         ],
     )
-
-    async with AsyncExitStack() as exit_stack:
-        env = await exit_stack.enter_async_context(
-            setup_environment(
-                exit_stack, setup_params, vpn=[ConnectionTag.DOCKER_VPN_1]
-            )
+    async def test_kill_external_udp_conn_on_vpn_reconnect(
+        self,
+        alpha_setup_params: SetupParameters,
+        env,
+    ) -> None:
+        alpha_node, alpha_conn, alpha_client = (
+            env.nodes[0],
+            env.connections[0].connection,
+            env.clients[0],
         )
 
-        alpha_connection, beta_connection, *_ = [
-            conn.connection for conn in env.connections
-        ]
-        alpha, beta, *_ = env.clients
+        serv_ip = (
+            config.UDP_SERVER_IP6
+            if alpha_setup_params.ip_stack == IPStack.IPv6
+            else config.UDP_SERVER_IP4
+        )
+
+        alpha = alpha_node
+        connection = alpha_conn
+        client = alpha_client
+
+        async def connect(wg_server: dict):
+            await client.connect_to_vpn(
+                wg_server["ipv4"], wg_server["port"], wg_server["public_key"]
+            )
+            await ping(connection, serv_ip)
+
+        await connect(config.WG_SERVER)
+
+        ip_proto = (
+            IPProto.IPv6
+            if alpha_setup_params.ip_stack == IPStack.IPv6
+            else IPProto.IPv4
+        )
+        alpha_ip: str = testing.unpack_optional(alpha.get_ip_address(ip_proto))
+
+        async with NetCatClient(
+            connection,
+            serv_ip,
+            2000,
+            udp=True,
+            ipv6=ip_proto == IPProto.IPv6,
+            source_ip=alpha_ip,
+        ).run() as nc_client:
+            await nc_client.connection_succeeded()
+            await client.disconnect_from_vpn(str(config.WG_SERVER["public_key"]))
+
+            await connect(config.WG_SERVER_2)
+
+            # nc client should be closed by the reset mechanism
+            await nc_client.is_done()
+
+
+class TestSingleVpn2Node:
+    """Tests requiring single VPN with 2-node non-mesh (env)."""
+
+    @pytest.fixture(name="vpn_tags")
+    def _vpn_tags(self) -> list:
+        return [ConnectionTag.DOCKER_VPN_1]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "alpha_setup_params, beta_setup_params",
+        [
+            pytest.param(
+                SetupParameters(
+                    connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
+                    adapter_type_override=TelioAdapterType.NEP_TUN,
+                    ip_stack=IPStack.IPv4,
+                ),
+                SetupParameters(
+                    connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2,
+                    adapter_type_override=TelioAdapterType.NEP_TUN,
+                    ip_stack=IPStack.IPv4,
+                    features=_make_blacklist_features(
+                        IpProtocol.TCP, config.PHOTO_ALBUM_IP, 80
+                    ),
+                ),
+                id="ipv4",
+            ),
+            pytest.param(
+                SetupParameters(
+                    connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
+                    adapter_type_override=TelioAdapterType.NEP_TUN,
+                    ip_stack=IPStack.IPv6,
+                ),
+                SetupParameters(
+                    connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2,
+                    adapter_type_override=TelioAdapterType.NEP_TUN,
+                    ip_stack=IPStack.IPv6,
+                    features=_make_blacklist_features(
+                        IpProtocol.TCP, config.PHOTO_ALBUM_IPV6, 80
+                    ),
+                ),
+                id="ipv6",
+            ),
+        ],
+    )
+    async def test_firewall_blacklist_tcp(
+        self,
+        alpha_setup_params: SetupParameters,
+        beta_setup_params: SetupParameters,  # pylint: disable=unused-argument
+        env,
+    ) -> None:
+        ipv4 = alpha_setup_params.ip_stack == IPStack.IPv4
+        serv_ip = config.PHOTO_ALBUM_IP if ipv4 else config.PHOTO_ALBUM_IPV6
+        serv_port = 80
+        wg_server: dict = config.WG_SERVER
+
+        alpha_connection = env.connections[0].connection
+        beta_connection = env.connections[1].connection
+        alpha = env.clients[0]
+        beta = env.clients[1]
 
         await alpha.connect_to_vpn(
             wg_server["ipv4"], wg_server["port"], wg_server["public_key"]
@@ -455,54 +565,61 @@ async def test_firewall_blacklist_tcp(ipv4: bool) -> None:
 
             await conntrack.wait_for_no_violations()
 
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "ipv4",
-    [
-        pytest.param(True),
-        pytest.param(False),
-    ],
-)
-async def test_firewall_blacklist_udp(ipv4: bool) -> None:
-    serv_ip = config.UDP_SERVER_IP4 if ipv4 else config.UDP_SERVER_IP6
-    serv_port = 2000
-    wg_server: dict = config.WG_SERVER
-
-    setup_params = [
-        SetupParameters(
-            connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-            adapter_type_override=TelioAdapterType.NEP_TUN,
-            ip_stack=IPStack.IPv4 if ipv4 else IPStack.IPv6,
-        ),
-        SetupParameters(
-            connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2,
-            adapter_type_override=TelioAdapterType.NEP_TUN,
-            ip_stack=IPStack.IPv4 if ipv4 else IPStack.IPv6,
-        ),
-    ]
-
-    setup_params[1].features.firewall = FeatureFirewall(
-        neptun_reset_conns=False,
-        boringtun_reset_conns=False,
-        exclude_private_ip_range=None,
-        outgoing_blacklist=[
-            FirewallBlacklistTuple(protocol=IpProtocol.UDP, ip=serv_ip, port=serv_port)
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "alpha_setup_params, beta_setup_params",
+        [
+            pytest.param(
+                SetupParameters(
+                    connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
+                    adapter_type_override=TelioAdapterType.NEP_TUN,
+                    ip_stack=IPStack.IPv4,
+                ),
+                SetupParameters(
+                    connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2,
+                    adapter_type_override=TelioAdapterType.NEP_TUN,
+                    ip_stack=IPStack.IPv4,
+                    features=_make_blacklist_features(
+                        IpProtocol.UDP, config.UDP_SERVER_IP4, 2000
+                    ),
+                ),
+                id="ipv4",
+            ),
+            pytest.param(
+                SetupParameters(
+                    connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
+                    adapter_type_override=TelioAdapterType.NEP_TUN,
+                    ip_stack=IPStack.IPv6,
+                ),
+                SetupParameters(
+                    connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2,
+                    adapter_type_override=TelioAdapterType.NEP_TUN,
+                    ip_stack=IPStack.IPv6,
+                    features=_make_blacklist_features(
+                        IpProtocol.UDP, config.UDP_SERVER_IP6, 2000
+                    ),
+                ),
+                id="ipv6",
+            ),
         ],
     )
+    async def test_firewall_blacklist_udp(
+        self,
+        alpha_setup_params: SetupParameters,
+        beta_setup_params: SetupParameters,  # pylint: disable=unused-argument
+        env,
+    ) -> None:
+        ipv4 = alpha_setup_params.ip_stack == IPStack.IPv4
+        serv_ip = config.UDP_SERVER_IP4 if ipv4 else config.UDP_SERVER_IP6
+        serv_port = 2000
+        wg_server: dict = config.WG_SERVER
 
-    async with AsyncExitStack() as exit_stack:
-        env = await exit_stack.enter_async_context(
-            setup_environment(
-                exit_stack, setup_params, vpn=[ConnectionTag.DOCKER_VPN_1]
-            )
-        )
-
-        alpha, beta, *_ = env.nodes
-        alpha_connection, beta_connection, *_ = [
-            conn.connection for conn in env.connections
-        ]
-        alpha_client, beta_client, *_ = env.clients
+        alpha = env.nodes[0]
+        beta = env.nodes[1]
+        alpha_connection = env.connections[0].connection
+        beta_connection = env.connections[1].connection
+        alpha_client = env.clients[0]
+        beta_client = env.clients[1]
 
         await alpha_client.connect_to_vpn(
             wg_server["ipv4"], wg_server["port"], wg_server["public_key"]
@@ -512,219 +629,121 @@ async def test_firewall_blacklist_udp(ipv4: bool) -> None:
             wg_server["ipv4"], wg_server["port"], wg_server["public_key"]
         )
 
-        alpha_nc_client = await exit_stack.enter_async_context(
-            NetCatClient(
-                alpha_connection,
-                serv_ip,
-                serv_port,
-                udp=True,
-                source_ip=testing.unpack_optional(
-                    alpha.get_ip_address(IPProto.IPv4 if ipv4 else IPProto.IPv6)
-                ),
-                ipv6=not ipv4,
-            ).run()
-        )
-        await alpha_nc_client.connection_succeeded()
-
-        with pytest.raises(ProcessExecError):
-            await NetCatClient(
-                beta_connection,
-                serv_ip,
-                serv_port,
-                udp=True,
-                source_ip=testing.unpack_optional(
-                    beta.get_ip_address(IPProto.IPv4 if ipv4 else IPProto.IPv6)
-                ),
-                ipv6=not ipv4,
-            ).execute()
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "setup_params",
-    [
-        # IPv4 public server
-        pytest.param(
-            SetupParameters(
-                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                adapter_type_override=TelioAdapterType.NEP_TUN,
-                ip_stack=IPStack.IPv4,
-                features=default_features(
-                    enable_firewall_connection_reset=True,
-                    enable_firewall_exclusion_range="10.0.0.0/8",
-                ),
-            )
-        ),
-        pytest.param(
-            SetupParameters(
-                connection_tag=ConnectionTag.VM_MAC,
-                adapter_type_override=TelioAdapterType.NEP_TUN,
-                ip_stack=IPStack.IPv4,
-                features=default_features(
-                    enable_firewall_connection_reset=True,
-                    enable_firewall_exclusion_range="10.0.0.0/8",
-                ),
+        async with NetCatClient(
+            alpha_connection,
+            serv_ip,
+            serv_port,
+            udp=True,
+            source_ip=testing.unpack_optional(
+                alpha.get_ip_address(IPProto.IPv4 if ipv4 else IPProto.IPv6)
             ),
-            marks=pytest.mark.mac,
-        ),
-        pytest.param(
-            SetupParameters(
-                connection_tag=ConnectionTag.DOCKER_OPEN_INTERNET_CLIENT_DUAL_STACK,
-                adapter_type_override=TelioAdapterType.NEP_TUN,
-                ip_stack=IPStack.IPv6,
-                features=default_features(enable_firewall_connection_reset=True),
-            )
-        ),
-    ],
-)
-async def test_kill_external_udp_conn_on_vpn_reconnect(
-    setup_params: SetupParameters,
-) -> None:
-    serv_ip = (
-        config.UDP_SERVER_IP6
-        if setup_params.ip_stack == IPStack.IPv6
-        else config.UDP_SERVER_IP4
+            ipv6=not ipv4,
+        ).run() as alpha_nc_client:
+            await alpha_nc_client.connection_succeeded()
+
+            with pytest.raises(ProcessExecError):
+                await NetCatClient(
+                    beta_connection,
+                    serv_ip,
+                    serv_port,
+                    udp=True,
+                    source_ip=testing.unpack_optional(
+                        beta.get_ip_address(IPProto.IPv4 if ipv4 else IPProto.IPv6)
+                    ),
+                    ipv6=not ipv4,
+                ).execute()
+
+
+class TestSingleVpn1Node:
+    """Tests requiring single VPN with 1-node non-mesh (env)."""
+
+    @pytest.fixture(name="vpn_tags")
+    def _vpn_tags(self) -> list:
+        return [ConnectionTag.DOCKER_VPN_1]
+
+    @pytest.mark.parametrize(
+        "alpha_setup_params, public_ip",
+        [
+            pytest.param(
+                SetupParameters(
+                    connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
+                    adapter_type_override=TelioAdapterType.NEP_TUN,
+                    connection_tracker_config=generate_connection_tracker_config(
+                        ConnectionTag.DOCKER_CONE_CLIENT_1,
+                        stun_limits=(1, 1),
+                        vpn_1_limits=(1, 1),
+                    ),
+                    is_meshnet=False,
+                ),
+                "10.0.254.1",
+            ),
+            pytest.param(
+                SetupParameters(
+                    connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
+                    adapter_type_override=TelioAdapterType.LINUX_NATIVE_TUN,
+                    connection_tracker_config=generate_connection_tracker_config(
+                        ConnectionTag.DOCKER_CONE_CLIENT_1,
+                        stun_limits=(1, 1),
+                        vpn_1_limits=(1, 1),
+                    ),
+                    is_meshnet=False,
+                ),
+                "10.0.254.1",
+                marks=pytest.mark.linux_native,
+            ),
+            pytest.param(
+                SetupParameters(
+                    connection_tag=ConnectionTag.VM_WINDOWS_1,
+                    adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
+                    connection_tracker_config=generate_connection_tracker_config(
+                        ConnectionTag.VM_WINDOWS_1,
+                        stun_limits=(1, 1),
+                        vpn_1_limits=(1, 1),
+                    ),
+                    is_meshnet=False,
+                ),
+                "10.0.254.15",
+                marks=[
+                    pytest.mark.windows,
+                ],
+            ),
+            pytest.param(
+                SetupParameters(
+                    connection_tag=ConnectionTag.VM_MAC,
+                    adapter_type_override=TelioAdapterType.NEP_TUN,
+                    connection_tracker_config=generate_connection_tracker_config(
+                        ConnectionTag.VM_MAC,
+                        stun_limits=(1, 1),
+                        vpn_1_limits=(1, 1),
+                    ),
+                    is_meshnet=False,
+                ),
+                "10.0.254.19",
+                marks=pytest.mark.mac,
+            ),
+        ],
     )
-
-    async with AsyncExitStack() as exit_stack:
-        env = await exit_stack.enter_async_context(
-            setup_environment(
-                exit_stack,
-                [setup_params],
-                vpn=[ConnectionTag.DOCKER_VPN_1, ConnectionTag.DOCKER_VPN_2],
-            )
+    async def test_vpn_connection_private_key_change(
+        self,
+        alpha_setup_params: SetupParameters,  # pylint: disable=unused-argument
+        public_ip: str,
+        env,
+        single_vpn_server_connection,
+    ) -> None:
+        alpha_node, alpha_conn, alpha_client = (
+            env.nodes[0],
+            env.connections[0].connection,
+            env.clients[0],
         )
-
-        alpha, *_ = env.nodes
-        connection, *_ = [conn.connection for conn in env.connections]
-        client, *_ = env.clients
-
-        async def connect(
-            wg_server: dict,
-        ):
-            await client.connect_to_vpn(
-                wg_server["ipv4"], wg_server["port"], wg_server["public_key"]
-            )
-
-            await ping(connection, serv_ip)
-
-        await connect(
-            config.WG_SERVER,
-        )
-
-        ip_proto = (
-            IPProto.IPv6 if setup_params.ip_stack == IPStack.IPv6 else IPProto.IPv4
-        )
-        alpha_ip = testing.unpack_optional(alpha.get_ip_address(ip_proto))
-
-        nc_client = await exit_stack.enter_async_context(
-            NetCatClient(
-                connection,
-                serv_ip,
-                2000,
-                udp=True,
-                ipv6=ip_proto == IPProto.IPv6,
-                source_ip=alpha_ip,
-            ).run()
-        )
-
-        await nc_client.connection_succeeded()
-        await client.disconnect_from_vpn(str(config.WG_SERVER["public_key"]))
-
-        await connect(
-            config.WG_SERVER_2,
-        )
-
-        # nc client should be closed by the reset mechanism
-        await nc_client.is_done()
-
-
-@pytest.mark.parametrize(
-    "alpha_setup_params, public_ip",
-    [
-        pytest.param(
-            SetupParameters(
-                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                adapter_type_override=TelioAdapterType.NEP_TUN,
-                connection_tracker_config=generate_connection_tracker_config(
-                    ConnectionTag.DOCKER_CONE_CLIENT_1,
-                    stun_limits=(1, 1),
-                    vpn_1_limits=(1, 1),
-                ),
-                is_meshnet=False,
-            ),
-            "10.0.254.1",
-        ),
-        pytest.param(
-            SetupParameters(
-                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
-                adapter_type_override=TelioAdapterType.LINUX_NATIVE_TUN,
-                connection_tracker_config=generate_connection_tracker_config(
-                    ConnectionTag.DOCKER_CONE_CLIENT_1,
-                    stun_limits=(1, 1),
-                    vpn_1_limits=(1, 1),
-                ),
-                is_meshnet=False,
-            ),
-            "10.0.254.1",
-            marks=pytest.mark.linux_native,
-        ),
-        pytest.param(
-            SetupParameters(
-                connection_tag=ConnectionTag.VM_WINDOWS_1,
-                adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
-                connection_tracker_config=generate_connection_tracker_config(
-                    ConnectionTag.VM_WINDOWS_1,
-                    stun_limits=(1, 1),
-                    vpn_1_limits=(1, 1),
-                ),
-                is_meshnet=False,
-            ),
-            "10.0.254.15",
-            marks=[
-                pytest.mark.windows,
-            ],
-        ),
-        pytest.param(
-            SetupParameters(
-                connection_tag=ConnectionTag.VM_MAC,
-                adapter_type_override=TelioAdapterType.NEP_TUN,
-                connection_tracker_config=generate_connection_tracker_config(
-                    ConnectionTag.VM_MAC,
-                    stun_limits=(1, 1),
-                    vpn_1_limits=(1, 1),
-                ),
-                is_meshnet=False,
-            ),
-            "10.0.254.19",
-            marks=pytest.mark.mac,
-        ),
-    ],
-)
-async def test_vpn_connection_private_key_change(
-    alpha_setup_params: SetupParameters,
-    public_ip: str,
-) -> None:
-    async with AsyncExitStack() as exit_stack:
-        env = await exit_stack.enter_async_context(
-            setup_environment(
-                exit_stack,
-                [alpha_setup_params],
-                vpn=[ConnectionTag.DOCKER_VPN_1],
-            )
-        )
-
-        alpha, *_ = env.nodes
-        client_conn, *_ = [conn.connection for conn in env.connections]
-        client_alpha, *_ = env.clients
+        alpha = alpha_node
+        client_conn = alpha_conn
+        client_alpha = alpha_client
+        vpn_connection = single_vpn_server_connection
 
         ip = await stun.get(client_conn, config.STUN_SERVER)
         assert ip == public_ip, f"wrong public IP before connecting to VPN {ip}"
 
         # connect to vpn as usually
-        vpn_connection, *_ = await setup_connections(
-            exit_stack, [ConnectionTag.DOCKER_VPN_1]
-        )
         await connect_vpn(
             client_conn,
             vpn_connection.connection,

--- a/nat-lab/tests/test_vpn.py
+++ b/nat-lab/tests/test_vpn.py
@@ -25,8 +25,6 @@ from tests.utils.ping import ping
 from tests.utils.process import ProcessExecError
 from tests.utils.router import IPProto, IPStack
 
-pytest_plugins = ["tests.helpers_fixtures"]
-
 
 class TestVpnConnection:
     """Tests for basic VPN connection (previously test_vpn_connection)."""

--- a/nat-lab/tests/utils/process/docker_process.py
+++ b/nat-lab/tests/utils/process/docker_process.py
@@ -13,6 +13,10 @@ from typing import List, Optional, AsyncIterator
 
 _PROCESS_START_TIMEOUT = 10.0  # seconds to wait for exec PID to appear
 
+# Exit codes for processes terminated by a signal: 128 + signal number
+_EXIT_CODE_SIGKILL = 137  # 128 + 9 (SIGKILL)
+_EXIT_CODE_SIGTERM = 143  # 128 + 15 (SIGTERM)
+
 
 class DockerProcess(Process):
     _container: DockerContainer
@@ -28,6 +32,7 @@ class DockerProcess(Process):
     _kill_id: (
         str  # Private ID added to find the process easily when it needs to be killed
     )
+    _kill_sent: bool  # Set to True once an intentional kill has been dispatched
 
     def __init__(
         self,
@@ -46,6 +51,7 @@ class DockerProcess(Process):
         self._stream = None
         self._execute = None
         self._kill_id = kill_id if kill_id else secrets.token_hex(8).upper()
+        self._kill_sent = False
 
     async def execute(
         self,
@@ -101,10 +107,15 @@ class DockerProcess(Process):
             raise
         exit_code = inspect["ExitCode"]
 
-        # 0 success
-        # 137 = SIGKILL (128+9), 143 = SIGTERM (128+15) — both are expected
-        # when the process is intentionally killed during cleanup
-        if exit_code and exit_code not in [0, 137, 143]:
+        # 0  — clean exit
+        # 137 (SIGKILL) / 143 (SIGTERM) — expected only when we dispatched
+        # an intentional kill via _kill_exec_if_running(); an unexpected
+        # SIGTERM from outside should still surface as an error.
+        intentional_kill = self._kill_sent and exit_code in (
+            _EXIT_CODE_SIGKILL,
+            _EXIT_CODE_SIGTERM,
+        )
+        if exit_code and not intentional_kill:
             raise ProcessExecError(
                 exit_code,
                 self._container_name,
@@ -138,6 +149,7 @@ class DockerProcess(Process):
         try:
             info = await self._wait_for_process_start()
             if info["ExitCode"] is None:
+                self._kill_sent = True
                 proc = await asyncio.create_subprocess_exec(
                     "docker",
                     "exec",

--- a/nat-lab/tests/utils/process/docker_process.py
+++ b/nat-lab/tests/utils/process/docker_process.py
@@ -1,8 +1,6 @@
 import asyncio
 import secrets
-import subprocess
 import sys
-import time
 from .process import Process, ProcessExecError, StreamCallback
 from aiodocker.containers import DockerContainer
 from aiodocker.execs import Exec
@@ -12,6 +10,8 @@ from tests.utils.asyncio_util import run_async_context
 from tests.utils.logger import log
 from tests.utils.moose import MOOSE_LOGS_DIR
 from typing import List, Optional, AsyncIterator
+
+_PROCESS_START_TIMEOUT = 10.0  # seconds to wait for exec PID to appear
 
 
 class DockerProcess(Process):
@@ -53,87 +53,121 @@ class DockerProcess(Process):
         stderr_callback: Optional[StreamCallback] = None,
         privileged: bool = False,
     ) -> "DockerProcess":
-        start_time = time.monotonic()
         try:
+            self._execute = await self._container.exec(
+                self._command,
+                stdin=True,
+                environment={
+                    "MOOSE_LOG": "Trace",
+                    "MOOSE_LOG_FILE": MOOSE_LOGS_DIR,
+                    "RUST_BACKTRACE": "full",
+                    "KILL_ID": self._kill_id,
+                    "LD_LIBRARY_PATH": "/libtelio/nat-lab/tests/uniffi",
+                },
+                privileged=privileged,
+            )
+        except:
+            log.error("[%s] Exception thrown:", self._container_name, exc_info=True)
+            raise
+        if self._execute is None:
+            return self
+        async with self._execute.start() as exe_stream:
+            self._stream = exe_stream
+            self._stdin_ready.set()
             try:
-                self._execute = await self._container.exec(
-                    self._command,
-                    stdin=True,
-                    environment={
-                        "MOOSE_LOG": "Trace",
-                        "MOOSE_LOG_FILE": MOOSE_LOGS_DIR,
-                        "RUST_BACKTRACE": "full",
-                        "KILL_ID": self._kill_id,
-                        "LD_LIBRARY_PATH": "/libtelio/nat-lab/tests/uniffi",
-                    },
-                    privileged=privileged,
+                await self._read_loop(exe_stream, stdout_callback, stderr_callback)
+            except asyncio.CancelledError:
+                log.debug(
+                    "[%s] '%s' process cancelled.", self._container_name, self._command
                 )
+                raise
             except:
                 log.error("[%s] Exception thrown:", self._container_name, exc_info=True)
                 raise
-            if self._execute is None:
-                return self
-            async with self._execute.start() as exe_stream:
-                self._stream = exe_stream
-                self._stdin_ready.set()
-                try:
-                    await self._read_loop(exe_stream, stdout_callback, stderr_callback)
-                except asyncio.CancelledError:
-                    log.debug(
-                        "[%s] '%s' process cancelled.",
-                        self._container_name,
-                        self._command,
-                    )
-                    raise
-                except:
-                    log.error(
-                        "[%s] Exception thrown:", self._container_name, exc_info=True
-                    )
-                    raise
-                finally:
-                    if self._execute:
-                        inspect = await self._execute.inspect()
-                        while inspect["Pid"] == 0 and inspect["ExitCode"] is None:
-                            inspect = await self._execute.inspect()
-                            await asyncio.sleep(0.01)
-                        if inspect["ExitCode"] is None:
-                            subprocess.run(
-                                [
-                                    "docker",
-                                    "exec",
-                                    "--privileged",
-                                    self._container.id,
-                                    "/opt/bin/kill_process_by_natlab_id",
-                                    self._kill_id,
-                                ],
-                                stdout=subprocess.DEVNULL,
-                                stderr=subprocess.DEVNULL,
-                            )
-                    self._stream = None
+            finally:
+                if self._execute:
+                    await self._kill_exec_if_running()
+                self._stream = None
 
+        try:
             inspect = await self._execute.inspect()
-            exit_code = inspect["ExitCode"]
-
-            # 0 success
-            # suppress 137 linux sigkill, since we kill those processes
-            if exit_code and exit_code not in [0, 137]:
-                raise ProcessExecError(
-                    exit_code,
+        except RuntimeError as e:
+            if "Session is closed" in str(e):
+                log.debug(
+                    "[%s] Docker session closed during cleanup",
                     self._container_name,
-                    self._command,
-                    self._stdout,
-                    self._stderr,
                 )
+                return self
+            raise
+        exit_code = inspect["ExitCode"]
 
-            return self
-        finally:
-            elapsed_ms = (time.monotonic() - start_time) * 1000
-            log.info(
-                "[%s] Finished %s in %.0fms",
+        # 0 success
+        # 137 = SIGKILL (128+9), 143 = SIGTERM (128+15) — both are expected
+        # when the process is intentionally killed during cleanup
+        if exit_code and exit_code not in [0, 137, 143]:
+            raise ProcessExecError(
+                exit_code,
                 self._container_name,
-                " ".join(self._command),
-                elapsed_ms,
+                self._command,
+                self._stdout,
+                self._stderr,
             )
+
+        return self
+
+    async def _wait_for_process_start(self) -> dict:
+        """Poll exec inspect until a PID or exit code appears.
+
+        Raises ``asyncio.TimeoutError`` if the process does not start
+        within ``_PROCESS_START_TIMEOUT`` seconds.
+        """
+        assert self._execute is not None
+        execute = self._execute
+
+        async def _poll() -> dict:
+            while True:
+                info = await execute.inspect()
+                if info["Pid"] != 0 or info["ExitCode"] is not None:
+                    return info
+                await asyncio.sleep(0.01)
+
+        return await asyncio.wait_for(_poll(), timeout=_PROCESS_START_TIMEOUT)
+
+    async def _kill_exec_if_running(self) -> None:
+        """Wait for the exec to start, then kill it if it hasn't exited."""
+        try:
+            info = await self._wait_for_process_start()
+            if info["ExitCode"] is None:
+                proc = await asyncio.create_subprocess_exec(
+                    "docker",
+                    "exec",
+                    "--privileged",
+                    self._container.id,
+                    "/opt/bin/kill_process_by_natlab_id",
+                    self._kill_id,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                )
+                stdout, stderr = await proc.communicate()
+                if proc.returncode != 0:
+                    log.warning(
+                        "[%s] Cleanup failed: %s",
+                        self._container_name,
+                        (stdout or b"").decode() + (stderr or b"").decode(),
+                    )
+        except asyncio.TimeoutError:
+            log.warning(
+                "[%s] Timed out waiting for exec process to start during cleanup",
+                self._container_name,
+            )
+        except RuntimeError as e:
+            if "Session is closed" in str(e):
+                log.debug(
+                    "[%s] Docker session closed during cleanup",
+                    self._container_name,
+                )
+            else:
+                raise
 
     @asynccontextmanager
     async def run(
@@ -142,52 +176,18 @@ class DockerProcess(Process):
         stderr_callback: Optional[StreamCallback] = None,
         privileged: bool = False,
     ) -> AsyncIterator["DockerProcess"]:
-        start_time = time.monotonic()
-
         async def mark_as_done():
             try:
                 await self.execute(stdout_callback, stderr_callback, privileged)
             finally:
                 self._is_done.set()
 
-        try:
-            async with run_async_context(mark_as_done()):
-                try:
-                    yield self
-                finally:
-                    if self._execute:
-                        inspect = await self._execute.inspect()
-                        while inspect["Pid"] == 0 and inspect["ExitCode"] is None:
-                            inspect = await self._execute.inspect()
-                            await asyncio.sleep(0.01)
-                        if inspect["ExitCode"] is None:
-                            proc = subprocess.run(
-                                [
-                                    "docker",
-                                    "exec",
-                                    "--privileged",
-                                    self._container.id,
-                                    "/opt/bin/kill_process_by_natlab_id",
-                                    self._kill_id,
-                                ],
-                                stdout=subprocess.PIPE,
-                                stderr=subprocess.PIPE,
-                                text=True,
-                            )
-                            if proc.returncode != 0:
-                                log.warning(
-                                    "[%s] Cleanup failed: %s",
-                                    self._container_name,
-                                    proc.stdout + proc.stderr,
-                                )
-        finally:
-            elapsed_ms = (time.monotonic() - start_time) * 1000
-            log.info(
-                "[%s] Finished %s in %.0fms",
-                self._container_name,
-                " ".join(self._command),
-                elapsed_ms,
-            )
+        async with run_async_context(mark_as_done()):
+            try:
+                yield self
+            finally:
+                if self._execute:
+                    await self._kill_exec_if_running()
 
     async def _read_loop(
         self,

--- a/nat-lab/tests/utils/process/ssh_process.py
+++ b/nat-lab/tests/utils/process/ssh_process.py
@@ -7,6 +7,9 @@ from tests.utils.asyncio_util import run_async_context
 from tests.utils.logger import log
 from typing import List, Optional, Callable, AsyncIterator
 
+# asyncssh reports signal-terminated processes with negative signal numbers
+_RETURNCODE_SIGKILL = -9  # SIGKILL
+
 
 class SshProcess(Process):
     _ssh_connection: asyncssh.SSHClientConnection
@@ -20,6 +23,7 @@ class SshProcess(Process):
     _process: Optional[asyncssh.SSHClientProcess]
     _running: bool
     _term_type: Optional[str]
+    _kill_sent: bool  # Set to True once an intentional kill has been dispatched
 
     def __init__(
         self,
@@ -41,6 +45,7 @@ class SshProcess(Process):
         self._process = None
         self._running = False
         self._term_type = term_type
+        self._kill_sent = False
 
     async def execute(
         self,
@@ -75,6 +80,7 @@ class SshProcess(Process):
                 raise
             finally:
                 if self._process and self._process.returncode is None:
+                    self._kill_sent = True
                     self._process.kill()
                     self._process.close()
                     await self._process.wait_closed()
@@ -86,9 +92,12 @@ class SshProcess(Process):
             exit_status = self._process.exit_status
             exit_signal = self._process.exit_signal
 
-            # 0 success
-            # suppress -9 sigkill, since we kill those processes
-            if returncode and returncode not in [0, -9]:
+            # 0  — clean exit
+            # _RETURNCODE_SIGKILL (-9) — expected only when we dispatched an
+            # intentional kill above; an unexpected external SIGKILL should
+            # still surface as an error.
+            intentional_kill = self._kill_sent and returncode == _RETURNCODE_SIGKILL
+            if returncode and not intentional_kill:
                 err = ProcessExecError(
                     returncode,
                     self._vm_name,
@@ -143,6 +152,7 @@ class SshProcess(Process):
                     yield self
                 finally:
                     if self._process and self._process.returncode is None:
+                        self._kill_sent = True
                         self._process.kill()
                         self._process.close()
                         await self._process.wait_closed()

--- a/nat-lab/tests/utils/router/linux_router.py
+++ b/nat-lab/tests/utils/router/linux_router.py
@@ -384,36 +384,48 @@ class LinuxRouter(Router):
         try:
             yield
         finally:
-            await self._connection.create_process(
-                [
-                    iptables_string,
-                    "--wait",  # Wait for xtables lock
-                    "--table",
-                    "filter",
-                    "--delete",
-                    "INPUT",
-                    "--source",
+            try:
+                await self._connection.create_process(
+                    [
+                        iptables_string,
+                        "--wait",  # Wait for xtables lock
+                        "--table",
+                        "filter",
+                        "--delete",
+                        "INPUT",
+                        "--source",
+                        address,
+                        "--jump",
+                        "DROP",
+                    ],
+                    quiet=True,
+                ).execute()
+            except ProcessExecError:
+                log.warning(
+                    "disable_path cleanup: INPUT rule for %s already removed",
                     address,
-                    "--jump",
-                    "DROP",
-                ],
-                quiet=True,
-            ).execute()
-            await self._connection.create_process(
-                [
-                    iptables_string,
-                    "--wait",  # Wait for xtables lock
-                    "--table",
-                    "filter",
-                    "--delete",
-                    "OUTPUT",
-                    "--destination",
+                )
+            try:
+                await self._connection.create_process(
+                    [
+                        iptables_string,
+                        "--wait",  # Wait for xtables lock
+                        "--table",
+                        "filter",
+                        "--delete",
+                        "OUTPUT",
+                        "--destination",
+                        address,
+                        "--jump",
+                        "DROP",
+                    ],
+                    quiet=True,
+                ).execute()
+            except ProcessExecError:
+                log.warning(
+                    "disable_path cleanup: OUTPUT rule for %s already removed",
                     address,
-                    "--jump",
-                    "DROP",
-                ],
-                quiet=True,
-            ).execute()
+                )
 
     @asynccontextmanager
     async def break_tcp_conn_to_host(self, address: str) -> AsyncIterator:
@@ -447,25 +459,31 @@ class LinuxRouter(Router):
         try:
             yield
         finally:
-            await self._connection.create_process(
-                [
-                    iptables_string,
-                    "--wait",  # Wait for xtables lock
-                    "--table",
-                    "filter",
-                    "--delete",
-                    "OUTPUT",
-                    "--destination",
+            try:
+                await self._connection.create_process(
+                    [
+                        iptables_string,
+                        "--wait",  # Wait for xtables lock
+                        "--table",
+                        "filter",
+                        "--delete",
+                        "OUTPUT",
+                        "--destination",
+                        address,
+                        "--protocol",
+                        "tcp",
+                        "--jump",
+                        "REJECT",
+                        "--reject-with",
+                        "tcp-reset",
+                    ],
+                    quiet=True,
+                ).execute()
+            except ProcessExecError:
+                log.warning(
+                    "break_tcp_conn_to_host cleanup: rule for %s already removed",
                     address,
-                    "--protocol",
-                    "tcp",
-                    "--jump",
-                    "REJECT",
-                    "--reject-with",
-                    "tcp-reset",
-                ],
-                quiet=True,
-            ).execute()
+                )
 
     @asynccontextmanager
     async def break_udp_conn_to_host(self, address: str) -> AsyncIterator:
@@ -499,25 +517,31 @@ class LinuxRouter(Router):
         try:
             yield
         finally:
-            await self._connection.create_process(
-                [
-                    iptables_string,
-                    "--wait",  # Wait for xtables lock
-                    "--table",
-                    "filter",
-                    "--delete",
-                    "OUTPUT",
-                    "--destination",
+            try:
+                await self._connection.create_process(
+                    [
+                        iptables_string,
+                        "--wait",  # Wait for xtables lock
+                        "--table",
+                        "filter",
+                        "--delete",
+                        "OUTPUT",
+                        "--destination",
+                        address,
+                        "--protocol",
+                        "udp",
+                        "--jump",
+                        "REJECT",
+                        "--reject-with",
+                        "icmp-host-unreachable",
+                    ],
+                    quiet=True,
+                ).execute()
+            except ProcessExecError:
+                log.warning(
+                    "break_udp_conn_to_host cleanup: rule for %s already removed",
                     address,
-                    "--protocol",
-                    "udp",
-                    "--jump",
-                    "REJECT",
-                    "--reject-with",
-                    "icmp-host-unreachable",
-                ],
-                quiet=True,
-            ).execute()
+                )
 
     # This function blocks outgoing data for a specific port to simulate permission denied error for the socket bound to that port.
     # It was added for LLT-4980, to test a specific code path in proxy.rs
@@ -542,21 +566,27 @@ class LinuxRouter(Router):
         try:
             yield
         finally:
-            await self._connection.create_process(
-                [
-                    "iptables",
-                    "--wait",  # Wait for xtables lock
-                    "--delete",
-                    "OUTPUT",
-                    "--protocol",
-                    "udp",
-                    "--sport",
-                    str(port),
-                    "--jump",
-                    "DROP",
-                ],
-                quiet=True,
-            ).execute()
+            try:
+                await self._connection.create_process(
+                    [
+                        "iptables",
+                        "--wait",  # Wait for xtables lock
+                        "--delete",
+                        "OUTPUT",
+                        "--protocol",
+                        "udp",
+                        "--sport",
+                        str(port),
+                        "--jump",
+                        "DROP",
+                    ],
+                    quiet=True,
+                ).execute()
+            except ProcessExecError:
+                log.warning(
+                    "block_udp_port cleanup: rule for port %d already removed",
+                    port,
+                )
 
     @asynccontextmanager
     async def block_tcp_port(self, port: int) -> AsyncIterator:
@@ -579,21 +609,27 @@ class LinuxRouter(Router):
         try:
             yield
         finally:
-            await self._connection.create_process(
-                [
-                    "iptables",
-                    "--wait",  # Wait for xtables lock
-                    "--delete",
-                    "OUTPUT",
-                    "--protocol",
-                    "tcp",
-                    "--dport",
-                    str(port),
-                    "--jump",
-                    "DROP",
-                ],
-                quiet=True,
-            ).execute()
+            try:
+                await self._connection.create_process(
+                    [
+                        "iptables",
+                        "--wait",  # Wait for xtables lock
+                        "--delete",
+                        "OUTPUT",
+                        "--protocol",
+                        "tcp",
+                        "--dport",
+                        str(port),
+                        "--jump",
+                        "DROP",
+                    ],
+                    quiet=True,
+                ).execute()
+            except ProcessExecError:
+                log.warning(
+                    "block_tcp_port cleanup: rule for port %d already removed",
+                    port,
+                )
 
     @asynccontextmanager
     async def reset_upnpd(self) -> AsyncIterator:

--- a/nat-lab/tests/utils/router/linux_router.py
+++ b/nat-lab/tests/utils/router/linux_router.py
@@ -400,11 +400,14 @@ class LinuxRouter(Router):
                     ],
                     quiet=True,
                 ).execute()
-            except ProcessExecError:
-                log.warning(
-                    "disable_path cleanup: INPUT rule for %s already removed",
-                    address,
-                )
+            except ProcessExecError as e:
+                if "matching rule" in e.stderr or "No chain" in e.stderr:
+                    log.warning(
+                        "disable_path cleanup: INPUT rule for %s already removed",
+                        address,
+                    )
+                else:
+                    raise
             try:
                 await self._connection.create_process(
                     [
@@ -421,11 +424,14 @@ class LinuxRouter(Router):
                     ],
                     quiet=True,
                 ).execute()
-            except ProcessExecError:
-                log.warning(
-                    "disable_path cleanup: OUTPUT rule for %s already removed",
-                    address,
-                )
+            except ProcessExecError as e:
+                if "matching rule" in e.stderr or "No chain" in e.stderr:
+                    log.warning(
+                        "disable_path cleanup: OUTPUT rule for %s already removed",
+                        address,
+                    )
+                else:
+                    raise
 
     @asynccontextmanager
     async def break_tcp_conn_to_host(self, address: str) -> AsyncIterator:
@@ -479,11 +485,14 @@ class LinuxRouter(Router):
                     ],
                     quiet=True,
                 ).execute()
-            except ProcessExecError:
-                log.warning(
-                    "break_tcp_conn_to_host cleanup: rule for %s already removed",
-                    address,
-                )
+            except ProcessExecError as e:
+                if "matching rule" in e.stderr or "No chain" in e.stderr:
+                    log.warning(
+                        "break_tcp_conn_to_host cleanup: rule for %s already removed",
+                        address,
+                    )
+                else:
+                    raise
 
     @asynccontextmanager
     async def break_udp_conn_to_host(self, address: str) -> AsyncIterator:
@@ -537,11 +546,14 @@ class LinuxRouter(Router):
                     ],
                     quiet=True,
                 ).execute()
-            except ProcessExecError:
-                log.warning(
-                    "break_udp_conn_to_host cleanup: rule for %s already removed",
-                    address,
-                )
+            except ProcessExecError as e:
+                if "matching rule" in e.stderr or "No chain" in e.stderr:
+                    log.warning(
+                        "break_udp_conn_to_host cleanup: rule for %s already removed",
+                        address,
+                    )
+                else:
+                    raise
 
     # This function blocks outgoing data for a specific port to simulate permission denied error for the socket bound to that port.
     # It was added for LLT-4980, to test a specific code path in proxy.rs
@@ -582,11 +594,14 @@ class LinuxRouter(Router):
                     ],
                     quiet=True,
                 ).execute()
-            except ProcessExecError:
-                log.warning(
-                    "block_udp_port cleanup: rule for port %d already removed",
-                    port,
-                )
+            except ProcessExecError as e:
+                if "matching rule" in e.stderr or "No chain" in e.stderr:
+                    log.warning(
+                        "block_udp_port cleanup: rule for port %d already removed",
+                        port,
+                    )
+                else:
+                    raise
 
     @asynccontextmanager
     async def block_tcp_port(self, port: int) -> AsyncIterator:
@@ -625,11 +640,14 @@ class LinuxRouter(Router):
                     ],
                     quiet=True,
                 ).execute()
-            except ProcessExecError:
-                log.warning(
-                    "block_tcp_port cleanup: rule for port %d already removed",
-                    port,
-                )
+            except ProcessExecError as e:
+                if "matching rule" in e.stderr or "No chain" in e.stderr:
+                    log.warning(
+                        "block_tcp_port cleanup: rule for port %d already removed",
+                        port,
+                    )
+                else:
+                    raise
 
     @asynccontextmanager
     async def reset_upnpd(self) -> AsyncIterator:


### PR DESCRIPTION
### Problem

Nat-lab test files use a factory-pattern for environment setup where each test manually calls `setup_mesh_nodes()` or `setup_environment()` at runtime, managing `AsyncExitStack` lifecycle inline. This leads to:

- Environment setup and teardown time is included in the test's reported runtime, inflating test durations and making it difficult to distinguish actual test logic performance from infrastructure overhead
- Duplicated setup/teardown boilerplate across every test function
- Inconsistent error handling during teardown (e.g. iptables cleanup failures crashing teardown)
- Proliferation of specialized fixture variants (`env_vpn_conntracked`, `env_pq_nlx_vpn`, `env_pq_nlx_vpn_rekey`, etc.) that differ only in minor parameter mutations
- Tight coupling between test logic and infrastructure orchestration, making tests harder to read and maintain

### Solution

Introduce a `helpers_fixtures.py` module with two generic setup-phase fixtures — `env_mesh` and `env` — that handle all environment lifecycle in pytest's fixture phase. By moving setup into fixtures, environment provisioning and teardown time is no longer counted as part of the test's execution duration, giving more accurate test timing metrics. Key design decisions:

- **Dynamic node resolution**: `_resolve_setup_params()` uses `request.getfixturevalue()` to auto-detect which `alpha_setup_params`, `beta_setup_params`, `gamma_setup_params` are parametrized on the test, eliminating the need for separate 1-node/2-node/3-node fixture variants
- **Compositional `vpn_tags` fixture**: A default fixture returning `[]` that tests override at class/module level to inject VPN server connections, replacing dedicated VPN-specific fixtures
- **Autouse mutation fixtures**: Test classes define small autouse fixtures (e.g. `_mutate_pq_version`, `_mutate_conntracker`) to apply parameter mutations, replacing 5 specialized environment fixtures with the generic `env`/`env` + composition
- **Robust teardown**: `linux_router.py` wraps all iptables teardown commands in `try/except ProcessExecError` to prevent cascading failures

This reduces the fixture count from 22 specialized fixtures to 2 generic ones (plus 1 kept specialized: `env_mesh_3node_ring_fw` which requires pre-setup API manipulation). Each of the 19 converted test files gets its own commit for reviewability.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
