### PR TITLE
LLT-7361: Add option to force plaintext DNS when TP-Lite stats collected is enabled

### DIFF
--- a/.unreleased/LLT-7361
+++ b/.unreleased/LLT-7361
@@ -1,0 +1,1 @@
+Add option to force plaintext DNS for TP-Lite DNS servers when stats collection is enabled

--- a/crates/telio-firewall/src/firewall.rs
+++ b/crates/telio-firewall/src/firewall.rs
@@ -161,6 +161,8 @@ pub struct FirewallState {
     pub ip_addresses: Vec<StdIpAddr>,
     /// Whether an exit node is currently active
     pub exit_node_present: bool,
+    /// List of DNS server IPs for which only plaintext DNS should be allowed
+    pub force_plaintext_dns_for_servers: Option<Vec<StdIpAddr>>,
 }
 
 /// Configuration for firewall initialization.
@@ -335,6 +337,11 @@ impl StatefulFirewall {
         config: TpLiteStatsOptions,
         collect_stats_cb: Box<dyn TpLiteStatsCallback>,
     ) -> Result<(), Error> {
+        let force_plaintext_dns_for_servers = config
+            .force_plaintext_dns
+            .unwrap_or(false)
+            .then(|| config.dns_server_ips.clone());
+
         let config = serde_json::to_string(&config).map_err(|err| {
             telio_log_warn!("Failed to convert TP-Lite config to json. {err:?}");
             Error::InvalidTpLiteConfig
@@ -350,6 +357,11 @@ impl StatefulFirewall {
         {
             let mut cb = self.tp_lite_stats_cb.callback.write();
             std::mem::swap(&mut old_cb, &mut cb);
+        }
+        if let Some(server_ips) = force_plaintext_dns_for_servers {
+            let mut state = self.get_state();
+            state.force_plaintext_dns_for_servers = Some(server_ips);
+            self.apply_state(state);
         }
         let res = unsafe {
             self.firewall_lib.libfw_enable_tp_lite_stats_collection(
@@ -370,6 +382,10 @@ impl StatefulFirewall {
 
     /// Disable collection of TP-Lite stats
     pub fn disable_tp_lite_stats_collection(&self) {
+        let mut state = self.get_state();
+        state.force_plaintext_dns_for_servers = None;
+        self.apply_state(state);
+
         unsafe {
             self.firewall_lib
                 .libfw_disable_tp_lite_stats_collection(self.firewall)
@@ -382,6 +398,16 @@ fn filter_dst_ip_all_ports(net: IpNet, inverted: bool) -> Filter {
         filter_data: FilterData::DstNetwork(NetworkFilterData {
             network: net,
             port_range: (0, 65535),
+        }),
+        inverted,
+    }
+}
+
+fn filter_dst_ip_single_port(net: IpNet, port: u16, inverted: bool) -> Filter {
+    Filter {
+        filter_data: FilterData::DstNetwork(NetworkFilterData {
+            network: net,
+            port_range: (port, port),
         }),
         inverted,
     }
@@ -463,6 +489,18 @@ pub(crate) fn build_chain_rules(
     local_ifs_addrs: &[StdIpAddr],
 ) -> Vec<Rule> {
     let mut rules = vec![];
+
+    if let Some(dns_server_ips) = &state.force_plaintext_dns_for_servers {
+        dns_server_ips.iter().for_each(|ip| {
+            rules.push(Rule {
+                filters: vec![
+                    filter_dst_ip_all_ports(IpNet::from(*ip), false),
+                    filter_dst_ip_single_port(IpNet::from(*ip), 53, true),
+                ],
+                action: LibfwVerdict::LibfwVerdictReject,
+            });
+        });
+    }
 
     // Drop all IPv6 packets when we don't allow ipv6 traffic
     const ALL_IP_V6_ADDRS: IpNet = IpNet::V6(Ipv6Net::new_assert(StdIpv6Addr::UNSPECIFIED, 0));
@@ -925,6 +963,7 @@ mod tests {
         let state = FirewallState {
             ip_addresses: vec![tunnel_ip],
             exit_node_present: true,
+            force_plaintext_dns_for_servers: None,
             whitelist: Whitelist {
                 vpn_peer: Some(vpn_pk),
                 ..Default::default()

--- a/crates/telio-firewall/tests/firewall_integration_tests.rs
+++ b/crates/telio-firewall/tests/firewall_integration_tests.rs
@@ -1097,6 +1097,7 @@ fn firewall_outbound_packet_with_wrong_src_ip_rejected() {
     fw.apply_state(FirewallState {
         ip_addresses: vec![IpAddr::V4(tunnel_ip)],
         exit_node_present: true,
+        force_plaintext_dns_for_servers: None,
         whitelist: telio_firewall::firewall::Whitelist {
             vpn_peer: Some(vpn_peer),
             ..Default::default()
@@ -1352,5 +1353,67 @@ mod tp_lite_stats {
             stats.lock().blocked_domains[0].domain_name,
             "blocked1.example.com".to_owned()
         );
+    }
+
+    #[test]
+    fn test_tp_lite_with_force_plaintext_dns() {
+        const SRC_ADDR: &str = "127.0.0.1:12345";
+        const OTHER_ADDR: &str = "1.1.1.1:853";
+        const PT_DNS_ADDR: &str = "10.5.0.53:53";
+        const DOT_DNS_ADDR: &str = "10.5.0.53:853";
+
+        let fw = StatefulFirewall::new(true, FeatureFirewall::default())
+            .expect("Failed to load libfirewall");
+        let mut state = fw.get_state();
+        state.ip_addresses = vec![
+            IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+            IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)),
+        ];
+        fw.apply_state(state.clone());
+
+        let stats = Arc::new(Mutex::new(Stats::default()));
+        let callback = Callback {
+            stats: stats.clone(),
+        };
+
+        // Enable TP-Lite stats collection with block_non_dns_traffic = true
+        let config = TpLiteStatsOptions {
+            dns_server_ips: vec![IpAddr::from([10, 5, 0, 53])],
+            ..Default::default()
+        };
+        fw.enable_tp_lite_stats_collection(config, Box::new(callback))
+            .unwrap();
+
+        // Before enabling TP-Lite stats collection, all outbound packets should be accepted
+        // regardless of destination IP or port.
+        //
+        // Packet 1: different IP, non-53 port (DoT port 853) — accepted
+        assert!(fw.process_outbound_packet_sink(&make_peer(), &make_udp(SRC_ADDR, OTHER_ADDR)));
+        // Packet 2: configured DNS IP, port 53 — accepted
+        assert!(fw.process_outbound_packet_sink(&make_peer(), &make_udp(SRC_ADDR, PT_DNS_ADDR)));
+        // Packet 3: configured DNS IP, non-53 port (DoT port 853) — accepted (flag not set)
+        assert!(fw.process_outbound_packet_sink(&make_peer(), &make_udp(SRC_ADDR, DOT_DNS_ADDR)));
+
+        // Re-enable TP-Lite stats collection with force_plaintext_dns = true
+        let config = TpLiteStatsOptions {
+            dns_server_ips: vec![IpAddr::from([10, 5, 0, 53])],
+            force_plaintext_dns: Some(true),
+            ..Default::default()
+        };
+        let stats = Arc::new(Mutex::new(Stats::default()));
+        let callback = Callback {
+            stats: stats.clone(),
+        };
+        fw.enable_tp_lite_stats_collection(config, Box::new(callback))
+            .unwrap();
+
+        // After enabling with force_plaintext_dns = true:
+        //
+        // Packet 1: different IP, non-53 port — still accepted (only the configured DNS IP is restricted)
+        assert!(fw.process_outbound_packet_sink(&make_peer(), &make_udp(SRC_ADDR, OTHER_ADDR)));
+        // Packet 2: configured DNS IP, port 53 — accepted (standard DNS is allowed)
+        assert!(fw.process_outbound_packet_sink(&make_peer(), &make_udp(SRC_ADDR, PT_DNS_ADDR)));
+        // Packet 3: configured DNS IP, non-53 port (DoT port 853) — rejected
+        assert!(!fw.process_outbound_packet_sink(&make_peer(), &make_udp(SRC_ADDR, DOT_DNS_ADDR)));
     }
 }

--- a/crates/telio-model/src/tp_lite_stats.rs
+++ b/crates/telio-model/src/tp_lite_stats.rs
@@ -44,6 +44,14 @@ pub struct TpLiteStatsOptions {
     ///
     /// Default value: same as blocked_domains_buffer_size
     pub max_open_requests: Option<u64>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// The stats collection can only operate on plaintext DNS packets
+    /// Setting this flag will block DoT and DoH packets, causing the client to fallback to plaintext
+    /// Note: Some clients can be configured with no plaintext fallback, which would then break if this flag is set
+    ///
+    /// Default value: false
+    pub force_plaintext_dns: Option<bool>,
 }
 
 /// A callback for getting TP-Lite stats from libfirewall

--- a/nat-lab/tests/test_tp_lite_stats.py
+++ b/nat-lab/tests/test_tp_lite_stats.py
@@ -45,6 +45,7 @@ def _tp_lite_config(dns_server_ips: Optional[list[str]] = None):
         blocked_domains_buffer_size=None,
         cache_size=None,
         max_open_requests=None,
+        force_plaintext_dns=None,
     )
 
 

--- a/src/device/wg_controller.rs
+++ b/src/device/wg_controller.rs
@@ -1593,6 +1593,7 @@ mod tests {
                 },
                 ip_addresses: expected_ips,
                 exit_node_present: true,
+                force_plaintext_dns_for_servers: None,
             }))
             .return_const(());
 
@@ -1642,6 +1643,7 @@ mod tests {
                 },
                 ip_addresses: expected_ips,
                 exit_node_present: true,
+                force_plaintext_dns_for_servers: None,
             }))
             .return_const(());
 
@@ -1736,6 +1738,7 @@ mod tests {
                 },
                 ip_addresses: expected_ips,
                 exit_node_present: true,
+                force_plaintext_dns_for_servers: None,
             }))
             .return_const(());
 
@@ -1788,6 +1791,7 @@ mod tests {
                 },
                 ip_addresses: expected_ips,
                 exit_node_present: true,
+                force_plaintext_dns_for_servers: None,
             }))
             .return_const(());
 

--- a/src/libtelio.udl
+++ b/src/libtelio.udl
@@ -1134,4 +1134,11 @@ dictionary TpLiteStatsOptions {
     ///
     /// Default value: same as blocked_domains_buffer_size
     u64? max_open_requests;
+
+    /// The stats collection can only operate on plaintext DNS packets
+    /// Setting this flag will block DoT and DoH packets, causing the client to fallback to plaintext
+    /// Note: Some clients can be configured with no plaintext fallback, which would then break if this flag is set 
+    ///
+    /// Default value: false
+    boolean? force_plaintext_dns;
 };


### PR DESCRIPTION
### Problem
Stats collection can only work on plaintext DNS packets, but some platforms, like android, eagerly use DoT and DoH. That means that the stats collection becomes mostly useless.

### Solution
Add a config option that allows apps to force plaintext DNS by adding rules to libfw to block traffic to all non-53 ports on TP-Lite DNS servers


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
