### PR TITLE
Bump rustls-webpki to 0.103.13 to fix RUSTSEC-2026-0104

### DIFF
--- a/.unreleased/bump_rustls-webpki_RUSTSEC-2026-0104
+++ b/.unreleased/bump_rustls-webpki_RUSTSEC-2026-0104
@@ -1,0 +1,1 @@
+Bump rustls-webpki to 0.103.13 to fix RUSTSEC-2026-0104 (reachable panic in CRL parsing)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4164,9 +4164,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
### Problem
`cargo-deny` linter fails with security advisory [RUSTSEC-2026-0104](https://rustsec.org/advisories/RUSTSEC-2026-0104) — a reachable panic in certificate revocation list parsing in `rustls-webpki 0.103.12`.

### Solution
Bump `rustls-webpki` to `0.103.13` which contains the fix.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests