### PR TITLE
nordvpnlite fix wait for start

### DIFF
--- a/clis/nordvpnlite/src/core_api.rs
+++ b/clis/nordvpnlite/src/core_api.rs
@@ -320,15 +320,11 @@ pub async fn get_countries_with_exp_backoff(
     loop {
         match get_countries(cert_path).await {
             Ok(countries) => return Ok(countries),
-            Err(Error::Reqwest(ref e)) if e.is_timeout() => {
-                warn!(
-                    "Failed to fetch countries due to {e}, will wait for {:?} and retry",
-                    backoff.get_backoff()
-                );
-                wait_with_backoff_delay(&mut backoff, &mut retries).await?;
-            }
             Err(e) => {
-                return Err(e);
+                warn!("Failed to fetch countries due to {e}",);
+                handle_api_error!(e)?;
+                warn!("Will wait for {:?} and retry", backoff.get_backoff());
+                wait_with_backoff_delay(&mut backoff, &mut retries).await?;
             }
         }
     }
@@ -374,15 +370,11 @@ pub async fn get_recommended_servers_with_exp_backoff(
     loop {
         match get_recommended_servers(country_id_filter, limit_filter, cert_path).await {
             Ok(servers) => return Ok(servers),
-            Err(Error::Reqwest(ref e)) if e.is_timeout() => {
-                warn!(
-                    "Failed to fetch recommended servers due to {e}, will wait for {:?} and retry",
-                    backoff.get_backoff()
-                );
-                wait_with_backoff_delay(&mut backoff, &mut retries).await?;
-            }
             Err(e) => {
-                return Err(e);
+                warn!("Failed to fetch recommended servers due to {e}",);
+                handle_api_error!(e)?;
+                warn!("Will wait for {:?} and retry", backoff.get_backoff());
+                wait_with_backoff_delay(&mut backoff, &mut retries).await?;
             }
         }
     }

--- a/clis/nordvpnlite/src/daemon.rs
+++ b/clis/nordvpnlite/src/daemon.rs
@@ -397,19 +397,23 @@ pub async fn daemon_event_loop(config: NordVpnLiteConfig) -> Result<(), NordVpnL
     };
 
     let config_clone = config.clone();
+    let (init_done_tx, init_done_rx) = oneshot::channel::<()>();
     let mut telio_task_handle = tokio::task::spawn_blocking(move || {
         let mut context = TelioContext::new(config_clone, nordlynx_private_key)?;
+        let _ = init_done_tx.send(());
         context.start_listening_commands(telio_rx)
     });
 
-    // Spawn the async task for exit node connection
-    // TODO: This can be triggered through nordvpnlite command to allow the user to stop/restart.
-    let config_clone = config.clone();
-    let tx_clone = telio_tx.clone();
-    tokio::spawn(async move {
-        handle_exit_node_connection(&config_clone, tx_clone).await;
-        debug!("Exit node connection task completed");
-    });
+    // Wait for interface setup to complete before making API calls.
+    if init_done_rx.await.is_ok() {
+        // TODO: This can be triggered through nordvpnlite command to allow the user to stop/restart.
+        let config_clone = config.clone();
+        let tx_clone = telio_tx.clone();
+        tokio::spawn(async move {
+            handle_exit_node_connection(&config_clone, tx_clone).await;
+            debug!("Exit node connection task completed");
+        });
+    }
 
     info!("Entering event loop");
     loop {

--- a/nat-lab/tests/nordvpnlite.py
+++ b/nat-lab/tests/nordvpnlite.py
@@ -290,31 +290,18 @@ class NordVpnLite:
             await self.remove_logs()
             await self.save_config()
 
-            async def wait_for_nordvpnlite_start():
-                await self.wait_for_nordvpnlite_socket()
-                while True:
-                    try:
-                        if not await self.is_alive():
-                            raise RuntimeError(
-                                "socket exists but daemon's not running."
-                            )
-                        break
-                    except IgnoreableError:
-                        await asyncio.sleep(self.NORDVPNLITE_CMD_CHECK_INTERVAL_S)
-                        continue
-
             cmd = ["start"]
             if not self.config.no_detach:
                 cmd.append("--config-file")
                 cmd.append(str(self.config.config_path))
                 stdout, stderr = await self.execute_command(cmd)
-                await wait_for_nordvpnlite_start()
+                await self.wait_for_nordvpnlite_start()
             else:
                 cmd.append("--no-detach")
                 cmd.append("--config-file")
                 cmd.append(str(self.config.config_path))
                 proc = await self.run_command(cmd)
-                await wait_for_nordvpnlite_start()
+                await self.wait_for_nordvpnlite_start()
                 stdout, stderr = proc.get_stdout(), proc.get_stderr()
 
             assert len(stderr) == 0, f"Stderr is not empty: {stderr}"
@@ -438,6 +425,17 @@ class NordVpnLite:
         await self.connection.create_process(
             ["rm", "-f", str(self.config.paths.socket_file)]
         ).execute()
+
+    async def wait_for_nordvpnlite_start(self):
+        await self.wait_for_nordvpnlite_socket()
+        while True:
+            try:
+                if not await self.is_alive():
+                    raise RuntimeError("socket exists but daemon's not running.")
+                break
+            except IgnoreableError:
+                await asyncio.sleep(self.NORDVPNLITE_CMD_CHECK_INTERVAL_S)
+                continue
 
     async def wait_for_nordvpnlite_socket(self):
         while True:

--- a/nat-lab/tests/test_openwrt.py
+++ b/nat-lab/tests/test_openwrt.py
@@ -61,6 +61,21 @@ OPENWRT_TAGS = [
 ]
 
 
+async def log_dns_state(connection: Connection) -> None:
+    try:
+        resolv = await connection.create_process(["cat", "/etc/resolv.conf"]).execute()
+        log.info("/etc/resolv.conf:\n%s", resolv.get_stdout())
+    except ProcessExecError as e:
+        log.info("/etc/resolv.conf not available: %s", e)
+    try:
+        dnsmasq = await connection.create_process(
+            ["sh", "-c", "netstat -ulnp 2>/dev/null | grep :53 || ss -ulnp | grep :53"]
+        ).execute()
+        log.info("DNS listeners (port 53):\n%s", dnsmasq.get_stdout())
+    except ProcessExecError as e:
+        log.info("Could not check DNS listeners: %s", e)
+
+
 async def check_gateway_and_client_ip(
     gateway_connection: Connection,
     client_connection: Connection,
@@ -642,6 +657,7 @@ async def test_openwrt_router_restart(
             gateway_connection_after_reboot is not None
         ), "OpenWrt router didn't get back online after reboot"
         log.info("Established new connection to the OpenWrt router")
+        await log_dns_state(gateway_connection_after_reboot)
         config_path = Paths(exec_path=Path("nordvpnlite"))
         nordvpnlite_after_reboot = NordVpnLite(
             gateway_connection_after_reboot,
@@ -651,6 +667,7 @@ async def test_openwrt_router_restart(
         # wrap into try/finally to always execute cleanup code
         try:
             log.info("wait for vpn connection to be re-established after reboot")
+            await log_dns_state(gateway_connection_after_reboot)
             await nordvpnlite_after_reboot.wait_for_nordvpnlite_start()
             await nordvpnlite_after_reboot.wait_for_vpn_connected_state()
             await check_gateway_and_client_ip(

--- a/nat-lab/tests/test_openwrt.py
+++ b/nat-lab/tests/test_openwrt.py
@@ -651,6 +651,7 @@ async def test_openwrt_router_restart(
         # wrap into try/finally to always execute cleanup code
         try:
             log.info("wait for vpn connection to be re-established after reboot")
+            await nordvpnlite_after_reboot.wait_for_nordvpnlite_start()
             await nordvpnlite_after_reboot.wait_for_vpn_connected_state()
             await check_gateway_and_client_ip(
                 gateway_connection_after_reboot,


### PR DESCRIPTION
### Problem

There is a race condition between `TelioContext::new()` and `handle_exit_node_connection()`:
1. `handle_exit_node_connection()` starts making API calls.
2. `TelioContext::new()` calls `set_ip()` -> `/etc/init.d/network reload` and disrupts the network stack.
3. Current in flight API calls can fail.

### Solution

1. Move `handle_exit_node_connection()` to run after `TelioContext::new()` completes.
2. Broaden retry logic (exponential backoff for all API calls).
3. Add additional DNS logs to restart test.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
