### PR TITLE
[LLT-7222] Fix LuCI TypeError in openwrt nordvpnlite

### DIFF
--- a/clis/nordvpnlite/openwrt/feed/net/nordvpnlite/files/luci/view/nordvpnlite/settings.js
+++ b/clis/nordvpnlite/openwrt/feed/net/nordvpnlite/files/luci/view/nordvpnlite/settings.js
@@ -66,7 +66,7 @@ return view.extend({
     },
 
     handleSave: async function () {
-        if (!this.vpn_option.isValid()) {
+        if (!this.vpn_option.isValid('config')) {
             ui.addNotification(_('Save failed'), E('p', _('Incorrect format of the country code')));
             return
         }


### PR DESCRIPTION
### Problem
When clicking Save in the NordVPN Lite settings page, a `TypeError: Section ID` required error was thrown from LuCI's `form.js`.
This happened because `isValid()` was called on a form option without passing the required `section_id` argument, which the LuCI framework requires to locate the corresponding UI element in the DOM.

### Solution
Pass the section name 'config' to `isValid()`, consistent with how formvalue() is already called in the same handler.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
