### PR TITLE
LLT-7321: Reject outgoing packets with stale addresses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ tcli.log
 *.nix
 *.prepared*
 *.dylib
+*.so
 /nat-lab/data/tcli*
 /3rd-party/ci-helper-scripts/
 /3rd-party/libmoose
@@ -18,7 +19,6 @@ tcli.log
 /nat-lab/3rd-party/iptables
 /nat-lab/3rd-party/netfilter-full-cone-nat
 /nat-lab/tests/uniffi/telio_bindings.py
-/nat-lab/tests/uniffi/libtelio.so
 /nat-lab/tests/uniffi/telio.dll
 /nat-lab/data/nordvpnlite/data.json
 /nat-lab/logs

--- a/.unreleased/LLT-7321
+++ b/.unreleased/LLT-7321
@@ -1,0 +1,1 @@
+Block outgoing packets with wrong source IP

--- a/clis/nordvpnlite/src/config.rs
+++ b/clis/nordvpnlite/src/config.rs
@@ -1,5 +1,7 @@
 use std::{
+    fs,
     io::Write,
+    net::IpAddr,
     net::Ipv4Addr,
     os::unix::fs::PermissionsExt,
     path::{Path, PathBuf},
@@ -8,16 +10,15 @@ use std::{
 };
 
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
-use std::fs;
 use tracing::{level_filters::LevelFilter, Level};
 
-use telio::{crypto::SecretKey, device::AdapterType, telio_utils::Hidden};
+use telio::{
+    crypto::{PublicKey, SecretKey},
+    device::AdapterType,
+    telio_utils::Hidden,
+};
 
 use crate::{interface::InterfaceConfig, NordVpnLiteError};
-use std::net::IpAddr;
-use telio::crypto::PublicKey;
-
-pub(crate) const LOCAL_IP: Ipv4Addr = Ipv4Addr::new(10, 5, 0, 2);
 
 // These IPs are documented but the documentation is not publicly available
 fn dns_default() -> Vec<IpAddr> {

--- a/clis/nordvpnlite/src/daemon.rs
+++ b/clis/nordvpnlite/src/daemon.rs
@@ -25,8 +25,11 @@ use telio::{
     crypto::SecretKey,
     device::{Device, DeviceConfig, Error as DeviceError},
     ffi::defaults_builder::FeaturesDefaultsBuilder,
-    telio_model::event::{ErrorLevel, Event},
-    telio_model::mesh::NodeState,
+    telio_model::{
+        constants::LOCAL_TUNNEL_IPV4,
+        event::{ErrorLevel, Event},
+        mesh::NodeState,
+    },
 };
 
 use crate::command_listener::{ClientCmd, ExitNodeConfig, TelioTaskCmd, TIMEOUT_SEC};
@@ -34,7 +37,7 @@ use crate::core_api::get_server_endpoints_list;
 use crate::{
     command_listener::CommandListener,
     comms::DaemonSocket,
-    config::{NordVpnLiteConfig, LOCAL_IP},
+    config::NordVpnLiteConfig,
     core_api::{request_nordlynx_key, Error as ApiError, DEFAULT_WIREGUARD_PORT},
     interface::ConfigureInterface,
 };
@@ -159,7 +162,7 @@ impl TelioContext {
         let mut interface_config_provider = config.interface.get_config_provider();
         interface_config_provider.initialize()?;
         interface_config_provider
-            .set_ip(&LOCAL_IP.into())
+            .set_ip(&LOCAL_TUNNEL_IPV4.into())
             .inspect_err(|e| error!("Failed to set interface IP with error '{e:?}'"))?;
 
         Ok(Self {

--- a/crates/telio-firewall/src/firewall.rs
+++ b/crates/telio-firewall/src/firewall.rs
@@ -159,6 +159,8 @@ pub struct FirewallState {
     pub whitelist: Whitelist,
     /// Local node ip addresses
     pub ip_addresses: Vec<StdIpAddr>,
+    /// Whether an exit node is currently active
+    pub exit_node_present: bool,
 }
 
 /// Configuration for firewall initialization.
@@ -181,7 +183,7 @@ pub struct StatefulFirewall {
     config: FirewallConfig,
     /// Current firewall state
     state: RwLock<FirewallState>,
-    /// Last known host interface IPs reported by network monitor.
+    /// Last known host interfaces reported by network monitor.
     interface_ips: RwLock<Vec<StdIpAddr>>,
     /// Chain configuration function
     configure_chain_fn: ConfigureChainFn,
@@ -196,7 +198,6 @@ unsafe impl Send for StatefulFirewall {}
 impl LocalInterfacesObserver for StatefulFirewall {
     fn notify(&self, addrs: &[StdIpAddr]) {
         telio_log_debug!("Firewall notified about network changes: {:?}", addrs);
-
         *self.interface_ips.write() = addrs.to_vec();
         self.refresh_chain();
     }
@@ -376,9 +377,19 @@ impl StatefulFirewall {
     }
 }
 
-fn dst_net_all_ports_filter(net: IpNet, inverted: bool) -> Filter {
+fn filter_dst_ip_all_ports(net: IpNet, inverted: bool) -> Filter {
     Filter {
         filter_data: FilterData::DstNetwork(NetworkFilterData {
+            network: net,
+            port_range: (0, 65535),
+        }),
+        inverted,
+    }
+}
+
+fn filter_src_ip_all_ports(net: IpNet, inverted: bool) -> Filter {
+    Filter {
+        filter_data: FilterData::SrcNetwork(NetworkFilterData {
             network: net,
             port_range: (0, 65535),
         }),
@@ -399,18 +410,18 @@ fn get_local_area_networks_filters(
 
     // Include packets which are going to local IPv4 networks
     let mut ipv4_local_area_network_filters = ipv4_local_area_networks
-        .map(|network| vec![dst_net_all_ports_filter(IpNet::V4(network), false)]);
+        .map(|network| vec![filter_dst_ip_all_ports(IpNet::V4(network), false)]);
 
     // Exclude packets from the exclude range
     if let Some(exclude_range) = exclude_ip_range {
         for local_net_filters in ipv4_local_area_network_filters.iter_mut() {
-            local_net_filters.push(dst_net_all_ports_filter(IpNet::V4(exclude_range), true));
+            local_net_filters.push(filter_dst_ip_all_ports(IpNet::V4(exclude_range), true));
         }
     }
 
     let mut ipv6_local_area_network_filters = vec![
         // Include packets which are going to local network
-        dst_net_all_ports_filter(
+        filter_dst_ip_all_ports(
             IpNet::V6(Ipv6Net::new_assert(
                 // TODO: Actually it Unique Local Address range should be (from what I found) fc00::/7,
                 // but it seems that we assume (and our tests do) that it is fc00::/6
@@ -420,7 +431,7 @@ fn get_local_area_networks_filters(
             false,
         ),
         // Exclude packets which are going to local interfaces
-        dst_net_all_ports_filter(
+        filter_dst_ip_all_ports(
             IpNet::V6(Ipv6Net::new_assert(
                 StdIpv6Addr::new(0xfd74, 0x656c, 0x696f, 0, 0, 0, 0, 0),
                 64,
@@ -432,10 +443,10 @@ fn get_local_area_networks_filters(
     for ip in local_ifs_addrs.iter() {
         if ip.is_ipv4() {
             for local_network_filters in ipv4_local_area_network_filters.iter_mut() {
-                local_network_filters.push(dst_net_all_ports_filter(IpNet::from(*ip), true));
+                local_network_filters.push(filter_dst_ip_all_ports(IpNet::from(*ip), true));
             }
         } else {
-            ipv6_local_area_network_filters.push(dst_net_all_ports_filter(IpNet::from(*ip), true));
+            ipv6_local_area_network_filters.push(filter_dst_ip_all_ports(IpNet::from(*ip), true));
         }
     }
 
@@ -444,19 +455,20 @@ fn get_local_area_networks_filters(
     result
 }
 
-/// Configures the firewall chain based on the provided configuration.
-pub(crate) fn configure_chain(
+/// Builds the rule list for the firewall chain. Separated from configure_chain
+/// so tests can inspect the Rule vec directly.
+pub(crate) fn build_chain_rules(
     config: &FirewallConfig,
     state: &FirewallState,
     local_ifs_addrs: &[StdIpAddr],
-) -> FfiChainGuard {
+) -> Vec<Rule> {
     let mut rules = vec![];
 
     // Drop all IPv6 packets when we don't allow ipv6 traffic
     const ALL_IP_V6_ADDRS: IpNet = IpNet::V6(Ipv6Net::new_assert(StdIpv6Addr::UNSPECIFIED, 0));
     if !config.allow_ipv6 {
         rules.push(Rule {
-            filters: vec![dst_net_all_ports_filter(ALL_IP_V6_ADDRS, false)],
+            filters: vec![filter_dst_ip_all_ports(ALL_IP_V6_ADDRS, false)],
             action: LibfwVerdict::LibfwVerdictDrop,
         });
     }
@@ -477,8 +489,24 @@ pub(crate) fn configure_chain(
                     filter_data: FilterData::NextLevelProtocol(next_level_protocol),
                     inverted: false,
                 },
-                dst_net_all_ports_filter(IpNet::from(blacklist_entry.ip), false),
+                filter_dst_ip_all_ports(IpNet::from(blacklist_entry.ip), false),
             ],
+            action: LibfwVerdict::LibfwVerdictReject,
+        });
+    }
+
+    // LLT-7321: reject outbound packets whose src is not a known tunnel IP.
+    // Filters within a rule are ANDed (see LibfwRule docs).
+    if state.exit_node_present && !state.ip_addresses.is_empty() {
+        let mut filters = vec![Filter {
+            filter_data: FilterData::Direction(Direction::Outbound),
+            inverted: false,
+        }];
+        for ip in &state.ip_addresses {
+            filters.push(filter_src_ip_all_ports(IpNet::from(*ip), true));
+        }
+        rules.push(Rule {
+            filters,
             action: LibfwVerdict::LibfwVerdictReject,
         });
     }
@@ -541,7 +569,7 @@ pub(crate) fn configure_chain(
                         filter_data: FilterData::AssociatedData(Some(peer.to_vec())),
                         inverted: false,
                     },
-                    dst_net_all_ports_filter(IpNet::from(*ip), false),
+                    filter_dst_ip_all_ports(IpNet::from(*ip), false),
                 ],
                 action: LibfwVerdict::LibfwVerdictAccept,
             });
@@ -554,7 +582,7 @@ pub(crate) fn configure_chain(
                     filter_data: FilterData::ConntrackState(ConnectionState::Established),
                     inverted: false,
                 },
-                dst_net_all_ports_filter(IpNet::from(*ip), false),
+                filter_dst_ip_all_ports(IpNet::from(*ip), false),
             ],
             action: LibfwVerdict::LibfwVerdictAccept,
         });
@@ -566,7 +594,7 @@ pub(crate) fn configure_chain(
                     filter_data: FilterData::ConntrackState(ConnectionState::Related),
                     inverted: false,
                 },
-                dst_net_all_ports_filter(IpNet::from(*ip), false),
+                filter_dst_ip_all_ports(IpNet::from(*ip), false),
             ],
             action: LibfwVerdict::LibfwVerdictAccept,
         });
@@ -599,7 +627,7 @@ pub(crate) fn configure_chain(
 
         // Drop rest of the packets going to local interfaces
         rules.push(Rule {
-            filters: vec![dst_net_all_ports_filter(IpNet::from(*ip), false)],
+            filters: vec![filter_dst_ip_all_ports(IpNet::from(*ip), false)],
             action: LibfwVerdict::LibfwVerdictDrop,
         });
     }
@@ -615,7 +643,18 @@ pub(crate) fn configure_chain(
         });
     }
 
-    (rules.as_slice()).into()
+    rules
+}
+
+/// Configures the firewall chain based on the provided configuration.
+pub(crate) fn configure_chain(
+    config: &FirewallConfig,
+    state: &FirewallState,
+    local_ifs_addrs: &[StdIpAddr],
+) -> FfiChainGuard {
+    build_chain_rules(config, state, local_ifs_addrs)
+        .as_slice()
+        .into()
 }
 
 extern "C" fn write_to_sink(
@@ -766,11 +805,11 @@ mod tests {
 
     #[test]
     fn test_notify_triggers_refresh_with_callback_addrs() {
-        let captured_addrs = Arc::new(ParkingLotMutex::new(Vec::<Vec<StdIpAddr>>::new()));
-        let addrs_clone = captured_addrs.clone();
+        let captured = Arc::new(ParkingLotMutex::new(Vec::<Vec<StdIpAddr>>::new()));
+        let captured_clone = captured.clone();
         let spy_fn =
             move |_config: &FirewallConfig, _state: &FirewallState, addrs: &[StdIpAddr]| {
-                addrs_clone.lock().push(addrs.to_vec());
+                captured_clone.lock().push(addrs.to_vec());
                 (Vec::<Rule>::new().as_slice()).into()
             };
 
@@ -789,29 +828,194 @@ mod tests {
             .once()
             .returning(|_| {});
 
-        firewall.notify(&[StdIpAddr::V4(Ipv4Addr::new(192, 168, 0, 11))]);
-        firewall.notify(&[StdIpAddr::V4(Ipv4Addr::new(192, 168, 0, 12))]);
+        let ip1 = StdIpAddr::V4(Ipv4Addr::new(192, 168, 0, 11));
+        let ip2 = StdIpAddr::V4(Ipv4Addr::new(192, 168, 0, 12));
+        firewall.notify(&[ip1]);
+        firewall.notify(&[ip2]);
 
-        let calls = captured_addrs.lock();
+        let calls = captured.lock();
         assert_eq!(calls.len(), 3);
         assert_eq!(calls[0], Vec::<StdIpAddr>::new());
-        assert_eq!(
-            calls[1],
-            vec![StdIpAddr::V4(Ipv4Addr::new(192, 168, 0, 11))]
-        );
-        assert_eq!(
-            calls[2],
-            vec![StdIpAddr::V4(Ipv4Addr::new(192, 168, 0, 12))]
+        assert_eq!(calls[1], vec![ip1]);
+        assert_eq!(calls[2], vec![ip2]);
+    }
+
+    #[test]
+    fn test_allowlist_rule_not_emitted_without_exit_node() {
+        let config = FirewallConfig {
+            allow_ipv6: false,
+            feature: FeatureFirewall::default(),
+        };
+        let state = FirewallState {
+            ip_addresses: vec![StdIpAddr::V4(Ipv4Addr::new(10, 5, 0, 1))],
+            exit_node_present: false,
+            ..Default::default()
+        };
+        let rules = build_chain_rules(&config, &state, &[]);
+        assert!(
+            rules
+                .iter()
+                .all(|r| r.action != LibfwVerdict::LibfwVerdictReject),
+            "found Reject rule without exit_node_present"
         );
     }
 
     #[test]
+    fn test_allowlist_rule_not_emitted_with_empty_ip_addresses() {
+        let config = FirewallConfig {
+            allow_ipv6: false,
+            feature: FeatureFirewall::default(),
+        };
+        let state = FirewallState {
+            ip_addresses: vec![],
+            exit_node_present: true,
+            ..Default::default()
+        };
+        let rules = build_chain_rules(&config, &state, &[]);
+        assert!(
+            rules
+                .iter()
+                .all(|r| r.action != LibfwVerdict::LibfwVerdictReject),
+            "found Reject rule with empty ip_addresses"
+        );
+    }
+
+    #[test]
+    fn test_allowlist_rule_emitted_as_single_rule_with_inverted_src_filters() {
+        let config = FirewallConfig {
+            allow_ipv6: false,
+            feature: FeatureFirewall::default(),
+        };
+        let tunnel_ip = StdIpAddr::V4(Ipv4Addr::new(10, 5, 0, 1));
+        let state = FirewallState {
+            ip_addresses: vec![tunnel_ip],
+            exit_node_present: true,
+            ..Default::default()
+        };
+        let rules = build_chain_rules(&config, &state, &[]);
+
+        let _rule = rules
+            .iter()
+            .filter(|r| r.action == LibfwVerdict::LibfwVerdictReject)
+            .find(|r| {
+                let has_outbound = r.filters.iter().any(|f| {
+                    f.filter_data == FilterData::Direction(Direction::Outbound) && !f.inverted
+                });
+                let has_inverted_src = r.filters.iter().any(|f| {
+                    matches!(&f.filter_data, FilterData::SrcNetwork(n)
+                        if n.network == IpNet::from(tunnel_ip))
+                        && f.inverted
+                });
+                has_outbound && has_inverted_src
+            })
+            .expect(
+                "expected a Reject rule with Direction::Outbound filter \
+                 and inverted SrcNetwork filter for tunnel IP",
+            );
+    }
+
+    #[test]
+    fn test_allowlist_rule_ordering_before_vpn_accept() {
+        let vpn_pk = PublicKey::new([0xAB; 32]);
+        let config = FirewallConfig {
+            allow_ipv6: false,
+            feature: FeatureFirewall::default(),
+        };
+        let tunnel_ip = StdIpAddr::V4(Ipv4Addr::new(10, 5, 0, 1));
+        let state = FirewallState {
+            ip_addresses: vec![tunnel_ip],
+            exit_node_present: true,
+            whitelist: Whitelist {
+                vpn_peer: Some(vpn_pk),
+                ..Default::default()
+            },
+        };
+        let rules = build_chain_rules(&config, &state, &[]);
+
+        let reject_pos = rules.iter().position(|r| {
+            r.action == LibfwVerdict::LibfwVerdictReject
+                && r.filters.iter().any(|f| {
+                    f.filter_data == FilterData::Direction(Direction::Outbound) && !f.inverted
+                })
+                && r.filters
+                    .iter()
+                    .any(|f| matches!(&f.filter_data, FilterData::SrcNetwork(_)) && f.inverted)
+        });
+        let accept_pos = rules.iter().position(|r| {
+            r.action == LibfwVerdict::LibfwVerdictAccept
+                && r.filters.iter().any(|f| {
+                    matches!(&f.filter_data, FilterData::AssociatedData(Some(k))
+                        if k == &vpn_pk.to_vec())
+                })
+        });
+        assert!(reject_pos.is_some(), "reject rule must exist");
+        assert!(accept_pos.is_some(), "vpn accept rule must exist");
+        assert!(
+            reject_pos.unwrap() < accept_pos.unwrap(),
+            "reject rule must come before vpn accept rule"
+        );
+    }
+
+    #[test]
+    fn test_allowlist_rule_two_ips_both_inverted_src_filters_in_one_rule() {
+        let config = FirewallConfig {
+            allow_ipv6: false,
+            feature: FeatureFirewall::default(),
+        };
+        let ip1 = StdIpAddr::V4(Ipv4Addr::new(10, 5, 0, 1));
+        let ip2 = StdIpAddr::V4(Ipv4Addr::new(100, 64, 0, 1));
+        let state = FirewallState {
+            ip_addresses: vec![ip1, ip2],
+            exit_node_present: true,
+            ..Default::default()
+        };
+        let rules = build_chain_rules(&config, &state, &[]);
+
+        let rule = rules
+            .iter()
+            .filter(|r| r.action == LibfwVerdict::LibfwVerdictReject)
+            .find(|r| {
+                r.filters.iter().any(|f| {
+                    f.filter_data == FilterData::Direction(Direction::Outbound) && !f.inverted
+                }) && r
+                    .filters
+                    .iter()
+                    .any(|f| matches!(&f.filter_data, FilterData::SrcNetwork(_)) && f.inverted)
+            })
+            .expect(
+                "expected a Reject rule with Direction::Outbound and inverted SrcNetwork filters",
+            );
+
+        let inverted_src_count = rule
+            .filters
+            .iter()
+            .filter(|f| matches!(&f.filter_data, FilterData::SrcNetwork(_)) && f.inverted)
+            .count();
+        assert_eq!(
+            inverted_src_count, 2,
+            "one inverted SrcNetwork filter per tunnel IP"
+        );
+
+        for ip in [ip1, ip2] {
+            assert!(
+                rule.filters.iter().any(|f| {
+                    matches!(&f.filter_data, FilterData::SrcNetwork(n)
+                        if n.network == IpNet::from(ip))
+                        && f.inverted
+                }),
+                "inverted SrcNetwork filter for {} must be present",
+                ip
+            );
+        }
+    }
+
+    #[test]
     fn test_notify_addrs_are_used_by_subsequent_refreshes() {
-        let captured_addrs = Arc::new(ParkingLotMutex::new(Vec::<Vec<StdIpAddr>>::new()));
-        let addrs_clone = captured_addrs.clone();
+        let captured = Arc::new(ParkingLotMutex::new(Vec::<Vec<StdIpAddr>>::new()));
+        let captured_clone = captured.clone();
         let spy_fn =
             move |_config: &FirewallConfig, _state: &FirewallState, addrs: &[StdIpAddr]| {
-                addrs_clone.lock().push(addrs.to_vec());
+                captured_clone.lock().push(addrs.to_vec());
                 (Vec::<Rule>::new().as_slice()).into()
             };
 
@@ -830,15 +1034,15 @@ mod tests {
             .once()
             .returning(|_| {});
 
-        let notify_addrs = vec![StdIpAddr::V4(Ipv4Addr::new(192, 168, 77, 7))];
-        firewall.notify(&notify_addrs);
+        let notify_ips = vec![StdIpAddr::V4(Ipv4Addr::new(192, 168, 77, 7))];
+        firewall.notify(&notify_ips);
         firewall.apply_state(FirewallState {
             ip_addresses: vec![StdIpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))],
             ..Default::default()
         });
 
-        assert_eq!(captured_addrs.lock().len(), 3);
-        assert_eq!(captured_addrs.lock()[1], notify_addrs);
-        assert_eq!(captured_addrs.lock()[2], notify_addrs);
+        assert_eq!(captured.lock().len(), 3);
+        assert_eq!(captured.lock()[1], notify_ips);
+        assert_eq!(captured.lock()[2], notify_ips);
     }
 }

--- a/crates/telio-firewall/tests/firewall_integration_tests.rs
+++ b/crates/telio-firewall/tests/firewall_integration_tests.rs
@@ -1063,6 +1063,87 @@ fn firewall_whitelist_port() {
     }
 }
 
+// When a VPN peer is set, outbound packets with a stale physical src IP
+//  must be rejected to prevent exit-node NAT pollution. [LLT-7321]
+#[test]
+fn firewall_outbound_packet_with_wrong_src_ip_rejected() {
+    let vpn_peer = make_random_peer();
+    let wlan_ip = Ipv4Addr::new(192, 168, 1, 5);
+    let tunnel_ip = Ipv4Addr::new(10, 5, 0, 2);
+    let remote_ip = Ipv4Addr::new(203, 0, 113, 1);
+
+    let fw = StatefulFirewall::new(true, FeatureFirewall::default())
+        .expect("Failed to load libfirewall");
+
+    // No exit node: outbound from any src should pass.
+    fw.apply_state(FirewallState {
+        ip_addresses: vec![IpAddr::V4(tunnel_ip)],
+        exit_node_present: false,
+        ..Default::default()
+    });
+    assert!(
+        fw.process_outbound_packet_sink(
+            &vpn_peer.0,
+            &make_tcp(
+                &format!("{wlan_ip}:12345"),
+                &format!("{remote_ip}:443"),
+                TcpFlags::SYN
+            )
+        ),
+        "outbound from physical IP should pass when no exit node"
+    );
+
+    // Exit node active + ip_addresses set: non-tunnel src rejected.
+    fw.apply_state(FirewallState {
+        ip_addresses: vec![IpAddr::V4(tunnel_ip)],
+        exit_node_present: true,
+        whitelist: telio_firewall::firewall::Whitelist {
+            vpn_peer: Some(vpn_peer),
+            ..Default::default()
+        },
+    });
+    assert!(
+        !fw.process_outbound_packet_sink(
+            &vpn_peer.0,
+            &make_tcp(
+                &format!("{wlan_ip}:12345"),
+                &format!("{remote_ip}:443"),
+                TcpFlags::SYN
+            )
+        ),
+        "outbound from physical IP should be rejected when exit node active"
+    );
+    assert!(
+        fw.process_outbound_packet_sink(
+            &vpn_peer.0,
+            &make_tcp(
+                &format!("{tunnel_ip}:54321"),
+                &format!("{remote_ip}:443"),
+                TcpFlags::SYN
+            )
+        ),
+        "outbound from tunnel IP should still pass"
+    );
+
+    // Exit node disconnected: rule gone.
+    fw.apply_state(FirewallState {
+        ip_addresses: vec![IpAddr::V4(tunnel_ip)],
+        exit_node_present: false,
+        ..Default::default()
+    });
+    assert!(
+        fw.process_outbound_packet_sink(
+            &vpn_peer.0,
+            &make_tcp(
+                &format!("{wlan_ip}:12345"),
+                &format!("{remote_ip}:443"),
+                TcpFlags::SYN
+            )
+        ),
+        "outbound from physical IP should pass after exit node disconnected"
+    );
+}
+
 mod tp_lite_stats {
     use std::sync::Arc;
 

--- a/crates/telio-firewall/tests/firewall_integration_tests.rs
+++ b/crates/telio-firewall/tests/firewall_integration_tests.rs
@@ -1069,7 +1069,7 @@ fn firewall_whitelist_port() {
 fn firewall_outbound_packet_with_wrong_src_ip_rejected() {
     let vpn_peer = make_random_peer();
     let wlan_ip = Ipv4Addr::new(192, 168, 1, 5);
-    let tunnel_ip = Ipv4Addr::new(10, 5, 0, 2);
+    let tunnel_ip = telio_model::constants::LOCAL_TUNNEL_IPV4;
     let remote_ip = Ipv4Addr::new(203, 0, 113, 1);
 
     let fw = StatefulFirewall::new(true, FeatureFirewall::default())

--- a/crates/telio-model/src/constants.rs
+++ b/crates/telio-model/src/constants.rs
@@ -9,6 +9,8 @@ pub const VPN_INTERNAL_IPV4: Ipv4Addr = Ipv4Addr::new(100, 64, 0, 1);
 pub const VPN_INTERNAL_IPV6: Ipv6Addr = Ipv6Addr::new(0xfd74, 0x656c, 0x696f, 0, 0, 0, 0, 1);
 /// VPN IPv4 Non-Meshnet Address
 pub const VPN_EXTERNAL_IPV4: Ipv4Addr = Ipv4Addr::new(10, 5, 0, 1);
+/// Local address for tunnel interface when VPN without meshnet is enabled
+pub const LOCAL_TUNNEL_IPV4: Ipv4Addr = Ipv4Addr::new(10, 5, 0, 2);
 /// Ipv4 multicast range
 pub const IPV4_MULTICAST_NETWORK: ConstIpv4Net = ConstIpv4Net::new(Ipv4Addr::new(224, 0, 0, 0), 4);
 /// Ipv6 multicast range

--- a/crates/telio-network-monitors/src/monitor.rs
+++ b/crates/telio-network-monitors/src/monitor.rs
@@ -1,13 +1,12 @@
 //! Module to monitor changes in network.
 //! Get notified when network paths change
 //! and update local IP address cache
-use crate::{local_interfaces::gather_local_interfaces, local_interfaces::GetIfAddrs};
+use crate::local_interfaces::{gather_local_interfaces, GetIfAddrs};
 use if_addrs::Interface;
 use once_cell::sync::Lazy;
 use parking_lot::Mutex;
 use std::{
     io,
-    net::IpAddr,
     sync::{Arc, Weak},
 };
 use telio_utils::{telio_log_debug, telio_log_info, telio_log_trace, telio_log_warn};
@@ -28,8 +27,8 @@ struct PausedState {
 
 /// Trait which should be implemented to receive local address change notifications
 pub trait LocalInterfacesObserver: Sync + Send {
-    /// Callback which allows to take certain actions when local interfaces changed
-    fn notify(&self, addrs: &[IpAddr]);
+    /// Callback which allows to take certain actions when local interfaces changed.
+    fn notify(&self, addrs: &[std::net::IpAddr]);
 }
 
 #[derive(Debug)]
@@ -45,9 +44,9 @@ pub struct NetworkMonitor {
     paused_state: Arc<Mutex<PausedState>>,
 }
 
-/// Result of a gather operation containing interface IPs and change status.
+/// Result of a gather operation containing IPs and change status.
 struct GatheredInterfaceIps {
-    addrs: Vec<IpAddr>,
+    addrs: Vec<std::net::IpAddr>,
     changed: bool,
 }
 
@@ -229,8 +228,7 @@ mod tests {
     use if_addrs::IfOperStatus;
     use serial_test::serial;
     use std::{
-        net::IpAddr,
-        net::Ipv4Addr,
+        net::{IpAddr, Ipv4Addr},
         sync::atomic::{AtomicU8, Ordering},
     };
 

--- a/crates/telio-network-monitors/src/monitor.rs
+++ b/crates/telio-network-monitors/src/monitor.rs
@@ -7,6 +7,7 @@ use once_cell::sync::Lazy;
 use parking_lot::Mutex;
 use std::{
     io,
+    net::IpAddr,
     sync::{Arc, Weak},
 };
 use telio_utils::{telio_log_debug, telio_log_info, telio_log_trace, telio_log_warn};
@@ -28,7 +29,7 @@ struct PausedState {
 /// Trait which should be implemented to receive local address change notifications
 pub trait LocalInterfacesObserver: Sync + Send {
     /// Callback which allows to take certain actions when local interfaces changed.
-    fn notify(&self, addrs: &[std::net::IpAddr]);
+    fn notify(&self, addrs: &[IpAddr]);
 }
 
 #[derive(Debug)]
@@ -46,7 +47,7 @@ pub struct NetworkMonitor {
 
 /// Result of a gather operation containing IPs and change status.
 struct GatheredInterfaceIps {
-    addrs: Vec<std::net::IpAddr>,
+    addrs: Vec<IpAddr>,
     changed: bool,
 }
 

--- a/crates/telio-pq/src/proto.rs
+++ b/crates/telio-pq/src/proto.rs
@@ -20,12 +20,13 @@ use pnet_packet::{
 use pqcrypto_kyber::{ffi::PQCLEAN_KYBER768_CLEAN_CRYPTO_SECRETKEYBYTES, kyber768};
 use pqcrypto_traits::kem::{Ciphertext, PublicKey, SecretKey, SharedSecret};
 use rand::{rand_core::UnwrapErr, rngs::SysRng};
-use telio_utils::{telio_log_debug, telio_log_error, telio_log_warn, Hidden};
 use tokio::net::{ToSocketAddrs, UdpSocket};
+
+use telio_model::constants::LOCAL_TUNNEL_IPV4;
+use telio_utils::{telio_log_debug, telio_log_error, telio_log_warn, Hidden};
 
 const SERVICE_PORT: u16 = 6480;
 const LOCAL_PORT_RANGE: RangeInclusive<u16> = 49152..=u16::MAX; // dynamic port range
-const LOCAL_IP: Ipv4Addr = Ipv4Addr::new(10, 5, 0, 2);
 const REMOTE_IP: Ipv4Addr = Ipv4Addr::new(10, 5, 0, 1);
 const CIPHERTEXT_LEN: u32 = kyber768::ciphertext_bytes() as _;
 const REKEY_METHOD_ID: u32 = 1;
@@ -362,7 +363,7 @@ fn validate_get_response_ip(ip: &Ipv4Packet) -> Result<(), String> {
     if ip.get_source() != REMOTE_IP {
         return Err("invalid src IP".to_owned());
     }
-    if ip.get_destination() != LOCAL_IP {
+    if ip.get_destination() != LOCAL_TUNNEL_IPV4 {
         return Err("invalid dst IP".to_owned());
     }
     let next_level_protocol = ip.get_next_level_protocol();
@@ -751,7 +752,7 @@ fn fill_get_packet_headers(pkgbuf: &mut [u8], local_port: u16) {
     udppkg.set_length((pkg_len - IPV4_HEADER_LEN) as _);
     udppkg.set_checksum(udp::ipv4_checksum(
         &udppkg.to_immutable(),
-        &LOCAL_IP,
+        &LOCAL_TUNNEL_IPV4,
         &REMOTE_IP,
     ));
     drop(udppkg);
@@ -766,7 +767,7 @@ fn fill_get_packet_headers(pkgbuf: &mut [u8], local_port: u16) {
     ippkg.set_flags(Ipv4Flags::DontFragment);
     ippkg.set_ttl(0xFF);
     ippkg.set_next_level_protocol(IpNextHeaderProtocols::Udp);
-    ippkg.set_source(LOCAL_IP);
+    ippkg.set_source(LOCAL_TUNNEL_IPV4);
     ippkg.set_destination(REMOTE_IP);
     ippkg.set_checksum(ipv4::checksum(&ippkg.to_immutable()));
 }

--- a/nat-lab/README.md
+++ b/nat-lab/README.md
@@ -195,6 +195,13 @@ Markers are defined in [pyproject.toml](pyproject.toml). Useful ones:
 - moose         requires build with “moose”
 - ipv4 / ipv6 / ipv4v6
 - utils
+- libfirewall   requires `libfirewall.so` (see below)
+
+### libfirewall tests
+
+Tests marked `libfirewall` depend on `tests/uniffi/libfirewall.so` being present. Without it, the firewall is a no-op and these tests are automatically skipped at collection time.
+
+In CI, `libfirewall.so` is downloaded and placed at `nat-lab/tests/uniffi/libfirewall.so` before tests run. For local runs, obtain the `.so` from the internal artifact registry and place it at that path manually.
 
 ### To include a marker
 

--- a/nat-lab/pyproject.toml
+++ b/nat-lab/pyproject.toml
@@ -194,6 +194,7 @@ markers = [
     "utils: tests the natlab utilities",
     "openwrt: tests that require OpenWrt VM to be running",
     "perf_profiling: tests that profile execution with perf",
+    "libfirewall: tests that require libfirewall.so to be present in nat-lab/tests/uniffi/",
 ]
 
 [tool.pyright]

--- a/nat-lab/tests/conftest.py
+++ b/nat-lab/tests/conftest.py
@@ -60,6 +60,7 @@ SESSION_SCOPE_EXIT_STACK: AsyncExitStack | None = None
 TASKS: List[asyncio.Task] = []
 END_TASKS: threading.Event = threading.Event()
 CURRENT_TEST_LOG_FILE = None
+_LIBFIREWALL_SO = os.path.join(os.path.dirname(__file__), "uniffi", "libfirewall.so")
 
 SESSION_VM_MARKS: set[str] = set()
 
@@ -141,10 +142,13 @@ def pytest_make_parametrize_id(config, val):
 
 
 def pytest_collection_modifyitems(items):
+    libfirewall_missing = not os.path.exists(_LIBFIREWALL_SO)
     for item in items:
         # Apply 5 minutes timeout to windows tests (due to constant lag)
         if item.get_closest_marker("windows"):
             item.add_marker(pytest.mark.timeout(300))
+        if libfirewall_missing and item.get_closest_marker("libfirewall"):
+            item.add_marker(pytest.mark.skip(reason="libfirewall.so not available"))
 
 
 def pytest_runtestloop(session):

--- a/nat-lab/tests/test_mesh_firewall.py
+++ b/nat-lab/tests/test_mesh_firewall.py
@@ -2,8 +2,11 @@
 
 import asyncio
 import pytest
+from contextlib import AsyncExitStack
 from tests import config
-from tests.helpers import SetupParameters, setup_api, Environment
+from tests.config import LAN_ADDR_MAP
+from tests.helpers import Environment, SetupParameters, setup_api, setup_environment
+from tests.helpers_vpn import connect_vpn
 from tests.mesh_api import Node
 from tests.utils import testing, stun
 from tests.utils.bindings import default_features, Features, TelioAdapterType
@@ -19,6 +22,7 @@ from tests.utils.logger import log
 from tests.utils.netcat import NetCatServer, NetCatClient
 from tests.utils.ping import ping
 from tests.utils.router import IPProto, IPStack
+from tests.utils.tcpdump import TcpDump
 from typing import Tuple, Optional, Callable, Awaitable
 
 
@@ -664,3 +668,165 @@ async def test_mesh_firewall_tcp_stuck_in_last_ack_state_conn_kill_from_client_s
             # if everything is correct -> conntrack should show LAST_ACK -> TIME_WAIT
             # if something goes wrong, it will be stuck at LAST_ACK state
             await conntrack.wait_for_no_violations()
+
+
+# LLT-7321: a TCP connection established BEFORE being connected to VPN
+# carries the client's physical interface IP as its source.
+#
+# After connecting to VPN, the kernel reroutes it through the tunnel
+# but still with the wrong source IP. Exit node's receive this packet,
+# poisoning their NAT table which causes return traffic to be misrouted.
+@pytest.mark.xfail(reason="LLT-7321")
+@pytest.mark.asyncio
+async def test_stale_src_ip_persist_after_connection(
+    exit_stack: AsyncExitStack,
+    setup_connections_factory: Callable[..., Awaitable[list]],
+) -> None:
+    setup_params = SetupParameters(
+        connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
+        adapter_type_override=TelioAdapterType.NEP_TUN,
+        ip_stack=IPStack.IPv4,
+        is_meshnet=False,
+        features=default_features(enable_firewall_exclusion_range="10.0.0.0/8"),
+    )
+
+    env = await exit_stack.enter_async_context(
+        setup_environment(
+            exit_stack,
+            [setup_params],
+            vpn=[ConnectionTag.DOCKER_VPN_1],
+        )
+    )
+
+    alpha, *_ = env.nodes
+    connection, *_ = [conn.connection for conn in env.connections]
+    client, *_ = env.clients
+
+    client_lan_ip = LAN_ADDR_MAP[ConnectionTag.DOCKER_CONE_CLIENT_1]["primary"]
+
+    await client.set_meshnet_config(env.api.get_meshnet_config(alpha.id))
+
+    # Open a TCP connection
+    pre_vpn_nc = await exit_stack.enter_async_context(
+        NetCatClient(
+            connection,
+            config.PHOTO_ALBUM_IP,
+            80,
+            source_ip=client_lan_ip,
+        ).run()
+    )
+    await pre_vpn_nc.connection_succeeded()
+
+    vpn_connection, *_ = await setup_connections_factory([ConnectionTag.DOCKER_VPN_1])
+    await connect_vpn(
+        connection,
+        vpn_connection.connection,
+        client,
+        alpha.ip_addresses[0],
+        config.WG_SERVER,
+    )
+
+    # A fresh connection through the tunnel (src = tunnel IP) must work.
+    await ping(connection, config.PHOTO_ALBUM_IP)
+
+    # Widen the VPN peer's AllowedIPs so WireGuard passes all inner-src IPs
+    # through to wg0, isolating the libtelio firewall.
+    await vpn_connection.connection.create_process([
+        "wg",
+        "set",
+        "wg0",
+        "peer",
+        alpha.public_key,
+        "allowed-ips",
+        "0.0.0.0/0",
+    ]).execute()
+
+    stale_ip_capture = TcpDump(
+        vpn_connection.connection,
+        interfaces=["wg0"],
+        expressions=[f"src host {client_lan_ip}"],
+        count=1,
+    )
+
+    # Send data through the stale connection and check the source ip
+    async with stale_ip_capture.run():
+        await pre_vpn_nc.send_data("GET / HTTP/1.0\r\n\r\n")
+        try:
+            await asyncio.wait_for(stale_ip_capture.execute(), timeout=5)
+            raise AssertionError(
+                f"Packet with stale source IP {client_lan_ip} reached the"
+                " VPN's wg0 interface."
+            )
+        except asyncio.TimeoutError:
+            pass
+
+
+# LLT-7321: same stale-src-IP scenario but using a meshnet peer as exit node.
+@pytest.mark.asyncio
+@pytest.mark.libfirewall
+async def test_stale_src_ip_persist_after_meshnet_exit_node_connection(
+    exit_stack: AsyncExitStack,
+    setup_mesh_nodes_factory: Callable[..., Awaitable[Environment]],
+) -> None:
+    env = await setup_mesh_nodes_factory(
+        [
+            SetupParameters(
+                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
+                adapter_type_override=TelioAdapterType.NEP_TUN,
+                ip_stack=IPStack.IPv4,
+                features=default_features(enable_firewall_exclusion_range="10.0.0.0/8"),
+            ),
+            SetupParameters(
+                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2,
+                ip_stack=IPStack.IPv4,
+                features=default_features(enable_firewall_exclusion_range="10.0.0.0/8"),
+            ),
+        ],
+    )
+
+    api = env.api
+    alpha, beta = env.nodes
+    connection_alpha, connection_beta = [conn.connection for conn in env.connections]
+    client_alpha, client_beta = env.clients
+
+    alpha_lan_ip = LAN_ADDR_MAP[ConnectionTag.DOCKER_CONE_CLIENT_1]["primary"]
+
+    beta.set_peer_firewall_settings(
+        alpha.id,
+        allow_incoming_connections=True,
+        allow_peer_traffic_routing=True,
+    )
+    await client_beta.set_meshnet_config(api.get_meshnet_config(beta.id))
+    await client_beta.get_router().create_exit_node_route()
+
+    pre_exit_nc = await exit_stack.enter_async_context(
+        NetCatClient(
+            connection_alpha,
+            config.PHOTO_ALBUM_IP,
+            80,
+            source_ip=alpha_lan_ip,
+        ).run()
+    )
+    await pre_exit_nc.connection_succeeded()
+
+    await client_alpha.connect_to_exit_node(beta.public_key)
+
+    await ping(connection_alpha, config.PHOTO_ALBUM_IP)
+
+    stale_ip_capture = TcpDump(
+        connection_beta,
+        interfaces=["tun10"],
+        expressions=[f"src host {alpha_lan_ip}"],
+        count=1,
+    )
+
+    async with stale_ip_capture.run():
+        await pre_exit_nc.send_data("GET / HTTP/1.0\r\n\r\n")
+        try:
+            await asyncio.wait_for(stale_ip_capture.execute(), timeout=5)
+            raise AssertionError(
+                f"Packet with stale source IP {alpha_lan_ip} reached the"
+                " meshnet exit node's interface."
+            )
+        except asyncio.TimeoutError:
+            pass

--- a/nat-lab/tests/test_mesh_firewall.py
+++ b/nat-lab/tests/test_mesh_firewall.py
@@ -92,6 +92,7 @@ def _setup_params(
     ],
 )
 @pytest.mark.asyncio
+@pytest.mark.libfirewall
 async def test_mesh_firewall_successful_passthrough(
     setup_mesh_nodes_factory: Callable[..., Awaitable[Environment]],
     alpha_ip_stack: IPStack,
@@ -186,6 +187,7 @@ async def test_mesh_firewall_successful_passthrough(
     ],
 )
 @pytest.mark.asyncio
+@pytest.mark.libfirewall
 async def test_mesh_firewall_reject_packet(
     setup_mesh_nodes_factory: Callable[..., Awaitable[Environment]],
     alpha_ip_stack: IPStack,
@@ -242,6 +244,7 @@ async def test_mesh_firewall_reject_packet(
 
 # This test uses 'stun' and our stun client does not IPv6
 @pytest.mark.asyncio
+@pytest.mark.libfirewall
 async def test_blocking_incoming_connections_from_exit_node(
     setup_mesh_nodes_factory: Callable[..., Awaitable[Environment]],
 ) -> None:
@@ -348,6 +351,7 @@ async def test_blocking_incoming_connections_from_exit_node(
 
 
 @pytest.mark.asyncio
+@pytest.mark.libfirewall
 @pytest.mark.parametrize(
     "alpha_ip_stack,beta_ip_stack",
     [
@@ -476,6 +480,7 @@ async def test_mesh_firewall_file_share_port(
 
 
 @pytest.mark.asyncio
+@pytest.mark.libfirewall
 @pytest.mark.parametrize(
     "alpha_ip_stack,beta_ip_stack",
     [
@@ -573,6 +578,7 @@ async def test_mesh_firewall_tcp_stuck_in_last_ack_state_conn_kill_from_server_s
 
 
 @pytest.mark.asyncio
+@pytest.mark.libfirewall
 @pytest.mark.parametrize(
     "alpha_ip_stack,beta_ip_stack",
     [
@@ -678,6 +684,7 @@ async def test_mesh_firewall_tcp_stuck_in_last_ack_state_conn_kill_from_client_s
 # poisoning their NAT table which causes return traffic to be misrouted.
 @pytest.mark.xfail(reason="LLT-7321")
 @pytest.mark.asyncio
+@pytest.mark.libfirewall
 async def test_stale_src_ip_persist_after_connection(
     exit_stack: AsyncExitStack,
     setup_connections_factory: Callable[..., Awaitable[list]],

--- a/nat-lab/tests/test_mesh_firewall.py
+++ b/nat-lab/tests/test_mesh_firewall.py
@@ -682,7 +682,6 @@ async def test_mesh_firewall_tcp_stuck_in_last_ack_state_conn_kill_from_client_s
 # After connecting to VPN, the kernel reroutes it through the tunnel
 # but still with the wrong source IP. Exit node's receive this packet,
 # poisoning their NAT table which causes return traffic to be misrouted.
-@pytest.mark.xfail(reason="LLT-7321")
 @pytest.mark.asyncio
 @pytest.mark.libfirewall
 async def test_stale_src_ip_persist_after_connection(

--- a/nat-lab/tests/test_tp_lite_stats.py
+++ b/nat-lab/tests/test_tp_lite_stats.py
@@ -92,6 +92,7 @@ class TestTpLiteStats:
         [pytest.param(_alpha_setup_params_with_firewall())],
     )
     @pytest.mark.asyncio
+    @pytest.mark.libfirewall
     async def test_tp_lite_stats_basic(
         self,
         alpha_setup_params: SetupParameters,  # pylint: disable=unused-argument
@@ -189,6 +190,7 @@ class TestTpLiteStats:
         [pytest.param(_alpha_setup_params_with_firewall())],
     )
     @pytest.mark.asyncio
+    @pytest.mark.libfirewall
     async def test_tp_lite_stats_re_enable_with_new_callback(
         self,
         alpha_setup_params: SetupParameters,  # pylint: disable=unused-argument
@@ -235,6 +237,7 @@ class TestTpLiteStats:
         [pytest.param(_alpha_setup_params_with_firewall())],
     )
     @pytest.mark.asyncio
+    @pytest.mark.libfirewall
     async def test_tp_lite_stats_empty_dns_server_ips_disables(
         self,
         alpha_setup_params: SetupParameters,  # pylint: disable=unused-argument
@@ -263,6 +266,7 @@ class TestTpLiteStats:
         [pytest.param(_alpha_setup_params_default())],
     )
     @pytest.mark.asyncio
+    @pytest.mark.libfirewall
     async def test_tp_lite_stats_requires_firewall_feature(
         self,
         alpha_setup_params: SetupParameters,  # pylint: disable=unused-argument

--- a/nat-lab/tests/test_vpn.py
+++ b/nat-lab/tests/test_vpn.py
@@ -373,6 +373,7 @@ class TestDualVpn:
                     await conntrack.wait_for_no_violations()
 
     @pytest.mark.asyncio
+    @pytest.mark.libfirewall
     @pytest.mark.parametrize(
         "alpha_setup_params",
         [
@@ -564,6 +565,7 @@ class TestSingleVpn2Node:
             await conntrack.wait_for_no_violations()
 
     @pytest.mark.asyncio
+    @pytest.mark.libfirewall
     @pytest.mark.parametrize(
         "alpha_setup_params, beta_setup_params",
         [

--- a/nat-lab/tests/utils/netcat.py
+++ b/nat-lab/tests/utils/netcat.py
@@ -9,6 +9,10 @@ from tests.utils.python import get_python_binary
 from typing import Optional, AsyncIterator
 
 
+class NetCatError(Exception):
+    """Raised when the netcat process exits before reaching an expected state."""
+
+
 def _get_netcat_base_command(connection: Connection) -> list[str]:
     if connection.target_os == TargetOS.Windows:
         # TODO: LLT-5689 implement for windows
@@ -86,6 +90,7 @@ class NetCat:
         self._stdout_data: str = ""
         self._output_notifier: OutputNotifier = OutputNotifier()
         self._data_received: asyncio.Event = asyncio.Event()
+        self._last_stderr: str = ""
 
     async def receive_data(self) -> str:
         """Receive data from stdout"""
@@ -108,9 +113,29 @@ class NetCat:
 
     async def on_stderr(self, stderr: str) -> None:
         """Handle verbose status messages"""
-        log.error("netcat: %s", stderr.strip())
-        await self._output_notifier.handle_output(stderr.strip())
+        line = stderr.strip()
+        log.error("netcat: %s", line)
+        self._last_stderr = line
+        await self._output_notifier.handle_output(line)
         return None
+
+    async def _wait_event_or_exit(self, event: asyncio.Event, label: str) -> None:
+        """Wait for `event`, but fail fast if the netcat process exits first."""
+        event_task = asyncio.create_task(event.wait())
+        done_task = asyncio.create_task(self._process.is_done())
+        try:
+            done, _ = await asyncio.wait(
+                {event_task, done_task},
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            if event_task in done:
+                event.clear()
+                return
+            raise NetCatError(f"netcat exited before {label}: {self._last_stderr!r}")
+        finally:
+            for t in (event_task, done_task):
+                if not t.done():
+                    t.cancel()
 
     async def execute(self) -> None:
         await self._process.execute(
@@ -162,13 +187,11 @@ class NetCatServer(NetCat):
 
     async def listening_started(self) -> None:
         """Wait for listening started event"""
-        await self._listening_event.wait()
-        self._listening_event.clear()
+        await self._wait_event_or_exit(self._listening_event, "listening started")
 
     async def connection_received(self) -> None:
         """Wait for connection received event"""
-        await self._connection_event.wait()
-        self._connection_event.clear()
+        await self._wait_event_or_exit(self._connection_event, "connection received")
 
 
 class NetCatClient(NetCat):
@@ -213,5 +236,4 @@ class NetCatClient(NetCat):
 
     async def connection_succeeded(self) -> None:
         """Wait for connection succeeded event"""
-        await self._connection_event.wait()
-        self._connection_event.clear()
+        await self._wait_event_or_exit(self._connection_event, "connection succeeded")

--- a/nat-lab/tests/utils/tcpdump.py
+++ b/nat-lab/tests/utils/tcpdump.py
@@ -178,15 +178,19 @@ def build_tcpdump_command(
     if flags:
         command += flags
 
+    if target_os != TargetOS.Windows and not include_ssh:
+        command += ["--immediate-mode"]
+
+    filter_parts: list[str] = []
     if not include_ssh:
         if target_os != TargetOS.Windows:
-            command += ["--immediate-mode"]
-            command += ["port not 22"]
+            filter_parts.append("port not 22")
         else:
-            command += ["not port 22"]
-
+            filter_parts.append("not port 22")
     if expressions:
-        command += expressions
+        filter_parts.extend(expressions)
+    if filter_parts:
+        command += [" and ".join(f"({p})" for p in filter_parts)]
 
     return command
 

--- a/src/device/wg_controller.rs
+++ b/src/device/wg_controller.rs
@@ -628,14 +628,16 @@ async fn consolidate_firewall<F: Firewall>(
         state.whitelist.peer_whitelists[Permissions::RoutingConnections].insert(key);
     }
 
-    if let Some(exit_node) = &requested_state.exit_node {
-        let is_vpn_exit_node =
-            !iter_peers(requested_state).any(|p| p.public_key == exit_node.public_key);
-
-        if is_vpn_exit_node {
+    let is_vpn_exit_node = if let Some(exit_node) = &requested_state.exit_node {
+        let is_vpn = !iter_peers(requested_state).any(|p| p.public_key == exit_node.public_key);
+        if is_vpn {
             state.whitelist.vpn_peer = Some(exit_node.public_key);
         }
-    }
+        state.exit_node_present = true;
+        is_vpn
+    } else {
+        false
+    };
 
     if let Some(meshnet_config) = &requested_state.meshnet_config {
         state.ip_addresses = meshnet_config
@@ -644,6 +646,15 @@ async fn consolidate_firewall<F: Firewall>(
             .clone()
             .ok_or(Error::IpNotSet)?;
     }
+
+    if is_vpn_exit_node {
+        state
+            .ip_addresses
+            .push(IpAddr::V4(Ipv4Addr::new(10, 5, 0, 2)));
+    }
+
+    state.ip_addresses.sort_unstable();
+    state.ip_addresses.dedup();
 
     firewall.apply_state(state);
 
@@ -1551,6 +1562,14 @@ mod tests {
             ..Default::default()
         });
 
+        let mut expected_ips = vec![
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            IpAddr::V6(Ipv6Addr::LOCALHOST),
+            IpAddr::V4(Ipv4Addr::new(10, 5, 0, 2)),
+        ];
+        expected_ips.sort_unstable();
+        expected_ips.dedup();
+
         firewall
             .expect_apply_state()
             .once()
@@ -1564,9 +1583,101 @@ mod tests {
                     port_whitelist: Default::default(),
                     vpn_peer: Some(pub_key_2),
                 },
-                ip_addresses: vec![IpAddr::V4(Ipv4Addr::LOCALHOST), IpAddr::V6(Ipv6Addr::LOCALHOST)],
-                ..Default::default()
+                ip_addresses: expected_ips,
+                exit_node_present: true,
             }))
+            .return_const(());
+
+        consolidate_firewall(
+            &requested_state,
+            &firewall,
+            Some(pub_key_starcast_vpeer),
+            None,
+        )
+        .await
+        .unwrap();
+    }
+
+    #[cfg(feature = "enable_firewall")]
+    #[tokio::test]
+    async fn vpn_exit_node_sets_exit_node_present_and_vpn_ip_addresses() {
+        let mut firewall = MockFirewall::new();
+        let pub_key_starcast_vpeer = SecretKey::gen().public();
+        let pub_key_vpn = SecretKey::gen().public();
+
+        let mut requested_state = create_requested_state(vec![]);
+        requested_state.exit_node = Some(ExitNode {
+            public_key: pub_key_vpn,
+            ..Default::default()
+        });
+
+        let mut expected_ips = vec![
+            IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+            IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)),
+            IpAddr::V4(Ipv4Addr::new(10, 5, 0, 2)),
+        ];
+        expected_ips.sort_unstable();
+        expected_ips.dedup();
+
+        firewall
+            .expect_apply_state()
+            .once()
+            .with(eq(FirewallState {
+                whitelist: Whitelist {
+                    peer_whitelists: enum_map! {
+                        Permissions::IncomingConnections => FwHashSet::from_iter([pub_key_starcast_vpeer]),
+                        Permissions::RoutingConnections => FwHashSet::from_iter([pub_key_starcast_vpeer]),
+                        Permissions::LocalAreaConnections => FwHashSet::default(),
+                    },
+                    port_whitelist: Default::default(),
+                    vpn_peer: Some(pub_key_vpn),
+                },
+                ip_addresses: expected_ips,
+                exit_node_present: true,
+            }))
+            .return_const(());
+
+        consolidate_firewall(
+            &requested_state,
+            &firewall,
+            Some(pub_key_starcast_vpeer),
+            None,
+        )
+        .await
+        .unwrap();
+    }
+
+    #[cfg(feature = "enable_firewall")]
+    #[tokio::test]
+    async fn meshnet_exit_node_sets_exit_node_present_without_vpn_ips() {
+        let mut firewall = MockFirewall::new();
+        let pub_key_starcast_vpeer = SecretKey::gen().public();
+        let pub_key_meshnet_peer = SecretKey::gen().public();
+
+        // Peer is in mesh AND used as exit node → is_vpn_exit_node = false
+        let mut requested_state = create_requested_state(vec![(
+            pub_key_meshnet_peer,
+            vec![],
+            false,
+            false,
+            false,
+            false,
+        )]);
+        requested_state.exit_node = Some(ExitNode {
+            public_key: pub_key_meshnet_peer,
+            ..Default::default()
+        });
+
+        firewall
+            .expect_apply_state()
+            .once()
+            .withf(|state: &FirewallState| {
+                state.exit_node_present
+                    && state.whitelist.vpn_peer.is_none()
+                    // VPN constants must NOT be in ip_addresses for meshnet exit
+                    && !state.ip_addresses.contains(&IpAddr::V4(VPN_INTERNAL_IPV4))
+                    && !state.ip_addresses.contains(&IpAddr::V4(VPN_EXTERNAL_IPV4))
+            })
             .return_const(());
 
         consolidate_firewall(
@@ -1595,6 +1706,13 @@ mod tests {
             ..Default::default()
         });
 
+        let mut expected_ips = vec![
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            IpAddr::V6(Ipv6Addr::LOCALHOST),
+        ];
+        expected_ips.sort_unstable();
+        expected_ips.dedup();
+
         firewall
             .expect_apply_state()
             .once()
@@ -1608,8 +1726,8 @@ mod tests {
                     port_whitelist: Default::default(),
                     vpn_peer: None,
                 },
-                ip_addresses: vec![IpAddr::V4(Ipv4Addr::LOCALHOST), IpAddr::V6(Ipv6Addr::LOCALHOST)],
-                ..Default::default()
+                ip_addresses: expected_ips,
+                exit_node_present: true,
             }))
             .return_const(());
 
@@ -1640,6 +1758,13 @@ mod tests {
             ..Default::default()
         });
 
+        let mut expected_ips = vec![
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            IpAddr::V6(Ipv6Addr::LOCALHOST),
+        ];
+        expected_ips.sort_unstable();
+        expected_ips.dedup();
+
         firewall
             .expect_apply_state()
             .once()
@@ -1653,8 +1778,8 @@ mod tests {
                     port_whitelist: Default::default(),
                     vpn_peer: None,
                 },
-                ip_addresses: vec![IpAddr::V4(Ipv4Addr::LOCALHOST), IpAddr::V6(Ipv6Addr::LOCALHOST)],
-                ..Default::default()
+                ip_addresses: expected_ips,
+                exit_node_present: true,
             }))
             .return_const(());
 

--- a/src/device/wg_controller.rs
+++ b/src/device/wg_controller.rs
@@ -1,20 +1,28 @@
-use super::{Entities, RequestedState, Result};
+use std::{
+    collections::{BTreeMap, HashMap, HashSet},
+    iter::FromIterator,
+    net::{IpAddr, Ipv4Addr},
+    sync::Arc,
+    time::Duration,
+};
+
 use futures::FutureExt;
 use ipnet::IpNet;
-use std::collections::{BTreeMap, HashMap, HashSet};
-use std::iter::FromIterator;
-use std::net::{IpAddr, Ipv4Addr};
-use std::sync::Arc;
-use std::time::Duration;
+use thiserror::Error as TError;
+use tokio::sync::Mutex;
+
 use telio_crypto::PublicKey;
 use telio_dns::DnsResolver;
 #[cfg(feature = "enable_firewall")]
 use telio_firewall::firewall::{Firewall, FirewallState, Permissions, FILE_SEND_PORT};
-use telio_model::constants::{VPN_EXTERNAL_IPV4, VPN_INTERNAL_IPV4, VPN_INTERNAL_IPV6};
-use telio_model::features::Features;
-use telio_model::mesh::{LinkState, NodeState};
-use telio_model::EndpointMap;
-use telio_model::SocketAddr;
+#[cfg(feature = "enable_firewall")]
+use telio_model::constants::LOCAL_TUNNEL_IPV4;
+use telio_model::{
+    constants::{VPN_EXTERNAL_IPV4, VPN_INTERNAL_IPV4, VPN_INTERNAL_IPV6},
+    features::Features,
+    mesh::{LinkState, NodeState},
+    EndpointMap, SocketAddr,
+};
 use telio_nurse::aggregator::ConnectivityDataAggregator;
 use telio_proto::{PeersStatesMap, Session};
 use telio_proxy::Proxy;
@@ -24,10 +32,12 @@ use telio_traversal::{
     SessionKeeperTrait, UpgradeSyncTrait, WireGuardEndpointCandidateChangeEvent,
 };
 use telio_utils::{build_ping_endpoint, telio_log_debug, telio_log_info, telio_log_warn, Instant};
-use telio_wg::uapi::{AnalyticsEvent, UpdateReason};
-use telio_wg::{uapi::Peer, WireGuard};
-use thiserror::Error as TError;
-use tokio::sync::Mutex;
+use telio_wg::{
+    uapi::{AnalyticsEvent, Peer, UpdateReason},
+    WireGuard,
+};
+
+use super::{Entities, RequestedState, Result};
 
 pub const DEFAULT_PEER_UPGRADE_WINDOW: u64 = 15;
 
@@ -648,9 +658,7 @@ async fn consolidate_firewall<F: Firewall>(
     }
 
     if is_vpn_exit_node {
-        state
-            .ip_addresses
-            .push(IpAddr::V4(Ipv4Addr::new(10, 5, 0, 2)));
+        state.ip_addresses.push(LOCAL_TUNNEL_IPV4.into());
     }
 
     state.ip_addresses.sort_unstable();
@@ -1565,7 +1573,7 @@ mod tests {
         let mut expected_ips = vec![
             IpAddr::V4(Ipv4Addr::LOCALHOST),
             IpAddr::V6(Ipv6Addr::LOCALHOST),
-            IpAddr::V4(Ipv4Addr::new(10, 5, 0, 2)),
+            LOCAL_TUNNEL_IPV4.into(),
         ];
         expected_ips.sort_unstable();
         expected_ips.dedup();
@@ -1612,9 +1620,9 @@ mod tests {
         });
 
         let mut expected_ips = vec![
-            IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
-            IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)),
-            IpAddr::V4(Ipv4Addr::new(10, 5, 0, 2)),
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            IpAddr::V6(Ipv6Addr::LOCALHOST),
+            LOCAL_TUNNEL_IPV4.into(),
         ];
         expected_ips.sort_unstable();
         expected_ips.dedup();


### PR DESCRIPTION
### Problem
After connecting to exit-node, past stale connections might still go through and pollute NAT with outdated addresses.

### Solution
Reject outbound packets (incoming on tunnel's POV) whose source IP are non-tunnel addresses.

Unit and integration tests added.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
