### PR TITLE
Fix unbounded memory usage during async http get requests in rust-igd

### DIFF
--- a/.unreleased/LLT-6230
+++ b/.unreleased/LLT-6230
@@ -1,1 +1,1 @@
-Fix possible DoS triggered by failed SSDP Search request
+Fix possible DoS triggered by failed SSDP Search request and by large http get body

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2326,8 +2326,13 @@ dependencies = [
 [[package]]
 name = "igd"
 version = "0.12.1"
-source = "git+https://github.com/NordSecurity/rust-igd.git?tag=v0.13.1#4ade34656729c2ce1fd93d9399488e5b8a2eeacb"
+source = "git+https://github.com/NordSecurity/rust-igd.git?tag=v0.13.2#d45266b27d01748c661d5e4f0e6da7782eda33b5"
 dependencies = [
+ "bytes",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
  "log",
  "rand 0.8.5",
  "reqwest",

--- a/crates/telio-traversal/Cargo.toml
+++ b/crates/telio-traversal/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 bytecodec = "0.5.0"
-igd = { git = "https://github.com/NordSecurity/rust-igd.git", tag = "v0.13.1", features = ["aio"], default-features = false }
+igd = { git = "https://github.com/NordSecurity/rust-igd.git", tag = "v0.13.2", features = ["aio"], default-features = false }
 stun_codec = "0.4"
 
 async-trait.workspace = true


### PR DESCRIPTION
### Problem
Before this change, it was possible for the malicious upnp gateway to trigger arbitrary large memory allocations on the client.
### Solution
This change caps the memory usage for both the HTTP headers and body.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
