### PR TITLE
Dependency updates May 2026

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "generic-array",
 ]
 
@@ -156,9 +156,9 @@ dependencies = [
 
 [[package]]
 name = "asn1-rs"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
 dependencies = [
  "asn1-rs-derive",
  "asn1-rs-impl",
@@ -535,7 +535,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -559,6 +559,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -759,7 +768,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
  "zeroize",
 ]
@@ -834,6 +843,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -866,6 +881,12 @@ checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "constant_time_eq"
@@ -974,6 +995,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "crypto_box"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1032,6 +1062,15 @@ dependencies = [
  "dispatch2",
  "nix 0.31.3",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -1305,9 +1344,21 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -1389,9 +1440,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "endian-type"
@@ -1695,9 +1746,9 @@ checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-timer"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
@@ -1973,7 +2024,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2038,6 +2098,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -2250,7 +2319,7 @@ dependencies = [
  "hyper-util",
  "log",
  "rand 0.9.4",
- "reqwest",
+ "reqwest 0.12.28",
  "thiserror 2.0.18",
  "tokio",
  "url",
@@ -2309,7 +2378,7 @@ dependencies = [
  "libc",
  "recvmsg",
  "tokio",
- "widestring 1.2.1",
+ "widestring",
  "windows-sys 0.61.2",
 ]
 
@@ -2342,7 +2411,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
 dependencies = [
  "socket2",
- "widestring 1.2.1",
+ "widestring",
  "windows-registry",
  "windows-result",
  "windows-sys 0.61.2",
@@ -2425,6 +2494,36 @@ dependencies = [
  "thiserror 1.0.69",
  "walkdir",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2832,7 +2931,7 @@ dependencies = [
  "crossbeam-channel",
  "dispatch",
  "hex",
- "hmac",
+ "hmac 0.12.1",
  "ip_network",
  "ip_network_table",
  "libc",
@@ -2860,9 +2959,9 @@ dependencies = [
 
 [[package]]
 name = "netlink-packet-route"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df9854ea6ad14e3f4698a7f03b65bce0833dd2d81d594a0e4a984170537146b6"
+checksum = "be8919612f6028ab4eacbbfe1234a9a43e3722c6e0915e7ff519066991905092"
 dependencies = [
  "bitflags",
  "libc",
@@ -2955,10 +3054,10 @@ dependencies = [
  "futures",
  "interprocess",
  "ipnet",
- "nix 0.30.1",
+ "nix 0.31.3",
  "rand 0.10.1",
  "regex",
- "reqwest",
+ "reqwest 0.13.3",
  "serde",
  "serde_json",
  "serial_test",
@@ -3029,9 +3128,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -3243,18 +3342,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.12"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf0d9e68100b3a7989b4901972f265cd542e560a3a8a724e1e20322f4d06ce9"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.12"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a990e22f43e84855daf260dded30524ef4a9021cc7541c26540500a50b624389"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3691,9 +3790,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
+checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
 dependencies = [
  "bitflags",
  "memchr",
@@ -3741,6 +3840,7 @@ version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -4001,6 +4101,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier 0.7.0",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "resolv-conf"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4151,7 +4291,28 @@ checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys 0.8.7",
- "jni",
+ "jni 0.21.1",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys 0.8.7",
+ "jni 0.22.4",
  "log",
  "once_cell",
  "rustls",
@@ -4361,9 +4522,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -4446,18 +4607,18 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
- "digest",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -4487,9 +4648,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook"
-version = "0.3.18"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+checksum = "b2a0c28ca5908dbdbcd52e6fdaa00358ab88637f8ab33e1f188dd510eb44b53d"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -4507,15 +4668,31 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-tokio"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213241f76fb1e37e27de3b6aa1b068a2c333233b59cca6634f634b80a27ecf1e"
+checksum = "e513e435a8898a0002270f29d0a708b7879708fb5c4d00e46983ca2d2d378cf0"
 dependencies = [
  "futures-core",
  "libc",
  "signal-hook",
  "tokio",
 ]
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "simple_logger"
@@ -4644,19 +4821,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
- "strum_macros 0.28.0",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "strum_macros",
 ]
 
 [[package]]
@@ -4680,7 +4845,7 @@ dependencies = [
  "bytecodec 0.5.0",
  "byteorder",
  "crc 3.4.0",
- "hmac",
+ "hmac 0.12.1",
  "md5 0.7.0",
  "sha1 0.10.6",
  "trackable 1.3.0",
@@ -4809,7 +4974,7 @@ dependencies = [
  "ipnet",
  "parking_lot",
  "regex",
- "reqwest",
+ "reqwest 0.13.3",
  "rustyline",
  "serde",
  "serde_json",
@@ -4845,7 +5010,7 @@ dependencies = [
  "futures",
  "ipnet",
  "itertools 0.14.0",
- "jni",
+ "jni 0.21.1",
  "lazy_static",
  "libloading 0.9.0",
  "maplit",
@@ -4856,7 +5021,7 @@ dependencies = [
  "parking_lot",
  "rand 0.10.1",
  "rstest",
- "rustls-platform-verifier",
+ "rustls-platform-verifier 0.6.2",
  "serde_json",
  "telio-crypto",
  "telio-dns",
@@ -4993,7 +5158,7 @@ dependencies = [
  "serde_json",
  "smart-default",
  "strum",
- "strum_macros 0.27.2",
+ "strum_macros",
  "telio-crypto",
  "telio-utils",
  "tracing",
@@ -5079,7 +5244,7 @@ dependencies = [
  "blake2",
  "blake3",
  "byteorder",
- "hmac",
+ "hmac 0.13.0",
  "mockall",
  "neptun",
  "parking_lot",
@@ -5183,7 +5348,7 @@ dependencies = [
  "rand 0.10.1",
  "rand_core_compat",
  "rstest",
- "rustls-platform-verifier",
+ "rustls-platform-verifier 0.6.2",
  "smart-default",
  "static_assertions",
  "telio-crypto",
@@ -5393,15 +5558,15 @@ dependencies = [
 
 [[package]]
 name = "temp-dir"
-version = "0.1.16"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83176759e9416cf81ee66cb6508dbfe9c96f20b8b56265a39917551c23c70964"
+checksum = "016ef9739649996fcc983b9c588fe3d557cf216d4d98503ce1b057ab5a66d689"
 
 [[package]]
 name = "temp-file"
-version = "0.1.9"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5ff282c3f91797f0acb021f3af7fffa8a78601f0f2fd0a9f79ee7dcf9a9af9e"
+checksum = "e08eac0f10a143ffa8883ff5964642eef36d867436cc389812c32790c778105f"
 
 [[package]]
 name = "tempfile"
@@ -5761,9 +5926,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.10"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags",
  "bytes",
@@ -6075,7 +6240,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -6374,12 +6539,6 @@ dependencies = [
  "once_cell",
  "rustix 0.38.44",
 ]
-
-[[package]]
-name = "widestring"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c168940144dd21fd8046987c16a46a33d5fc84eec29ef9dcddc2ac9e31526b7c"
 
 [[package]]
 name = "widestring"
@@ -6772,21 +6931,21 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "winreg"
-version = "0.55.0"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
+checksum = "7d6f32a0ff4a9f6f01231eb2059cc85479330739333e0e58cadf03b6af2cca10"
 dependencies = [
  "cfg-if",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6801,18 +6960,18 @@ dependencies = [
 [[package]]
 name = "wireguard-nt"
 version = "1.0.0"
-source = "git+https://github.com/NordSecurity/wireguard-nt-rust-wrapper?tag=v1.2.0#f6c5684fc8cb49958b99ad5178cc61ace3e8a4c1"
+source = "git+https://github.com/NordSecurity/wireguard-nt-rust-wrapper?tag=v1.3.0#f554a48131a24743389713a7624a3b9ef17d619b"
 dependencies = [
  "bitflags",
- "getrandom 0.2.17",
+ "getrandom 0.4.2",
  "ipnet",
- "libloading 0.8.9",
+ "libloading 0.9.0",
  "log",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tracing",
- "widestring 0.4.3",
+ "widestring",
  "winapi",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
  "wireguard-uapi",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,16 +105,16 @@ base64 = "0.22"
 blake3 = "1.8"
 bytes = "1"
 cc = "1"
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.6", features = ["derive"] }
 crypto_box = { version = "0.9.1", features = ["std"] }
 enum-map = "2.7.3"
 env_logger = "0.11"
-futures = "0.3.31"
+futures = "0.3.32"
 hashlink = "0.11"
 hex = "0.4.3"
 httparse = "1.10"
 if-addrs = "0.15.0"
-ipnet = { version = "2.11", features = ["serde"] }
+ipnet = { version = "2.12", features = ["serde"] }
 itertools = "0.14"
 lazy_static = "1.5"
 libc = "0.2"
@@ -127,7 +127,7 @@ mockall = "0.14"
 mockall_double = "0.3.1"
 modifier = "0.1.0"
 nat-detect = { git = "https://github.com/NordSecurity/nat-detect.git", tag = "v0.1.9" }
-nix = { version = "0.31.1", features = ["fs", "socket", "uio", "net"] }
+nix = { version = "0.31.3", features = ["fs", "socket", "uio", "net"] }
 ntest = "0.9"
 num_cpus = "1"
 num_enum = "0.7"
@@ -135,12 +135,12 @@ once_cell = "1"
 parking_lot = "0.12"
 pnet_packet = "0.35"
 pretty_assertions = "1"
-proptest = "1.9"
+proptest = "1.11"
 proptest-derive = "0.8.0"
 protobuf-codegen = "3.7.2"
 rand = "0.10.1"
-rand_core = "0.10.0"
-rand_core_compat = { version = "0.1.0", features = ["rand_core_0_6", "rand_core_0_9"] }
+rand_core = "0.10.1"
+rand_core_compat = { version = "0.1.1", features = ["rand_core_0_6", "rand_core_0_9"] }
 regex = "1.12"
 rstest = "0.26.1"
 rustc-hash = "2"
@@ -152,7 +152,7 @@ rustls = { version = "0.23", default-features = false, features = [
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serial_test = "3.4"
-sha2 = "0.10.9"
+sha2 = "0.11.0"
 slog = "2.8"
 smart-default = "0.7.1"
 sn_fake_clock = "0.4"
@@ -169,7 +169,7 @@ tracing-subscriber = { version = "0.3", features = [
 tracing-appender = "0.2"
 uniffi = "0.28.3"
 url = "2.5"
-uuid = { version = "1.19", features = ["v4"] }
+uuid = { version = "1.23", features = ["v4"] }
 wireguard-uapi = { git = "https://github.com/NordSecurity/wireguard-uapi-rs.git", rev = "5f5d9952ced4faf10f56d98153e4a8e560102e5c", features = ["xplatform", "zeroize"], default-features = false  }
 winapi = { version = "0.3", features = ["netioapi", "ws2def", "cfgmgr32", "setupapi", "winreg", "iphlpapi", "errhandlingapi", "ifdef"] }
 windows = { version = "0.62.2", features = [
@@ -177,7 +177,7 @@ windows = { version = "0.62.2", features = [
   "Win32_NetworkManagement_IpHelper",
   "Win32_NetworkManagement_Ndis",
 ] }
-winreg = "0.55.0"
+winreg = "0.56.0"
 
 neptun = { git = "https://github.com/NordSecurity/neptun.git", tag = "v2.3.0", features = [
   "device",
@@ -187,7 +187,7 @@ x25519-dalek = { version = "2.0.1", features = [
   "static_secrets",
 ] }
 zeroize = { version = "1.8.2", features = ["derive"] }
-hyper-util = "0.1.19"
+hyper-util = "0.1.20"
 
 telio-crypto = { version = "0.1.0", path = "./crates/telio-crypto" }
 telio-dns = { version = "0.1.0", path = "./crates/telio-dns" }

--- a/clis/derpcli/Cargo.toml
+++ b/clis/derpcli/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/NordSecurity/libtelio"
 
 [dependencies]
 atomic-counter = "1.0.1"
-ctrlc = "3.5.1"
+ctrlc = "3.5.2"
 
 anyhow.workspace = true
 base64.workspace = true

--- a/clis/nordvpnlite/Cargo.toml
+++ b/clis/nordvpnlite/Cargo.toml
@@ -17,20 +17,21 @@ tracing-subscriber.workspace = true
 # Used as a lightweight and safe (because a TCP server has the risk of remote code execution)
 # way for the API and daemon to communicate.
 # Tokio support is needed, because the daemon runs on the async runtime.
-interprocess = { version = "2.2.3", features = ["tokio"] }
+interprocess = { version = "2.4.2", features = ["tokio"] }
 
-nix = { version = "0.30.1", features = ["signal"] }
+nix = { version = "0.31.3", features = ["signal"] }
 
 telio = { path = "../..", features = ["disable_ens"], default-features = false }
 tokio.workspace = true
-signal-hook-tokio = { version = "0.3.1", features = ["futures-v0_3"] }
+signal-hook-tokio = { version = "0.4.0", features = ["futures-v0_3"] }
 futures.workspace = true
 thiserror.workspace = true
 regex.workspace = true
 ipnet.workspace = true
-reqwest = { version = "0.12.26", default-features = false, features = [
+reqwest = { version = "0.13.3", default-features = false, features = [
   "json",
-  "rustls-tls",
+  "rustls",
+  "query",
 ] }
 uuid = { workspace = true, features = ["serde"] }
 anyhow.workspace = true
@@ -40,7 +41,7 @@ rand.workspace = true
 
 [dev-dependencies]
 serial_test.workspace = true
-temp-dir = "0.1.16"
-temp-file = "0.1.9"
+temp-dir = "0.2.0"
+temp-file = "0.2.0"
 visibility = "0.1.1"
 assert_matches = "1.5.0"

--- a/clis/tcli/Cargo.toml
+++ b/clis/tcli/Cargo.toml
@@ -8,10 +8,12 @@ default-run = "tcli"
 
 [dependencies]
 dirs = "6.0.0"
-reqwest = { version = "0.12.26", default-features = false, features = [
+reqwest = { version = "0.13.3", default-features = false, features = [
   "json",
   "blocking",
-  "rustls-tls",
+  "rustls",
+  "form",
+  "query",
 ] }
 rustyline = "17.0"
 shellwords = "1.1.0"

--- a/crates/telio-crypto/Cargo.toml
+++ b/crates/telio-crypto/Cargo.toml
@@ -10,9 +10,9 @@ publish = false
 aead = { version = "0.5.2", default-features = false }
 serde_with = { features = [
   "macros",
-], default-features = false, version = "3.16.1" }
+], default-features = false, version = "3.20.0" }
 chacha20poly1305 = { default-features = false, version = "0.10.1" }
-chacha20 = { default-features = false, version = "0.9.1" }
+chacha20 = { default-features = false, version = "0.9" }
 zeroize = { workspace = true, default-features = false }
 curve25519-dalek = { default-features = false, version = "4.1.3" }
 

--- a/crates/telio-model/Cargo.toml
+++ b/crates/telio-model/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 pretend_to_be_macos = []
 
 [dependencies]
-strum_macros = "0.27"
+strum_macros = "0.28"
 
 ipnet.workspace = true
 itertools.workspace = true

--- a/crates/telio-network-monitors/Cargo.toml
+++ b/crates/telio-network-monitors/Cargo.toml
@@ -27,7 +27,7 @@ block2 = "0.6"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 neli = { version = "0.7.4", features = ["async"] }
-netlink-packet-route = "0.29.0"
+netlink-packet-route = "0.30.0"
 netlink-packet-core = "0.8.1"
 
 [target.'cfg(windows)'.dependencies]

--- a/crates/telio-nurse/Cargo.toml
+++ b/crates/telio-nurse/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/NordSecurity/libtelio"
 publish = false
 
 [dependencies]
-bitflags = "2.10.0"
+bitflags = "2.11.1"
 histogram = "0.6.9"
 md5 = { default-features = false, version = "0.8" }
 csv = "1.4"

--- a/crates/telio-pq/Cargo.toml
+++ b/crates/telio-pq/Cargo.toml
@@ -16,7 +16,7 @@ fuzzing = []
 pqcrypto-kyber = { version = "=0.7.6", default-features = false }
 pqcrypto-internals = "=0.2.5"
 pqcrypto-traits = { default-features = false, version = "0.3.5" }
-hmac = { version = "0.12.1", default-features = false }
+hmac = { version = "0.13.0", default-features = false }
 blake2 = { default-features = false, version = "0.10.6" }
 blake3 = { workspace = true, default-features = false }
 

--- a/crates/telio-pq/src/proto.rs
+++ b/crates/telio-pq/src/proto.rs
@@ -8,7 +8,7 @@ use std::{
 
 use blake2::Digest;
 use byteorder::{LittleEndian, ReadBytesExt};
-use hmac::Mac;
+use hmac::{KeyInit, Mac};
 use neptun::noise;
 use pnet_packet::{
     icmp::IcmpPacket,

--- a/crates/telio-proto/Cargo.toml
+++ b/crates/telio-proto/Cargo.toml
@@ -27,16 +27,16 @@ enable_ens = [
 http = { version = "1.4.0", optional = true }
 llt-proto = { git = "https://github.com/NordSecurity/llt-proto.git", tag = "v1.0.0", optional = true }
 hyper-util = { workspace = true, optional = true }
-prost = { version = "0.14.1", optional = true }
+prost = { version = "0.14.3", optional = true }
 protobuf = "3.7.2"
 rustls = { version = "0.23", default-features = false, features = ["std", "ring"] }
-rustls-webpki = { version = "0.103.12", optional = true }
+rustls-webpki = { version = "0.103.13", optional = true }
 aws-lc-rs = { version = "=1.16.2", features = ["bindgen"], optional = true }
-tokio-stream = { version = "0.1.17", optional = true }
+tokio-stream = { version = "0.1.18", optional = true }
 tokio-rustls = { version = "0.26.4", default-features = false, optional = true }
-tonic = { version = "0.14.2", optional = true }
+tonic = { version = "0.14.6", optional = true }
 tonic-prost = { version = "0.14", optional = true }
-tower = { version = "0.5.2", optional = true }
+tower = { version = "0.5.3", optional = true }
 
 anyhow.workspace = true
 base64.workspace = true
@@ -63,11 +63,11 @@ protobuf-codegen.workspace = true
 [dev-dependencies]
 assert_matches = "1.5.0"
 async-channel = "2.5.0"
-rcgen = "0.14.6"
+rcgen = "0.14.8"
 telio-utils = { workspace = true, features = ["mockall"] }
-test-log = { version = "0.2.19", features = ["trace"] }
+test-log = { version = "0.2.20", features = ["trace"] }
 tokio = { workspace = true, features = ["sync"] }
-tonic = { version = "0.14.2", features = ["tls-aws-lc"] }
+tonic = { version = "0.14.6", features = ["tls-aws-lc"] }
 
 [package.metadata.cargo-machete]
 ignored = ["prost", "tonic-prost"]

--- a/crates/telio-relay/Cargo.toml
+++ b/crates/telio-relay/Cargo.toml
@@ -11,8 +11,8 @@ enable_ens = ["telio-proto/enable_ens"]
 
 [dependencies]
 tokio-rustls = { version = "0.26.4", default-features = false }
-tokio-util = "0.7.17"
-tokio-stream = { default-features = false, version = "0.1.17" }
+tokio-util = "0.7.18"
+tokio-stream = { default-features = false, version = "0.1.18" }
 
 async-trait.workspace = true
 bytes.workspace = true
@@ -36,7 +36,7 @@ telio-proto.workspace = true
 telio-sockets.workspace = true
 telio-task.workspace = true
 telio-utils.workspace = true
-webpki-roots = "1.0.4"
+webpki-roots = "1.0.7"
 smart-default.workspace = true
 
 [dev-dependencies]
@@ -57,7 +57,7 @@ tokio = { workspace = true, features = [
 telio-nurse = { workspace = true, features = ["mockall"] }
 telio-task = { workspace = true, features = ["test-util"] }
 telio-test.workspace = true
-hyper = { version = "1.8.1", features = ["full", "http1"] }
+hyper = { version = "1.9.0", features = ["full", "http1"] }
 hyper-util.workspace = true
 http-body-util = "0.1.3"
 

--- a/crates/telio-traversal/Cargo.toml
+++ b/crates/telio-traversal/Cargo.toml
@@ -43,7 +43,7 @@ mockall.workspace = true
 ntest.workspace = true
 serial_test.workspace = true
 tokio = { workspace = true, features = ["test-util"] }
-test-log = { version = "0.2.19", features = ["trace"] }
+test-log = { version = "0.2.20", features = ["trace"] }
 
 
 telio-task = { workspace = true, features = ["test-util"] }

--- a/crates/telio-wg/Cargo.toml
+++ b/crates/telio-wg/Cargo.toml
@@ -50,7 +50,7 @@ telio-task = { workspace = true, features = ["test-util"] }
 telio-test.workspace = true
 proptest.workspace = true
 proptest-derive.workspace = true
-test-log = { version = "0.2.19", features = ["trace"] }
+test-log = { version = "0.2.20", features = ["trace"] }
 
 [build-dependencies]
 cc.workspace = true
@@ -63,7 +63,7 @@ winreg.workspace = true
 uuid.workspace = true
 utf16_lit = "2.0.2"
 
-wireguard-nt = { git = "https://github.com/NordSecurity/wireguard-nt-rust-wrapper", tag = "v1.2.0" }
+wireguard-nt = { git = "https://github.com/NordSecurity/wireguard-nt-rust-wrapper", tag = "v1.3.0" }
 
 windows = { workspace = true, features = [
     "Win32_Security",


### PR DESCRIPTION
Routine dependency updates, May 2026

Most dependencies were updated to the latest available version, but
some had to be skipped for now. rustls-platform verifier could not
be updated to 0.7.0 because it has a direct dependency to
core-foundation 0.10, while also having a dependency on
security-foundation which depends on core-foundation 0.9, causing
a dependency mismatch. We need to wait for a new security-foundation
version. And jni 0.22 is incompatible with rustls-platform-verifier
0.6.2 so we need to wait until we can update rustls-platform-verifier
before we can update jni. Additionally, but unrelated, rustyline in
tcli depends on unstable compiler features so that cannot yet be
updated.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
