### PR TITLE
LLT-6821: Zeroize authentication token after its last use

### DIFF
--- a/.unreleased/LLT-6821
+++ b/.unreleased/LLT-6821
@@ -1,0 +1,1 @@
+nordvpnlite: Zeroize authentication token after its last use

--- a/clis/nordvpnlite/src/config.rs
+++ b/clis/nordvpnlite/src/config.rs
@@ -55,6 +55,10 @@ impl NordToken {
             "<PASTE_YOUR_AUTHENTICATION_TOKEN_HERE>".to_owned().into(),
         ))
     }
+
+    pub fn zeroize(&mut self) {
+        self.0 = Arc::new(Hidden::from(String::new()));
+    }
 }
 
 impl Default for NordToken {

--- a/clis/nordvpnlite/src/daemon.rs
+++ b/clis/nordvpnlite/src/daemon.rs
@@ -348,7 +348,7 @@ async fn handle_exit_node_connection(config: &NordVpnLiteConfig, tx: mpsc::Sende
     }
 }
 
-pub async fn daemon_event_loop(config: NordVpnLiteConfig) -> Result<(), NordVpnLiteError> {
+pub async fn daemon_event_loop(mut config: NordVpnLiteConfig) -> Result<(), NordVpnLiteError> {
     debug!("started with config: {config:?}");
 
     let mut signals = Signals::new([SIGHUP, SIGTERM, SIGINT, SIGQUIT])?;
@@ -395,6 +395,8 @@ pub async fn daemon_event_loop(config: NordVpnLiteConfig) -> Result<(), NordVpnL
             };
         }
     };
+
+    config.authentication_token.zeroize();
 
     let config_clone = config.clone();
     let mut telio_task_handle = tokio::task::spawn_blocking(move || {


### PR DESCRIPTION
### Problem
NordVPN authentication token was zeroized only when NordVPNLite configuration struct was dropped. The token could still be read after its last use and before it was dropped which is incorrect from security standpoint.

### Solution
Explicitly zeroize NordVPN authentication token after its last use, which is after nordlynx private key is obtained.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
