### PR TITLE
LLT-7324: Fix missing `docker inspect`

### DIFF
--- a/nat-lab/natlab.py
+++ b/nat-lab/natlab.py
@@ -279,11 +279,15 @@ def check_containers(
     # Check health status of running containers
     for service in running_services:
         container_ids_raw = run_command_with_output(
-            ["docker", "compose", "ps", "-q", service], hide_output=True
+            ["docker", "compose", "ps", "-q", "--all", service], hide_output=True
         ).strip()
         container_ids = [
             cid.strip() for cid in container_ids_raw.splitlines() if cid.strip()
         ]
+
+        # If no containers are found for the service, consider it a problem and add it to missing_services
+        if not container_ids:
+            missing_services.append(service)
 
         for cid in container_ids:
             container_state_raw = run_command_with_output(


### PR DESCRIPTION
Add the `--all` flag to retrieve IDs of all containers per service. Lack of this flag caused the command to return an empty string for containers in the `exited` or `created` state.

Report service without any containers as missing.

### Problem
*During container startup we check that containers have started but currently that just checks if the service exists, not if it has any running containers associated with it. That can lead to a situation where the setup code considers all containers started and healthy and starts running tests, but then tests start failing because containers are missing. It will not check closed containers and not started.*

### Solution
*Solution is based on adding flag `-all` to get list of all containers from the service and add service to the list of `missing services` if no single container is visible for this service.*


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
