### PR TITLE
Fix dns check in OpenWrt test

### DIFF
--- a/nat-lab/tests/test_openwrt.py
+++ b/nat-lab/tests/test_openwrt.py
@@ -240,6 +240,13 @@ async def test_openwrt_vpn_connection(
             log.debug("</logread>")
             return lines
 
+        async def wait_for_nameserver_lines(expected: int) -> list[str]:
+            while True:
+                ns_lines = await grep_logread("using nameserver")
+                if len(ns_lines) >= expected:
+                    return ns_lines
+                await asyncio.sleep(1)
+
         # Restarting the log daemon clears the log. This makes the testcase safe to be execute in any order.
         await gateway_connection.create_process(
             ["/etc/init.d/log", "restart"]
@@ -248,11 +255,7 @@ async def test_openwrt_vpn_connection(
             ["/etc/init.d/dnsmasq", "restart"]
         ).execute()
 
-        # Dnsmasq restart will populate the logs soon
-        await asyncio.sleep(5)
-
-        ns_lines = await grep_logread("nameserver")
-        assert len(ns_lines) == 1
+        ns_lines = await wait_for_nameserver_lines(1)
         assert "daemon.info dnsmasq[1]: using nameserver 10.0.80.82" in ns_lines[0]
 
         async with nordvpnlite.start():
@@ -267,12 +270,8 @@ async def test_openwrt_vpn_connection(
         await wait_for_log_line(logread_proc)
         log.info("Network has been reloaded")
 
-        # Dnsmasq restart will populate the logs soon
-        await asyncio.sleep(5)
-
         # check if DHCP DNS nameservers were restored
-        ns_lines = await grep_logread("nameserver")
-        assert len(ns_lines) == 3
+        ns_lines = await wait_for_nameserver_lines(3)
         assert "daemon.info dnsmasq[1]: using nameserver 10.0.80.82" in ns_lines[0]
         assert "daemon.info dnsmasq[1]: using nameserver 10.0.80.83" in ns_lines[1]
         assert "daemon.info dnsmasq[1]: using nameserver 10.0.80.82" in ns_lines[2]


### PR DESCRIPTION
### Problem
*--test_openwrt_vpn_connection uses time sleep to wait for dns changes to take place. This approach is flaky on arm64 VM that is much slower--*

### Solution
*--Replace time sleep with wait condition--*


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
