### PR TITLE
Make ens dependencies optionally hidden behind enable_ens flag

### DIFF
--- a/crates/telio-proto/Cargo.toml
+++ b/crates/telio-proto/Cargo.toml
@@ -7,22 +7,36 @@ repository = "https://github.com/NordSecurity/libtelio"
 publish = false
 
 [features]
-enable_ens = ["rustls/aws_lc_rs", "dep:aws-lc-rs", "dep:rustls-webpki"]
+enable_ens = [
+    "rustls/aws_lc_rs",
+    "dep:aws-lc-rs",
+    "dep:http",
+    "dep:hyper-util",
+    "dep:llt-proto",
+    "dep:prost",
+    "dep:rustls-webpki",
+    "dep:tokio-rustls",
+    "dep:tokio-stream",
+    "dep:tonic-prost",
+    "dep:tonic",
+    "dep:tower",
+    "dep:uuid",
+]
 
 [dependencies]
-http = "1.4.0"
-llt-proto = { git = "https://github.com/NordSecurity/llt-proto.git", tag = "v1.0.0" }
-hyper-util.workspace = true
-prost = "0.14.1"
+http = { version = "1.4.0", optional = true }
+llt-proto = { git = "https://github.com/NordSecurity/llt-proto.git", tag = "v1.0.0", optional = true }
+hyper-util = { workspace = true, optional = true }
+prost = { version = "0.14.1", optional = true }
 protobuf = "3.7.2"
-rustls = { version = "0.23", default-features = false, features = ["std"] }
+rustls = { version = "0.23", default-features = false, features = ["std", "ring"] }
 rustls-webpki = { version = "0.103.12", optional = true }
 aws-lc-rs = { version = "=1.16.2", features = ["bindgen"], optional = true }
-tokio-stream = "0.1.17"
-tokio-rustls = { version = "0.26.4", default-features = false }
-tonic = { version = "0.14.2" }
-tonic-prost = "0.14"
-tower = "0.5.2"
+tokio-stream = { version = "0.1.17", optional = true }
+tokio-rustls = { version = "0.26.4", default-features = false, optional = true }
+tonic = { version = "0.14.2", optional = true }
+tonic-prost = { version = "0.14", optional = true }
+tower = { version = "0.5.2", optional = true }
 
 anyhow.workspace = true
 base64.workspace = true
@@ -34,7 +48,7 @@ strum.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["full"] }
 tracing.workspace = true
-uuid = { workspace = true, features = ["v4"] }
+uuid = { workspace = true, features = ["v4"], optional = true }
 
 telio-crypto.workspace = true
 telio-model.workspace = true

--- a/crates/telio-proto/src/ens/ens_impl.rs
+++ b/crates/telio-proto/src/ens/ens_impl.rs
@@ -45,7 +45,7 @@ pub(crate) mod grpc {
 const CONTEXT: &str = "ens-auth";
 const ENS_PORT: u16 = 993;
 const AUTHENTICATION_KEY: &str = "authentication";
-const DEFAULT_ROOT_CERTIFICATE: &[u8] = include_bytes!("../data/default_root_certificate.der");
+const DEFAULT_ROOT_CERTIFICATE: &[u8] = include_bytes!("../../data/default_root_certificate.der");
 
 /// ENS errors
 #[derive(Debug, thiserror::Error)]

--- a/crates/telio-proto/src/ens/ens_impl.rs
+++ b/crates/telio-proto/src/ens/ens_impl.rs
@@ -9,7 +9,6 @@ use blake3::{derive_key, keyed_hash};
 use http::Uri;
 use hyper_util::rt::TokioIo;
 
-#[cfg(feature = "enable_ens")]
 use rustls::{
     client::danger::ServerCertVerifier, crypto::CryptoProvider, pki_types::CertificateDer,
     ClientConfig, RootCertStore,
@@ -388,16 +387,6 @@ async fn create_external_channel(
         .await?)
 }
 
-#[cfg(not(feature = "enable_ens"))]
-fn make_tls_connector(
-    _allow_only_mlkem: bool,
-    _root_certificate: &[u8],
-) -> std::io::Result<TlsConnector> {
-    telio_log_warn!("An attempt was made to enable ENS when it is disabled at compile time");
-    Err(std::io::Error::other("ENS is disabled"))
-}
-
-#[cfg(feature = "enable_ens")]
 fn make_crypto_provider(allow_only_mlkem: bool) -> Arc<CryptoProvider> {
     let mut provider = tokio_rustls::rustls::crypto::aws_lc_rs::default_provider();
 
@@ -409,7 +398,6 @@ fn make_crypto_provider(allow_only_mlkem: bool) -> Arc<CryptoProvider> {
     Arc::new(provider)
 }
 
-#[cfg(feature = "enable_ens")]
 fn make_trusted_root_cert_verifier(
     crypto_provider: Arc<CryptoProvider>,
     root_certificate: &[u8],
@@ -493,7 +481,6 @@ fn make_trusted_root_cert_verifier(
     Ok(Arc::new(CertFingerprintLogger(verifier)))
 }
 
-#[cfg(feature = "enable_ens")]
 fn make_tls_connector(
     allow_only_mlkem: bool,
     root_certificate: &[u8],
@@ -524,19 +511,8 @@ fn authentication_tag(secret: SharedSecret, message: &[u8]) -> [u8; 32] {
 ///
 /// In case there are two providers present (ring and aws-lc-rs) rustls requires the user
 /// to explicitly configure the one which should be used by default.
-#[cfg(feature = "enable_ens")]
 pub fn install_default_crypto_provider() {
     if let Err(e) = rustls::crypto::aws_lc_rs::default_provider().install_default() {
-        telio_log_warn!("Failed to install default crypto provider for rustls: {e:?}");
-    }
-}
-
-/// When ENS is disabled, we should only have ring provider and there should be no need
-/// to explicitly configure the default crypto provider. But just to be on the safe side,
-/// (and handle a case where there 3rd crypto provider) we will configure ring either way.
-#[cfg(not(feature = "enable_ens"))]
-pub fn install_default_crypto_provider() {
-    if let Err(e) = rustls::crypto::ring::default_provider().install_default() {
         telio_log_warn!("Failed to install default crypto provider for rustls: {e:?}");
     }
 }
@@ -1042,7 +1018,6 @@ mod tests {
         ))
     }
 
-    #[cfg(feature = "enable_ens")]
     #[test]
     fn test_cert_verification_rejects_invalid_request() {
         use rustls::{
@@ -1089,7 +1064,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "enable_ens")]
     #[test]
     fn test_cert_verification_accepts_correct_request() {
         use rustls::{
@@ -1114,7 +1088,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "enable_ens")]
     #[test]
     fn test_cert_verification_rejects_incorrect_request() {
         use rustls::pki_types::{ServerName, UnixTime};

--- a/crates/telio-proto/src/ens/ens_stub.rs
+++ b/crates/telio-proto/src/ens/ens_stub.rs
@@ -1,0 +1,81 @@
+use std::sync::Arc;
+
+use telio_crypto::SecretKey;
+use telio_model::PublicKey;
+use telio_sockets::SocketPool;
+use telio_task::io::{
+    chan::{Rx, Tx},
+    Chan,
+};
+use telio_utils::exponential_backoff::Backoff;
+use telio_utils::telio_log_warn;
+
+pub(crate) mod grpc {
+    /// Stub VPN connection error for when ENS is disabled at compile time.
+    #[derive(Debug, Clone, Default)]
+    pub struct ConnectionError {
+        /// gRPC error code
+        pub code: i32,
+    }
+
+    /// Stub gRPC error enum for when ENS is disabled at compile time.
+    #[repr(i32)]
+    #[derive(Debug)]
+    #[allow(missing_docs)]
+    pub enum Error {
+        ConnectionLimitReached = 1,
+        ServerMaintenance = 2,
+        Unauthenticated = 3,
+        Superseded = 4,
+    }
+}
+
+/// ENS errors (stub when ENS is disabled at compile time)
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// ENS is not available (disabled at compile time)
+    #[error("ENS is disabled at compile time")]
+    Disabled,
+}
+
+/// Stub ErrorNotificationService for when ENS is disabled at compile time.
+pub struct ErrorNotificationService {
+    _tx: Tx<(grpc::ConnectionError, PublicKey)>,
+}
+
+impl ErrorNotificationService {
+    /// Create stub instance (ENS is disabled at compile time)
+    pub fn new(
+        buffer_size: usize,
+        _socket_pool: Arc<SocketPool>,
+        _allow_only_mlkem: bool,
+        _root_certificate_override: Option<Vec<u8>>,
+    ) -> (Self, Rx<(grpc::ConnectionError, PublicKey)>) {
+        let Chan { rx, tx }: Chan<(grpc::ConnectionError, PublicKey)> = Chan::new(buffer_size);
+        (Self { _tx: tx }, rx)
+    }
+
+    /// No-op: ENS is disabled at compile time
+    pub async fn start_monitor(
+        &mut self,
+        _vpn_ip: std::net::IpAddr,
+        _vpn_public_key: PublicKey,
+        _local_private_key: SecretKey,
+        _backoff: impl Backoff,
+    ) -> Result<(), Error> {
+        telio_log_warn!("ENS start_monitor called but ENS is disabled at compile time");
+        Err(Error::Disabled)
+    }
+
+    /// No-op: ENS is disabled at compile time
+    pub async fn stop(&mut self) {}
+}
+
+/// When ENS is disabled, we should only have ring provider and there should be no need
+/// to explicitly configure the default crypto provider. But just to be on the safe side,
+/// (and handle a case where there 3rd crypto provider) we will configure ring either way.
+pub fn install_default_crypto_provider() {
+    if let Err(e) = rustls::crypto::ring::default_provider().install_default() {
+        telio_log_warn!("Failed to install default crypto provider for rustls: {e:?}");
+    }
+}

--- a/crates/telio-proto/src/ens/mod.rs
+++ b/crates/telio-proto/src/ens/mod.rs
@@ -1,0 +1,18 @@
+//! ENS (Error Notification Service) module
+//!
+//! This module provides a facade that conditionally includes either the full implementation
+//! (when `enable_ens` feature is on) or a stub implementation (when disabled).
+
+#[cfg(feature = "enable_ens")]
+mod ens_impl;
+#[cfg(feature = "enable_ens")]
+pub(crate) use ens_impl::grpc;
+#[cfg(feature = "enable_ens")]
+pub use ens_impl::{install_default_crypto_provider, Error, ErrorNotificationService};
+
+#[cfg(not(feature = "enable_ens"))]
+mod ens_stub;
+#[cfg(not(feature = "enable_ens"))]
+pub(crate) use ens_stub::grpc;
+#[cfg(not(feature = "enable_ens"))]
+pub use ens_stub::{install_default_crypto_provider, Error, ErrorNotificationService};


### PR DESCRIPTION
### Problem

When building with `disable_ens` feature (nordvpnlite, for example) the dependencies
add around 750kb (~10%) to the release binary. 

### Solution

Mark ens dependencies as optional and conditionally include them only when feature is on

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests