### PR TITLE
[LLT-7206] Upgrade wireguard nt to 1.0

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-TRIGGERED_REF=v5.15.10
+TRIGGERED_REF=LLT-7206-upgrade-wireguard-nt

--- a/nat-lab/tests/config.py
+++ b/nat-lab/tests/config.py
@@ -241,7 +241,7 @@ WINDUMP_BINARY_WINDOWS = "C:/workspace/WinDump.exe".replace("/", "\\")
 
 # Network Adapter device setup class registry path
 # https://learn.microsoft.com/en-us/windows-hardware/drivers/install/system-defined-device-setup-classes-available-to-vendors
-WINDOWS_NETWORK_ADAPTER_REGISTRY_KEY = r"HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Class\{4d36e972-e325-11ce-bfc1-08002be10318}"
+WINDOWS_NETWORK_ADAPTER_REGISTRY_KEY = r"HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Class\{62f9c741-b25a-46ce-b54c-9bccce08b6f2}"
 
 # JIRA issue: LLT-1664
 # The directories between host and Docker container are shared via

--- a/nat-lab/tests/test_adapter.py
+++ b/nat-lab/tests/test_adapter.py
@@ -90,9 +90,18 @@ async def test_adapter_gone_event(
 
         elif conn.target_os == TargetOS.Windows:
             try:
-                await conn.create_process(
-                    ["netsh", "interface", "set", "interface", iface, "disable"]
-                ).execute()
+                result = await conn.create_process([
+                    "reg",
+                    "query",
+                    r"HKLM\SYSTEM\CurrentControlSet\Enum\SWD\WireGuard",
+                ]).execute()
+                for line in result.get_stdout().splitlines():
+                    line = line.strip()
+                    if line.startswith("HKEY_LOCAL_MACHINE"):
+                        instance_id = "\\".join(line.split("\\")[-3:])
+                        await conn.create_process(
+                            ["pnputil", "/remove-device", instance_id]
+                        ).execute()
             except ProcessExecError as e:
                 if e.returncode != 1:
                     raise

--- a/nat-lab/tests/test_wg_adapter.py
+++ b/nat-lab/tests/test_wg_adapter.py
@@ -16,7 +16,7 @@ QUERY_CMD = [
     WINDOWS_NETWORK_ADAPTER_REGISTRY_KEY,
     "/s",
     "/f",
-    "DeviceInstanceID",
+    "DriverDesc",
 ]
 
 


### PR DESCRIPTION
### Problem
wireguard-nt is upgraded from 0.10.1 to 1.0. Commit [c89926e8](https://git.zx2c4.com/wireguard-nt/commit/?id=c89926e8) ("api: adapter: don't set DriverRequired on stub device") changed adapter creation: the stub device no longer has `SWDeviceCapabilitiesDriverRequired` set, which changed how Windows PnP installs the driver and where it writes the per-adapter driver key - moving it from the Net class (`{4d36e972...}`) to the SoftwareDevice class (`{62f9c741...}`). This caused two NAT-LAB test failures:
- `test_wg_adapter_cleanup` queried `DeviceInstanceID` under `{4d36e972...}` - the query succeeded but returned only non-WireGuard entries, causing `AssertionError: 'WireGuard' not in output`
- `test_adapter_gone_event` timed out - `netsh interface set interface <name> disable` operates at the NDIS layer and no longer triggers the device removal event that wireguard-nt's interface watcher listens for, so the "Interface gone" event never fired

### Solution
- Updated `WINDOWS_NETWORK_ADAPTER_REGISTRY_KEY` from `{4d36e972...}` to `{62f9c741...}` in `config.py` so registry queries correctly find WireGuard adapter entries under the SoftwareDevice class 
- Changed QUERY_CMD in `test_wg_adapter_cleanup` to use `DriverDesc` instead of `DeviceInstanceID` — wireguard-nt 1.0 no longer writes `DeviceInstanceID` under the driver class key
- Replaced `netsh disable` in `test_adapter_gone_event` with `pnputil /remove-device SWD\WireGuard\{guid}`, which removes the device node directly at the PnP level and triggers the "Interface gone" event that wireguard-nt's interface watcher reacts to

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
