### PR TITLE
Do not run setup nlx server if no nlx container is running

### DIFF
--- a/nat-lab/tests/conftest_helpers/setup_checks.py
+++ b/nat-lab/tests/conftest_helpers/setup_checks.py
@@ -306,8 +306,14 @@ async def setup_check_arp_cache(session_vm_marks: set[str]):
         raise Exception("ARP cache not ready for VMs: " + ", ".join(failures))
 
 
-async def setup_nlx_vpn_server() -> None:
+async def setup_nlx_vpn_server(
+    session_is_container_running: dict[ConnectionTag, bool],
+) -> None:
     """Populate NLX_SERVER keys in tests.config (global, survives between tests)."""
+    if not session_is_container_running.get(ConnectionTag.VM_LINUX_NLX_1, False):
+        setup_log.info("NLX container is not running, skipping NLX VPN server setup..")
+        return
+
     async with AsyncExitStack() as exit_stack:
         conn = await exit_stack.enter_async_context(
             new_connection_raw(ConnectionTag.VM_LINUX_NLX_1)
@@ -374,7 +380,10 @@ async def perform_setup_checks(
     for target, timeout, retries in SETUP_CHECKS:
         while retries > 0:
             try:
-                if target is setup_check_duplicate_mac_addresses:
+                if target in [
+                    setup_check_duplicate_mac_addresses,
+                    setup_nlx_vpn_server,
+                ]:
                     await asyncio.wait_for(
                         asyncio.shield(target(session_is_container_running)), timeout
                     )


### PR DESCRIPTION
### Problem
`nlx-01` container is part of the speciality containers and should not be required to be running by default.

At the moment natlab runs will fail setup check if this container is not running which is often the case when run locally (most of the tests don't require it).

### Solution
Add check to `setup_nlx_vpn_server()` to skip if the container is not running.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
