### PR TITLE
Llt 7085 - Refactor telio-dns: Replace string-based error handling with strongly-typed enums across library and tests

### DIFF
--- a/crates/telio-dns/src/dns.rs
+++ b/crates/telio-dns/src/dns.rs
@@ -1,4 +1,8 @@
-use crate::{bind_tun, LocalNameServer, NameServer, Records};
+use crate::{
+    bind_tun,
+    error::{DnsIoError, Error, Result},
+    LocalNameServer, NameServer, Records,
+};
 use async_trait::async_trait;
 use ipnet::IpNet;
 use neptun::noise::Tunn;
@@ -25,14 +29,9 @@ pub trait DnsResolver {
     /// Stop the server.
     async fn stop(&self);
     /// Insert or update zone records used by the server.
-    async fn upsert(
-        &self,
-        zone: &str,
-        records: &Records,
-        ttl_value: TtlValue,
-    ) -> Result<(), String>;
+    async fn upsert(&self, zone: &str, records: &Records, ttl_value: TtlValue) -> Result<()>;
     /// Configure list of forward DNS servers for zone '.'.
-    async fn forward(&self, to: &[IpAddr]) -> Result<(), String>;
+    async fn forward(&self, to: &[IpAddr]) -> Result<()>;
     /// Get public key of this DNS server.
     fn public_key(&self) -> PublicKey;
     /// Get Peer of this DNS server with selected allowed IPs.
@@ -66,26 +65,17 @@ impl LocalDnsResolver {
         forward_ips: &[IpAddr],
         tun: Option<&Tun>,
         dns_features: &FeatureDns,
-    ) -> Result<Self, String> {
+    ) -> Result<Self> {
         let socket = UdpSocket::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
             .await
-            .map_err(|e| {
-                telio_log_error!("Failed to bind dns socket: {:?}", e);
-                format!("Failed to bind dns socket: {e:?}")
-            })?;
+            .map_err(DnsIoError::BindDnsSocket)?;
 
         let socket_port = socket
             .local_addr()
-            .map_err(|e| {
-                telio_log_error!("Failed to get socket port: {:?}", e);
-                format!("Failed to get socket port: {e:?}",)
-            })?
+            .map_err(DnsIoError::GetSocketAddr)?
             .port();
 
-        bind_tun::set_tun(tun).map_err(|e| {
-            telio_log_debug!("Failing setting tun: {:?}", e);
-            format!("{e}")
-        })?;
+        bind_tun::set_tun(tun).map_err(DnsIoError::ConfigureTunnel)?;
 
         // DNS secret key
         let dns_secret_key = SecretKey::gen();
@@ -105,14 +95,17 @@ impl LocalDnsResolver {
         Ok(LocalDnsResolver {
             socket: Arc::new(socket),
             secret_key: dns_secret_key.clone(),
-            peer: Arc::new(Mutex::new(Tunn::new(
-                StaticSecret::from(dns_secret_key.into_bytes()),
-                telio_public_key,
-                None,
-                None,
-                0,
-                None,
-            )?)),
+            peer: Arc::new(Mutex::new(
+                Tunn::new(
+                    StaticSecret::from(dns_secret_key.into_bytes()),
+                    telio_public_key,
+                    None,
+                    None,
+                    0,
+                    None,
+                )
+                .map_err(|e| Error::CreateTunnel(e.to_string()))?,
+            )),
             socket_port,
             nameserver,
             auto_switch_ips,
@@ -133,19 +126,14 @@ impl DnsResolver for LocalDnsResolver {
         self.nameserver.stop().await;
     }
 
-    async fn upsert(
-        &self,
-        zone: &str,
-        records: &Records,
-        ttl_value: TtlValue,
-    ) -> Result<(), String> {
+    async fn upsert(&self, zone: &str, records: &Records, ttl_value: TtlValue) -> Result<()> {
         telio_log_debug!("Dns - upsert {:?} {:?}", zone, records);
-        Ok(self.nameserver.upsert(zone, records, ttl_value).await?)
+        self.nameserver.upsert(zone, records, ttl_value).await
     }
 
-    async fn forward(&self, to: &[IpAddr]) -> Result<(), String> {
+    async fn forward(&self, to: &[IpAddr]) -> Result<()> {
         telio_log_debug!("Dns - forward {:?}", to);
-        Ok(self.nameserver.forward(to).await?)
+        self.nameserver.forward(to).await
     }
 
     fn public_key(&self) -> PublicKey {

--- a/crates/telio-dns/src/error.rs
+++ b/crates/telio-dns/src/error.rs
@@ -1,0 +1,61 @@
+use crate::forwarder::ForwardError;
+use crate::zone::NordZoneError;
+use std::{io, net::AddrParseError};
+use thiserror::Error;
+
+/// Result type used by the telio-dns crate
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// An IO error during DNS operations
+#[derive(Debug, Error)]
+pub enum DnsIoError {
+    /// Binding the DNS UDP socket
+    #[error("Failed to bind DNS socket: {0}")]
+    BindDnsSocket(io::Error),
+    /// Getting the local address of the DNS socket
+    #[error("Failed to get DNS socket local address: {0}")]
+    GetSocketAddr(io::Error),
+    /// Configuring tunnel binding for DNS
+    #[error("Failed to configure tunnel binding: {0}")]
+    ConfigureTunnel(io::Error),
+}
+
+/// Error type for the telio-dns crate
+///
+/// This enum represents all errors in the public interfaces
+/// that can occur when configuring or running the DNS resolver
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum Error {
+    /// An IO error during DNS socket or tunnel operations
+    #[error(transparent)]
+    Io(#[from] DnsIoError),
+
+    /// Failed to create WireGuard tunnel
+    #[error("Failed to create WireGuard tunnel: {0}")]
+    CreateTunnel(String),
+
+    /// Invalid DNS name
+    #[error("Invalid DNS name: {0}")]
+    InvalidDnsName(#[from] hickory_server::proto::error::ProtoError),
+
+    /// Record does not belong to the specified DNS zone
+    #[error("Record '{0}' does not belong to zone '{1}'")]
+    RecordOutsideZone(String, String),
+
+    /// Invalid IP address
+    #[error("Invalid IP address: {0}")]
+    AddressParse(#[from] AddrParseError),
+
+    /// Failed to create the raw DNS forwarder
+    #[error("Failed to create DNS forwarder: {0}")]
+    CreateForwarder(#[from] ForwardError),
+
+    /// Failed to upsert a record into a zone
+    #[error("Upsert failed: {0}")]
+    UpsertFailed(#[from] NordZoneError),
+
+    /// Nameserver is stopped
+    #[error("Nameserver stopped")]
+    Stopped,
+}

--- a/crates/telio-dns/src/error.rs
+++ b/crates/telio-dns/src/error.rs
@@ -59,3 +59,33 @@ pub enum Error {
     #[error("Nameserver stopped")]
     Stopped,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Test helper: creates io::Error with given message.
+    fn fake_io_error(msg: &str) -> io::Error {
+        io::Error::other(msg)
+    }
+
+    // Tests DnsIoError display format: "{context}: {source}" from thiserror::Error implementation
+    #[test]
+    fn dns_io_error_display() {
+        let err = DnsIoError::BindDnsSocket(fake_io_error("port busy"));
+        assert_eq!(err.to_string(), "Failed to bind DNS socket: port busy");
+    }
+
+    // Tests Error::Io — conversion from DnsIoError via #[from] from thiserror::Error implementation
+    #[test]
+    fn error_io_from_dns_io_error() {
+        let io_err = DnsIoError::GetSocketAddr(fake_io_error("no address"));
+        let err = Error::from(io_err);
+        assert!(matches!(err, Error::Io(_)));
+        // transparent display should show inner DnsIoError message
+        assert_eq!(
+            err.to_string(),
+            "Failed to get DNS socket local address: no address"
+        );
+    }
+}

--- a/crates/telio-dns/src/forward.rs
+++ b/crates/telio-dns/src/forward.rs
@@ -31,7 +31,7 @@ use hickory_server::{
 use telio_utils::{telio_log_debug, telio_log_info, telio_log_trace, telio_log_warn};
 use tokio::net::UdpSocket;
 
-use crate::bind_tun;
+use crate::{bind_tun, error::Error};
 
 #[derive(Default, Clone)]
 pub struct TelioRuntimeProvider(TokioRuntimeProvider);
@@ -141,7 +141,7 @@ impl ForwardAuthority {
         origin: Name,
         _zone_type: ZoneType,
         config: ForwardConfig,
-    ) -> Result<Self, String> {
+    ) -> Result<Self, Error> {
         telio_log_info!("loading forwarder config: {}", origin);
 
         let name_servers = config.name_servers;

--- a/crates/telio-dns/src/lib.rs
+++ b/crates/telio-dns/src/lib.rs
@@ -15,6 +15,8 @@ mod resolver;
 mod zone;
 
 pub mod bind_tun;
+/// Error types used by the telio-dns crate.
+pub mod error;
 
 pub(crate) mod forward;
 

--- a/crates/telio-dns/src/nameserver.rs
+++ b/crates/telio-dns/src/nameserver.rs
@@ -1,3 +1,4 @@
+use crate::error::Result as DnsResult;
 use crate::{
     forwarder::RawForwarder,
     packet_decoder::{find_nord_query, normalize_qname, parse_dns_query_packet, DnsParseError},
@@ -116,16 +117,11 @@ pub trait NameServer {
     /// Stop the server.
     async fn stop(&self);
     /// Configure list of forward DNS servers for zone '.'.
-    async fn forward(&self, to: &[IpAddr]) -> Result<(), String>;
+    async fn forward(&self, to: &[IpAddr]) -> DnsResult<()>;
     /// Configure list of forward DNS servers with explicit socket addresses.
-    async fn forward_to_addrs(&self, to: &[SocketAddr]) -> Result<(), String>;
+    async fn forward_to_addrs(&self, to: &[SocketAddr]) -> DnsResult<()>;
     /// Insert or update zone records used by the server.
-    async fn upsert(
-        &self,
-        zone: &str,
-        records: &Records,
-        ttl_value: TtlValue,
-    ) -> Result<(), String>;
+    async fn upsert(&self, zone: &str, records: &Records, ttl_value: TtlValue) -> DnsResult<()>;
 }
 
 /// Helper to update wg timers
@@ -169,13 +165,9 @@ impl LocalNameServer {
     pub async fn new(
         forward_ips: &[IpAddr],
         use_raw_forwarder: bool,
-    ) -> Result<Arc<RwLock<Self>>, String> {
+    ) -> DnsResult<Arc<RwLock<Self>>> {
         let raw_forwarder: Option<RawForwarder> = if use_raw_forwarder {
-            Some(
-                RawForwarder::new()
-                    .await
-                    .map_err(|e| format!("Failed to create forwarder: {e:?}"))?,
-            )
+            Some(RawForwarder::new().await?)
         } else {
             None
         };
@@ -403,7 +395,7 @@ impl LocalNameServer {
                     let response = forwarder
                         .query(&raw_query)
                         .await
-                        .map_err(|e| format!("Forward failed: {e:?}"))?;
+                        .map_err(|e| PacketError::LookupFailed(Box::new(e)))?;
 
                     telio_log_debug!("Forwarder responded");
                     if let Some(dns_packet) = DnsPacket::new(&response) {
@@ -416,9 +408,8 @@ impl LocalNameServer {
                     let resolver = Resolver::new();
                     let zones = nameserver.zones().await;
 
-                    let forward = MessageRequest::from_bytes(&raw_query).map_err(|_| {
-                        String::from("Failed to build MessageRequest from request packet")
-                    })?;
+                    let forward = MessageRequest::from_bytes(&raw_query)
+                        .map_err(|_| PacketError::DecodeMessageRequestFailed)?;
                     let dns_request =
                         Request::new(forward, request_info.dns_source(), Protocol::Udp);
                     telio_log_debug!("DNS request: {:?}", &dns_request);
@@ -426,7 +417,7 @@ impl LocalNameServer {
                     zones
                         .lookup(&dns_request, resolver.clone())
                         .await
-                        .map_err(|e| format!("Lookup failed {e}"))?;
+                        .map_err(|e| PacketError::LookupFailed(Box::new(e)))?;
 
                     let dns_response = resolver.0.lock().await;
                     telio_log_debug!("Nameserver response: {:?}", &dns_response);
@@ -902,7 +893,7 @@ impl NameServer for Arc<RwLock<LocalNameServer>> {
         Ok(())
     }
 
-    async fn forward(&self, to: &[IpAddr]) -> Result<(), String> {
+    async fn forward(&self, to: &[IpAddr]) -> DnsResult<()> {
         self.zones_mut().await.upsert(
             LowerName::from_str(".")?,
             Box::new(Arc::new(ForwardZone::new(".", to).await?)),
@@ -915,7 +906,7 @@ impl NameServer for Arc<RwLock<LocalNameServer>> {
         Ok(())
     }
 
-    async fn forward_to_addrs(&self, to: &[SocketAddr]) -> Result<(), String> {
+    async fn forward_to_addrs(&self, to: &[SocketAddr]) -> DnsResult<()> {
         let ns = self.read().await;
         if let Some(forwarder) = &ns.forwarder {
             forwarder.set_upstreams(to.to_vec()).await;
@@ -1087,7 +1078,7 @@ mod tests {
         let ns = nameserver.read().await;
         assert!(ns.forwarder.is_none());
     }
-    
+
     // PacketError internal unit tests
 
     const SRC_IPV4: Ipv4Addr = Ipv4Addr::new(10, 0, 0, 1);
@@ -1131,7 +1122,7 @@ mod tests {
 
     /// Helper to create local NameServer (used to test packet processing)
     async fn test_nameserver() -> Arc<RwLock<LocalNameServer>> {
-        LocalNameServer::new(&[IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))])
+        LocalNameServer::new(&[IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))], false)
             .await
             .unwrap()
     }

--- a/crates/telio-dns/src/nameserver.rs
+++ b/crates/telio-dns/src/nameserver.rs
@@ -1,7 +1,7 @@
 use crate::{
     forwarder::RawForwarder,
-    packet_decoder::{find_nord_query, normalize_qname, parse_dns_query_packet},
-    packet_encoder::DnsResponseBuilder,
+    packet_decoder::{find_nord_query, normalize_qname, parse_dns_query_packet, DnsParseError},
+    packet_encoder::{DnsBuildError, DnsResponseBuilder},
     resolver::Resolver,
     zone::{AuthoritativeZone, ClonableZones, ForwardZone, NordZone, Records, NORD_ZONE},
 };
@@ -34,6 +34,8 @@ use tokio::{net::UdpSocket, sync::Mutex};
 
 use telio_utils::{format_hex, telio_log_debug, telio_log_error, telio_log_trace, telio_log_warn};
 
+use thiserror::Error;
+
 const IPV4_HEADER: usize = 20; // bytes
 const IPV6_HEADER: usize = 40; // bytes
 const MAX_PACKET: usize = 2048;
@@ -42,6 +44,66 @@ const TCP_MIN_HEADER: usize = 20;
 const MAX_CONCURRENT_QUERIES: usize = 256;
 const IDLE_TIME: Duration = Duration::from_secs(1);
 const DNS_PORT: u16 = 53;
+
+#[derive(Debug, Error)]
+enum PacketError {
+    #[error("Empty request packet")]
+    EmptyPacket,
+
+    #[error("Invalid IP version: {0}")]
+    InvalidIpVersion(u8),
+
+    #[error("Invalid IP packet")]
+    InvalidIpPacket,
+
+    #[error("Unsupported protocol for DNS request")]
+    InvalidProtocol,
+
+    #[error("Invalid UDP checksum")]
+    InvalidUdpChecksum,
+
+    #[error("Invalid DNS port: {0}")]
+    InvalidDnsPort(u16),
+
+    #[error("Failed to build IP packet")]
+    IpPacketCreationFailed,
+
+    #[error("Failed to build UDP packet")]
+    UdpPacketCreationFailed,
+
+    #[error("Failed to build TCP packet from request packet")]
+    TcpPacketCreationFailed,
+
+    #[error("Failed to decode DNS request")]
+    DecodeMessageRequestFailed,
+
+    #[error("Missing DNS request payload")]
+    MissingDnsRequest,
+
+    #[error("DNS lookup failed: {0}")]
+    LookupFailed(Box<dyn std::error::Error + Send + Sync>),
+
+    #[error("DNS parse error: {0}")]
+    DnsParseFailed(DnsParseError),
+
+    #[error("Failed building DNS response packet: {0}")]
+    DnsResponseBuildFailed(DnsBuildError),
+
+    #[error("Out of bounds on response packet buffer")]
+    ResponseBufferOverflow,
+
+    #[error("Failed to build MutableUdpPacket for response packet")]
+    MutableUdpPacketCreationFailed,
+
+    #[error("Failed to build MutableTcpPacket for response packet")]
+    MutableTcpPacketCreationFailed,
+
+    #[error("Failed to build MutableIpv4Packet for response packet")]
+    MutableIpv4PacketCreationFailed,
+
+    #[error("Failed to build MutableIpv6Packet for response packet")]
+    MutableIpv6PacketCreationFailed,
+}
 
 /// NameServer is a server that stores the DNS records.
 #[async_trait]
@@ -270,15 +332,13 @@ impl LocalNameServer {
     async fn resolve_dns_request(
         nameserver: Arc<RwLock<LocalNameServer>>,
         request_info: &mut RequestInfo,
-    ) -> Result<Vec<u8>, String> {
+    ) -> Result<Vec<u8>, PacketError> {
         telio_log_debug!("Preparing DNS request");
         let dns_request = match &mut request_info.payload {
             PayloadRequestInfo::Udp {
                 ref mut dns_request,
                 ..
-            } => dns_request
-                .take()
-                .ok_or_else(|| String::from("Inexistent DNS request"))?,
+            } => dns_request.take().ok_or(PacketError::MissingDnsRequest)?,
             _ => return Ok(Vec::new()),
         };
 
@@ -307,7 +367,7 @@ impl LocalNameServer {
                 // build response packet bytes
                 DnsResponseBuilder::new(id, query, ttl.0, response_kind, recursion_desired)
                     .build()
-                    .map_err(|e| format!("Failed building DNS response packet: {e:?}"))?
+                    .map_err(PacketError::DnsResponseBuildFailed)?
             }
             PayloadDestination::Forward(raw_query) => {
                 let raw_forwarder = {
@@ -382,14 +442,14 @@ impl LocalNameServer {
         nameserver: Arc<RwLock<LocalNameServer>>,
         request_packet: &[u8],
         response_packet: &mut [u8],
-    ) -> Result<usize, String> {
+    ) -> Result<usize, PacketError> {
         let mut request_info = request_packet
             .first()
-            .ok_or_else(|| String::from("Empty request packet"))
+            .ok_or(PacketError::EmptyPacket)
             .and_then(|first_byte| match first_byte >> 4 {
                 4 => LocalNameServer::process_ip_packet::<Ipv4Packet>(request_packet),
                 6 => LocalNameServer::process_ip_packet::<Ipv6Packet>(request_packet),
-                _ => Err(String::from("Invalid IP version")),
+                _ => Err(PacketError::InvalidIpVersion(first_byte >> 4)),
             })?;
 
         let dns_response =
@@ -400,25 +460,24 @@ impl LocalNameServer {
 
     fn process_ip_packet<'a, P: IpPacket<'a>>(
         request_packet: &'a [u8],
-    ) -> Result<RequestInfo, String> {
-        let ip = P::try_from(request_packet)
-            .ok_or_else(|| String::from("Failed to build IpPacket from request packet"))?;
+    ) -> Result<RequestInfo, PacketError> {
+        let ip = P::try_from(request_packet).ok_or(PacketError::IpPacketCreationFailed)?;
 
         if !ip.check_valid() {
-            return Err(String::from("Invalid IpPacket"));
+            return Err(PacketError::InvalidIpPacket);
         }
 
         let payload = match ip.next_level_protocol() {
             IpNextHeaderProtocols::Udp => {
-                let udp_request = UdpPacket::new(ip.payload())
-                    .ok_or_else(|| String::from("Failed to build UdpPacket from request packet"))?;
+                let udp_request =
+                    UdpPacket::new(ip.payload()).ok_or(PacketError::UdpPacketCreationFailed)?;
                 LocalNameServer::process_udp_packet(&udp_request, |udp_packet| {
                     ip.udp_checksum(udp_packet)
                 })?
             }
             IpNextHeaderProtocols::Tcp => {
-                let tcp_request = TcpPacket::new(ip.payload())
-                    .ok_or_else(|| String::from("Failed to build TcpPacket from request packet"))?;
+                let tcp_request =
+                    TcpPacket::new(ip.payload()).ok_or(PacketError::TcpPacketCreationFailed)?;
                 PayloadRequestInfo::Tcp {
                     source_port: tcp_request.get_source(),
                     destination_port: tcp_request.get_destination(),
@@ -426,7 +485,7 @@ impl LocalNameServer {
                 }
             }
             _ => {
-                return Err(String::from("Invalid protocol for DNS request"));
+                return Err(PacketError::InvalidProtocol);
             }
         };
 
@@ -439,15 +498,15 @@ impl LocalNameServer {
     fn process_udp_packet<F: Fn(&UdpPacket) -> u16>(
         udp_request: &UdpPacket,
         get_checksum: F,
-    ) -> Result<PayloadRequestInfo, String> {
+    ) -> Result<PayloadRequestInfo, PacketError> {
         // Validate UDP checksum
         if get_checksum(udp_request) != udp_request.get_checksum() {
-            return Err(String::from("Invalid UDP checksum"));
+            return Err(PacketError::InvalidUdpChecksum);
         }
 
         // Validate DNS port
         if udp_request.get_destination() != DNS_PORT {
-            return Err(String::from("Invalid DNS port"));
+            return Err(PacketError::InvalidDnsPort(udp_request.get_destination()));
         }
 
         let payload = udp_request.payload();
@@ -468,7 +527,7 @@ impl LocalNameServer {
             }
             Err(e) => {
                 // malformed DNS query
-                return Err(format!("Failed to parse DNS payload: {e}"));
+                return Err(PacketError::DnsParseFailed(e));
             }
         };
 
@@ -575,7 +634,7 @@ impl RequestInfo {
         &self,
         dns_response: &[u8],
         response_packet: &mut [u8],
-    ) -> Result<usize, String> {
+    ) -> Result<usize, PacketError> {
         let payload_header = match self.payload {
             PayloadRequestInfo::Udp { .. } => UDP_HEADER,
             PayloadRequestInfo::Tcp { .. } => TCP_MIN_HEADER,
@@ -590,7 +649,7 @@ impl RequestInfo {
         &self,
         payload_length: usize,
         response_packet: &mut [u8],
-    ) -> Result<usize, String> {
+    ) -> Result<usize, PacketError> {
         match &self.ip {
             IpRequestInfo::V4 {
                 source_ip,
@@ -600,9 +659,8 @@ impl RequestInfo {
                 ttl,
                 identification,
             } => {
-                let mut ip_response = MutableIpv4Packet::new(response_packet).ok_or_else(|| {
-                    String::from("Failed to build MutableIpv4Packet for response packet")
-                })?;
+                let mut ip_response = MutableIpv4Packet::new(response_packet)
+                    .ok_or(PacketError::MutableIpv4PacketCreationFailed)?;
 
                 ip_response.set_version(4);
                 ip_response.set_header_length((IPV4_HEADER / 4) as u8);
@@ -632,9 +690,8 @@ impl RequestInfo {
                 source_ip,
                 destination_ip,
             } => {
-                let mut ip_response = MutableIpv6Packet::new(response_packet).ok_or_else(|| {
-                    String::from("Failed to build MutableIpv6Packet for response packet")
-                })?;
+                let mut ip_response = MutableIpv6Packet::new(response_packet)
+                    .ok_or(PacketError::MutableIpv6PacketCreationFailed)?;
 
                 ip_response.set_version(6);
                 ip_response.set_traffic_class(0);
@@ -663,7 +720,7 @@ impl RequestInfo {
         ihl: usize,
         dns_response: &[u8],
         response_packet: &mut [u8],
-    ) -> Result<usize, String> {
+    ) -> Result<usize, PacketError> {
         match self.payload {
             PayloadRequestInfo::Udp {
                 source_port,
@@ -673,11 +730,10 @@ impl RequestInfo {
                 let length = ihl + UDP_HEADER + dns_response.len();
                 let buffer_slice = response_packet
                     .get_mut(ihl..length)
-                    .ok_or_else(|| String::from("Out of bounds on response packet buffer"))?;
+                    .ok_or(PacketError::ResponseBufferOverflow)?;
 
-                let mut udp_response = MutableUdpPacket::new(buffer_slice).ok_or_else(|| {
-                    String::from("Failed to build MutableUdpPacket for response packet")
-                })?;
+                let mut udp_response = MutableUdpPacket::new(buffer_slice)
+                    .ok_or(PacketError::MutableUdpPacketCreationFailed)?;
 
                 udp_response.set_source(destination_port);
                 udp_response.set_destination(source_port);
@@ -698,10 +754,9 @@ impl RequestInfo {
                 let length = ihl + TCP_MIN_HEADER;
                 let buffer_slice = response_packet
                     .get_mut(ihl..length)
-                    .ok_or_else(|| String::from("Out of bounds on response packet buffer"))?;
-                let mut tcp_response = MutableTcpPacket::new(buffer_slice).ok_or_else(|| {
-                    String::from("Failed to build MutableTcpPacket for response packet")
-                })?;
+                    .ok_or(PacketError::ResponseBufferOverflow)?;
+                let mut tcp_response = MutableTcpPacket::new(buffer_slice)
+                    .ok_or(PacketError::MutableTcpPacketCreationFailed)?;
 
                 tcp_response.set_source(destination_port);
                 tcp_response.set_destination(source_port);
@@ -832,17 +887,10 @@ impl WithZones for Arc<RwLock<LocalNameServer>> {
 
 #[async_trait]
 impl NameServer for Arc<RwLock<LocalNameServer>> {
-    async fn upsert(
-        &self,
-        zone: &str,
-        records: &Records,
-        ttl_value: TtlValue,
-    ) -> Result<(), String> {
+    async fn upsert(&self, zone: &str, records: &Records, ttl_value: TtlValue) -> DnsResult<()> {
         if normalize_qname(zone) == NORD_ZONE {
             let mut ns = self.write().await;
-            ns.nord_zone
-                .upsert(records, ttl_value)
-                .map_err(|e| format!("Upsert failed: {e}"))?;
+            ns.nord_zone.upsert(records, ttl_value)?;
         }
 
         // TODO: LLT-7054: Remove AuthoritativeZone once migration is fully validated

--- a/crates/telio-dns/src/nameserver.rs
+++ b/crates/telio-dns/src/nameserver.rs
@@ -950,7 +950,8 @@ mod tests {
         rr::Name,
         serialize::binary::{BinDecoder, BinEncodable},
     };
-    use std::{net::Ipv4Addr, str::FromStr};
+    use std::net::{Ipv4Addr, Ipv6Addr};
+    use std::str::FromStr;
 
     const USE_RAW_FORWARDER: bool = true;
 
@@ -1085,5 +1086,244 @@ mod tests {
 
         let ns = nameserver.read().await;
         assert!(ns.forwarder.is_none());
+    }
+    
+    // PacketError internal unit tests
+
+    const SRC_IPV4: Ipv4Addr = Ipv4Addr::new(10, 0, 0, 1);
+    const DST_IPV4: Ipv4Addr = Ipv4Addr::new(10, 0, 0, 2);
+
+    /// Helper: build IPv4 packet with the given next-level protocol and payload.
+    fn build_ipv4_packet(protocol: IpNextHeaderProtocol, payload: &[u8]) -> Vec<u8> {
+        let total_len = IPV4_HEADER + payload.len();
+        let mut buf = vec![0u8; total_len];
+        {
+            let mut ip = MutableIpv4Packet::new(&mut buf).unwrap();
+            ip.set_version(4);
+            ip.set_header_length(5);
+            ip.set_total_length(total_len as u16);
+            ip.set_ttl(64);
+            ip.set_next_level_protocol(protocol);
+            ip.set_source(SRC_IPV4);
+            ip.set_destination(DST_IPV4);
+            ip.set_payload(payload);
+            ip.set_checksum(0);
+            ip.set_checksum(checksum(&ip.to_immutable()));
+        }
+        buf
+    }
+
+    /// Helper: build UDP segment with correct IPv4 checksum for SRC_IPV4 / DST_IPV4.
+    fn build_udp_segment(src_port: u16, dst_port: u16, data: &[u8]) -> Vec<u8> {
+        let len = UDP_HEADER + data.len();
+        let mut buf = vec![0u8; len];
+        {
+            let mut udp = MutableUdpPacket::new(&mut buf).unwrap();
+            udp.set_source(src_port);
+            udp.set_destination(dst_port);
+            udp.set_length(len as u16);
+            udp.set_payload(data);
+            udp.set_checksum(0);
+            udp.set_checksum(ipv4_checksum(&udp.to_immutable(), &SRC_IPV4, &DST_IPV4));
+        }
+        buf
+    }
+
+    /// Helper to create local NameServer (used to test packet processing)
+    async fn test_nameserver() -> Arc<RwLock<LocalNameServer>> {
+        LocalNameServer::new(&[IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))])
+            .await
+            .unwrap()
+    }
+
+    // Tests PacketError::EmptyPacket
+    #[tokio::test]
+    async fn packet_error_empty_packet() {
+        let ns = test_nameserver().await;
+        let mut response = vec![0u8; MAX_PACKET];
+        let result = LocalNameServer::process_packet(ns, &[], &mut response).await;
+        assert!(matches!(result, Err(PacketError::EmptyPacket)));
+    }
+
+    // Tests PacketError::InvalidIpVersion
+    #[tokio::test]
+    async fn packet_error_invalid_ip_version() {
+        let ns = test_nameserver().await;
+        let mut response = vec![0u8; MAX_PACKET];
+        // Version 3: first byte 0x30, 0x30 >> 4 == 3
+        let result = LocalNameServer::process_packet(ns, &[0x30], &mut response).await;
+        assert!(matches!(result, Err(PacketError::InvalidIpVersion(3))));
+    }
+
+    // Tests PacketError::IpPacketCreationFailed
+    #[test]
+    fn packet_error_ip_packet_creation_failed() {
+        // Buffer too short for a 20-byte IPv4 header
+        let short = [0x45; 4];
+        let result = LocalNameServer::process_ip_packet::<Ipv4Packet>(&short);
+        assert!(matches!(result, Err(PacketError::IpPacketCreationFailed)));
+    }
+
+    // Tests PacketError::InvalidIpPacket
+    #[test]
+    fn packet_error_invalid_ip_packet() {
+        let mut packet = build_ipv4_packet(IpNextHeaderProtocols::Udp, &[0; UDP_HEADER]);
+        // Corrupt TTL (byte 8) so the IP checksum no longer matches
+        packet[8] ^= 0xFF;
+        let result = LocalNameServer::process_ip_packet::<Ipv4Packet>(&packet);
+        assert!(matches!(result, Err(PacketError::InvalidIpPacket)));
+    }
+
+    // Tests PacketError::InvalidProtocol
+    #[test]
+    fn packet_error_invalid_protocol() {
+        let packet = build_ipv4_packet(IpNextHeaderProtocols::Icmp, &[0; 8]);
+        let result = LocalNameServer::process_ip_packet::<Ipv4Packet>(&packet);
+        assert!(matches!(result, Err(PacketError::InvalidProtocol)));
+    }
+
+    // Tests PacketError::UdpPacketCreationFailed
+    #[test]
+    fn packet_error_udp_packet_creation_failed() {
+        // Valid IPv4 header with UDP protocol, but only 2 bytes of payload (need 8)
+        let packet = build_ipv4_packet(IpNextHeaderProtocols::Udp, &[0; 2]);
+        let result = LocalNameServer::process_ip_packet::<Ipv4Packet>(&packet);
+        assert!(matches!(result, Err(PacketError::UdpPacketCreationFailed)));
+    }
+
+    // Tests PacketError::TcpPacketCreationFailed
+    #[test]
+    fn packet_error_tcp_packet_creation_failed() {
+        // Valid IPv4 header with TCP protocol, but only 2 bytes of payload (need 20)
+        let packet = build_ipv4_packet(IpNextHeaderProtocols::Tcp, &[0; 2]);
+        let result = LocalNameServer::process_ip_packet::<Ipv4Packet>(&packet);
+        assert!(matches!(result, Err(PacketError::TcpPacketCreationFailed)));
+    }
+
+    // Tests PacketError::InvalidUdpChecksum
+    #[test]
+    fn packet_error_invalid_udp_checksum() {
+        let mut udp_seg = build_udp_segment(12345, 53, &[0; 4]);
+        // Corrupt UDP checksum (bytes 6-7)
+        udp_seg[6] ^= 0xFF;
+        let packet = build_ipv4_packet(IpNextHeaderProtocols::Udp, &udp_seg);
+        let result = LocalNameServer::process_ip_packet::<Ipv4Packet>(&packet);
+        assert!(matches!(result, Err(PacketError::InvalidUdpChecksum)));
+    }
+
+    // Tests PacketError::InvalidDnsPort
+    #[test]
+    fn packet_error_invalid_dns_port() {
+        let udp_seg = build_udp_segment(12345, 80, &[0; 4]);
+        let packet = build_ipv4_packet(IpNextHeaderProtocols::Udp, &udp_seg);
+        let result = LocalNameServer::process_ip_packet::<Ipv4Packet>(&packet);
+        assert!(matches!(result, Err(PacketError::InvalidDnsPort(80))));
+    }
+
+    // Tests PacketError::DecodeMessageRequestFailed
+    #[tokio::test]
+    async fn packet_error_decode_message_request_failed() {
+        // A DNS payload that passes parse_dns_query_packet() (pnet is lenient) but fails
+        // MessageRequest::from_bytes() (hickory-dns is stricter).
+        //
+        // DNS header: ID=0x1234, flags=0x0100 (standard query, RD=1),
+        // QDCOUNT=1, all other counts=0.
+        // Question section: a valid label "a" (0x01, 0x61) followed by root (0x00),
+        // but QTYPE and QCLASS are missing — pnet reads query_count from header and
+        // doesn't validate the question body, but hickory requires complete QTYPE+QCLASS.
+        #[rustfmt::skip]
+        let dns_payload: &[u8] = &[
+            0x12, 0x34, // ID
+            0x01, 0x00, // flags: QR=0 (query), opcode=0 (standard), RD=1
+            0x00, 0x01, // QDCOUNT = 1
+            0x00, 0x00, // ANCOUNT = 0
+            0x00, 0x00, // NSCOUNT = 0
+            0x00, 0x00, // ARCOUNT = 0
+            // Question name: "a." (label len=1, 'a', root terminator)
+            0x01, b'a', 0x00,
+            // QTYPE and QCLASS intentionally missing → hickory fails to decode
+        ];
+        let udp_seg = build_udp_segment(12345, 53, dns_payload);
+        let packet = build_ipv4_packet(IpNextHeaderProtocols::Udp, &udp_seg);
+        let ns = test_nameserver().await;
+        let mut response = vec![0u8; MAX_PACKET];
+        let result = LocalNameServer::process_packet(ns, &packet, &mut response).await;
+        assert!(matches!(
+            result,
+            Err(PacketError::DecodeMessageRequestFailed)
+        ));
+    }
+
+    // Tests PacketError::MutableIpv4PacketCreationFailed
+    #[test]
+    fn packet_error_mutable_ipv4_packet_creation_failed() {
+        let info = RequestInfo {
+            ip: IpRequestInfo::V4 {
+                source_ip: SRC_IPV4,
+                destination_ip: DST_IPV4,
+                dscp: 0,
+                ecn: 0,
+                ttl: 64,
+                identification: 0,
+            },
+            payload: PayloadRequestInfo::Udp {
+                source_port: 12345,
+                destination_port: 53,
+                dns_request: None,
+            },
+        };
+        let mut buf = vec![0u8; 4]; // too small for 20-byte IPv4 header
+        let result = info.build_ip_header(0, &mut buf);
+        assert!(matches!(
+            result,
+            Err(PacketError::MutableIpv4PacketCreationFailed)
+        ));
+    }
+
+    // Tests PacketError::MutableIpv6PacketCreationFailed
+    #[test]
+    fn packet_error_mutable_ipv6_packet_creation_failed() {
+        let info = RequestInfo {
+            ip: IpRequestInfo::V6 {
+                source_ip: Ipv6Addr::LOCALHOST,
+                destination_ip: Ipv6Addr::LOCALHOST,
+            },
+            payload: PayloadRequestInfo::Udp {
+                source_port: 12345,
+                destination_port: 53,
+                dns_request: None,
+            },
+        };
+        let mut buf = vec![0u8; 4]; // too small for 40-byte IPv6 header
+        let result = info.build_ip_header(0, &mut buf);
+        assert!(matches!(
+            result,
+            Err(PacketError::MutableIpv6PacketCreationFailed)
+        ));
+    }
+
+    // Tests PacketError::ResponseBufferOverflow
+    #[test]
+    fn packet_error_response_buffer_overflow() {
+        let info = RequestInfo {
+            ip: IpRequestInfo::V4 {
+                source_ip: SRC_IPV4,
+                destination_ip: DST_IPV4,
+                dscp: 0,
+                ecn: 0,
+                ttl: 64,
+                identification: 0,
+            },
+            payload: PayloadRequestInfo::Udp {
+                source_port: 12345,
+                destination_port: 53,
+                dns_request: None,
+            },
+        };
+        let dns_response = vec![0u8; 100];
+        // Too small buffer: here is a room for IP header but not for UDP header + 100-byte payload
+        let mut buf = vec![0u8; IPV4_HEADER + 4];
+        let result = info.build_payload(IPV4_HEADER, &dns_response, &mut buf);
+        assert!(matches!(result, Err(PacketError::ResponseBufferOverflow)));
     }
 }

--- a/crates/telio-dns/src/zone.rs
+++ b/crates/telio-dns/src/zone.rs
@@ -843,3 +843,30 @@ mod tests {
         assert!(!nz.records.contains_key("bob.nord."));
     }
 }
+
+#[cfg(test)]
+mod error_tests {
+    use super::*;
+    use std::net::IpAddr;
+    use telio_model::features::TtlValue;
+
+    // Helper for tests: creates Records with one entry (domain, ip)
+    // Used to test zone validation
+    fn make_records(domain: &str, ip: IpAddr) -> Records {
+        let mut records = Records::new();
+        records.insert(domain.to_string(), vec![ip]);
+        records
+    }
+
+    // Test: returns Error::RecordOutsideZone if record domain does not match zone
+    #[tokio::test]
+    async fn returns_record_outside_zone_error() {
+        let records = make_records("domain.bad.", IpAddr::from([1, 2, 3, 4]));
+        let result = AuthoritativeZone::new("nord", &records, TtlValue(60)).await;
+        assert!(matches!(
+            result,
+            Err(Error::RecordOutsideZone(ref domain, ref zone))
+                if domain == "domain.bad." && zone == "nord"
+        ));
+    }
+}

--- a/crates/telio-dns/src/zone.rs
+++ b/crates/telio-dns/src/zone.rs
@@ -23,6 +23,7 @@ use telio_model::features::TtlValue;
 use telio_utils::{telio_log_debug, telio_log_warn};
 use thiserror::Error;
 
+use crate::error::{Error, Result as DnsResult};
 pub(crate) const NORD_ZONE: &str = "nord.";
 pub(crate) const NORD_ZONE_SUFFIX: &str = ".nord.";
 
@@ -38,7 +39,7 @@ pub type Records = HashMap<String, Vec<IpAddr>>;
 
 /// Errors returned by local nord zone resolver
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
-pub(crate) enum NordZoneError {
+pub enum NordZoneError {
     /// Record contains a non nord entry
     #[error("record contains non-nord entry {0}")]
     NonNordRecord(String),
@@ -192,15 +193,11 @@ pub(crate) struct AuthoritativeZone {
 }
 
 impl AuthoritativeZone {
-    pub(crate) async fn new(
-        name: &str,
-        records: &Records,
-        ttl_value: TtlValue,
-    ) -> Result<Self, String> {
+    pub(crate) async fn new(name: &str, records: &Records, ttl_value: TtlValue) -> DnsResult<Self> {
         // TODO: rewrite code so that this assert is not needed.
         for domain in records.keys() {
             if !domain.contains(name) {
-                return Err(format!("{domain} does not end with {name}"));
+                return Err(Error::RecordOutsideZone(domain.into(), name.into()));
             }
         }
         let zone_name = Name::from_str(name)?;
@@ -329,7 +326,7 @@ pub(crate) struct ForwardZone {
 }
 
 impl ForwardZone {
-    pub(crate) async fn new(name: &str, ips: &[IpAddr]) -> Result<Self, String> {
+    pub(crate) async fn new(name: &str, ips: &[IpAddr]) -> DnsResult<Self> {
         let mut options = ResolverOpts::default();
         // Some tools and browsers do not accept responses without intermediates preserved
         options.preserve_intermediates = true;

--- a/src/device.rs
+++ b/src/device.rs
@@ -147,7 +147,7 @@ pub enum Error {
     #[error("Failed to set fwmark for WG socket")]
     WgFwmark,
     #[error("DNS resolver error: {0}")]
-    DnsResolverError(String),
+    DnsResolverError(#[from] telio_dns::error::Error),
     #[error("DNS module should be disabled when executing this operation")]
     DnsNotDisabled,
     #[error("Failed to reconnect to DERP server")]
@@ -1717,8 +1717,7 @@ impl Runtime {
             peers.extend(wildcarded_peers);
 
             dns.upsert("nord", &peers, self.features.dns.ttl_value)
-                .await
-                .map_err(Error::DnsResolverError)?;
+                .await?;
         }
 
         Ok(())


### PR DESCRIPTION
### Problem

The `telio-dns` crate was using `String` as the error type across both public API and internal logic. This made error handling non-idiomatic and limited:

- no ability to match on specific error types
- error handling required string parsing at call sites
- inconsistent error propagation across modules
- reduced clarity of failure modes in the public API

Additionally, there was no clear separation between errors that are part of the public API contract and those used internally for DNS packet processing.

---

### Solution

Refactored error handling in `telio-dns` to use typed enums instead of `String`,
with a clear separation between public and internal error domains.

Key changes:

- Introduced a public `Error` enum (in `error.rs`) and `Result<T>` alias
- Introduced DnsIoError enum to wrap io::Error with context
- Replaced all `Result<_, String>` in the public API with typed errors
- Updated public traits (`DnsResolver`, `NameServer`) and constructors to return `Error`
- Defined a separate internal `PacketError` enum (in `nameserver.rs`) for DNS packet parsing and runtime errors
- Ensured internal errors are not exposed through the public API
- Replaced manual `format!`-based error construction with structured error variants
- Updated code outside of the `telio-dns` ( `device.rs`) to use typed errors and `From` for propagation

Additionally:
- Replaced `DnsResolverError(String)` with `DnsResolverError(#[from] telio_dns::error::Error)`
  to enable automatic error propagation via `?`

This change introduces a clean boundary between:
- **public API errors** (stable, typed, exposed via `Error`)
- **internal runtime errors** (private, implementation-specific via `PacketError`)

As a result, the API will be more robust, type-safe, and easier to extend without breaking external contracts.

### To do in the future (not subject of this PR):
- Refactor the codebase to enable dependency injection for key components, especially in the DNS server logic. This would allow unit tests to simulate errors from external modules (such as Neptune) or the OS, making it possible to test error propagation and handling in the public API.
- Currently, it is not feasible to fully test error scenarios in the DNS server using unit tests, because the code structure does not allow for mocking or simulating failures in dependencies like Neptune or system calls. As a result, some error-handling paths in the public API cannot be reliably covered by unit tests.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
