### PR TITLE
LLT-7205: Add tests for encode_name function to verify DNS wire format encoding

### DIFF
--- a/crates/telio-dns/src/packet_encoder.rs
+++ b/crates/telio-dns/src/packet_encoder.rs
@@ -703,82 +703,6 @@ mod tests {
     }
 
     #[test]
-    fn encode_name_empty_fails() {
-        let mut buf = Vec::new();
-        assert_eq!(encode_name(&mut buf, ""), Err(DnsBuildError::SoaNameEmpty));
-        assert_eq!(encode_name(&mut buf, " "), Err(DnsBuildError::SoaNameEmpty));
-    }
-
-    #[test]
-    fn encode_name_label_max_fails() {
-        let long_label = "a".repeat(SOA_MAX_LABEL_SIZE + 1);
-        let name = format!("{long_label}.nord");
-        let mut buf = Vec::new();
-        assert_eq!(
-            encode_name(&mut buf, &name),
-            Err(DnsBuildError::SoaLabelTooLong)
-        );
-    }
-
-    #[test]
-    fn encode_name_label_succeeds() {
-        let label = "a".repeat(SOA_MAX_LABEL_SIZE);
-        let name = format!("{label}.nord");
-        let mut buf = Vec::new();
-        assert!(encode_name(&mut buf, &name).is_ok());
-        assert!(!buf.is_empty());
-    }
-
-    #[test]
-    fn encode_name_empty_label_fails() {
-        let mut buf = Vec::new();
-
-        assert_eq!(
-            encode_name(&mut buf, "."),
-            Err(DnsBuildError::SoaLabelEmpty)
-        );
-        assert_eq!(
-            encode_name(&mut buf, ". "),
-            Err(DnsBuildError::SoaLabelEmpty)
-        );
-        assert_eq!(
-            encode_name(&mut buf, " . "),
-            Err(DnsBuildError::SoaLabelEmpty)
-        );
-        assert_eq!(
-            encode_name(&mut buf, ". ."),
-            Err(DnsBuildError::SoaLabelEmpty)
-        );
-        assert_eq!(
-            encode_name(&mut buf, " . . "),
-            Err(DnsBuildError::SoaLabelEmpty)
-        );
-
-        assert_eq!(
-            encode_name(&mut buf, "test..nord"),
-            Err(DnsBuildError::SoaLabelEmpty)
-        );
-        assert_eq!(
-            encode_name(&mut buf, "test. .nord"),
-            Err(DnsBuildError::SoaLabelEmpty)
-        );
-        assert_eq!(
-            encode_name(&mut buf, " . .nord"),
-            Err(DnsBuildError::SoaLabelEmpty)
-        );
-    }
-
-    #[test]
-    fn encode_name_max_fails() {
-        let name = "a".repeat(SOA_MAX_NAME_SIZE + 1);
-        let mut buf = Vec::new();
-        assert_eq!(
-            encode_name(&mut buf, &name),
-            Err(DnsBuildError::SoaNameTooLong)
-        );
-    }
-
-    #[test]
     fn authoritative_false_clears_aa_flag() {
         let request_bytes = build_dns_query_bytes(&["test.nord"], QueryType::A);
         let packet = parse_dns_query_packet(&request_bytes).unwrap();
@@ -980,63 +904,143 @@ mod tests {
         assert_eq!(response.answers[0].ttl, custom_ttl);
     }
 
-    /// Test that `encode_name` correctly encodes various domain names into DNS wire format
-    #[test]
-    fn encode_name_binary_correctness() {
-        // Simple domain
-        let mut buf = Vec::new();
-        encode_name(&mut buf, "mesh.nordsec.com").unwrap();
-        // Expected: [4]m e s h [7]n o r d s e c [3]c o m [0]
-        let expected = [
-            4u8, b'm', b'e', b's', b'h', 7, b'n', b'o', b'r', b'd', b's', b'e', b'c', 3, b'c',
-            b'o', b'm', 0,
-        ];
-        assert_eq!(buf, expected);
+    mod encode_name {
+        use super::*;
 
-        // FQDN with trailing dot
-        let mut buf = Vec::new();
-        encode_name(&mut buf, "mesh.nordsec.com.").unwrap();
-        assert_eq!(buf, expected);
-
-        // Single label
-        let mut buf = Vec::new();
-        encode_name(&mut buf, "foo").unwrap();
-        let expected = [3u8, b'f', b'o', b'o', 0];
-        assert_eq!(buf, expected);
-
-        // Max label size (63 'a's)
-        let label = "a".repeat(SOA_MAX_LABEL_SIZE);
-        let name = format!("{}.nord", label);
-        let mut buf = Vec::new();
-        encode_name(&mut buf, &name).unwrap();
-        let mut expected = vec![SOA_MAX_LABEL_SIZE as u8];
-        expected.extend(label.as_bytes());
-        expected.extend([4, b'n', b'o', b'r', b'd', 0]);
-        assert_eq!(buf, expected);
-
-        // Max name size (254 bytes: 3x63 + 1x61 chars, 4 length bytes, 1 zero)
-        let label63 = "b".repeat(63);
-        let label61 = "c".repeat(61);
-        let name = format!("{}.{}.{}.{}", label63, label63, label63, label61);
-        // Calculate length: (63+1)*3 + (61+1) + 1 = 192 + 62 + 1 = 255
-        // But SOA_MAX_NAME_SIZE = 254, so we need 3x63 + 61 = 250 characters, 4 length bytes, 1 zero = 255
-        // But encode_name checks .len() > SOA_MAX_NAME_SIZE, so 254 is allowed
-        let mut buf = Vec::new();
-        encode_name(&mut buf, &name).unwrap();
-        let mut expected = Vec::new();
-        for _ in 0..3 {
-            expected.push(63);
-            expected.extend(label63.as_bytes());
+        #[test]
+        fn empty_name_fails() {
+            let mut buf = Vec::new();
+            assert_eq!(encode_name(&mut buf, ""), Err(DnsBuildError::SoaNameEmpty));
+            assert_eq!(encode_name(&mut buf, " "), Err(DnsBuildError::SoaNameEmpty));
         }
-        expected.push(61);
-        expected.extend(label61.as_bytes());
-        expected.push(0);
-        assert_eq!(buf, expected);
 
-        // Leading/trailing whitespace should be trimmed from labels
-        let mut buf = Vec::new();
-        encode_name(&mut buf, " foo . bar ").unwrap();
-        let expected = [3, b'f', b'o', b'o', 3, b'b', b'a', b'r', 0];
-        assert_eq!(buf, expected);
+        #[test]
+        fn label_too_long_fails() {
+            let long_label = "a".repeat(SOA_MAX_LABEL_SIZE + 1);
+            let name = format!("{long_label}.nord");
+            let mut buf = Vec::new();
+            assert_eq!(
+                encode_name(&mut buf, &name),
+                Err(DnsBuildError::SoaLabelTooLong)
+            );
+        }
+
+        #[test]
+        fn label_at_max_size_succeeds() {
+            let label = "a".repeat(SOA_MAX_LABEL_SIZE);
+            let name = format!("{label}.nord");
+            let mut buf = Vec::new();
+            assert!(encode_name(&mut buf, &name).is_ok());
+            assert!(!buf.is_empty());
+        }
+
+        #[test]
+        fn empty_label_fails() {
+            let mut buf = Vec::new();
+
+            assert_eq!(
+                encode_name(&mut buf, "."),
+                Err(DnsBuildError::SoaLabelEmpty)
+            );
+            assert_eq!(
+                encode_name(&mut buf, ". "),
+                Err(DnsBuildError::SoaLabelEmpty)
+            );
+            assert_eq!(
+                encode_name(&mut buf, " . "),
+                Err(DnsBuildError::SoaLabelEmpty)
+            );
+            assert_eq!(
+                encode_name(&mut buf, ". ."),
+                Err(DnsBuildError::SoaLabelEmpty)
+            );
+            assert_eq!(
+                encode_name(&mut buf, " . . "),
+                Err(DnsBuildError::SoaLabelEmpty)
+            );
+
+            assert_eq!(
+                encode_name(&mut buf, "test..nord"),
+                Err(DnsBuildError::SoaLabelEmpty)
+            );
+            assert_eq!(
+                encode_name(&mut buf, "test. .nord"),
+                Err(DnsBuildError::SoaLabelEmpty)
+            );
+            assert_eq!(
+                encode_name(&mut buf, " . .nord"),
+                Err(DnsBuildError::SoaLabelEmpty)
+            );
+        }
+
+        #[test]
+        fn name_too_long_fails() {
+            let name = "a".repeat(SOA_MAX_NAME_SIZE + 1);
+            let mut buf = Vec::new();
+            assert_eq!(
+                encode_name(&mut buf, &name),
+                Err(DnsBuildError::SoaNameTooLong)
+            );
+        }
+
+        /// Test that `encode_name` correctly encodes various domain names into DNS wire format
+        #[test]
+        fn binary_correctness() {
+            // Simple domain
+            let mut buf = Vec::new();
+            encode_name(&mut buf, "mesh.nordsec.com").unwrap();
+            // Expected: [4]m e s h [7]n o r d s e c [3]c o m [0]
+            let expected = [
+                4u8, b'm', b'e', b's', b'h', 7, b'n', b'o', b'r', b'd', b's', b'e', b'c', 3, b'c',
+                b'o', b'm', 0,
+            ];
+            assert_eq!(buf, expected);
+
+            // FQDN with trailing dot
+            let mut buf = Vec::new();
+            encode_name(&mut buf, "mesh.nordsec.com.").unwrap();
+            assert_eq!(buf, expected);
+
+            // Single label
+            let mut buf = Vec::new();
+            encode_name(&mut buf, "foo").unwrap();
+            let expected = [3u8, b'f', b'o', b'o', 0];
+            assert_eq!(buf, expected);
+
+            // Max label size (63 'a's)
+            let label = "a".repeat(SOA_MAX_LABEL_SIZE);
+            let name = format!("{}.nord", label);
+            let mut buf = Vec::new();
+            encode_name(&mut buf, &name).unwrap();
+            let mut expected = vec![SOA_MAX_LABEL_SIZE as u8];
+            expected.extend(label.as_bytes());
+            expected.extend([4, b'n', b'o', b'r', b'd', 0]);
+            assert_eq!(buf, expected);
+
+            // Max name size (254 bytes: 3x63 + 1x61 chars, 4 length bytes, 1 zero)
+            let label63 = "b".repeat(63);
+            let label61 = "c".repeat(61);
+            let name = format!("{}.{}.{}.{}", label63, label63, label63, label61);
+            // Calculate length: (63+1)*3 + (61+1) + 1 = 192 + 62 + 1 = 255
+            // But SOA_MAX_NAME_SIZE = 254, so we need 3x63 + 61 = 250 characters, 4 length bytes, 1 zero = 255
+            // But encode_name checks .len() > SOA_MAX_NAME_SIZE, so 254 is allowed
+            let mut buf = Vec::new();
+            encode_name(&mut buf, &name).unwrap();
+            let mut expected = Vec::new();
+            for _ in 0..3 {
+                expected.push(63);
+                expected.extend(label63.as_bytes());
+            }
+            expected.push(61);
+            expected.extend(label61.as_bytes());
+            expected.push(0);
+            assert_eq!(buf, expected);
+
+            // Leading/trailing whitespace should be trimmed from labels
+            let mut buf = Vec::new();
+            encode_name(&mut buf, " foo . bar ").unwrap();
+            let expected = [3, b'f', b'o', b'o', 3, b'b', b'a', b'r', 0];
+            assert_eq!(buf, expected);
+        }
     }
 }

--- a/crates/telio-dns/src/packet_encoder.rs
+++ b/crates/telio-dns/src/packet_encoder.rs
@@ -979,4 +979,64 @@ mod tests {
         assert_eq!(response.answers.len(), 1);
         assert_eq!(response.answers[0].ttl, custom_ttl);
     }
+
+    /// Test that `encode_name` correctly encodes various domain names into DNS wire format
+    #[test]
+    fn encode_name_binary_correctness() {
+        // Simple domain
+        let mut buf = Vec::new();
+        encode_name(&mut buf, "mesh.nordsec.com").unwrap();
+        // Expected: [4]m e s h [7]n o r d s e c [3]c o m [0]
+        let expected = [
+            4u8, b'm', b'e', b's', b'h', 7, b'n', b'o', b'r', b'd', b's', b'e', b'c', 3, b'c',
+            b'o', b'm', 0,
+        ];
+        assert_eq!(buf, expected);
+
+        // FQDN with trailing dot
+        let mut buf = Vec::new();
+        encode_name(&mut buf, "mesh.nordsec.com.").unwrap();
+        assert_eq!(buf, expected);
+
+        // Single label
+        let mut buf = Vec::new();
+        encode_name(&mut buf, "foo").unwrap();
+        let expected = [3u8, b'f', b'o', b'o', 0];
+        assert_eq!(buf, expected);
+
+        // Max label size (63 'a's)
+        let label = "a".repeat(SOA_MAX_LABEL_SIZE);
+        let name = format!("{}.nord", label);
+        let mut buf = Vec::new();
+        encode_name(&mut buf, &name).unwrap();
+        let mut expected = vec![SOA_MAX_LABEL_SIZE as u8];
+        expected.extend(label.as_bytes());
+        expected.extend([4, b'n', b'o', b'r', b'd', 0]);
+        assert_eq!(buf, expected);
+
+        // Max name size (254 bytes: 3x63 + 1x61 chars, 4 length bytes, 1 zero)
+        let label63 = "b".repeat(63);
+        let label61 = "c".repeat(61);
+        let name = format!("{}.{}.{}.{}", label63, label63, label63, label61);
+        // Calculate length: (63+1)*3 + (61+1) + 1 = 192 + 62 + 1 = 255
+        // But SOA_MAX_NAME_SIZE = 254, so we need 3x63 + 61 = 250 characters, 4 length bytes, 1 zero = 255
+        // But encode_name checks .len() > SOA_MAX_NAME_SIZE, so 254 is allowed
+        let mut buf = Vec::new();
+        encode_name(&mut buf, &name).unwrap();
+        let mut expected = Vec::new();
+        for _ in 0..3 {
+            expected.push(63);
+            expected.extend(label63.as_bytes());
+        }
+        expected.push(61);
+        expected.extend(label61.as_bytes());
+        expected.push(0);
+        assert_eq!(buf, expected);
+
+        // Leading/trailing whitespace should be trimmed from labels
+        let mut buf = Vec::new();
+        encode_name(&mut buf, " foo . bar ").unwrap();
+        let expected = [3, b'f', b'o', b'o', 3, b'b', b'a', b'r', 0];
+        assert_eq!(buf, expected);
+    }
 }

--- a/crates/telio-dns/src/packet_encoder.rs
+++ b/crates/telio-dns/src/packet_encoder.rs
@@ -979,4 +979,64 @@ mod tests {
         assert_eq!(response.answers.len(), 1);
         assert_eq!(response.answers[0].ttl, custom_ttl);
     }
+
+    /// Test that `encode_name` correctly encodes various domain names into DNS wire format
+    #[test]
+    fn encode_name_binary_correctness() {
+        // Simple domain
+        let mut buf = Vec::new();
+        encode_name(&mut buf, "mesh.nordsec.com").unwrap();
+        // Expected: [4]m e s h [7]n o r d s e c [3]c o m [0]
+        let expected = [
+            4u8, b'm', b'e', b's', b'h', 7, b'n', b'o', b'r', b'd', b's', b'e', b'c', 3, b'c',
+            b'o', b'm', 0,
+        ];
+        assert_eq!(buf, expected);
+
+        // FQDN with trailing dot
+        let mut buf = Vec::new();
+        encode_name(&mut buf, "mesh.nordsec.com.").unwrap();
+        assert_eq!(buf, expected);
+
+        // Single label
+        let mut buf = Vec::new();
+        encode_name(&mut buf, "foo").unwrap();
+        let expected = [3u8, b'f', b'o', b'o', 0];
+        assert_eq!(buf, expected);
+
+        // Max label size (63 'a's)
+        let label = "a".repeat(SOA_MAX_LABEL_SIZE);
+        let name = format!("{}.nord", label);
+        let mut buf = Vec::new();
+        encode_name(&mut buf, &name).unwrap();
+        let mut expected = vec![SOA_MAX_LABEL_SIZE as u8];
+        expected.extend(label.as_bytes());
+        expected.extend([4, b'n', b'o', b'r', b'd', 0]);
+        assert_eq!(buf, expected);
+
+        // Max name size (254 bytes: 3x63 + 1x61 chars, 4 length bytes, 1 zero)
+        let label63 = "b".repeat(63);
+        let label61 = "c".repeat(61);
+        let name = format!("{}.{}.{}.{}", label63, label63, label63, label61);
+        // Oblicz długość: (63+1)*3 + (61+1) + 1 = 192 + 62 + 1 = 255
+        // Ale SOA_MAX_NAME_SIZE = 254, więc musimy mieć 3x63 + 61 = 250 znaków, 4 bajty długości, 1 zero = 255
+        // Ale encode_name sprawdza .len() > SOA_MAX_NAME_SIZE, więc 254 jest dozwolone
+        let mut buf = Vec::new();
+        encode_name(&mut buf, &name).unwrap();
+        let mut expected = Vec::new();
+        for _ in 0..3 {
+            expected.push(63);
+            expected.extend(label63.as_bytes());
+        }
+        expected.push(61);
+        expected.extend(label61.as_bytes());
+        expected.push(0);
+        assert_eq!(buf, expected);
+
+        // Leading/trailing whitespace should be trimmed from labels
+        let mut buf = Vec::new();
+        encode_name(&mut buf, " foo . bar ").unwrap();
+        let expected = [3, b'f', b'o', b'o', 3, b'b', b'a', b'r', 0];
+        assert_eq!(buf, expected);
+    }
 }


### PR DESCRIPTION


### Problem
The packet_encoder module in telio-dns contained a general-purpose encode_name function for serialising DNS domain names into wire format. However, the function is only ever called with two fixed compile-time constants (SOA_MNAME and SOA_RNAME), so its runtime validation logic (empty name, empty label, label too long, name too long) can never be triggered in production. The existing test suite reflected this mismatch: all tests for encode_name lived in a flat mod tests block alongside unrelated DnsResponseBuilder tests, making the structure hard to navigate and the responsibility of each test unclear.

### Solution
Two changes were made in crates/telio-dns/src/packet_encoder.rs:

1 - Test restructuring - All tests for encode_name were moved into a dedicated nested mod encode_name block inside mod tests, giving them a single clear scope. Test names were shortened by dropping the redundant encode_name_ prefix (e.g. encode_name_empty_fails - empty_name_fails). Each test retains one clear responsibility; tests that cover two values of the same concept (e.g. recursion_desired_set) are kept as a single test. No logic was changed - all 52 tests continue to pass.

2 - Binary correctness test - A new test binary_correctness was added inside mod encode_name that verifies encode_name produces the correct DNS wire-format bytes for a representative set of inputs: a multi-label domain, an FQDN with a trailing dot, a single-label name, a label at the maximum allowed size (63 bytes), a name at the maximum allowed total size (255 bytes encoded), and a name with leading/trailing whitespace that should be trimmed. This test documents and guards the exact byte-level output of the function, which is the format consumed directly by the SOA RDATA builder.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
