### PR TITLE
LLT-7247: Add dynamic debug for WireGuard module

### DIFF
--- a/nat-lab/natlab.py
+++ b/nat-lab/natlab.py
@@ -176,6 +176,17 @@ def start(skip_keywords=None, force_recreate=False, services_to_start=None):
     command += services_to_start
 
     if "GITLAB_CI" in os.environ:
+        try:
+            run_command(["sudo", "mount", "-t", "debugfs", "none", "/sys/kernel/debug"])
+            run_command([
+                "sudo",
+                "sh",
+                "-c",
+                "echo 'module wireguard +p' > /sys/kernel/debug/dynamic_debug/control",
+            ])
+        except subprocess.CalledProcessError as e:
+            print(f"Enabling WireGuard dynamic debug failed: {e}")
+
         command.append("--quiet-pull")
     try:
         run_command(
@@ -191,6 +202,17 @@ def start(skip_keywords=None, force_recreate=False, services_to_start=None):
 
 
 def stop():
+    if "GITLAB_CI" in os.environ:
+        try:
+            run_command([
+                "sudo",
+                "sh",
+                "-c",
+                "echo 'module wireguard -p' > /sys/kernel/debug/dynamic_debug/control",
+            ])
+        except subprocess.CalledProcessError as e:
+            print(f"Could not disable WireGuard dynamic debug: {e}")
+
     run_command(["docker", "compose", "down"])
 
 


### PR DESCRIPTION
### Problem
When the `test_vpn_connection_private_key_change` failed on `ping PHOTO_ALBUM_IP`, we didn’t have the kernel dynamic debugging for WireGuard module enabled in the NAT-LAB’s VPN server. Because of that, we weren’t able to track the exact timestamp in which the server-side peer key update happened and confirm the race condition between the server-side and client-side key change.

### Solution
Enable kernel level dynamic debug logs for WireGuard module for the NAT-LAB’s VPN server. As the test VPN servers run in Docker containers, dynamic debug for WireGuard module has to be enabled on the host. The change is limited to the CI environment, so that local NAT-LAB tests execution doesn't affect the local host environment.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
