### PR TITLE
Bump rust nightly version in fuzzing jobs

### DIFF
--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -13,7 +13,7 @@ jobs:
         - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         - uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.6
           with:
-            toolchain: nightly-2025-08-07
+            toolchain: nightly-2026-02-27
             override: true
         - run: cargo install cargo-fuzz --locked --version 0.12.0
         - name: fuzz telio proto
@@ -25,7 +25,7 @@ jobs:
         - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         - uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.6
           with:
-            toolchain: nightly-2025-08-07
+            toolchain: nightly-2026-02-27
             override: true
         - run: cargo install cargo-fuzz --locked --version 0.12.0
         - name: fuzz telio crypto decrypt_request
@@ -43,7 +43,7 @@ jobs:
         - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         - uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.6
           with:
-            toolchain: nightly-2025-08-07
+            toolchain: nightly-2026-02-27
             override: true
         - run: cargo install cargo-fuzz --locked --version 0.12.0
         - name: fuzz telio pq parse_get_packet
@@ -62,7 +62,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.6
         with:
-          toolchain: nightly-2025-08-07
+          toolchain: nightly-2026-02-27
           override: true
       - run: cargo install cargo-fuzz --locked --version 0.12.0
       - name: fuzz telio starcast nat translate_incoming


### PR DESCRIPTION
### Problem
One of our fuzzing jobs fails because a dependency is incompatible with rust 1.91.0 which is what the nightly version we use in the fuzzing jobs corresponds to

### Solution
Bump rust nightly to a version that corresponds to rust 1.95.0, which is compatible with that dependency


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
