### PR TITLE
LLT-6727: natlab command execution times

### DIFF
--- a/nat-lab/tests/mesh_api.py
+++ b/nat-lab/tests/mesh_api.py
@@ -403,17 +403,20 @@ class API:
             f' \'echo "{wg_conf}" > /etc/wireguard/wg0.conf; wg-quick down'
             " /etc/wireguard/wg0.conf; wg-quick up /etc/wireguard/wg0.conf'"
         )
+        start_time = time.monotonic()
         ret = subprocess.run(
             cmd,
             shell=True,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
         )
+        elapsed_ms = (time.monotonic() - start_time) * 1000
         log.debug(
-            "Executing %s on %s with result %s",
+            "Executed %s on %s with result %s in %.0fms",
             cmd,
             server_config["container"],
             ret,
+            elapsed_ms,
         )
 
     def config_dynamic_nodes(

--- a/nat-lab/tests/utils/connection/docker_connection.py
+++ b/nat-lab/tests/utils/connection/docker_connection.py
@@ -181,7 +181,10 @@ class DockerConnection(Connection):
         self, command: List[str], kill_id=None, term_type=None, quiet=False
     ) -> "Process":
         process = DockerProcess(
-            self._container, container_id(self.tag), command, kill_id
+            self._container,
+            container_id(self.tag),
+            command,
+            kill_id,
         )
 
         if not quiet:

--- a/nat-lab/tests/utils/connection/ssh_connection.py
+++ b/nat-lab/tests/utils/connection/ssh_connection.py
@@ -158,7 +158,11 @@ class SshConnection(Connection):
             assert False, f"not supported target_os '{self.target_os}'"
 
         return SshProcess(
-            self._connection, self.tag.name, command, escape_argument, term_type
+            self._connection,
+            self.tag.name,
+            command,
+            escape_argument,
+            term_type,
         )
 
     async def get_ip_address(self) -> tuple[str, str]:

--- a/nat-lab/tests/utils/process/docker_process.py
+++ b/nat-lab/tests/utils/process/docker_process.py
@@ -2,6 +2,7 @@ import asyncio
 import secrets
 import subprocess
 import sys
+import time
 from .process import Process, ProcessExecError, StreamCallback
 from aiodocker.containers import DockerContainer
 from aiodocker.execs import Exec
@@ -52,72 +53,86 @@ class DockerProcess(Process):
         stderr_callback: Optional[StreamCallback] = None,
         privileged: bool = False,
     ) -> "DockerProcess":
+        start_time = time.monotonic()
         try:
-            self._execute = await self._container.exec(
-                self._command,
-                stdin=True,
-                environment={
-                    "MOOSE_LOG": "Trace",
-                    "MOOSE_LOG_FILE": MOOSE_LOGS_DIR,
-                    "RUST_BACKTRACE": "full",
-                    "KILL_ID": self._kill_id,
-                },
-                privileged=privileged,
-            )
-        except:
-            log.error("[%s] Exception thrown:", self._container_name, exc_info=True)
-            raise
-        if self._execute is None:
-            return self
-        async with self._execute.start() as exe_stream:
-            self._stream = exe_stream
-            self._stdin_ready.set()
             try:
-                await self._read_loop(exe_stream, stdout_callback, stderr_callback)
-            except asyncio.CancelledError:
-                log.debug(
-                    "[%s] '%s' process cancelled.", self._container_name, self._command
+                self._execute = await self._container.exec(
+                    self._command,
+                    stdin=True,
+                    environment={
+                        "MOOSE_LOG": "Trace",
+                        "MOOSE_LOG_FILE": MOOSE_LOGS_DIR,
+                        "RUST_BACKTRACE": "full",
+                        "KILL_ID": self._kill_id,
+                    },
+                    privileged=privileged,
                 )
-                raise
             except:
                 log.error("[%s] Exception thrown:", self._container_name, exc_info=True)
                 raise
-            finally:
-                if self._execute:
-                    inspect = await self._execute.inspect()
-                    while inspect["Pid"] == 0 and inspect["ExitCode"] is None:
+            if self._execute is None:
+                return self
+            async with self._execute.start() as exe_stream:
+                self._stream = exe_stream
+                self._stdin_ready.set()
+                try:
+                    await self._read_loop(exe_stream, stdout_callback, stderr_callback)
+                except asyncio.CancelledError:
+                    log.debug(
+                        "[%s] '%s' process cancelled.",
+                        self._container_name,
+                        self._command,
+                    )
+                    raise
+                except:
+                    log.error(
+                        "[%s] Exception thrown:", self._container_name, exc_info=True
+                    )
+                    raise
+                finally:
+                    if self._execute:
                         inspect = await self._execute.inspect()
-                        await asyncio.sleep(0.01)
-                    if inspect["ExitCode"] is None:
-                        subprocess.run(
-                            [
-                                "docker",
-                                "exec",
-                                "--privileged",
-                                self._container.id,
-                                "/opt/bin/kill_process_by_natlab_id",
-                                self._kill_id,
-                            ],
-                            stdout=subprocess.DEVNULL,
-                            stderr=subprocess.DEVNULL,
-                        )
-                self._stream = None
+                        while inspect["Pid"] == 0 and inspect["ExitCode"] is None:
+                            inspect = await self._execute.inspect()
+                            await asyncio.sleep(0.01)
+                        if inspect["ExitCode"] is None:
+                            subprocess.run(
+                                [
+                                    "docker",
+                                    "exec",
+                                    "--privileged",
+                                    self._container.id,
+                                    "/opt/bin/kill_process_by_natlab_id",
+                                    self._kill_id,
+                                ],
+                                stdout=subprocess.DEVNULL,
+                                stderr=subprocess.DEVNULL,
+                            )
+                    self._stream = None
 
-        inspect = await self._execute.inspect()
-        exit_code = inspect["ExitCode"]
+            inspect = await self._execute.inspect()
+            exit_code = inspect["ExitCode"]
 
-        # 0 success
-        # suppress 137 linux sigkill, since we kill those processes
-        if exit_code and exit_code not in [0, 137]:
-            raise ProcessExecError(
-                exit_code,
+            # 0 success
+            # suppress 137 linux sigkill, since we kill those processes
+            if exit_code and exit_code not in [0, 137]:
+                raise ProcessExecError(
+                    exit_code,
+                    self._container_name,
+                    self._command,
+                    self._stdout,
+                    self._stderr,
+                )
+
+            return self
+        finally:
+            elapsed_ms = (time.monotonic() - start_time) * 1000
+            log.info(
+                "[%s] Finished %s in %.0fms",
                 self._container_name,
-                self._command,
-                self._stdout,
-                self._stderr,
+                " ".join(self._command),
+                elapsed_ms,
             )
-
-        return self
 
     @asynccontextmanager
     async def run(
@@ -126,41 +141,52 @@ class DockerProcess(Process):
         stderr_callback: Optional[StreamCallback] = None,
         privileged: bool = False,
     ) -> AsyncIterator["DockerProcess"]:
+        start_time = time.monotonic()
+
         async def mark_as_done():
             try:
                 await self.execute(stdout_callback, stderr_callback, privileged)
             finally:
                 self._is_done.set()
 
-        async with run_async_context(mark_as_done()):
-            try:
-                yield self
-            finally:
-                if self._execute:
-                    inspect = await self._execute.inspect()
-                    while inspect["Pid"] == 0 and inspect["ExitCode"] is None:
+        try:
+            async with run_async_context(mark_as_done()):
+                try:
+                    yield self
+                finally:
+                    if self._execute:
                         inspect = await self._execute.inspect()
-                        await asyncio.sleep(0.01)
-                    if inspect["ExitCode"] is None:
-                        proc = subprocess.run(
-                            [
-                                "docker",
-                                "exec",
-                                "--privileged",
-                                self._container.id,
-                                "/opt/bin/kill_process_by_natlab_id",
-                                self._kill_id,
-                            ],
-                            stdout=subprocess.PIPE,
-                            stderr=subprocess.PIPE,
-                            text=True,
-                        )
-                        if proc.returncode != 0:
-                            log.warning(
-                                "[%s] Cleanup failed: %s",
-                                self._container_name,
-                                proc.stdout + proc.stderr,
+                        while inspect["Pid"] == 0 and inspect["ExitCode"] is None:
+                            inspect = await self._execute.inspect()
+                            await asyncio.sleep(0.01)
+                        if inspect["ExitCode"] is None:
+                            proc = subprocess.run(
+                                [
+                                    "docker",
+                                    "exec",
+                                    "--privileged",
+                                    self._container.id,
+                                    "/opt/bin/kill_process_by_natlab_id",
+                                    self._kill_id,
+                                ],
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE,
+                                text=True,
                             )
+                            if proc.returncode != 0:
+                                log.warning(
+                                    "[%s] Cleanup failed: %s",
+                                    self._container_name,
+                                    proc.stdout + proc.stderr,
+                                )
+        finally:
+            elapsed_ms = (time.monotonic() - start_time) * 1000
+            log.info(
+                "[%s] Finished %s in %.0fms",
+                self._container_name,
+                " ".join(self._command),
+                elapsed_ms,
+            )
 
     async def _read_loop(
         self,

--- a/nat-lab/tests/utils/process/ssh_process.py
+++ b/nat-lab/tests/utils/process/ssh_process.py
@@ -1,5 +1,6 @@
 import asyncio
 import asyncssh
+import time
 from .process import Process, ProcessExecError, StreamCallback
 from contextlib import asynccontextmanager
 from tests.utils.asyncio_util import run_async_context
@@ -47,69 +48,79 @@ class SshProcess(Process):
         stderr_callback: Optional[StreamCallback] = None,
         privileged: bool = False,
     ) -> "SshProcess":
-        if privileged:
-            log.warning("'privileged' does nothing for ssh processes")
-        escaped = [self._escape_argument(arg) for arg in self._command]
-        command_str = " ".join(escaped)
-
+        start_time = time.monotonic()
         try:
-            self._process = await self._ssh_connection.create_process(
-                command_str, term_type=self._term_type
-            )
-            self._running = True
-            self._stdin = self._process.stdin
-            self._stdin_ready.set()
+            if privileged:
+                log.warning("'privileged' does nothing for ssh processes")
+            escaped = [self._escape_argument(arg) for arg in self._command]
+            command_str = " ".join(escaped)
 
-            await asyncio.gather(
-                self._stdout_loop(self._process.stdout, stdout_callback),
-                self._stderr_loop(self._process.stderr, stderr_callback),
-            )
-        except asyncio.CancelledError:
-            log.debug("[%s] '%s' process cancelled.", self._vm_name, self._command)
-            raise
-        except:
-            log.error("[%s] Exception thrown:", self._vm_name, exc_info=True)
-            raise
+            try:
+                self._process = await self._ssh_connection.create_process(
+                    command_str, term_type=self._term_type
+                )
+                self._running = True
+                self._stdin = self._process.stdin
+                self._stdin_ready.set()
+
+                await asyncio.gather(
+                    self._stdout_loop(self._process.stdout, stdout_callback),
+                    self._stderr_loop(self._process.stderr, stderr_callback),
+                )
+            except asyncio.CancelledError:
+                log.debug("[%s] '%s' process cancelled.", self._vm_name, self._command)
+                raise
+            except:
+                log.error("[%s] Exception thrown:", self._vm_name, exc_info=True)
+                raise
+            finally:
+                if self._process and self._process.returncode is None:
+                    self._process.kill()
+                    self._process.close()
+                    await self._process.wait_closed()
+                self._running = False
+
+            await self._process.wait()
+
+            returncode = self._process.returncode
+            exit_status = self._process.exit_status
+            exit_signal = self._process.exit_signal
+
+            # 0 success
+            # suppress -9 sigkill, since we kill those processes
+            if returncode and returncode not in [0, -9]:
+                err = ProcessExecError(
+                    returncode,
+                    self._vm_name,
+                    self._command,
+                    self._stdout,
+                    self._stderr,
+                    exit_status,
+                    exit_signal,
+                )
+                log.debug(
+                    "[%s] Command failed on %s: %s; returncode=%s exit_status=%s exit_signal=%s; "
+                    "stdout=%s; stderr=%s",
+                    self._vm_name,
+                    err.remote_name,
+                    command_str,
+                    err.returncode,
+                    err.exit_status,
+                    err.exit_signal,
+                    err.stdout,
+                    err.stderr,
+                )
+                raise err
+
+            return self
         finally:
-            if self._process and self._process.returncode is None:
-                self._process.kill()
-                self._process.close()
-                await self._process.wait_closed()
-            self._running = False
-
-        await self._process.wait()
-
-        returncode = self._process.returncode
-        exit_status = self._process.exit_status
-        exit_signal = self._process.exit_signal
-
-        # 0 success
-        # suppress -9 sigkill, since we kill those processes
-        if returncode and returncode not in [0, -9]:
-            err = ProcessExecError(
-                returncode,
+            elapsed_ms = (time.monotonic() - start_time) * 1000
+            log.info(
+                "[%s] Finished %s in %.0fms",
                 self._vm_name,
-                self._command,
-                self._stdout,
-                self._stderr,
-                exit_status,
-                exit_signal,
+                " ".join(self._command),
+                elapsed_ms,
             )
-            log.debug(
-                "[%s] Command failed on %s: %s; returncode=%s exit_status=%s exit_signal=%s; "
-                "stdout=%s; stderr=%s",
-                self._vm_name,
-                err.remote_name,
-                command_str,
-                err.returncode,
-                err.exit_status,
-                err.exit_signal,
-                err.stdout,
-                err.stderr,
-            )
-            raise err
-
-        return self
 
     @asynccontextmanager
     async def run(
@@ -118,20 +129,31 @@ class SshProcess(Process):
         stderr_callback: Optional[StreamCallback] = None,
         privileged: bool = False,
     ) -> AsyncIterator["SshProcess"]:
+        start_time = time.monotonic()
+
         async def mark_as_done():
             try:
                 await self.execute(stdout_callback, stderr_callback, privileged)
             finally:
                 self._is_done.set()
 
-        async with run_async_context(mark_as_done()):
-            try:
-                yield self
-            finally:
-                if self._process and self._process.returncode is None:
-                    self._process.kill()
-                    self._process.close()
-                    await self._process.wait_closed()
+        try:
+            async with run_async_context(mark_as_done()):
+                try:
+                    yield self
+                finally:
+                    if self._process and self._process.returncode is None:
+                        self._process.kill()
+                        self._process.close()
+                        await self._process.wait_closed()
+        finally:
+            elapsed_ms = (time.monotonic() - start_time) * 1000
+            log.info(
+                "[%s] Finished %s in %.0fms",
+                self._vm_name,
+                " ".join(self._command),
+                elapsed_ms,
+            )
 
     async def _stdout_loop(
         self, stdout: asyncssh.SSHReader, stdout_callback: Optional[StreamCallback]


### PR DESCRIPTION
### Problem
Investigating test failures due to timeouts is difficult since we do not know how long the commands were executed for. In some cases we can interpolate between nearby calls.

### Solution
Add "Finished ... in Xms" log lines after every command execution in NatLab, so that test failure investigation can show how long each command took. Duration is logged at INFO level using `time.monotonic()` for accuracy.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
