### PR TITLE
Backport NepTUN version bump to v2.3.1

### DIFF
--- a/.unreleased/LLT-7073
+++ b/.unreleased/LLT-7073
@@ -1,0 +1,1 @@
+Bump NepTUN to v2.3.1 to fix speed degradation on Apple platforms

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2898,7 +2898,7 @@ dependencies = [
 [[package]]
 name = "neptun"
 version = "2.2.3"
-source = "git+https://github.com/NordSecurity/neptun.git?tag=v2.3.0#faa23c9b02b3ce1cd27aa1fc65c8baae1a2fcf5d"
+source = "git+https://github.com/NordSecurity/neptun.git?tag=v2.3.1#99bf5b6e8962fab13734e860003c372a0241de66"
 dependencies = [
  "aead",
  "base64 0.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -178,7 +178,7 @@ windows = { version = "0.62.2", features = [
 ] }
 winreg = "0.55.0"
 
-neptun = { git = "https://github.com/NordSecurity/neptun.git", tag = "v2.3.0", features = [
+neptun = { git = "https://github.com/NordSecurity/neptun.git", tag = "v2.3.1", features = [
   "device",
 ] }
 x25519-dalek = { version = "2.0.1", features = [


### PR DESCRIPTION
### Problem
Current NepTUN version shows degraded performance on Apple platforms. The fix was merged to main, but we want to release a hotfix.

### Solution
Back port #1772 NepTUN version bump to `v2.3.1`, which provides the fix for speed degradation on Apple platforms.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
