### PR TITLE
LLT-7053: Integrate DNS forwarder

### DIFF
--- a/.unreleased/LLT-7053_integrate_forwarder
+++ b/.unreleased/LLT-7053_integrate_forwarder
@@ -1,0 +1,1 @@
+Add `use_raw_forwarder` feature flag to `FeatureDns` to opt-in to the new raw DNS forwarder (default: off, uses hickory-server)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4924,6 +4924,7 @@ dependencies = [
  "pnet_packet 0.35.0",
  "rand 0.10.1",
  "rand_core_compat",
+ "rstest",
  "telio-crypto",
  "telio-model",
  "telio-utils",

--- a/crates/telio-dns/Cargo.toml
+++ b/crates/telio-dns/Cargo.toml
@@ -29,5 +29,6 @@ telio-wg.workspace = true
 [dev-dependencies]
 dns-parser = "0.8.0"
 rand_core_compat.workspace = true
+rstest.workspace = true
 
 mockall.workspace = true

--- a/crates/telio-dns/src/dns.rs
+++ b/crates/telio-dns/src/dns.rs
@@ -11,7 +11,7 @@ use tokio::net::UdpSocket;
 use tokio::sync::{Mutex, RwLock};
 use x25519_dalek::{PublicKey as PublicKeyDalek, StaticSecret};
 
-use telio_model::features::{FeatureExitDns, TtlValue};
+use telio_model::features::{FeatureDns, TtlValue};
 
 //debug tools
 use telio_utils::{telio_log_debug, telio_log_error};
@@ -65,7 +65,7 @@ impl LocalDnsResolver {
         public_key: &PublicKey,
         forward_ips: &[IpAddr],
         tun: Option<&Tun>,
-        exit_dns: Option<FeatureExitDns>,
+        dns_features: &FeatureDns,
     ) -> Result<Self, String> {
         let socket = UdpSocket::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
             .await
@@ -93,10 +93,14 @@ impl LocalDnsResolver {
         // Telio public key
         let telio_public_key: PublicKeyDalek = PublicKeyDalek::from(public_key.0);
 
-        let nameserver = LocalNameServer::new(forward_ips).await?;
+        let use_raw_forwarder = dns_features.use_raw_forwarder.unwrap_or(false);
 
-        let auto_switch_ips =
-            exit_dns.is_some_and(|feature| feature.auto_switch_dns_ips.unwrap_or(true));
+        let nameserver = LocalNameServer::new(forward_ips, use_raw_forwarder).await?;
+
+        let auto_switch_ips = dns_features
+            .exit_dns
+            .as_ref()
+            .is_some_and(|feature| feature.auto_switch_dns_ips.unwrap_or(true));
 
         Ok(LocalDnsResolver {
             socket: Arc::new(socket),
@@ -212,9 +216,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_default_dns_allowed_ips() {
-        let resolver = LocalDnsResolver::new(&SecretKey::gen().public(), &[], None, None)
-            .await
-            .unwrap();
+        let resolver = LocalDnsResolver::new(
+            &SecretKey::gen().public(),
+            &[],
+            None,
+            &FeatureDns::default(),
+        )
+        .await
+        .unwrap();
         assert_eq!(
             vec![
                 "100.64.0.2/32".parse::<IpNet>().unwrap(),
@@ -228,9 +237,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_exit_connected_dns_allowed_ips() {
-        let resolver = LocalDnsResolver::new(&SecretKey::gen().public(), &[], None, None)
-            .await
-            .unwrap();
+        let resolver = LocalDnsResolver::new(
+            &SecretKey::gen().public(),
+            &[],
+            None,
+            &FeatureDns::default(),
+        )
+        .await
+        .unwrap();
         assert_eq!(
             vec![
                 "100.64.0.2/32".parse::<IpNet>().unwrap(),
@@ -242,9 +256,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_default_dns_servers() {
-        let resolver = LocalDnsResolver::new(&SecretKey::gen().public(), &[], None, None)
-            .await
-            .unwrap();
+        let resolver = LocalDnsResolver::new(
+            &SecretKey::gen().public(),
+            &[],
+            None,
+            &FeatureDns::default(),
+        )
+        .await
+        .unwrap();
         assert_eq!(
             vec![
                 "100.64.0.3".parse::<IpAddr>().unwrap(),

--- a/crates/telio-dns/src/nameserver.rs
+++ b/crates/telio-dns/src/nameserver.rs
@@ -1,5 +1,6 @@
 use crate::{
-    packet_decoder::{find_nord_query, normalize_qname, parse_dns_query_packet, DnsParseError},
+    forwarder::RawForwarder,
+    packet_decoder::{find_nord_query, normalize_qname, parse_dns_query_packet},
     packet_encoder::DnsResponseBuilder,
     resolver::Resolver,
     zone::{AuthoritativeZone, ClonableZones, ForwardZone, NordZone, Records, NORD_ZONE},
@@ -12,7 +13,7 @@ use hickory_server::{
 };
 use neptun::noise::{Tunn, TunnResult};
 use pnet_packet::{
-    dns::DnsQuery,
+    dns::{DnsPacket, DnsQuery},
     ip::{IpNextHeaderProtocol, IpNextHeaderProtocols},
     ipv4::{checksum, Ipv4Packet, MutableIpv4Packet},
     ipv6::{Ipv6Packet, MutableIpv6Packet},
@@ -40,6 +41,7 @@ const UDP_HEADER: usize = 8;
 const TCP_MIN_HEADER: usize = 20;
 const MAX_CONCURRENT_QUERIES: usize = 256;
 const IDLE_TIME: Duration = Duration::from_secs(1);
+const DNS_PORT: u16 = 53;
 
 /// NameServer is a server that stores the DNS records.
 #[async_trait]
@@ -53,6 +55,8 @@ pub trait NameServer {
     async fn stop(&self);
     /// Configure list of forward DNS servers for zone '.'.
     async fn forward(&self, to: &[IpAddr]) -> Result<(), String>;
+    /// Configure list of forward DNS servers with explicit socket addresses.
+    async fn forward_to_addrs(&self, to: &[SocketAddr]) -> Result<(), String>;
     /// Insert or update zone records used by the server.
     async fn upsert(
         &self,
@@ -94,16 +98,30 @@ pub struct LocalNameServer {
     nord_zone: NordZone,
     zones: Arc<ClonableZones>,
     task_handle: Option<JoinHandle<()>>,
+    forwarder: Option<RawForwarder>,
 }
 
 impl LocalNameServer {
     /// Create a new `LocalNameServer` with forwarding dns servers from `forward_ips`
     /// configured for zone `.`.
-    pub async fn new(forward_ips: &[IpAddr]) -> Result<Arc<RwLock<Self>>, String> {
+    pub async fn new(
+        forward_ips: &[IpAddr],
+        use_raw_forwarder: bool,
+    ) -> Result<Arc<RwLock<Self>>, String> {
+        let raw_forwarder: Option<RawForwarder> = if use_raw_forwarder {
+            Some(
+                RawForwarder::new()
+                    .await
+                    .map_err(|e| format!("Failed to create forwarder: {e:?}"))?,
+            )
+        } else {
+            None
+        };
         let ns = Arc::new(RwLock::new(LocalNameServer {
             nord_zone: NordZone::new(),
             zones: Arc::new(ClonableZones::new()),
             task_handle: None,
+            forwarder: raw_forwarder,
         }));
         ns.forward(forward_ips).await?;
         Ok(ns)
@@ -291,23 +309,69 @@ impl LocalNameServer {
                     .build()
                     .map_err(|e| format!("Failed building DNS response packet: {e:?}"))?
             }
-            PayloadDestination::Forward(question) => {
-                telio_log_debug!("Forwarding request dns");
-                let resolver = Resolver::new();
-                telio_log_debug!("Getting DNS zones");
-                let zones = nameserver.zones().await;
+            PayloadDestination::Forward(raw_query) => {
+                let raw_forwarder = {
+                    let ns = nameserver.read().await;
+                    ns.forwarder.clone()
+                };
+                if let Some(forwarder) = raw_forwarder {
+                    telio_log_debug!(
+                        "Forwarding raw DNS request from port {:?}",
+                        request_info.dns_source_port(),
+                    );
+                    // TODO: LLT-7054: Remove once migration is fully validated
+                    if let Some(dns_packet) = DnsPacket::new(&raw_query) {
+                        telio_log_debug!(
+                            "Request: id: {} is_response: {} opcode: {:?} recursion_desired: {} query_count: {} rcode: {:?}",
+                            dns_packet.get_id(),
+                            dns_packet.get_is_response(),
+                            dns_packet.get_opcode(),
+                            dns_packet.get_is_recursion_desirable(),
+                            dns_packet.get_query_count(),
+                            dns_packet.get_rcode(),
+                        );
+                        for query in dns_packet.get_queries() {
+                            telio_log_debug!(
+                                "  qtype: {} qclass: {} qname: {}",
+                                query.qtype,
+                                query.qclass,
+                                query.get_qname_parsed()
+                            );
+                        }
+                    }
 
-                let dns_request = Request::new(question, request_info.dns_source(), Protocol::Udp);
-                telio_log_debug!("DNS request: {:?}", &dns_request);
+                    let response = forwarder
+                        .query(&raw_query)
+                        .await
+                        .map_err(|e| format!("Forward failed: {e:?}"))?;
 
-                zones
-                    .lookup(&dns_request, resolver.clone())
-                    .await
-                    .map_err(|e| format!("Lookup failed {e}"))?;
+                    telio_log_debug!("Forwarder responded");
+                    if let Some(dns_packet) = DnsPacket::new(&response) {
+                        telio_log_debug!("Response: {:#?}", dns_packet);
+                    }
 
-                let dns_response = resolver.0.lock().await;
-                telio_log_debug!("Nameserver response: {:?}", &dns_response);
-                dns_response.to_vec()
+                    response
+                } else {
+                    telio_log_debug!("Forwarding DNS request (hickory-server)");
+                    let resolver = Resolver::new();
+                    let zones = nameserver.zones().await;
+
+                    let forward = MessageRequest::from_bytes(&raw_query).map_err(|_| {
+                        String::from("Failed to build MessageRequest from request packet")
+                    })?;
+                    let dns_request =
+                        Request::new(forward, request_info.dns_source(), Protocol::Udp);
+                    telio_log_debug!("DNS request: {:?}", &dns_request);
+
+                    zones
+                        .lookup(&dns_request, resolver.clone())
+                        .await
+                        .map_err(|e| format!("Lookup failed {e}"))?;
+
+                    let dns_response = resolver.0.lock().await;
+                    telio_log_debug!("Nameserver response: {:?}", &dns_response);
+                    dns_response.to_vec()
+                }
             }
         };
 
@@ -382,7 +446,7 @@ impl LocalNameServer {
         }
 
         // Validate DNS port
-        if udp_request.get_destination() != 53 {
+        if udp_request.get_destination() != DNS_PORT {
             return Err(String::from("Invalid DNS port"));
         }
 
@@ -399,19 +463,8 @@ impl LocalNameServer {
                     })
                 } else {
                     // not .nord, forward unchanged
-                    let forward = MessageRequest::from_bytes(payload).map_err(|_| {
-                        String::from("Failed to build MessageRequest from request packet")
-                    })?;
-                    Some(PayloadDestination::Forward(forward))
+                    Some(PayloadDestination::Forward(payload.to_vec()))
                 }
-            }
-            Err(DnsParseError::UnsupportedOpcode(c)) => {
-                telio_log_warn!("Unsupported DNS query Opcode: {c:?}");
-                // still forward it as a fallback
-                let forward = MessageRequest::from_bytes(payload).map_err(|_| {
-                    String::from("Failed to build MessageRequest from request packet")
-                })?;
-                Some(PayloadDestination::Forward(forward))
             }
             Err(e) => {
                 // malformed DNS query
@@ -466,17 +519,15 @@ impl IpRequestInfo {
     }
 }
 
-#[allow(clippy::large_enum_variant)]
 enum PayloadDestination {
     Local {
         id: u16,
         recursion_desired: bool,
         query: DnsQuery,
     },
-    Forward(MessageRequest),
+    Forward(Vec<u8>),
 }
 
-#[allow(clippy::large_enum_variant)]
 enum PayloadRequestInfo {
     Udp {
         source_port: u16,
@@ -497,11 +548,14 @@ struct RequestInfo {
 
 impl RequestInfo {
     fn dns_source(&self) -> SocketAddr {
-        let source_port = match self.payload {
+        SocketAddr::new(self.ip.source_ip(), self.dns_source_port())
+    }
+
+    fn dns_source_port(&self) -> u16 {
+        match self.payload {
             PayloadRequestInfo::Udp { source_port, .. }
             | PayloadRequestInfo::Tcp { source_port, .. } => source_port,
-        };
-        SocketAddr::new(self.ip.source_ip(), source_port)
+        }
     }
 
     fn build_response_packet(
@@ -792,6 +846,20 @@ impl NameServer for Arc<RwLock<LocalNameServer>> {
             LowerName::from_str(".")?,
             Box::new(Arc::new(ForwardZone::new(".", to).await?)),
         );
+
+        let upstreams: Vec<SocketAddr> =
+            to.iter().map(|ip| SocketAddr::new(*ip, DNS_PORT)).collect();
+        self.forward_to_addrs(&upstreams).await?;
+
+        Ok(())
+    }
+
+    async fn forward_to_addrs(&self, to: &[SocketAddr]) -> Result<(), String> {
+        let ns = self.read().await;
+        if let Some(forwarder) = &ns.forwarder {
+            forwarder.set_upstreams(to.to_vec()).await;
+        }
+
         Ok(())
     }
 
@@ -816,16 +884,14 @@ impl NameServer for Arc<RwLock<LocalNameServer>> {
 mod tests {
     use super::*;
     use crate::zone::{Records, NORD_ZONE};
-    use hickory_server::{
-        authority::MessageRequest,
-        proto::{
-            op::{Message, Query},
-            rr::Name,
-            serialize::binary::{BinDecodable, BinDecoder, BinEncodable},
-        },
-        server::Request,
+    use hickory_server::proto::{
+        op::{Message, Query},
+        rr::Name,
+        serialize::binary::{BinDecoder, BinEncodable},
     };
     use std::{net::Ipv4Addr, str::FromStr};
+
+    const USE_RAW_FORWARDER: bool = true;
 
     fn dns_request(host: String) -> Request {
         let mut question = Message::new();
@@ -849,9 +915,10 @@ mod tests {
             entry_name.clone(),
             vec![IpAddr::V4(Ipv4Addr::new(100, 69, 69, 69))],
         );
-        let nameserver = LocalNameServer::new(&[IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))])
-            .await
-            .unwrap();
+        let nameserver =
+            LocalNameServer::new(&[IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))], USE_RAW_FORWARDER)
+                .await
+                .unwrap();
         nameserver
             .upsert(NORD_ZONE, &records, TtlValue(60))
             .await
@@ -884,9 +951,10 @@ mod tests {
             name1.clone(),
             vec![IpAddr::V4(Ipv4Addr::new(100, 69, 69, 69))],
         );
-        let nameserver = LocalNameServer::new(&[IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))])
-            .await
-            .unwrap();
+        let nameserver =
+            LocalNameServer::new(&[IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))], USE_RAW_FORWARDER)
+                .await
+                .unwrap();
         let raw_read_ptr1 = Arc::as_ptr(&nameserver.zones().await);
         nameserver
             .upsert(NORD_ZONE, &records, TtlValue(60))
@@ -923,9 +991,10 @@ mod tests {
             name1.clone(),
             vec![IpAddr::V4(Ipv4Addr::new(100, 69, 69, 69))],
         );
-        let nameserver = LocalNameServer::new(&[IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))])
-            .await
-            .unwrap();
+        let nameserver =
+            LocalNameServer::new(&[IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))], USE_RAW_FORWARDER)
+                .await
+                .unwrap();
         nameserver
             .upsert(NORD_ZONE, &records, TtlValue(60))
             .await
@@ -934,5 +1003,26 @@ mod tests {
         let zones = nameserver.zones().await;
         assert!(zones.contains(&LowerName::from_str(".").unwrap()));
         assert!(zones.contains(&LowerName::from_str("nord").unwrap()));
+    }
+
+    #[tokio::test]
+    async fn nameserver_creates_forwarder_when_raw_flag_set() {
+        let nameserver =
+            LocalNameServer::new(&[IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))], USE_RAW_FORWARDER)
+                .await
+                .unwrap();
+
+        let ns = nameserver.read().await;
+        assert!(ns.forwarder.is_some());
+    }
+
+    #[tokio::test]
+    async fn nameserver_skips_forwarder_by_default() {
+        let nameserver = LocalNameServer::new(&[IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))], false)
+            .await
+            .unwrap();
+
+        let ns = nameserver.read().await;
+        assert!(ns.forwarder.is_none());
     }
 }

--- a/crates/telio-dns/src/packet_decoder.rs
+++ b/crates/telio-dns/src/packet_decoder.rs
@@ -22,9 +22,6 @@ pub(crate) enum DnsParseError {
     /// The packet has no DNS queries
     #[error("no DNS queries")]
     NoQueries,
-    /// Opcode is not supported
-    #[error("unsupported opcode: {0:?}")]
-    UnsupportedOpcode(Opcode),
 }
 
 /// Check if `name` is in the `.nord` top-level domain
@@ -58,11 +55,6 @@ pub(crate) fn parse_dns_query_packet(packet_bytes: &[u8]) -> Result<DnsPacket<'_
         return Err(DnsParseError::NoQueries);
     }
 
-    let opcode = dns_packet.get_opcode();
-    if opcode != Opcode::StandardQuery {
-        return Err(DnsParseError::UnsupportedOpcode(opcode));
-    }
-
     Ok(dns_packet)
 }
 
@@ -72,6 +64,12 @@ pub(crate) fn parse_dns_query_packet(packet_bytes: &[u8]) -> Result<DnsPacket<'_
 /// DNS spec in theory makes it possible to have multiple query per packet
 /// but in practice this is never implemented
 pub(crate) fn find_nord_query(dns_packet: &DnsPacket) -> Option<DnsQuery> {
+    let opcode = dns_packet.get_opcode();
+    if opcode != Opcode::StandardQuery {
+        telio_log_warn!("Unsupported Opcode for nord query: {opcode:?}");
+        return None;
+    }
+
     if dns_packet.get_query_count() > 1 {
         telio_log_warn!(
             "DNS packet contains multiple queries: {}",
@@ -166,12 +164,12 @@ mod tests {
     }
 
     #[test]
-    fn parse_unsupported_opcode() {
+    fn parse_opcode() {
         let mut bytes = build_dns_query_bytes(&["test.nord"], QueryType::A);
         // Set opcode to 2 (Status) while keeping QR=0
         bytes[2] = (bytes[2] & 0x80) | (2 << 3);
-        let err = parse_dns_query_packet(&bytes).unwrap_err();
-        assert!(matches!(err, DnsParseError::UnsupportedOpcode(_)));
+        let packet = parse_dns_query_packet(&bytes).unwrap();
+        assert_eq!(packet.get_opcode(), Opcode::ServerStatusRequest);
     }
 
     #[test]

--- a/crates/telio-dns/src/zone.rs
+++ b/crates/telio-dns/src/zone.rs
@@ -9,7 +9,7 @@ use hickory_server::{
     },
     proto::rr::{rdata, rdata::SOA, DNSClass, LowerName, Name, RData, Record, RecordType},
     resolver::config::{NameServerConfigGroup, ResolverOpts},
-    server::{Request, RequestInfo, ResponseHandler, ResponseInfo},
+    server::RequestInfo,
     store::{forwarder::ForwardConfig, in_memory::InMemoryAuthority},
 };
 use pnet_packet::dns::{DnsQuery, DnsTypes};
@@ -416,11 +416,11 @@ impl ClonableZones {
         self.names.insert(name);
     }
 
-    pub async fn lookup<R: ResponseHandler>(
+    pub async fn lookup<R: hickory_server::server::ResponseHandler>(
         &self,
-        request: &Request,
+        request: &hickory_server::server::Request,
         response_handle: R,
-    ) -> Result<ResponseInfo, LookupError> {
+    ) -> Result<hickory_server::server::ResponseInfo, LookupError> {
         self.zones.lookup(request, None, response_handle).await
     }
 

--- a/crates/telio-dns/tests/nameserver.rs
+++ b/crates/telio-dns/tests/nameserver.rs
@@ -11,6 +11,7 @@ use pnet_packet::{
     Packet,
 };
 use rand_core_compat::rand_core_0_6::OsRng;
+use rstest::rstest;
 use std::{
     io::ErrorKind,
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
@@ -19,6 +20,7 @@ use std::{
 };
 use telio_dns::{LocalNameServer, NameServer, Records};
 use telio_model::features::TtlValue;
+use tokio::task::JoinHandle;
 use tokio::time::sleep;
 use tokio::{
     self,
@@ -36,6 +38,9 @@ const UDP_HEADER: usize = 8;
 const TCP_MIN_HEADER: usize = 20;
 const ICMP_HEADER: usize = 8;
 const MAX_PACKET: usize = 2048;
+const USE_RAW_FORWARDER: bool = true;
+const TEST_TIMEOUT: Duration = Duration::from_secs(5);
+const RESPONSE_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DnsResponse {
@@ -205,7 +210,7 @@ impl WGClient {
         }
 
         let result = timeout(
-            Duration::from_secs(10),
+            RESPONSE_TIMEOUT,
             self.client_socket.recv(&mut receiving_buffer),
         )
         .await;
@@ -539,10 +544,12 @@ async fn dns_test(
     test_type: DnsTestType,
     local_records: Option<(String, Records)>,
     ttl_value: TtlValue,
+    use_raw_forwarder: bool,
 ) -> Option<DnsResponse> {
-    let nameserver = LocalNameServer::new(&[IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))])
-        .await
-        .expect("Failed to create a LocalNameServer");
+    let nameserver =
+        LocalNameServer::new(&[IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))], use_raw_forwarder)
+            .await
+            .expect("Failed to create a LocalNameServer");
 
     dns_test_with_server(query, test_type, local_records, nameserver, ttl_value).await
 }
@@ -597,6 +604,67 @@ async fn init_client_and_server(
     nameserver.start(server_peer.clone(), server_socket).await;
 
     (client, server_peer)
+}
+
+enum UpstreamStubBehavior {
+    Reply(Ipv4Addr),
+    BlackHole,
+}
+
+/// Builds a minimal DNS response with a single A record.
+fn build_upstream_dns_response(query_bytes: &[u8], answer_ip: Ipv4Addr) -> Vec<u8> {
+    let parsed = dns_parser::Packet::parse(query_bytes).expect("Failed to parse incoming query");
+    let qname = parsed.questions[0].qname.to_string();
+
+    let mut builder = Builder::new_query(parsed.header.id, true);
+    builder.add_question(&qname, false, QueryType::A, QueryClass::IN);
+    let mut buf = builder.build().unwrap();
+
+    const FLAGS_OFFSET: usize = 2;
+    const ANCOUNT_OFFSET: usize = 6;
+    const QR_RD_RA: u16 = 0x8180;
+    const TYPE_A: u16 = 1;
+    const CLASS_IN: u16 = 1;
+    const TTL_SECS: u32 = 300;
+    const IPV4_RDLENGTH: u16 = 4;
+    // NAME: compression pointer to qname at offset 0x0C
+    const NAME_PTR: [u8; 2] = [0xC0, 0x0C];
+
+    // Patch the existing header: set QR=1, RD=1, RA=1 flags and answer count=1
+    buf[FLAGS_OFFSET..FLAGS_OFFSET + 2].copy_from_slice(&QR_RD_RA.to_be_bytes());
+    buf[ANCOUNT_OFFSET..ANCOUNT_OFFSET + 2].copy_from_slice(&1_u16.to_be_bytes());
+
+    // Append the answer RR after the question section
+    buf.extend_from_slice(&NAME_PTR);
+    buf.extend_from_slice(&TYPE_A.to_be_bytes());
+    buf.extend_from_slice(&CLASS_IN.to_be_bytes());
+    buf.extend_from_slice(&TTL_SECS.to_be_bytes());
+    buf.extend_from_slice(&IPV4_RDLENGTH.to_be_bytes());
+    buf.extend_from_slice(&answer_ip.octets());
+
+    buf
+}
+
+// Helper for stub upstream resolver
+async fn spawn_upstream_dns_stub(behavior: UpstreamStubBehavior) -> (SocketAddr, JoinHandle<()>) {
+    let socket = tokio::net::UdpSocket::bind("127.0.0.1:0")
+        .await
+        .expect("Failed to bind stub socket");
+    let addr = socket.local_addr().unwrap();
+
+    let handle = tokio::spawn(async move {
+        let mut buf = vec![0u8; 4096];
+        let (n, src) = socket.recv_from(&mut buf).await.unwrap();
+        match behavior {
+            UpstreamStubBehavior::Reply(answer_ip) => {
+                let response = build_upstream_dns_response(&buf[..n], answer_ip);
+                socket.send_to(&response, src).await.unwrap();
+            }
+            UpstreamStubBehavior::BlackHole => {}
+        }
+    });
+
+    (addr, handle)
 }
 
 macro_rules! assert_no_data {
@@ -680,12 +748,13 @@ async fn dns_request_local_soa() {
     let zone = String::from("nord");
 
     let response = timeout(
-        Duration::from_secs(60),
+        TEST_TIMEOUT,
         dns_test(
             "nord",
             DnsTestType::SoaQuerry,
             Some((zone, records)),
             TtlValue(60),
+            USE_RAW_FORWARDER,
         ),
     )
     .await
@@ -713,12 +782,13 @@ async fn dns_request_local_txt() {
     let zone = String::from("nord");
 
     let response = timeout(
-        Duration::from_secs(60),
+        TEST_TIMEOUT,
         dns_test(
             "test.nord",
             DnsTestType::TxtQuerry,
             Some((zone, records)),
             TtlValue(60),
+            USE_RAW_FORWARDER,
         ),
     )
     .await
@@ -737,12 +807,13 @@ async fn dns_request_local_tld() {
     let zone = String::from("nord");
 
     let response = timeout(
-        Duration::from_secs(60),
+        TEST_TIMEOUT,
         dns_test(
             "nord",
             DnsTestType::CorrectIpv4,
             Some((zone, records)),
             TtlValue(60),
+            USE_RAW_FORWARDER,
         ),
     )
     .await
@@ -758,12 +829,13 @@ async fn dns_request_local_no_address() {
     let zone = String::from("nord");
 
     let response = timeout(
-        Duration::from_secs(60),
+        TEST_TIMEOUT,
         dns_test(
             "test.nord",
             DnsTestType::CorrectIpv4,
             Some((zone, records)),
             TtlValue(60),
+            USE_RAW_FORWARDER,
         ),
     )
     .await
@@ -780,12 +852,13 @@ async fn dns_request_local_ipv4() {
     let zone = String::from("nord");
 
     let response = timeout(
-        Duration::from_secs(60),
+        TEST_TIMEOUT,
         dns_test(
             "test.nord",
             DnsTestType::CorrectIpv4,
             Some((zone, records)),
             TtlValue(60),
+            USE_RAW_FORWARDER,
         ),
     )
     .await
@@ -802,12 +875,13 @@ async fn dns_request_local_nickname() {
     records.insert(String::from("nickname.nord"), address.clone());
 
     let response_nickname = timeout(
-        Duration::from_secs(60),
+        TEST_TIMEOUT,
         dns_test(
             "nickname.nord",
             DnsTestType::CorrectIpv4,
             Some(("nord".into(), records.clone())),
             TtlValue(60),
+            USE_RAW_FORWARDER,
         ),
     )
     .await
@@ -815,12 +889,13 @@ async fn dns_request_local_nickname() {
     .expect("Expected some DNS response");
 
     let response_nordname = timeout(
-        Duration::from_secs(60),
+        TEST_TIMEOUT,
         dns_test(
             "big-mountain.nord",
             DnsTestType::CorrectIpv4,
             Some(("nord".into(), records)),
             TtlValue(60),
+            USE_RAW_FORWARDER,
         ),
     )
     .await
@@ -842,12 +917,13 @@ async fn dns_request_local_ipv4_multiple() {
     let zone = String::from("nord");
 
     let response = timeout(
-        Duration::from_secs(60),
+        TEST_TIMEOUT,
         dns_test(
             "test.nord",
             DnsTestType::CorrectIpv4,
             Some((zone, records)),
             TtlValue(60),
+            USE_RAW_FORWARDER,
         ),
     )
     .await
@@ -864,12 +940,13 @@ async fn dns_request_local_case_insensitive() {
     let zone = String::from("nord");
 
     let response = timeout(
-        Duration::from_secs(60),
+        TEST_TIMEOUT,
         dns_test(
             "TeSt.NoRd",
             DnsTestType::CorrectIpv4,
             Some((zone, records)),
             TtlValue(60),
+            USE_RAW_FORWARDER,
         ),
     )
     .await
@@ -888,12 +965,13 @@ async fn dns_request_unknown_local_ipv4() {
     let zone = String::from("nord");
 
     let response = timeout(
-        Duration::from_secs(60),
+        TEST_TIMEOUT,
         dns_test(
             "unknown.nord",
             DnsTestType::CorrectIpv4,
             Some((zone, records)),
             TtlValue(60),
+            USE_RAW_FORWARDER,
         ),
     )
     .await
@@ -912,12 +990,13 @@ async fn dns_request_unknown_local_ipv6() {
     let zone = String::from("nord");
 
     let response = timeout(
-        Duration::from_secs(60),
+        TEST_TIMEOUT,
         dns_test(
             "unknown.nord",
             DnsTestType::CorrectIpv6,
             Some((zone, records)),
             TtlValue(60),
+            USE_RAW_FORWARDER,
         ),
     )
     .await
@@ -935,12 +1014,13 @@ async fn dns_request_local_ipv6() {
     records.insert(String::from("test.nord."), vec![address4, address6]);
     let zone = String::from("nord");
     let response = timeout(
-        Duration::from_secs(60),
+        TEST_TIMEOUT,
         dns_test(
             "test.nord",
             DnsTestType::CorrectIpv6,
             Some((zone, records)),
             TtlValue(60),
+            USE_RAW_FORWARDER,
         ),
     )
     .await
@@ -961,12 +1041,13 @@ async fn dns_request_local_aaaa_but_only_a_exists() {
     );
     let zone = String::from("nord");
     let response = timeout(
-        Duration::from_secs(60),
+        TEST_TIMEOUT,
         dns_test(
             "test.nord",
             DnsTestType::CorrectIpv6,
             Some((zone, records)),
             TtlValue(60),
+            USE_RAW_FORWARDER,
         ),
     )
     .await
@@ -984,12 +1065,13 @@ async fn dns_request_local_a_but_only_aaaa_exists() {
     );
     let zone = String::from("nord");
     let response = timeout(
-        Duration::from_secs(60),
+        TEST_TIMEOUT,
         dns_test(
             "test.nord",
             DnsTestType::CorrectIpv4,
             Some((zone, records)),
             TtlValue(60),
+            USE_RAW_FORWARDER,
         ),
     )
     .await
@@ -998,22 +1080,35 @@ async fn dns_request_local_a_but_only_aaaa_exists() {
     assert_no_data!(response);
 }
 
+#[rstest]
+#[case::hickory(false)]
+#[case::raw(true)]
 #[tokio::test]
-async fn dns_request_forward() {
+async fn dns_request_forward(#[case] use_raw_forwarder: bool) {
     timeout(
-        Duration::from_secs(60),
-        dns_test("google.com", DnsTestType::CorrectIpv4, None, TtlValue(60)),
+        TEST_TIMEOUT,
+        dns_test(
+            "google.com",
+            DnsTestType::CorrectIpv4,
+            None,
+            TtlValue(60),
+            use_raw_forwarder,
+        ),
     )
     .await
     .expect("Test timeout")
     .expect("Expected some DNS response");
 }
 
+#[rstest]
+#[case::hickory(false)]
+#[case::raw(true)]
 #[tokio::test]
-async fn dns_request_forward_to_slow_server() {
-    let nameserver = LocalNameServer::new(&[IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0))])
-        .await
-        .unwrap();
+async fn dns_request_forward_to_slow_server(#[case] use_raw_forwarder: bool) {
+    let nameserver =
+        LocalNameServer::new(&[IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0))], use_raw_forwarder)
+            .await
+            .unwrap();
 
     // Start a query that will run for several seconds
     tokio::spawn(dns_test_with_server(
@@ -1034,11 +1129,15 @@ async fn dns_request_forward_to_slow_server() {
         .is_ok());
 }
 
+#[rstest]
+#[case::hickory(false)]
+#[case::raw(true)]
 #[tokio::test]
-async fn dns_request_to_non_responding_forward_server() {
-    let nameserver = LocalNameServer::new(&[IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0))])
-        .await
-        .unwrap();
+async fn dns_request_to_non_responding_forward_server(#[case] use_raw_forwarder: bool) {
+    let nameserver =
+        LocalNameServer::new(&[IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0))], use_raw_forwarder)
+            .await
+            .unwrap();
 
     dns_test_with_server(
         "google.com",
@@ -1050,134 +1149,152 @@ async fn dns_request_to_non_responding_forward_server() {
     .await;
 }
 
+#[rstest]
+#[case::hickory(false)]
+#[case::raw(true)]
 #[tokio::test]
-async fn dns_request_bad_ip_checksum_ipv4() {
+async fn dns_request_bad_ip_checksum_ipv4(#[case] use_raw_forwarder: bool) {
+    dns_test(
+        "google.com",
+        DnsTestType::BadIpChecksumIpv4,
+        None,
+        TtlValue(60),
+        use_raw_forwarder,
+    )
+    .await;
+}
+
+#[rstest]
+#[case::hickory(false)]
+#[case::raw(true)]
+#[tokio::test]
+async fn dns_request_bad_udp_checksum_ipv4(#[case] use_raw_forwarder: bool) {
+    dns_test(
+        "google.com",
+        DnsTestType::BadUdpChecksumIpv4,
+        None,
+        TtlValue(60),
+        use_raw_forwarder,
+    )
+    .await;
+}
+
+#[rstest]
+#[case::hickory(false)]
+#[case::raw(true)]
+#[tokio::test]
+async fn dns_request_bad_udp_checksum_ipv6(#[case] use_raw_forwarder: bool) {
+    dns_test(
+        "google.com",
+        DnsTestType::BadUdpChecksumIpv6,
+        None,
+        TtlValue(60),
+        use_raw_forwarder,
+    )
+    .await;
+}
+
+#[rstest]
+#[case::hickory(false)]
+#[case::raw(true)]
+#[tokio::test]
+async fn dns_request_bad_udp_port_ipv4(#[case] use_raw_forwarder: bool) {
+    dns_test(
+        "google.com",
+        DnsTestType::BadUdpPortIpv4,
+        None,
+        TtlValue(60),
+        use_raw_forwarder,
+    )
+    .await;
+}
+
+#[rstest]
+#[case::hickory(false)]
+#[case::raw(true)]
+#[tokio::test]
+async fn dns_request_bad_udp_port_ipv6(#[case] use_raw_forwarder: bool) {
+    dns_test(
+        "google.com",
+        DnsTestType::BadUdpPortIpv6,
+        None,
+        TtlValue(60),
+        use_raw_forwarder,
+    )
+    .await;
+}
+
+#[rstest]
+#[case::hickory(false)]
+#[case::raw(true)]
+#[tokio::test]
+async fn dns_request_tcp_ipv4(#[case] use_raw_forwarder: bool) {
     timeout(
-        Duration::from_secs(60),
+        TEST_TIMEOUT,
         dns_test(
             "google.com",
-            DnsTestType::BadIpChecksumIpv4,
+            DnsTestType::TcpIpv4,
             None,
             TtlValue(60),
+            use_raw_forwarder,
         ),
     )
     .await
     .expect("Test timeout");
 }
 
+#[rstest]
+#[case::hickory(false)]
+#[case::raw(true)]
 #[tokio::test]
-async fn dns_request_bad_udp_checksum_ipv4() {
+async fn dns_request_tcp_ipv6(#[case] use_raw_forwarder: bool) {
     timeout(
-        Duration::from_secs(60),
+        TEST_TIMEOUT,
         dns_test(
             "google.com",
-            DnsTestType::BadUdpChecksumIpv4,
+            DnsTestType::TcpIpv6,
             None,
             TtlValue(60),
+            use_raw_forwarder,
         ),
     )
     .await
     .expect("Test timeout");
 }
 
+#[rstest]
+#[case::hickory(false)]
+#[case::raw(true)]
 #[tokio::test]
-async fn dns_request_bad_udp_checksum_ipv6() {
-    timeout(
-        Duration::from_secs(60),
-        dns_test(
-            "google.com",
-            DnsTestType::BadUdpChecksumIpv6,
-            None,
-            TtlValue(60),
-        ),
+async fn dns_request_unsupported_protocol_ipv4(#[case] use_raw_forwarder: bool) {
+    dns_test(
+        "google.com",
+        DnsTestType::UnsupportedProtocolIpv4,
+        None,
+        TtlValue(60),
+        use_raw_forwarder,
     )
-    .await
-    .expect("Test timeout");
+    .await;
 }
 
+#[rstest]
+#[case::hickory(false)]
+#[case::raw(true)]
 #[tokio::test]
-async fn dns_request_bad_udp_port_ipv4() {
-    timeout(
-        Duration::from_secs(60),
-        dns_test(
-            "google.com",
-            DnsTestType::BadUdpPortIpv4,
-            None,
-            TtlValue(60),
-        ),
+async fn dns_request_unsupported_protocol_ipv6(#[case] use_raw_forwarder: bool) {
+    dns_test(
+        "google.com",
+        DnsTestType::UnsupportedProtocolIpv6,
+        None,
+        TtlValue(60),
+        use_raw_forwarder,
     )
-    .await
-    .expect("Test timeout");
-}
-
-#[tokio::test]
-async fn dns_request_bad_udp_port_ipv6() {
-    timeout(
-        Duration::from_secs(60),
-        dns_test(
-            "google.com",
-            DnsTestType::BadUdpPortIpv6,
-            None,
-            TtlValue(60),
-        ),
-    )
-    .await
-    .expect("Test timeout");
-}
-
-#[tokio::test]
-async fn dns_request_tcp_ipv4() {
-    timeout(
-        Duration::from_secs(60),
-        dns_test("google.com", DnsTestType::TcpIpv4, None, TtlValue(60)),
-    )
-    .await
-    .expect("Test timeout");
-}
-
-#[tokio::test]
-async fn dns_request_tcp_ipv6() {
-    timeout(
-        Duration::from_secs(60),
-        dns_test("google.com", DnsTestType::TcpIpv6, None, TtlValue(60)),
-    )
-    .await
-    .expect("Test timeout");
-}
-
-#[tokio::test]
-async fn dns_request_unsupported_protocol_ipv4() {
-    timeout(
-        Duration::from_secs(60),
-        dns_test(
-            "google.com",
-            DnsTestType::UnsupportedProtocolIpv4,
-            None,
-            TtlValue(60),
-        ),
-    )
-    .await
-    .expect("Test timeout");
-}
-
-#[tokio::test]
-async fn dns_request_unsupported_protocol_ipv6() {
-    timeout(
-        Duration::from_secs(60),
-        dns_test(
-            "google.com",
-            DnsTestType::UnsupportedProtocolIpv6,
-            None,
-            TtlValue(60),
-        ),
-    )
-    .await
-    .expect("Test timeout");
+    .await;
 }
 
 #[tokio::test]
 async fn test_tcp_rst() {
-    let nameserver = LocalNameServer::new(&[])
+    let nameserver = LocalNameServer::new(&[], USE_RAW_FORWARDER)
         .await
         .expect("Failed to create a LocalNameServer");
     init_client_and_server(None, nameserver, TtlValue(60)).await;
@@ -1186,11 +1303,15 @@ async fn test_tcp_rst() {
     assert_eq!(error_kind, ErrorKind::ConnectionRefused);
 }
 
+#[rstest]
+#[case::hickory(false)]
+#[case::raw(true)]
 #[tokio::test]
-async fn test_timers_updated() {
-    let nameserver = LocalNameServer::new(&[IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))])
-        .await
-        .expect("Failed to create a LocalNameServer");
+async fn test_timers_updated(#[case] use_raw_forwarder: bool) {
+    let nameserver =
+        LocalNameServer::new(&[IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))], use_raw_forwarder)
+            .await
+            .expect("Failed to create a LocalNameServer");
     let (client, server_peer) = init_client_and_server(None, nameserver, TtlValue(1)).await;
     client.do_handshake().await;
 
@@ -1230,4 +1351,182 @@ async fn test_timers_updated() {
         !client.tunnel.lock().await.is_expired(),
         "Client should not expire due to keepalives"
     );
+}
+
+#[tokio::test]
+async fn dns_request_forward_to_stub_upstream() {
+    let expected_ip = Ipv4Addr::new(93, 184, 216, 34);
+    let (stub_addr, _stub_handle) =
+        spawn_upstream_dns_stub(UpstreamStubBehavior::Reply(expected_ip)).await;
+
+    let nameserver = LocalNameServer::new(&[], USE_RAW_FORWARDER)
+        .await
+        .expect("Failed to create a LocalNameServer");
+    nameserver
+        .forward_to_addrs(&[stub_addr])
+        .await
+        .expect("Failed to set stub upstream");
+
+    let response = timeout(
+        TEST_TIMEOUT,
+        dns_test_with_server(
+            "example.com",
+            DnsTestType::CorrectIpv4,
+            None,
+            nameserver,
+            TtlValue(60),
+        ),
+    )
+    .await
+    .expect("Test timeout")
+    .expect("Expected some DNS response");
+
+    assert!(response.no_error());
+    assert_eq!(response.a_addrs(), vec![expected_ip]);
+}
+
+#[tokio::test]
+async fn dns_request_forward_fallback_to_second_stub() {
+    let expected_ip = Ipv4Addr::new(10, 0, 0, 1);
+    let (blackhole_addr, _bh_handle) =
+        spawn_upstream_dns_stub(UpstreamStubBehavior::BlackHole).await;
+    let (stub_addr, _stub_handle) =
+        spawn_upstream_dns_stub(UpstreamStubBehavior::Reply(expected_ip)).await;
+
+    let nameserver = LocalNameServer::new(&[], USE_RAW_FORWARDER)
+        .await
+        .expect("Failed to create a LocalNameServer");
+    nameserver
+        .forward_to_addrs(&[blackhole_addr, stub_addr])
+        .await
+        .expect("Failed to set stub upstreams");
+
+    let response = timeout(
+        TEST_TIMEOUT,
+        dns_test_with_server(
+            "example.com",
+            DnsTestType::CorrectIpv4,
+            None,
+            nameserver,
+            TtlValue(60),
+        ),
+    )
+    .await
+    .expect("Test timeout")
+    .expect("Expected some DNS response");
+
+    assert!(response.no_error());
+    assert_eq!(response.a_addrs(), vec![expected_ip]);
+}
+
+#[rstest]
+#[case::hickory(false)]
+#[case::raw(true)]
+#[tokio::test]
+async fn dns_request_forward_timeout_returns_no_response(#[case] use_raw_forwarder: bool) {
+    let (blackhole_addr, _bh_handle) =
+        spawn_upstream_dns_stub(UpstreamStubBehavior::BlackHole).await;
+
+    let nameserver = LocalNameServer::new(&[], use_raw_forwarder)
+        .await
+        .expect("Failed to create a LocalNameServer");
+    nameserver
+        .forward_to_addrs(&[blackhole_addr])
+        .await
+        .expect("Failed to set stub upstream");
+
+    let result = dns_test_with_server(
+        "example.com",
+        DnsTestType::NonRespondingForwardServer,
+        None,
+        nameserver,
+        TtlValue(60),
+    )
+    .await;
+
+    assert!(result.is_none());
+}
+
+#[tokio::test]
+async fn dns_request_nord_bypasses_forwarder() {
+    let (blackhole_addr, _bh_handle) =
+        spawn_upstream_dns_stub(UpstreamStubBehavior::BlackHole).await;
+
+    let nameserver = LocalNameServer::new(&[], USE_RAW_FORWARDER)
+        .await
+        .expect("Failed to create a LocalNameServer");
+    nameserver
+        .forward_to_addrs(&[blackhole_addr])
+        .await
+        .expect("Failed to set stub upstream");
+
+    let mut records = Records::new();
+    let expected_ip = Ipv4Addr::new(100, 64, 0, 1);
+    records.insert(String::from("test.nord."), vec![IpAddr::V4(expected_ip)]);
+
+    let response = timeout(
+        TEST_TIMEOUT,
+        dns_test_with_server(
+            "test.nord",
+            DnsTestType::CorrectIpv4,
+            Some(("nord".into(), records)),
+            nameserver,
+            TtlValue(60),
+        ),
+    )
+    .await
+    .expect("Test timeout")
+    .expect("Expected some DNS response");
+
+    assert_a_records!(response, vec![IpAddr::V4(expected_ip)]);
+}
+
+#[tokio::test]
+async fn dns_request_forward_hickory_forwarder() {
+    let nameserver = LocalNameServer::new(&[IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))], false)
+        .await
+        .expect("Failed to create a LocalNameServer");
+
+    let response = timeout(
+        TEST_TIMEOUT,
+        dns_test_with_server(
+            "google.com",
+            DnsTestType::CorrectIpv4,
+            None,
+            nameserver,
+            TtlValue(60),
+        ),
+    )
+    .await
+    .expect("Test timeout")
+    .expect("Expected some DNS response");
+
+    assert!(response.no_error());
+    assert!(!response.a_addrs().is_empty());
+}
+
+#[tokio::test]
+async fn dns_request_local_nord_with_hickory_forwarder() {
+    let mut records = Records::new();
+    let address = vec![IpAddr::V4(Ipv4Addr::new(100, 100, 100, 100))];
+    records.insert(String::from("test.nord."), address.clone());
+
+    let nameserver = LocalNameServer::new(&[IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))], false)
+        .await
+        .expect("Failed to create a LocalNameServer");
+
+    let response = timeout(
+        TEST_TIMEOUT,
+        dns_test_with_server(
+            "test.nord",
+            DnsTestType::CorrectIpv4,
+            Some(("nord".into(), records)),
+            nameserver,
+            TtlValue(60),
+        ),
+    )
+    .await
+    .expect("Test timeout")
+    .expect("Expected some DNS response");
+    assert_a_records!(response, address);
 }

--- a/crates/telio-model/src/features.rs
+++ b/crates/telio-model/src/features.rs
@@ -510,6 +510,9 @@ pub struct FeatureDns {
     /// Configure options for exit dns
     #[serde(default)]
     pub exit_dns: Option<FeatureExitDns>,
+    /// Use the raw DNS forwarder instead of the old hickory-server
+    #[serde(default)]
+    pub use_raw_forwarder: Option<bool>,
 }
 
 /// Newtype for TTL value to ensure that the default function returns the actual default value and not 0.
@@ -754,7 +757,8 @@ mod tests {
                 "ttl_value": 19,
                 "exit_dns": {
                     "auto_switch_dns_ips": true
-                }
+                },
+                "use_raw_forwarder": true
             },
             "multicast": true,
             "error_notification_service": {
@@ -856,6 +860,7 @@ mod tests {
                         exit_dns: Some(FeatureExitDns {
                             auto_switch_dns_ips: Some(true),
                         }),
+                        use_raw_forwarder: Some(true),
                     },
                     multicast: true,
                     error_notification_service: Some(FeatureErrorNotificationService {

--- a/nat-lab/tests/test_dns.py
+++ b/nat-lab/tests/test_dns.py
@@ -28,6 +28,11 @@ from tests.utils.process import ProcessExecError
 from tests.utils.router import IPStack
 from typing import List, Optional
 
+DNS_FORWARDER_PARAMS = [
+    pytest.param(False, id="hickory"),
+    pytest.param(True, id="raw"),
+]
+
 
 def get_dns_server_address(ip_stack: IPStack) -> str:
     return (
@@ -37,8 +42,15 @@ def get_dns_server_address(ip_stack: IPStack) -> str:
     )
 
 
+def _dns_features(use_raw_forwarder: bool, **kwargs):
+    features = default_features(**kwargs)
+    features.dns.use_raw_forwarder = use_raw_forwarder
+    return features
+
+
 # TODO: Linux native has to be removed
 @pytest.mark.asyncio
+@pytest.mark.parametrize("use_raw_forwarder", DNS_FORWARDER_PARAMS)
 @pytest.mark.parametrize(
     ["alpha_ip_stack", "alpha_setup_params"],
     [
@@ -101,12 +113,14 @@ async def test_dns(
     alpha_ip_stack: IPStack,
     alpha_setup_params: SetupParameters,
     beta_ip_stack: IPStack,
+    use_raw_forwarder: bool,
 ) -> None:
     async with AsyncExitStack() as exit_stack:
         dns_server_address_alpha = get_dns_server_address(alpha_ip_stack)
         dns_server_address_beta = (
             LIBTELIO_DNS_IPV4 if beta_ip_stack == IPStack.IPv4 else LIBTELIO_DNS_IPV6
         )
+        alpha_setup_params.features = _dns_features(use_raw_forwarder)
         env = await setup_mesh_nodes(
             exit_stack,
             [
@@ -117,6 +131,7 @@ async def test_dns(
                         ConnectionTag.DOCKER_CONE_CLIENT_2,
                         derp_1_limits=(1, 1),
                     ),
+                    features=_dns_features(use_raw_forwarder),
                 ),
             ],
         )
@@ -187,6 +202,7 @@ async def test_dns(
 
 # TODO: Linux native has to be removed
 @pytest.mark.asyncio
+@pytest.mark.parametrize("use_raw_forwarder", DNS_FORWARDER_PARAMS)
 @pytest.mark.parametrize(
     ["alpha_ip_stack", "alpha_setup_params"],
     [
@@ -231,9 +247,11 @@ async def test_dns(
 async def test_dns_port(
     alpha_ip_stack: IPStack,
     alpha_setup_params: SetupParameters,
+    use_raw_forwarder: bool,
 ) -> None:
     async with AsyncExitStack() as exit_stack:
         dns_server_address_alpha = get_dns_server_address(alpha_ip_stack)
+        alpha_setup_params.features = _dns_features(use_raw_forwarder)
         env = await setup_mesh_nodes(
             exit_stack,
             [
@@ -245,6 +263,7 @@ async def test_dns_port(
                         ConnectionTag.DOCKER_CONE_CLIENT_2,
                         derp_1_limits=(1, 1),
                     ),
+                    features=_dns_features(use_raw_forwarder),
                 ),
             ],
         )
@@ -326,6 +345,7 @@ async def test_dns_port(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("use_raw_forwarder", DNS_FORWARDER_PARAMS)
 @pytest.mark.parametrize(
     "alpha_ip_stack",
     [
@@ -343,7 +363,7 @@ async def test_dns_port(
         ),
     ],
 )
-async def test_vpn_dns(alpha_ip_stack: IPStack) -> None:
+async def test_vpn_dns(alpha_ip_stack: IPStack, use_raw_forwarder: bool) -> None:
     async with AsyncExitStack() as exit_stack:
         dns_server_address = get_dns_server_address(alpha_ip_stack)
         env = await exit_stack.enter_async_context(
@@ -358,6 +378,7 @@ async def test_vpn_dns(alpha_ip_stack: IPStack) -> None:
                             vpn_1_limits=(1, 1),
                         ),
                         is_meshnet=False,
+                        features=_dns_features(use_raw_forwarder),
                     )
                 ],
                 vpn=[ConnectionTag.DOCKER_VPN_1],
@@ -405,6 +426,7 @@ async def test_vpn_dns(alpha_ip_stack: IPStack) -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("use_raw_forwarder", DNS_FORWARDER_PARAMS)
 @pytest.mark.parametrize(
     "alpha_ip_stack",
     [
@@ -422,7 +444,9 @@ async def test_vpn_dns(alpha_ip_stack: IPStack) -> None:
         ),
     ],
 )
-async def test_dns_after_mesh_off(alpha_ip_stack: IPStack) -> None:
+async def test_dns_after_mesh_off(
+    alpha_ip_stack: IPStack, use_raw_forwarder: bool
+) -> None:
     async with AsyncExitStack() as exit_stack:
         dns_server_address = get_dns_server_address(alpha_ip_stack)
         api, (_, beta) = setup_api([(False, alpha_ip_stack), (False, IPStack.IPv4v6)])
@@ -436,7 +460,7 @@ async def test_dns_after_mesh_off(alpha_ip_stack: IPStack) -> None:
                             ConnectionTag.DOCKER_CONE_CLIENT_1
                         ),
                         derp_servers=[],
-                        features=default_features(enable_ipv6=True),
+                        features=_dns_features(use_raw_forwarder, enable_ipv6=True),
                     )
                 ],
                 provided_api=api,
@@ -482,6 +506,7 @@ async def test_dns_after_mesh_off(alpha_ip_stack: IPStack) -> None:
 @pytest.mark.asyncio
 @pytest.mark.long
 @pytest.mark.timeout(timeouts.TEST_DNS_STABILITY_TIMEOUT)
+@pytest.mark.parametrize("use_raw_forwarder", DNS_FORWARDER_PARAMS)
 @pytest.mark.parametrize(
     "alpha_ip_stack",
     [
@@ -499,7 +524,7 @@ async def test_dns_after_mesh_off(alpha_ip_stack: IPStack) -> None:
         ),
     ],
 )
-async def test_dns_stability(alpha_ip_stack: IPStack) -> None:
+async def test_dns_stability(alpha_ip_stack: IPStack, use_raw_forwarder: bool) -> None:
     async with AsyncExitStack() as exit_stack:
         dns_server_address = get_dns_server_address(alpha_ip_stack)
         env = await setup_mesh_nodes(
@@ -513,6 +538,7 @@ async def test_dns_stability(alpha_ip_stack: IPStack) -> None:
                         ConnectionTag.DOCKER_CONE_CLIENT_1,
                         derp_1_limits=(1, 1),
                     ),
+                    features=_dns_features(use_raw_forwarder),
                 ),
                 SetupParameters(
                     connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2,
@@ -521,6 +547,7 @@ async def test_dns_stability(alpha_ip_stack: IPStack) -> None:
                         ConnectionTag.DOCKER_CONE_CLIENT_2,
                         derp_1_limits=(1, 1),
                     ),
+                    features=_dns_features(use_raw_forwarder),
                 ),
             ],
         )
@@ -602,6 +629,7 @@ async def test_set_meshnet_config_dns_update(
                             ConnectionTag.DOCKER_CONE_CLIENT_1
                         ),
                         derp_servers=[],
+                        features=_dns_features(use_raw_forwarder=False),
                     )
                 ],
             )
@@ -637,6 +665,7 @@ async def test_set_meshnet_config_dns_update(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("use_raw_forwarder", DNS_FORWARDER_PARAMS)
 @pytest.mark.parametrize(
     "alpha_ip_stack",
     [
@@ -654,7 +683,7 @@ async def test_set_meshnet_config_dns_update(
         ),
     ],
 )
-async def test_dns_update(alpha_ip_stack: IPStack) -> None:
+async def test_dns_update(alpha_ip_stack: IPStack, use_raw_forwarder: bool) -> None:
     async with AsyncExitStack() as exit_stack:
         dns_server_address = get_dns_server_address(alpha_ip_stack)
         env = await exit_stack.enter_async_context(
@@ -669,6 +698,7 @@ async def test_dns_update(alpha_ip_stack: IPStack) -> None:
                             vpn_1_limits=(1, 1),
                         ),
                         is_meshnet=False,
+                        features=_dns_features(use_raw_forwarder),
                     )
                 ],
                 vpn=[ConnectionTag.DOCKER_VPN_1],
@@ -703,7 +733,10 @@ async def test_dns_update(alpha_ip_stack: IPStack) -> None:
 
 
 @pytest.mark.asyncio
-async def test_dns_duplicate_requests_on_multiple_forward_servers() -> None:
+@pytest.mark.parametrize("use_raw_forwarder", DNS_FORWARDER_PARAMS)
+async def test_dns_duplicate_requests_on_multiple_forward_servers(
+    use_raw_forwarder: bool,
+) -> None:
     async with AsyncExitStack() as exit_stack:
         FIRST_DNS_SERVER = "10.0.80.83"
         SECOND_DNS_SERVER = "10.0.80.82"
@@ -765,6 +798,7 @@ async def test_dns_duplicate_requests_on_multiple_forward_servers() -> None:
                     ip_stack=IPStack.IPv4v6,
                     connection_tracker_config=[SingleConnectionToAnyNatlabDNS()],
                     derp_servers=[],
+                    features=_dns_features(use_raw_forwarder),
                 )
             ],
         )
@@ -782,7 +816,11 @@ async def test_dns_aaaa_records() -> None:
     async with AsyncExitStack() as exit_stack:
         api, (_, beta) = setup_api([(False, IPStack.IPv4v6), (False, IPStack.IPv4v6)])
         env = await exit_stack.enter_async_context(
-            setup_environment(exit_stack, [SetupParameters()], provided_api=api)
+            setup_environment(
+                exit_stack,
+                [SetupParameters(features=_dns_features(use_raw_forwarder=False))],
+                provided_api=api,
+            )
         )
         connection_alpha, *_ = [conn.connection for conn in env.connections]
         client_alpha, *_ = env.clients
@@ -812,7 +850,9 @@ async def test_dns_nickname() -> None:
                         ConnectionTag.DOCKER_CONE_CLIENT_1,
                         derp_1_limits=(1, 1),
                     ),
-                    features=default_features(enable_nicknames=True),
+                    features=_dns_features(
+                        use_raw_forwarder=False, enable_nicknames=True
+                    ),
                 ),
                 SetupParameters(
                     connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2,
@@ -820,7 +860,9 @@ async def test_dns_nickname() -> None:
                         ConnectionTag.DOCKER_CONE_CLIENT_2,
                         derp_1_limits=(1, 1),
                     ),
-                    features=default_features(enable_nicknames=True),
+                    features=_dns_features(
+                        use_raw_forwarder=False, enable_nicknames=True
+                    ),
                 ),
             ],
             provided_api=api,
@@ -869,7 +911,9 @@ async def test_dns_change_nickname() -> None:
                         ConnectionTag.DOCKER_CONE_CLIENT_1,
                         derp_1_limits=(1, 1),
                     ),
-                    features=default_features(enable_nicknames=True),
+                    features=_dns_features(
+                        use_raw_forwarder=False, enable_nicknames=True
+                    ),
                 ),
                 SetupParameters(
                     connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2,
@@ -877,7 +921,9 @@ async def test_dns_change_nickname() -> None:
                         ConnectionTag.DOCKER_CONE_CLIENT_2,
                         derp_1_limits=(1, 1),
                     ),
-                    features=default_features(enable_nicknames=True),
+                    features=_dns_features(
+                        use_raw_forwarder=False, enable_nicknames=True
+                    ),
                 ),
             ],
             provided_api=api,
@@ -967,7 +1013,9 @@ async def test_dns_wildcarded_records() -> None:
                         ConnectionTag.DOCKER_CONE_CLIENT_1,
                         derp_1_limits=(1, 1),
                     ),
-                    features=default_features(enable_nicknames=True),
+                    features=_dns_features(
+                        use_raw_forwarder=False, enable_nicknames=True
+                    ),
                 ),
                 SetupParameters(
                     connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2,
@@ -975,7 +1023,9 @@ async def test_dns_wildcarded_records() -> None:
                         ConnectionTag.DOCKER_CONE_CLIENT_2,
                         derp_1_limits=(1, 1),
                     ),
-                    features=default_features(enable_nicknames=True),
+                    features=_dns_features(
+                        use_raw_forwarder=False, enable_nicknames=True
+                    ),
                 ),
             ],
             provided_api=api,
@@ -1031,7 +1081,9 @@ async def test_dns_ttl_value() -> None:
 
         features_without_exit_dns = default_features()
         features_without_exit_dns.dns = FeatureDns(
-            exit_dns=None, ttl_value=EXPECTED_TTL_VALUE
+            exit_dns=None,
+            ttl_value=EXPECTED_TTL_VALUE,
+            use_raw_forwarder=False,
         )
 
         api, (_, _) = setup_api([(False, IPStack.IPv4v6), (False, IPStack.IPv4v6)])
@@ -1052,6 +1104,7 @@ async def test_dns_ttl_value() -> None:
                         ConnectionTag.DOCKER_CONE_CLIENT_2,
                         derp_1_limits=(1, 1),
                     ),
+                    features=_dns_features(use_raw_forwarder=False),
                 ),
             ],
             provided_api=api,
@@ -1091,7 +1144,13 @@ async def test_dns_nickname_in_any_case() -> None:
         env = await exit_stack.enter_async_context(
             setup_environment(
                 exit_stack,
-                [SetupParameters(features=default_features(enable_nicknames=True))],
+                [
+                    SetupParameters(
+                        features=_dns_features(
+                            use_raw_forwarder=False, enable_nicknames=True
+                        )
+                    )
+                ],
                 provided_api=api,
             )
         )
@@ -1119,7 +1178,8 @@ def all_cases(name: str) -> List[str]:
 
 
 @pytest.mark.asyncio
-async def test_dns_no_error_return_code() -> None:
+@pytest.mark.parametrize("use_raw_forwarder", DNS_FORWARDER_PARAMS)
+async def test_dns_no_error_return_code(use_raw_forwarder: bool) -> None:
     async with AsyncExitStack() as exit_stack:
         FIRST_DNS_SERVER = "10.0.80.83"
         SECOND_DNS_SERVER = "10.0.80.82"
@@ -1134,6 +1194,7 @@ async def test_dns_no_error_return_code() -> None:
                         ConnectionTag.DOCKER_CONE_CLIENT_1,
                         derp_1_limits=(1, 1),
                     ),
+                    features=_dns_features(use_raw_forwarder),
                 )
             ],
         )
@@ -1148,12 +1209,5 @@ async def test_dns_no_error_return_code() -> None:
             "53",
             "error-with-noerror-return-code.com",
             dns_server=LIBTELIO_DNS_IPV4,
-        )
-
-        await client_alpha.wait_for_log(
-            "Got an error response with NoError code for error-with-noerror-return-code.com., this should not happen so converting to ServFail"
-        )
-
-        await client_alpha.wait_for_log(
-            'DNS name resolution failed (no records): ResolveError { kind: NoRecordsFound { query: Query { name: Name("error-with-noerror-return-code.com."), query_type: A, query_class: IN }, soa: None, negative_ttl: None, response_code: NoError, trusted: true } }'
+            expected_output=["status: NOERROR", "ANSWER: 0"],
         )

--- a/nat-lab/tests/test_dns_through_exit.py
+++ b/nat-lab/tests/test_dns_through_exit.py
@@ -3,7 +3,8 @@ import pytest
 from contextlib import AsyncExitStack
 from tests import config
 from tests.helpers import setup_api, setup_mesh_nodes, SetupParameters
-from tests.utils.bindings import default_features, TelioAdapterType
+from tests.test_dns import _dns_features, DNS_FORWARDER_PARAMS
+from tests.utils.bindings import TelioAdapterType
 from tests.utils.connection import ConnectionTag
 from tests.utils.connection_util import generate_connection_tracker_config
 from tests.utils.dns import query_dns
@@ -13,6 +14,7 @@ from typing import List, Tuple
 
 # IPv6 tests are failing because we do not have IPV6 internet connection
 @pytest.mark.asyncio
+@pytest.mark.parametrize("use_raw_forwarder", DNS_FORWARDER_PARAMS)
 @pytest.mark.parametrize(
     "alpha_info",
     [
@@ -103,7 +105,6 @@ from typing import List, Tuple
                     ConnectionTag.DOCKER_CONE_CLIENT_2,
                     derp_1_limits=(1, 1),
                 ),
-                features=default_features(enable_firewall_exclusion_range="10.0.0.0/8"),
             ),
             id="b",
         )
@@ -114,6 +115,7 @@ async def test_dns_through_exit(
     beta_setup_params: SetupParameters,
     alpha_info: Tuple[IPStack, List[str]],
     exit_info: Tuple[IPStack, List[str]],
+    use_raw_forwarder: bool,
 ) -> None:
     async with AsyncExitStack() as exit_stack:
         if (alpha_info[0] == IPStack.IPv4 and exit_info[0] == IPStack.IPv6) or (
@@ -138,6 +140,11 @@ async def test_dns_through_exit(
         )
         beta.set_peer_firewall_settings(
             alpha.id, allow_incoming_connections=True, allow_peer_traffic_routing=True
+        )
+
+        alpha_setup_params.features = _dns_features(use_raw_forwarder)
+        beta_setup_params.features = _dns_features(
+            use_raw_forwarder, enable_firewall_exclusion_range="10.0.0.0/8"
         )
 
         env = await setup_mesh_nodes(

--- a/nat-lab/tests/test_telio_tasks.py
+++ b/nat-lab/tests/test_telio_tasks.py
@@ -36,6 +36,7 @@ async def test_telio_tasks_with_all_features() -> None:
         features.dns = FeatureDns(
             exit_dns=FeatureExitDns(auto_switch_dns_ips=True),
             ttl_value=60,
+            use_raw_forwarder=True,
         )
         env = await setup_mesh_nodes(
             exit_stack,

--- a/src/device.rs
+++ b/src/device.rs
@@ -1846,7 +1846,7 @@ impl Runtime {
                     &public_key,
                     upstream_dns_servers,
                     dns_entity.virtual_host_tun_fd.as_ref(),
-                    self.features.dns.exit_dns.clone(),
+                    &self.features.dns,
                 )
                 .await
                 .map_err(Error::DnsResolverError)?;

--- a/src/device/wg_controller.rs
+++ b/src/device/wg_controller.rs
@@ -1774,6 +1774,7 @@ mod tests {
                     dns: FeatureDns {
                         exit_dns: None,
                         ttl_value: TtlValue(60),
+                        use_raw_forwarder: None,
                     },
                     multicast: false,
                     error_notification_service: None,

--- a/src/libtelio.udl
+++ b/src/libtelio.udl
@@ -841,6 +841,8 @@ dictionary FeatureDns {
     TtlValue ttl_value;
     /// Configure options for exit dns [default None]
     FeatureExitDns? exit_dns;
+    /// Use the raw DNS forwarder instead of the old hickory-server
+    boolean? use_raw_forwarder;
 };
 
 /// Turns on post quantum VPN tunnel


### PR DESCRIPTION
### Problem

Non `.nord` DNS queries are forwarded through hickory-server's ForwardAuthority zone. We want to remove  `hickory` dependencies as it adds unnecessary overhead, requires additional maintenance and was a source of bugs.

### Solution

Integrate `RawForwarder` into `LocalNameServer` behind a new `use_raw_forwarder` feature flag.

- Add `use_raw_forwarder: Option<bool>` to `FeatureDns` (default: None, uses hickory-server)
- When `use_raw_forwarder` is true, `LocalNameServer` routes non `.nord` queries through `RawForwarder` instead of hickory `Resolver` and `ClonableZones::lookup()`.
- The hickory-server path remains the default
- Parametrize nat-lab DNS tests to run with both hickory and raw forwarder

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests