### PR TITLE
Increase nordvpnlite client timeout to 20 seconds

### DIFF
--- a/clis/nordvpnlite/src/command_listener.rs
+++ b/clis/nordvpnlite/src/command_listener.rs
@@ -12,7 +12,7 @@ use crate::{
     daemon::{NordVpnLiteError, TelioStatusReport},
 };
 
-pub(crate) const TIMEOUT_SEC: u64 = 10;
+pub(crate) const TIMEOUT_SEC: u64 = 20;
 
 #[derive(Parser, Debug, PartialEq)]
 #[clap()]


### PR DESCRIPTION
### Problem
*--OpenWrt arm64 nat-lab VM is slower due to full QEMU emulation that requires a longer timeout for nordvpnlite to work. `nordvpnlite stop` command takes up-to 15 seconds--*

### Solution
*--Increase timeout to 20 seconds--*


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
