### PR TITLE
LLT-7325: Fix UPNP flaky test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5294,6 +5294,7 @@ dependencies = [
  "parking_lot",
  "rand 0.10.1",
  "rstest",
+ "serial_test",
  "stun_codec",
  "surge-ping",
  "telio-crypto",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,6 +151,7 @@ rustls = { version = "0.23", default-features = false, features = [
 ] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+serial_test = "3.4"
 sha2 = "0.10.9"
 slog = "2.8"
 smart-default = "0.7.1"

--- a/clis/nordvpnlite/Cargo.toml
+++ b/clis/nordvpnlite/Cargo.toml
@@ -39,7 +39,7 @@ daemonize = "0.5.0"
 rand.workspace = true
 
 [dev-dependencies]
-serial_test = "3.2.0"
+serial_test.workspace = true
 temp-dir = "0.1.16"
 temp-file = "0.1.9"
 visibility = "0.1.1"

--- a/crates/telio-firewall/Cargo.toml
+++ b/crates/telio-firewall/Cargo.toml
@@ -33,7 +33,7 @@ mockall_double.workspace = true
 if-addrs.workspace = true
 mockall.workspace = true
 sn_fake_clock.workspace = true
-serial_test = "3.2.0"
+serial_test.workspace = true
 
 telio-utils = {workspace = true, features = ["sn_fake_clock"] }
 

--- a/crates/telio-lana/Cargo.toml
+++ b/crates/telio-lana/Cargo.toml
@@ -18,7 +18,7 @@ time.workspace = true
 telio-utils.workspace = true
 
 [dev-dependencies]
-serial_test = "3.2.0"
+serial_test.workspace = true
 
 [build-dependencies]
 anyhow.workspace = true

--- a/crates/telio-network-monitors/Cargo.toml
+++ b/crates/telio-network-monitors/Cargo.toml
@@ -36,4 +36,4 @@ windows.workspace = true
 [dev-dependencies]
 assert_matches = "1.5.0"
 lazy_static.workspace = true
-serial_test = "3.2.0"
+serial_test.workspace = true

--- a/crates/telio-traversal/Cargo.toml
+++ b/crates/telio-traversal/Cargo.toml
@@ -41,6 +41,7 @@ env_logger.workspace = true
 maplit.workspace = true
 mockall.workspace = true
 ntest.workspace = true
+serial_test.workspace = true
 tokio = { workspace = true, features = ["test-util"] }
 test-log = { version = "0.2.19", features = ["trace"] }
 

--- a/crates/telio-traversal/src/connectivity_check/cross_ping_check.rs
+++ b/crates/telio-traversal/src/connectivity_check/cross_ping_check.rs
@@ -1744,7 +1744,7 @@ mod tests {
         ];
 
         // Verify all possible permutations are sorted in defined order
-        for mut candidate_permutation in expected_candidates
+        for candidate_permutation in expected_candidates
             .iter()
             .permutations(expected_candidates.len())
         {
@@ -1764,7 +1764,7 @@ mod tests {
         ];
 
         // Verify all possible permutations are sorted in defined order again
-        for mut candidate_permutation in expected_candidates
+        for candidate_permutation in expected_candidates
             .iter()
             .permutations(expected_candidates.len())
         {

--- a/crates/telio-traversal/src/endpoint_providers/upnp.rs
+++ b/crates/telio-traversal/src/endpoint_providers/upnp.rs
@@ -822,6 +822,7 @@ mod tests {
     use lazy_static::lazy_static;
     use mockall::mock;
     use parking_lot::Mutex;
+    use serial_test::serial;
     use telio_crypto::PublicKey;
     use telio_crypto::SecretKey;
     use telio_model::mesh::LinkState;
@@ -860,7 +861,6 @@ mod tests {
     }
 
     lazy_static! {
-        static ref SEQUENTIAL_LOCK: Arc<TMutex<bool>> = Arc::new(TMutex::new(true));
         static ref IGD_IS_AVAILABLE: Arc<Mutex<bool>> = Arc::new(Mutex::new(false));
         static ref ENDPOINT: Arc<Mutex<EndpointCandidate>> =
             Arc::new(Mutex::new(EndpointCandidate {
@@ -916,10 +916,23 @@ mod tests {
             )
             .unwrap(),
         );
-        let udp_socket = spool
-            .new_external_udp((Ipv4Addr::UNSPECIFIED, 55555), None)
-            .await
-            .unwrap();
+        let udp_socket = {
+            let mut attempts = 10;
+            loop {
+                match spool
+                    .new_external_udp((Ipv4Addr::UNSPECIFIED, 55555), None)
+                    .await
+                {
+                    Ok(s) => break s,
+                    Err(e) if attempts > 1 => {
+                        attempts -= 1;
+                        println!("Failed to bind socket to port 55555: {e}");
+                        tokio::time::sleep(Duration::from_millis(500)).await;
+                    }
+                    Err(e) => panic!("Failed to bind port 55555 after retries: {e}"),
+                }
+            }
+        };
 
         // Set to default ports
         let mut epc = ENDPOINT.lock();
@@ -984,8 +997,8 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn create_upnp_endpoint() {
-        let _quard = SEQUENTIAL_LOCK.lock().await;
         let upnp = prepare_test_setup().await;
 
         tokio::time::sleep(Duration::from_millis(100 + 20)).await;
@@ -998,8 +1011,8 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn check_igd_function_execution() {
-        let _quard = SEQUENTIAL_LOCK.lock().await;
         let upnp = prepare_test_setup().await;
         tokio::time::sleep(Duration::from_millis(100 + 20)).await;
 
@@ -1022,8 +1035,8 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_no_igd_on_router() {
-        let _quard = SEQUENTIAL_LOCK.lock().await;
         // Avoid initial search
         *IGD_IS_AVAILABLE.lock() = true;
         let _upnp = prepare_test_setup().await;
@@ -1038,8 +1051,8 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_upnp_route_corruption_on_router() {
-        let _quard = SEQUENTIAL_LOCK.lock().await;
         let _upnp = prepare_test_setup().await;
         tokio::time::sleep(Duration::from_millis(100 + 20)).await;
 
@@ -1058,6 +1071,7 @@ mod tests {
 
     #[tokio::test]
     #[test_log::test]
+    #[serial]
     async fn test_ensure_igd_gateway_is_called_with_exponential_backoff() {
         let spool = SocketPool::new(
             NativeProtector::new(
@@ -1071,10 +1085,12 @@ mod tests {
             .await
             .unwrap();
 
-        // Set to default ports
-        let mut epc = ENDPOINT.lock();
-        epc.wg.set_port(1000);
-        epc.udp.set_port(2000);
+        {
+            // Set to default ports
+            let mut epc = ENDPOINT.lock();
+            epc.wg.set_port(1000);
+            epc.udp.set_port(2000);
+        }
 
         // These are not properly used yet, just dummy variables
         let mut wg = MockWg::default();

--- a/crates/telio-traversal/src/session_keeper.rs
+++ b/crates/telio-traversal/src/session_keeper.rs
@@ -237,7 +237,7 @@ mod tests {
                         continue;
                     }
                     _ = &mut timeout => {
-                        assert!(false, "Timeout!");
+                        panic!("Timeout!");
                     }
                 }
             }

--- a/crates/telio-traversal/src/upgrade_sync.rs
+++ b/crates/telio-traversal/src/upgrade_sync.rs
@@ -622,7 +622,7 @@ mod tests {
         intercoms_them.tx.send((pk, upg_msg.clone())).await.unwrap();
 
         // Runtime
-        let _ = tokio::spawn(async move {
+        tokio::spawn(async move {
             let timeout = time::sleep(Duration::from_secs(1));
             tokio::pin!(timeout);
 
@@ -632,7 +632,7 @@ mod tests {
             loop {
                 tokio::select! {
                     _ = intercoms_them.rx.recv() => {
-                        assert!(false, "Should not rx here");
+                        panic!("Should not rx here");
                     }
                     Some(_upg_rq) = upg_rq_rx.recv() => {
                         if !expecting_old_rq {
@@ -646,7 +646,7 @@ mod tests {
                         }
                     }
                     _ = &mut timeout => {
-                        assert!(false, "Timeout!");
+                        panic!("Timeout!");
                     }
                 }
             }
@@ -674,21 +674,17 @@ mod tests {
             .parse::<PublicKey>()
             .unwrap();
 
-        intercoms_them
-            .tx
-            .send((pk.clone(), upg_msg.clone()))
-            .await
-            .unwrap();
+        intercoms_them.tx.send((pk, upg_msg.clone())).await.unwrap();
 
         // Runtime
-        let _ = tokio::spawn(async move {
+        tokio::spawn(async move {
             let timeout = time::sleep(Duration::from_secs(1));
             tokio::pin!(timeout);
 
             loop {
                 tokio::select! {
                     msg = intercoms_them.rx.recv() => {
-                        assert!(false, "Should not rx here, msg: {:?}", msg);
+                        panic!("Should not rx here, msg: {:?}", msg);
                     }
                     Some(_upg_rq) = upg_rq_rx.recv() => {
                         break;
@@ -699,7 +695,7 @@ mod tests {
                         continue;
                     }
                     _ = &mut timeout => {
-                        assert!(false, "Timeout!");
+                        panic!("Timeout!");
                     }
                 }
             }
@@ -853,11 +849,7 @@ mod tests {
             .parse::<PublicKey>()
             .unwrap();
 
-        intercoms_them
-            .tx
-            .send((pk.clone(), upg_msg.clone()))
-            .await
-            .unwrap();
+        intercoms_them.tx.send((pk, upg_msg.clone())).await.unwrap();
 
         wait_for(Duration::from_secs(15), || async {
             !upg_sync.get_upgrade_requests().await.unwrap().is_empty()


### PR DESCRIPTION
### Problem
UPnP tests in `telio-traversal` crate are flaky due to port binding issues.

`prepare_test_setup()` binds a UDP socket to hardcoded port 55555. Since cargo test runs test binaries in parallel, another process on the same machine can hold this port, causing `AddrInUse` panics.

### Solution
- Replace `SEQUENTIAL_LOCK` with `serial_test` crate.
- Add a retry loop (10 attempts, 500ms each) around the port 55555 bind in `prepare_test_setup()`
- Fix clippy warnings in tests


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
