### PR TITLE
Implement tplite dns domain whitelisting

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-TRIGGERED_REF=LLT-7230-tplite-dns-whitelisting
+TRIGGERED_REF=v5.15.9

--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-TRIGGERED_REF=v5.15.7
+TRIGGERED_REF=LLT-7230-tplite-dns-whitelisting

--- a/.unreleased/LLT-7230
+++ b/.unreleased/LLT-7230
@@ -1,0 +1,1 @@
+TP-Lite DNS whitelisting

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,12 +451,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -1315,7 +1309,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "atomic-counter",
- "base64 0.22.1",
+ "base64",
  "clap",
  "crypto_box",
  "ctrlc",
@@ -2165,7 +2159,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -2922,10 +2916,10 @@ dependencies = [
 [[package]]
 name = "neptun"
 version = "2.2.3"
-source = "git+https://github.com/NordSecurity/neptun.git?tag=v2.3.1#99bf5b6e8962fab13734e860003c372a0241de66"
+source = "git+https://github.com/NordSecurity/neptun.git?tag=v3.0.0#2d739150cff117c781c1a6b31c0ffc742084d227"
 dependencies = [
  "aead",
- "base64 0.13.1",
+ "base64",
  "blake2",
  "chacha20poly1305",
  "crossbeam-channel",
@@ -2946,6 +2940,7 @@ dependencies = [
  "tracing",
  "untrusted 0.9.0",
  "x25519-dalek",
+ "zeroize",
 ]
 
 [[package]]
@@ -3048,7 +3043,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert_matches",
- "base64 0.22.1",
+ "base64",
  "clap",
  "daemonize",
  "futures",
@@ -3319,7 +3314,7 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "serde_core",
 ]
 
@@ -4066,7 +4061,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -4106,7 +4101,7 @@ version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -4967,7 +4962,7 @@ name = "tcli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "base64 0.22.1",
+ "base64",
  "clap",
  "dirs",
  "hex",
@@ -5003,7 +4998,7 @@ version = "7.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "base64 0.22.1",
+ "base64",
  "cfg-if",
  "enum-map",
  "ffi_helpers",
@@ -5057,7 +5052,7 @@ name = "telio-crypto"
 version = "0.1.0"
 dependencies = [
  "aead",
- "base64 0.22.1",
+ "base64",
  "bstr",
  "chacha20 0.9.1",
  "chacha20poly1305",
@@ -5146,7 +5141,7 @@ dependencies = [
 name = "telio-model"
 version = "0.1.0"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "ipnet",
  "itertools 0.14.0",
  "modifier",
@@ -5241,7 +5236,7 @@ dependencies = [
 name = "telio-pq"
 version = "0.1.0"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "blake2",
  "blake3",
  "byteorder",
@@ -5275,7 +5270,7 @@ dependencies = [
  "assert_matches",
  "async-channel 2.5.0",
  "aws-lc-rs",
- "base64 0.22.1",
+ "base64",
  "blake3",
  "bytes",
  "hex",
@@ -5845,7 +5840,7 @@ checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
  "axum",
- "base64 0.22.1",
+ "base64",
  "bytes",
  "h2",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,7 +179,7 @@ windows = { version = "0.62.2", features = [
 ] }
 winreg = "0.56.0"
 
-neptun = { git = "https://github.com/NordSecurity/neptun.git", tag = "v2.3.1", features = [
+neptun = { git = "https://github.com/NordSecurity/neptun.git", tag = "v3.0.0", features = [
   "device",
 ] }
 x25519-dalek = { version = "2.0.1", features = [

--- a/crates/telio-firewall/src/chain_helpers.rs
+++ b/crates/telio-firewall/src/chain_helpers.rs
@@ -1,22 +1,28 @@
+use std::ffi::{c_void, CString};
+use std::net::SocketAddrV4;
+use std::os::raw::c_char;
 use std::pin::Pin;
 use std::{fmt::Debug, net::IpAddr};
 
 use ipnet::IpNet;
+use telio_utils::telio_log_warn;
 
 use crate::libfirewall::{
-    LibfwAssociatedData, LibfwChain, LibfwFilter, LibfwFilterData, LibfwIpAddr, LibfwIpData,
-    LibfwNetworkFilter, LibfwRule, LibfwVerdict, LIBFW_CONTRACK_STATE_ESTABLISHED,
-    LIBFW_CONTRACK_STATE_INVALID, LIBFW_CONTRACK_STATE_NEW, LIBFW_CONTRACK_STATE_RELATED,
-    LIBFW_DIRECTION_INBOUND, LIBFW_DIRECTION_OUTBOUND, LIBFW_FILTER_ASSOCIATED_DATA,
-    LIBFW_FILTER_CONNTRACK_STATE, LIBFW_FILTER_DIRECTION, LIBFW_FILTER_DST_NETWORK,
-    LIBFW_FILTER_ICMP_TYPE, LIBFW_FILTER_NEXT_LVL_PROTO, LIBFW_FILTER_SRC_NETWORK,
-    LIBFW_FILTER_TCP_FLAGS, LIBFW_ICMP_TYPE_DESTINATION_UNREACHABLE, LIBFW_ICMP_TYPE_ECHO_REPLY,
+    LibfwAssociatedData, LibfwChainV2, LibfwDnatTarget, LibfwDnsDomainSet, LibfwFilter,
+    LibfwFilterData, LibfwIpAddr, LibfwIpData, LibfwNetworkFilter, LibfwRuleV2,
+    LIBFW_ACTION_ACCEPT, LIBFW_ACTION_DNAT, LIBFW_ACTION_DROP, LIBFW_ACTION_REJECT,
+    LIBFW_CONTRACK_STATE_ESTABLISHED, LIBFW_CONTRACK_STATE_INVALID, LIBFW_CONTRACK_STATE_NEW,
+    LIBFW_CONTRACK_STATE_RELATED, LIBFW_DIRECTION_INBOUND, LIBFW_DIRECTION_OUTBOUND,
+    LIBFW_FILTER_ASSOCIATED_DATA, LIBFW_FILTER_CONNTRACK_STATE, LIBFW_FILTER_DIRECTION,
+    LIBFW_FILTER_DNS_QUERY_DOMAIN, LIBFW_FILTER_DST_NETWORK, LIBFW_FILTER_ICMP_TYPE,
+    LIBFW_FILTER_NEXT_LVL_PROTO, LIBFW_FILTER_SRC_NETWORK, LIBFW_FILTER_TCP_FLAGS,
+    LIBFW_ICMP_TYPE_DESTINATION_UNREACHABLE, LIBFW_ICMP_TYPE_ECHO_REPLY,
     LIBFW_ICMP_TYPE_ECHO_REQUEST, LIBFW_ICMP_TYPE_PARAMETER_PROBLEM,
     LIBFW_ICMP_TYPE_REDIRECT_MESSAGE, LIBFW_ICMP_TYPE_ROUTER_ADVERTISEMENT,
     LIBFW_ICMP_TYPE_ROUTER_SOLICITATION, LIBFW_ICMP_TYPE_TIMESTAMP,
     LIBFW_ICMP_TYPE_TIMESTAMP_REPLY, LIBFW_ICMP_TYPE_TIME_EXCEEDED, LIBFW_IP_TYPE_V4,
     LIBFW_IP_TYPE_V6, LIBFW_NEXT_PROTO_ICMP, LIBFW_NEXT_PROTO_ICMPV6, LIBFW_NEXT_PROTO_TCP,
-    LIBFW_NEXT_PROTO_UDP, LIBFW_VERDICT_ACCEPT, LIBFW_VERDICT_DROP, LIBFW_VERDICT_REJECT,
+    LIBFW_NEXT_PROTO_UDP,
 };
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -80,19 +86,29 @@ pub(crate) enum ConnectionState {
 pub(crate) enum FilterData {
     AssociatedData(Option<Vec<u8>>),
     ConntrackState(ConnectionState),
-    #[allow(dead_code)]
     SrcNetwork(NetworkFilterData),
     DstNetwork(NetworkFilterData),
     Direction(Direction),
     NextLevelProtocol(NextLevelProtocol),
     TcpFlags(u8),
     IcmpType(IcmpType),
+    DnsQueryDomain(Vec<String>),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct Filter {
     pub(crate) filter_data: FilterData,
     pub(crate) inverted: bool,
+}
+
+/// Rule action. Uses libfirewall's V2 action set (LIBFW_ACTION_*) so DNAT
+/// can carry a target endpoint as action data.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum RuleAction {
+    Accept,
+    Drop,
+    Reject,
+    Dnat(SocketAddrV4),
 }
 
 impl From<&[u8]> for LibfwAssociatedData {
@@ -130,13 +146,26 @@ impl From<&NetworkFilterData> for LibfwNetworkFilter {
 }
 
 type PinnedAssocData = Pin<Box<Vec<u8>>>;
-type PinnedFilters = Pin<Box<Vec<LibfwFilter>>>;
-type PinnedRuleData = (PinnedFilters, Vec<Option<PinnedAssocData>>);
-type PinnedRules = Pin<Box<Vec<LibfwRule>>>;
+type PinnedDomainSet = Pin<Box<(Vec<CString>, Vec<*const c_char>)>>;
 
-impl From<&Filter> for (LibfwFilter, Option<PinnedAssocData>) {
+#[allow(dead_code)]
+pub(crate) enum FilterExtraData {
+    AssocData(PinnedAssocData),
+    DomainSet(PinnedDomainSet),
+}
+
+type PinnedFilters = Pin<Box<Vec<LibfwFilter>>>;
+type PinnedDnatTarget = Pin<Box<LibfwDnatTarget>>;
+type PinnedRuleData = (
+    PinnedFilters,
+    Vec<Option<FilterExtraData>>,
+    Option<PinnedDnatTarget>,
+);
+type PinnedRules = Pin<Box<Vec<LibfwRuleV2>>>;
+
+impl From<&Filter> for (LibfwFilter, Option<FilterExtraData>) {
     fn from(value: &Filter) -> Self {
-        let (filter, filter_type, assoc_data) = match &value.filter_data {
+        let (filter, filter_type, extra) = match &value.filter_data {
             FilterData::AssociatedData(assoc_data) => {
                 if let Some(assoc_data) = assoc_data {
                     let cloned_assoc_data = Box::pin(assoc_data.to_vec());
@@ -148,7 +177,7 @@ impl From<&Filter> for (LibfwFilter, Option<PinnedAssocData>) {
                             },
                         },
                         LIBFW_FILTER_ASSOCIATED_DATA,
-                        Some(cloned_assoc_data),
+                        Some(FilterExtraData::AssocData(cloned_assoc_data)),
                     )
                 } else {
                     (
@@ -212,6 +241,31 @@ impl From<&Filter> for (LibfwFilter, Option<PinnedAssocData>) {
                 LIBFW_FILTER_ICMP_TYPE,
                 None,
             ),
+            FilterData::DnsQueryDomain(domains) => {
+                let cstrings: Vec<CString> = domains
+                    .iter()
+                    .filter_map(|d| match CString::new(d.as_str()) {
+                        Ok(cstring) => Some(cstring),
+                        Err(err) => {
+                            telio_log_warn!("Skipping invalid DNS whitelist domain {d:?}: {err}");
+                            None
+                        }
+                    })
+                    .collect();
+                let ptrs: Vec<*const c_char> = cstrings.iter().map(|c| c.as_ptr()).collect();
+                let pinned: PinnedDomainSet = Box::pin((cstrings, ptrs));
+                let (domains_ptr, num_domains) = (pinned.1.as_ptr(), pinned.1.len());
+                (
+                    LibfwFilterData {
+                        dns_domain_set: LibfwDnsDomainSet {
+                            domains: domains_ptr,
+                            num_domains,
+                        },
+                    },
+                    LIBFW_FILTER_DNS_QUERY_DOMAIN,
+                    Some(FilterExtraData::DomainSet(pinned)),
+                )
+            }
         };
         (
             LibfwFilter {
@@ -219,7 +273,7 @@ impl From<&Filter> for (LibfwFilter, Option<PinnedAssocData>) {
                 filter_type,
                 filter,
             },
-            assoc_data,
+            extra,
         )
     }
 }
@@ -227,50 +281,75 @@ impl From<&Filter> for (LibfwFilter, Option<PinnedAssocData>) {
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) struct Rule {
     pub(crate) filters: Vec<Filter>,
-    pub(crate) action: LibfwVerdict,
+    pub(crate) action: RuleAction,
 }
 
-impl From<&Rule> for (LibfwRule, (PinnedFilters, Vec<Option<PinnedAssocData>>)) {
+fn dnat_target_for(target: &SocketAddrV4) -> LibfwDnatTarget {
+    LibfwDnatTarget {
+        addr: LibfwIpAddr {
+            ip_type: LIBFW_IP_TYPE_V4,
+            ip_data: LibfwIpData {
+                ipv4_bytes: target.ip().octets(),
+            },
+        },
+        port: target.port(),
+    }
+}
+
+impl From<&Rule> for (LibfwRuleV2, PinnedRuleData) {
     fn from(value: &Rule) -> Self {
         let (ffi_filters, additional_data): (Vec<_>, Vec<_>) =
             value.filters.iter().map(|filter| filter.into()).unzip();
         let ffi_filters = Box::pin(ffi_filters);
+
+        let (action, action_data_ptr, pinned_target): (
+            u8,
+            *const c_void,
+            Option<PinnedDnatTarget>,
+        ) = match &value.action {
+            RuleAction::Accept => (LIBFW_ACTION_ACCEPT, std::ptr::null(), None),
+            RuleAction::Drop => (LIBFW_ACTION_DROP, std::ptr::null(), None),
+            RuleAction::Reject => (LIBFW_ACTION_REJECT, std::ptr::null(), None),
+            RuleAction::Dnat(target) => {
+                let pinned = Box::pin(dnat_target_for(target));
+                let ptr = (&*pinned) as *const LibfwDnatTarget as *const c_void;
+                (LIBFW_ACTION_DNAT, ptr, Some(pinned))
+            }
+        };
+
         (
-            LibfwRule {
+            LibfwRuleV2 {
                 filters: ffi_filters.as_ptr(),
                 filter_count: ffi_filters.len(),
-                action: match value.action {
-                    LibfwVerdict::LibfwVerdictAccept => LIBFW_VERDICT_ACCEPT,
-                    LibfwVerdict::LibfwVerdictDrop => LIBFW_VERDICT_DROP,
-                    LibfwVerdict::LibfwVerdictReject => LIBFW_VERDICT_REJECT,
-                },
+                action,
+                action_data: action_data_ptr,
             },
-            (ffi_filters, additional_data),
+            (ffi_filters, additional_data, pinned_target),
         )
     }
 }
 
-// Helper structure for LibfwChain - it keeps all of the allocated stuff and the chain
-// remains usable as long as it's not dropped
+// Helper structure for LibfwChainV2 - it keeps all of the allocated stuff and the chain
+// remains usable as long as it's not dropped.
 pub(crate) struct FfiChainGuard {
-    pub(crate) ffi_chain: LibfwChain,
+    pub(crate) ffi_chain: LibfwChainV2,
     _ffi_rules: PinnedRules,
-    _ffi_filters: Vec<(PinnedFilters, Vec<Option<PinnedAssocData>>)>,
+    _ffi_rule_data: Vec<PinnedRuleData>,
 }
 
 impl From<&[Rule]> for FfiChainGuard {
     fn from(value: &[Rule]) -> Self {
-        let (ffi_rules, _ffi_filters): (Vec<LibfwRule>, Vec<PinnedRuleData>) =
+        let (ffi_rules, _ffi_rule_data): (Vec<LibfwRuleV2>, Vec<PinnedRuleData>) =
             value.iter().map(|rule| rule.into()).unzip();
         let _ffi_rules = Box::pin(ffi_rules);
 
         FfiChainGuard {
-            ffi_chain: LibfwChain {
+            ffi_chain: LibfwChainV2 {
                 rule_count: value.len(),
                 rules: _ffi_rules.as_ptr(),
             },
             _ffi_rules,
-            _ffi_filters,
+            _ffi_rule_data,
         }
     }
 }
@@ -278,7 +357,12 @@ impl From<&[Rule]> for FfiChainGuard {
 #[cfg(test)]
 #[allow(missing_docs, unused)]
 pub mod tests {
-    use std::{mem::ManuallyDrop, net::Ipv4Addr};
+    use std::{
+        ffi::{CStr, CString},
+        mem::ManuallyDrop,
+        net::{Ipv4Addr, SocketAddrV4},
+        os::raw::c_char,
+    };
 
     use ipnet::Ipv4Net;
     use pnet_packet::tcp::TcpFlags;
@@ -287,22 +371,23 @@ pub mod tests {
     use crate::{
         chain_helpers::{
             ConnectionState, Direction, FfiChainGuard, Filter, FilterData, IcmpType,
-            NetworkFilterData, NextLevelProtocol, Rule,
+            NetworkFilterData, NextLevelProtocol, Rule, RuleAction,
         },
         libfirewall::{
-            LibfwAssociatedData, LibfwChain, LibfwFilter, LibfwFilterData, LibfwIpAddr,
-            LibfwIpData, LibfwNetworkFilter, LibfwRule, LibfwVerdict,
+            LibfwAssociatedData, LibfwChainV2, LibfwDnatTarget, LibfwDnsDomainSet, LibfwFilter,
+            LibfwFilterData, LibfwIpAddr, LibfwIpData, LibfwNetworkFilter, LibfwRuleV2,
+            LIBFW_ACTION_ACCEPT, LIBFW_ACTION_DNAT, LIBFW_ACTION_DROP, LIBFW_ACTION_REJECT,
             LIBFW_CONTRACK_STATE_ESTABLISHED, LIBFW_DIRECTION_INBOUND, LIBFW_DIRECTION_OUTBOUND,
             LIBFW_FILTER_ASSOCIATED_DATA, LIBFW_FILTER_CONNTRACK_STATE, LIBFW_FILTER_DIRECTION,
-            LIBFW_FILTER_DST_NETWORK, LIBFW_FILTER_ICMP_TYPE, LIBFW_FILTER_NEXT_LVL_PROTO,
-            LIBFW_FILTER_SRC_NETWORK, LIBFW_FILTER_TCP_FLAGS, LIBFW_ICMP_TYPE_ECHO_REPLY,
-            LIBFW_IP_TYPE_V4, LIBFW_IP_TYPE_V6, LIBFW_NEXT_PROTO_UDP, LIBFW_VERDICT_ACCEPT,
-            LIBFW_VERDICT_DROP, LIBFW_VERDICT_REJECT,
+            LIBFW_FILTER_DNS_QUERY_DOMAIN, LIBFW_FILTER_DST_NETWORK, LIBFW_FILTER_ICMP_TYPE,
+            LIBFW_FILTER_NEXT_LVL_PROTO, LIBFW_FILTER_SRC_NETWORK, LIBFW_FILTER_TCP_FLAGS,
+            LIBFW_ICMP_TYPE_ECHO_REPLY, LIBFW_IP_TYPE_V4, LIBFW_IP_TYPE_V6, LIBFW_NEXT_PROTO_UDP,
         },
     };
 
     #[test]
     fn test_conversion_correctness() {
+        let dnat_target = SocketAddrV4::new(Ipv4Addr::new(1, 1, 1, 1), 53);
         let rules = vec![
             Rule {
                 filters: vec![
@@ -332,7 +417,7 @@ pub mod tests {
                         inverted: true,
                     },
                 ],
-                action: LibfwVerdict::LibfwVerdictAccept,
+                action: RuleAction::Accept,
             },
             Rule {
                 filters: vec![
@@ -345,7 +430,7 @@ pub mod tests {
                         inverted: true,
                     },
                 ],
-                action: LibfwVerdict::LibfwVerdictDrop,
+                action: RuleAction::Drop,
             },
             Rule {
                 filters: vec![
@@ -358,12 +443,36 @@ pub mod tests {
                         inverted: false,
                     },
                 ],
-                action: LibfwVerdict::LibfwVerdictReject,
+                action: RuleAction::Reject,
+            },
+            Rule {
+                filters: vec![
+                    Filter {
+                        filter_data: FilterData::Direction(Direction::Outbound),
+                        inverted: false,
+                    },
+                    Filter {
+                        filter_data: FilterData::NextLevelProtocol(NextLevelProtocol::Udp),
+                        inverted: false,
+                    },
+                    Filter {
+                        filter_data: FilterData::DnsQueryDomain(vec![
+                            "example.com".into(),
+                            "foo.bar".into(),
+                        ]),
+                        inverted: false,
+                    },
+                ],
+                action: RuleAction::Dnat(dnat_target),
             },
         ];
 
         let chain_guard: FfiChainGuard = rules.as_slice().into();
         let test_chain_conv = &chain_guard.ffi_chain;
+
+        let test_chain_conv_rules = unsafe {
+            std::slice::from_raw_parts(test_chain_conv.rules, test_chain_conv.rule_count)
+        };
 
         let filters1 = vec![
             LibfwFilter {
@@ -433,7 +542,7 @@ pub mod tests {
             },
         ];
 
-        let mut assoc_data = vec![1u8; 32];
+        let assoc_data = vec![1u8; 32];
         let filters3 = vec![
             LibfwFilter {
                 inverted: true,
@@ -454,194 +563,154 @@ pub mod tests {
             },
         ];
 
-        let rules = vec![
-            LibfwRule {
-                filter_count: filters1.len(),
-                filters: filters1.as_ptr(),
-                action: LIBFW_VERDICT_ACCEPT,
+        let dns_cstrings = [
+            CString::new("example.com").unwrap(),
+            CString::new("foo.bar").unwrap(),
+        ];
+        let dns_ptrs: Vec<*const c_char> = dns_cstrings.iter().map(|c| c.as_ptr()).collect();
+        let filters4 = vec![
+            LibfwFilter {
+                inverted: false,
+                filter_type: LIBFW_FILTER_DIRECTION,
+                filter: LibfwFilterData {
+                    direction_filter: LIBFW_DIRECTION_OUTBOUND,
+                },
             },
-            LibfwRule {
-                filter_count: filters2.len(),
-                filters: filters2.as_ptr(),
-                action: LIBFW_VERDICT_DROP,
+            LibfwFilter {
+                inverted: false,
+                filter_type: LIBFW_FILTER_NEXT_LVL_PROTO,
+                filter: LibfwFilterData {
+                    next_level_protocol: LIBFW_NEXT_PROTO_UDP,
+                },
             },
-            LibfwRule {
-                filter_count: filters3.len(),
-                filters: filters3.as_ptr(),
-                action: LIBFW_VERDICT_REJECT,
+            LibfwFilter {
+                inverted: false,
+                filter_type: LIBFW_FILTER_DNS_QUERY_DOMAIN,
+                filter: LibfwFilterData {
+                    dns_domain_set: LibfwDnsDomainSet {
+                        domains: dns_ptrs.as_ptr(),
+                        num_domains: dns_ptrs.len(),
+                    },
+                },
             },
         ];
 
-        let test_ffi_chain = LibfwChain {
-            rule_count: rules.len(),
-            rules: rules.as_ptr(),
-        };
+        let expected_actions = [
+            LIBFW_ACTION_ACCEPT,
+            LIBFW_ACTION_DROP,
+            LIBFW_ACTION_REJECT,
+            LIBFW_ACTION_DNAT,
+        ];
 
-        let test_chain_conv_rules = unsafe {
-            std::slice::from_raw_parts(test_chain_conv.rules, test_chain_conv.rule_count)
-        };
-        let test_ffi_chain_rules =
-            unsafe { std::slice::from_raw_parts(test_ffi_chain.rules, test_ffi_chain.rule_count) };
+        assert_eq!(test_chain_conv.rule_count, expected_actions.len());
 
-        assert_eq!(test_chain_conv.rule_count, test_ffi_chain.rule_count);
-
-        for i in 0..test_chain_conv.rule_count {
+        for (rule_idx, expected_filters) in
+            [filters1, filters2, filters3, filters4].iter().enumerate()
+        {
+            let rule = &test_chain_conv_rules[rule_idx];
             assert_eq!(
-                test_chain_conv_rules[i].filter_count,
-                test_ffi_chain_rules[i].filter_count
+                rule.filter_count,
+                expected_filters.len(),
+                "rule {rule_idx} filter count"
             );
+            let conv_filters =
+                unsafe { std::slice::from_raw_parts(rule.filters, rule.filter_count) };
+            for (conv, expected) in conv_filters.iter().zip(expected_filters.iter()) {
+                assert_filter_eq(conv, expected);
+            }
 
-            let test_chain_conv_filters = unsafe {
-                std::slice::from_raw_parts(
-                    test_chain_conv_rules[i].filters,
-                    test_chain_conv_rules[i].filter_count,
-                )
-            };
-            let test_ffi_chain_filters = unsafe {
-                std::slice::from_raw_parts(
-                    test_ffi_chain_rules[i].filters,
-                    test_ffi_chain_rules[i].filter_count,
-                )
-            };
+            let expected_action = expected_actions[rule_idx];
+            assert_eq!(test_chain_conv_rules[rule_idx].action, expected_action);
+            if expected_action == LIBFW_ACTION_DNAT {
+                assert!(!test_chain_conv_rules[rule_idx].action_data.is_null());
+                let target = unsafe {
+                    &*(test_chain_conv_rules[rule_idx].action_data as *const LibfwDnatTarget)
+                };
+                assert_eq!(target.addr.ip_type, LIBFW_IP_TYPE_V4);
+                assert_eq!(unsafe { target.addr.ip_data.ipv4_bytes }, [1, 1, 1, 1]);
+                assert_eq!(target.port, 53);
+            } else {
+                assert!(test_chain_conv_rules[rule_idx].action_data.is_null());
+            }
+        }
+    }
 
-            for j in 0..test_chain_conv_rules[i].filter_count {
-                assert_eq!(
-                    test_chain_conv_filters[j].filter_type,
-                    test_ffi_chain_filters[j].filter_type
-                );
-
-                match test_chain_conv_filters[j].filter_type {
-                    LIBFW_FILTER_ASSOCIATED_DATA => {
-                        assert_eq!(
-                            unsafe {
-                                test_chain_conv_filters[j]
-                                    .filter
-                                    .associated_data_filter
-                                    .associated_data_len
-                            },
-                            unsafe {
-                                test_ffi_chain_filters[j]
-                                    .filter
-                                    .associated_data_filter
-                                    .associated_data_len
-                            }
-                        );
-                        if unsafe {
-                            test_chain_conv_filters[j]
-                                .filter
-                                .associated_data_filter
-                                .associated_data
-                                .is_null()
-                        } {
-                            assert!(unsafe {
-                                test_ffi_chain_filters[j]
-                                    .filter
-                                    .associated_data_filter
-                                    .associated_data
-                                    .is_null()
-                            });
-                        } else {
-                            assert!(!unsafe {
-                                test_ffi_chain_filters[j]
-                                    .filter
-                                    .associated_data_filter
-                                    .associated_data
-                                    .is_null()
-                            });
-                            let test_chain_conv_assoc_data = unsafe {
-                                std::slice::from_raw_parts(
-                                    test_chain_conv_filters[j]
-                                        .filter
-                                        .associated_data_filter
-                                        .associated_data,
-                                    test_chain_conv_filters[j]
-                                        .filter
-                                        .associated_data_filter
-                                        .associated_data_len,
-                                )
-                            };
-                            let test_ffi_chain_assoc_data = unsafe {
-                                std::slice::from_raw_parts(
-                                    test_ffi_chain_filters[j]
-                                        .filter
-                                        .associated_data_filter
-                                        .associated_data,
-                                    test_ffi_chain_filters[j]
-                                        .filter
-                                        .associated_data_filter
-                                        .associated_data_len,
-                                )
-                            };
-
-                            for k in 0..test_ffi_chain_assoc_data.len() {
-                                assert_eq!(
-                                    test_ffi_chain_assoc_data[k],
-                                    test_chain_conv_assoc_data[k]
-                                );
-                            }
-                        }
-                    }
-                    LIBFW_FILTER_CONNTRACK_STATE => assert_eq!(
-                        unsafe { test_chain_conv_filters[j].filter.conntrack_state_filter },
-                        unsafe { test_ffi_chain_filters[j].filter.conntrack_state_filter }
-                    ),
-                    LIBFW_FILTER_SRC_NETWORK | LIBFW_FILTER_DST_NETWORK => {
-                        let conv_network_filter =
-                            unsafe { test_chain_conv_filters[j].filter.network_filter };
-                        let ffi_network_filter =
-                            unsafe { test_ffi_chain_filters[j].filter.network_filter };
-                        assert_eq!(
-                            conv_network_filter.network_addr.ip_type,
-                            ffi_network_filter.network_addr.ip_type
-                        );
-                        match conv_network_filter.network_addr.ip_type {
-                            LIBFW_IP_TYPE_V4 => {
-                                assert_eq!(
-                                    unsafe { conv_network_filter.network_addr.ip_data.ipv4_bytes },
-                                    unsafe { ffi_network_filter.network_addr.ip_data.ipv4_bytes }
-                                );
-                            }
-                            LIBFW_IP_TYPE_V6 => {
-                                assert_eq!(
-                                    unsafe { conv_network_filter.network_addr.ip_data.ipv6_bytes },
-                                    unsafe { ffi_network_filter.network_addr.ip_data.ipv6_bytes }
-                                );
-                            }
-                            _ => unreachable!("Unknown IP type"),
-                        };
-
-                        assert_eq!(
-                            conv_network_filter.network_prefix,
-                            ffi_network_filter.network_prefix
-                        );
-                        assert_eq!(
-                            conv_network_filter.port_range_start,
-                            ffi_network_filter.port_range_start
-                        );
-                        assert_eq!(
-                            conv_network_filter.port_range_end,
-                            ffi_network_filter.port_range_end
-                        );
-                    }
-                    LIBFW_FILTER_DIRECTION => assert_eq!(
-                        unsafe { test_chain_conv_filters[j].filter.direction_filter },
-                        unsafe { test_ffi_chain_filters[j].filter.direction_filter }
-                    ),
-                    LIBFW_FILTER_NEXT_LVL_PROTO => assert_eq!(
-                        unsafe { test_chain_conv_filters[j].filter.next_level_protocol },
-                        unsafe { test_ffi_chain_filters[j].filter.next_level_protocol }
-                    ),
-                    LIBFW_FILTER_TCP_FLAGS => assert_eq!(
-                        unsafe { test_chain_conv_filters[j].filter.tcp_flags },
-                        unsafe { test_ffi_chain_filters[j].filter.tcp_flags }
-                    ),
-                    LIBFW_FILTER_ICMP_TYPE => assert_eq!(
-                        unsafe { test_chain_conv_filters[j].filter.icmp_type },
-                        unsafe { test_ffi_chain_filters[j].filter.icmp_type }
-                    ),
-                    _ => unreachable!("Unexpected filter type"),
+    /// Asserts that a converted FFI filter matches the expected one, comparing
+    /// the payload of whichever union variant the `filter_type` selects.
+    fn assert_filter_eq(conv: &LibfwFilter, expected: &LibfwFilter) {
+        assert_eq!(conv.filter_type, expected.filter_type, "filter type");
+        assert_eq!(conv.inverted, expected.inverted, "filter inverted flag");
+        match conv.filter_type {
+            LIBFW_FILTER_ASSOCIATED_DATA => {
+                let c = unsafe { conv.filter.associated_data_filter };
+                let e = unsafe { expected.filter.associated_data_filter };
+                assert_eq!(c.associated_data_len, e.associated_data_len);
+                if e.associated_data.is_null() {
+                    assert!(c.associated_data.is_null());
+                } else {
+                    assert!(!c.associated_data.is_null());
+                    let c_bytes = unsafe {
+                        std::slice::from_raw_parts(c.associated_data, c.associated_data_len)
+                    };
+                    let e_bytes = unsafe {
+                        std::slice::from_raw_parts(e.associated_data, e.associated_data_len)
+                    };
+                    assert_eq!(c_bytes, e_bytes, "associated data bytes");
                 }
             }
+            LIBFW_FILTER_DIRECTION => assert_eq!(unsafe { conv.filter.direction_filter }, unsafe {
+                expected.filter.direction_filter
+            }),
+            LIBFW_FILTER_SRC_NETWORK | LIBFW_FILTER_DST_NETWORK => {
+                let c = unsafe { conv.filter.network_filter };
+                let e = unsafe { expected.filter.network_filter };
+                assert_eq!(c.network_addr.ip_type, e.network_addr.ip_type);
+                match c.network_addr.ip_type {
+                    LIBFW_IP_TYPE_V4 => {
+                        assert_eq!(unsafe { c.network_addr.ip_data.ipv4_bytes }, unsafe {
+                            e.network_addr.ip_data.ipv4_bytes
+                        })
+                    }
+                    LIBFW_IP_TYPE_V6 => {
+                        assert_eq!(unsafe { c.network_addr.ip_data.ipv6_bytes }, unsafe {
+                            e.network_addr.ip_data.ipv6_bytes
+                        })
+                    }
+                    _ => unreachable!("Unknown IP type"),
+                };
+                assert_eq!(c.network_prefix, e.network_prefix);
+                assert_eq!(c.port_range_start, e.port_range_start);
+                assert_eq!(c.port_range_end, e.port_range_end);
+            }
+            LIBFW_FILTER_CONNTRACK_STATE => {
+                assert_eq!(unsafe { conv.filter.conntrack_state_filter }, unsafe {
+                    expected.filter.conntrack_state_filter
+                })
+            }
+            LIBFW_FILTER_NEXT_LVL_PROTO => {
+                assert_eq!(unsafe { conv.filter.next_level_protocol }, unsafe {
+                    expected.filter.next_level_protocol
+                })
+            }
+            LIBFW_FILTER_TCP_FLAGS => assert_eq!(unsafe { conv.filter.tcp_flags }, unsafe {
+                expected.filter.tcp_flags
+            }),
+            LIBFW_FILTER_ICMP_TYPE => assert_eq!(unsafe { conv.filter.icmp_type }, unsafe {
+                expected.filter.icmp_type
+            }),
+            LIBFW_FILTER_DNS_QUERY_DOMAIN => {
+                let c = unsafe { conv.filter.dns_domain_set };
+                let e = unsafe { expected.filter.dns_domain_set };
+                assert_eq!(c.num_domains, e.num_domains, "domain count");
+                let c_ptrs = unsafe { std::slice::from_raw_parts(c.domains, c.num_domains) };
+                let e_ptrs = unsafe { std::slice::from_raw_parts(e.domains, e.num_domains) };
+                for (cp, ep) in c_ptrs.iter().zip(e_ptrs.iter()) {
+                    assert_eq!(unsafe { CStr::from_ptr(*cp) }, unsafe {
+                        CStr::from_ptr(*ep)
+                    });
+                }
+            }
+            _ => unreachable!("Unexpected filter type"),
         }
     }
 }

--- a/crates/telio-firewall/src/firewall.rs
+++ b/crates/telio-firewall/src/firewall.rs
@@ -33,9 +33,9 @@ use telio_utils::{
 use crate::{
     chain_helpers::{
         ConnectionState, Direction, FfiChainGuard, Filter, FilterData, NetworkFilterData,
-        NextLevelProtocol, Rule,
+        NextLevelProtocol, Rule, RuleAction,
     },
-    libfirewall::{LibfwChain, LibfwFirewall, LibfwLogLevel, LibfwResult, LibfwVerdict},
+    libfirewall::{LibfwChainV2, LibfwFirewall, LibfwLogLevel, LibfwResult, LibfwVerdict},
     tp_lite_stats::{collect_stats, CallbackManager},
 };
 
@@ -96,7 +96,7 @@ pub trait Firewall: Sync + Send {
     fn process_outbound_packet(
         &self,
         public_key: &[u8; 32],
-        buffer: &[u8],
+        buffer: &mut [u8],
         sink: &mut dyn io::Write,
     ) -> bool;
 
@@ -321,8 +321,10 @@ impl StatefulFirewall {
         let state = self.state.read().clone();
         let ffi_chain = (self.configure_chain_fn)(&self.config, &state, interface_ips);
         unsafe {
-            self.firewall_lib
-                .libfw_configure_chain(self.firewall, (&ffi_chain.ffi_chain) as *const LibfwChain);
+            self.firewall_lib.libfw_configure_chain_v2(
+                self.firewall,
+                (&ffi_chain.ffi_chain) as *const LibfwChainV2,
+            );
         }
     }
 
@@ -497,7 +499,7 @@ pub(crate) fn build_chain_rules(
                     filter_dst_ip_all_ports(IpNet::from(*ip), false),
                     filter_dst_ip_single_port(IpNet::from(*ip), 53, true),
                 ],
-                action: LibfwVerdict::LibfwVerdictReject,
+                action: RuleAction::Reject,
             });
         });
     }
@@ -507,7 +509,7 @@ pub(crate) fn build_chain_rules(
     if !config.allow_ipv6 {
         rules.push(Rule {
             filters: vec![filter_dst_ip_all_ports(ALL_IP_V6_ADDRS, false)],
-            action: LibfwVerdict::LibfwVerdictDrop,
+            action: RuleAction::Drop,
         });
     }
 
@@ -529,7 +531,7 @@ pub(crate) fn build_chain_rules(
                 },
                 filter_dst_ip_all_ports(IpNet::from(blacklist_entry.ip), false),
             ],
-            action: LibfwVerdict::LibfwVerdictReject,
+            action: RuleAction::Reject,
         });
     }
 
@@ -545,8 +547,42 @@ pub(crate) fn build_chain_rules(
         }
         rules.push(Rule {
             filters,
-            action: LibfwVerdict::LibfwVerdictReject,
+            action: RuleAction::Reject,
         });
+    }
+
+    // DNS whitelisting: redirect outbound DNS queries for whitelisted domains
+    // away from the "blocking" DNS server to the "standard" one via DNAT.
+    if let Some(dns) = &config.feature.dns_whitelisting {
+        if !dns.domains.is_empty() {
+            for redirect in &dns.redirects {
+                let blocking_net = IpNet::from(StdIpAddr::V4(*redirect.blocking.ip()));
+                rules.push(Rule {
+                    filters: vec![
+                        Filter {
+                            filter_data: FilterData::Direction(Direction::Outbound),
+                            inverted: false,
+                        },
+                        Filter {
+                            filter_data: FilterData::NextLevelProtocol(NextLevelProtocol::Udp),
+                            inverted: false,
+                        },
+                        Filter {
+                            filter_data: FilterData::DstNetwork(NetworkFilterData {
+                                network: blocking_net,
+                                port_range: (redirect.blocking.port(), redirect.blocking.port()),
+                            }),
+                            inverted: false,
+                        },
+                        Filter {
+                            filter_data: FilterData::DnsQueryDomain(dns.domains.clone()),
+                            inverted: false,
+                        },
+                    ],
+                    action: RuleAction::Dnat(redirect.standard),
+                });
+            }
+        }
     }
 
     rules.push(Rule {
@@ -554,7 +590,7 @@ pub(crate) fn build_chain_rules(
             filter_data: FilterData::Direction(Direction::Outbound),
             inverted: false,
         }],
-        action: LibfwVerdict::LibfwVerdictAccept,
+        action: RuleAction::Accept,
     });
 
     // Add VPN rule
@@ -564,7 +600,7 @@ pub(crate) fn build_chain_rules(
                 filter_data: FilterData::AssociatedData(Some(vpn_pk.to_vec())),
                 inverted: false,
             }],
-            action: LibfwVerdict::LibfwVerdictAccept,
+            action: RuleAction::Accept,
         });
     }
 
@@ -583,7 +619,7 @@ pub(crate) fn build_chain_rules(
             filters.extend_from_slice(local_net);
             rules.push(Rule {
                 filters,
-                action: LibfwVerdict::LibfwVerdictAccept,
+                action: RuleAction::Accept,
             });
         }
     }
@@ -592,7 +628,7 @@ pub(crate) fn build_chain_rules(
     for filters in local_network_filters {
         rules.push(Rule {
             filters,
-            action: LibfwVerdict::LibfwVerdictDrop,
+            action: RuleAction::Drop,
         });
     }
 
@@ -609,7 +645,7 @@ pub(crate) fn build_chain_rules(
                     },
                     filter_dst_ip_all_ports(IpNet::from(*ip), false),
                 ],
-                action: LibfwVerdict::LibfwVerdictAccept,
+                action: RuleAction::Accept,
             });
         }
 
@@ -622,7 +658,7 @@ pub(crate) fn build_chain_rules(
                 },
                 filter_dst_ip_all_ports(IpNet::from(*ip), false),
             ],
-            action: LibfwVerdict::LibfwVerdictAccept,
+            action: RuleAction::Accept,
         });
 
         // And packets related to them
@@ -634,7 +670,7 @@ pub(crate) fn build_chain_rules(
                 },
                 filter_dst_ip_all_ports(IpNet::from(*ip), false),
             ],
-            action: LibfwVerdict::LibfwVerdictAccept,
+            action: RuleAction::Accept,
         });
 
         // Accept packets for whitelisted ports
@@ -658,7 +694,7 @@ pub(crate) fn build_chain_rules(
                             inverted: false,
                         },
                     ],
-                    action: LibfwVerdict::LibfwVerdictAccept,
+                    action: RuleAction::Accept,
                 });
             }
         }
@@ -666,7 +702,7 @@ pub(crate) fn build_chain_rules(
         // Drop rest of the packets going to local interfaces
         rules.push(Rule {
             filters: vec![filter_dst_ip_all_ports(IpNet::from(*ip), false)],
-            action: LibfwVerdict::LibfwVerdictDrop,
+            action: RuleAction::Drop,
         });
     }
 
@@ -677,7 +713,7 @@ pub(crate) fn build_chain_rules(
                 filter_data: FilterData::AssociatedData(Some(peer.to_vec())),
                 inverted: false,
             }],
-            action: LibfwVerdict::LibfwVerdictAccept,
+            action: RuleAction::Accept,
         });
     }
 
@@ -744,7 +780,7 @@ impl Firewall for StatefulFirewall {
     fn process_outbound_packet(
         &self,
         public_key: &[u8; 32],
-        buffer: &[u8],
+        buffer: &mut [u8],
         sink: &mut dyn io::Write,
     ) -> bool {
         let sink_ptr = &sink as *const &mut dyn io::Write;
@@ -752,7 +788,7 @@ impl Firewall for StatefulFirewall {
             == unsafe {
                 self.firewall_lib.libfw_process_outbound_packet(
                     self.firewall,
-                    buffer.as_ptr(),
+                    buffer.as_mut_ptr(),
                     buffer.len(),
                     public_key as *const u8,
                     public_key.len(),
@@ -826,7 +862,7 @@ mod tests {
 
             result
                 .get_libfirewall_mock()
-                .expect_libfw_configure_chain()
+                .expect_libfw_configure_chain_v2()
                 .once()
                 .returning(|_, _| crate::libfirewall::LibfwResult::LibfwSuccess);
 
@@ -856,7 +892,7 @@ mod tests {
 
         firewall
             .get_libfirewall_mock()
-            .expect_libfw_configure_chain()
+            .expect_libfw_configure_chain_v2()
             .times(2)
             .returning(|_, _| crate::libfirewall::LibfwResult::LibfwSuccess);
 
@@ -891,9 +927,7 @@ mod tests {
         };
         let rules = build_chain_rules(&config, &state, &[]);
         assert!(
-            rules
-                .iter()
-                .all(|r| r.action != LibfwVerdict::LibfwVerdictReject),
+            rules.iter().all(|r| r.action != RuleAction::Reject),
             "found Reject rule without exit_node_present"
         );
     }
@@ -911,9 +945,7 @@ mod tests {
         };
         let rules = build_chain_rules(&config, &state, &[]);
         assert!(
-            rules
-                .iter()
-                .all(|r| r.action != LibfwVerdict::LibfwVerdictReject),
+            rules.iter().all(|r| r.action != RuleAction::Reject),
             "found Reject rule with empty ip_addresses"
         );
     }
@@ -934,7 +966,7 @@ mod tests {
 
         let _rule = rules
             .iter()
-            .filter(|r| r.action == LibfwVerdict::LibfwVerdictReject)
+            .filter(|r| r.action == RuleAction::Reject)
             .find(|r| {
                 let has_outbound = r.filters.iter().any(|f| {
                     f.filter_data == FilterData::Direction(Direction::Outbound) && !f.inverted
@@ -972,7 +1004,7 @@ mod tests {
         let rules = build_chain_rules(&config, &state, &[]);
 
         let reject_pos = rules.iter().position(|r| {
-            r.action == LibfwVerdict::LibfwVerdictReject
+            r.action == RuleAction::Reject
                 && r.filters.iter().any(|f| {
                     f.filter_data == FilterData::Direction(Direction::Outbound) && !f.inverted
                 })
@@ -981,7 +1013,7 @@ mod tests {
                     .any(|f| matches!(&f.filter_data, FilterData::SrcNetwork(_)) && f.inverted)
         });
         let accept_pos = rules.iter().position(|r| {
-            r.action == LibfwVerdict::LibfwVerdictAccept
+            r.action == RuleAction::Accept
                 && r.filters.iter().any(|f| {
                     matches!(&f.filter_data, FilterData::AssociatedData(Some(k))
                         if k == &vpn_pk.to_vec())
@@ -1012,7 +1044,7 @@ mod tests {
 
         let rule = rules
             .iter()
-            .filter(|r| r.action == LibfwVerdict::LibfwVerdictReject)
+            .filter(|r| r.action == RuleAction::Reject)
             .find(|r| {
                 r.filters.iter().any(|f| {
                     f.filter_data == FilterData::Direction(Direction::Outbound) && !f.inverted
@@ -1063,7 +1095,7 @@ mod tests {
 
         firewall
             .get_libfirewall_mock()
-            .expect_libfw_configure_chain()
+            .expect_libfw_configure_chain_v2()
             .times(2)
             .returning(|_, _| crate::libfirewall::LibfwResult::LibfwSuccess);
 

--- a/crates/telio-firewall/src/libfirewall.rs
+++ b/crates/telio-firewall/src/libfirewall.rs
@@ -24,6 +24,10 @@ pub const LIBFW_ICMP_TYPE_TIMESTAMP_REPLY: u8 = 14;
 pub const LIBFW_VERDICT_ACCEPT: u8 = 0;
 pub const LIBFW_VERDICT_DROP: u8 = 1;
 pub const LIBFW_VERDICT_REJECT: u8 = 2;
+pub const LIBFW_ACTION_ACCEPT: u8 = 0;
+pub const LIBFW_ACTION_DROP: u8 = 1;
+pub const LIBFW_ACTION_REJECT: u8 = 2;
+pub const LIBFW_ACTION_DNAT: u8 = 3;
 pub const LIBFW_CONTRACK_STATE_NEW: u8 = 0;
 pub const LIBFW_CONTRACK_STATE_ESTABLISHED: u8 = 1;
 pub const LIBFW_CONTRACK_STATE_INVALID: u8 = 2;
@@ -40,6 +44,7 @@ pub const LIBFW_FILTER_DIRECTION: u8 = 4;
 pub const LIBFW_FILTER_NEXT_LVL_PROTO: u8 = 5;
 pub const LIBFW_FILTER_TCP_FLAGS: u8 = 6;
 pub const LIBFW_FILTER_ICMP_TYPE: u8 = 7;
+pub const LIBFW_FILTER_DNS_QUERY_DOMAIN: u8 = 8;
 #[repr(u32)]
 #[doc = " Log levels used in LibfwLogCallback\n"]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -148,6 +153,15 @@ pub struct LibfwNetworkFilter {
     #[doc = " Maximum port accepted by the filter"]
     pub port_range_end: u16,
 }
+#[doc = " A set of DNS domain patterns to match against DNS query QNAMEs\n"]
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct LibfwDnsDomainSet {
+    #[doc = " Pointer to an array of null-terminated C strings representing domain patterns"]
+    pub domains: *const *const ::std::os::raw::c_char,
+    #[doc = " Number of domain patterns in the array"]
+    pub num_domains: usize,
+}
 #[doc = " Data for the certain filter type\n"]
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -166,6 +180,8 @@ pub union LibfwFilterData {
     pub tcp_flags: u8,
     #[doc = " Checked ICMP types, only ICMP packets can match this filter\n Use when filter_type = LibfwFilterConntrackState"]
     pub icmp_type: u8,
+    #[doc = " Set of DNS domain patterns to match against DNS query QNAMEs\n Use when filter_type = LibfwFilterDnsQueryDomain"]
+    pub dns_domain_set: LibfwDnsDomainSet,
 }
 #[doc = " Struct describing a single Libfw filter\n"]
 #[repr(C)]
@@ -198,6 +214,28 @@ pub struct LibfwChain {
     #[doc = " List of the rules"]
     pub rules: *const LibfwRule,
 }
+#[doc = " V2 rule shape with action data: extends `LibfwRule` to carry an\n optional pointer to action-specific data.\n"]
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct LibfwRuleV2 {
+    #[doc = " List of filters all of which match in order to consider rule's action"]
+    pub filters: *const LibfwFilter,
+    #[doc = " Length of the filter list"]
+    pub filter_count: usize,
+    #[doc = " One of LIBFW_ACTION_ACCEPT, LIBFW_ACTION_DROP, LIBFW_ACTION_REJECT,\n LIBFW_ACTION_DNAT."]
+    pub action: u8,
+    #[doc = " Action-specific data. NULL for ACCEPT/DROP/REJECT. Points to\n `LibfwDnatTarget` for LIBFW_ACTION_DNAT."]
+    pub action_data: *const ::std::os::raw::c_void,
+}
+#[doc = " V2 chain shape carrying `LibfwRuleV2` rules.\n"]
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct LibfwChainV2 {
+    #[doc = " Chain size"]
+    pub rule_count: usize,
+    #[doc = " List of the rules"]
+    pub rules: *const LibfwRuleV2,
+}
 #[doc = " A callback type to enable libfirewall to\n inject packets into VPN tunnel interface\n\n Normally only called when stale connection\n closing is triggered.\n\n @param data - The same pointer as passed in @ref libfw_init. It is meant to\n              provide facilities for callback implementors to add context\n              information to the callback itself. If integrators of libfirewall\n              does not need context information - `null` may be passed in\n              @ref libfw_init\n @param packet - byte array of IP packet\n @param packet_len - length in bytes of IP packet in @param packet\n @param associated_data - if associated data was passed in inbound\n                          and outbound packet processing function\n                          this field will provide the same associated\n                          data. Inteded to be used as peer identifier\n                          in case of nordlynx\n @param associated_data_len - the length in bytes of associated data\n"]
 pub type LibfwInjectPacketCallback = ::std::option::Option<
     unsafe extern "C" fn(
@@ -208,6 +246,15 @@ pub type LibfwInjectPacketCallback = ::std::option::Option<
         associated_data_len: usize,
     ),
 >;
+#[doc = " Target address+port for a DNAT action. Pointed at by `LibfwRuleV2::action_data`\n when `LibfwRuleV2::action == LIBFW_ACTION_DNAT`.\n"]
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct LibfwDnatTarget {
+    #[doc = " Target IP address (v4 or v6, per `ip_type`)"]
+    pub addr: LibfwIpAddr,
+    #[doc = " Target port"]
+    pub port: u16,
+}
 pub struct Libfirewall {
     __library: ::libloading::Library,
     pub libfw_set_log_callback:
@@ -223,6 +270,10 @@ pub struct Libfirewall {
     pub libfw_configure_chain: unsafe extern "C" fn(
         fw: *mut LibfwFirewall,
         ffi_chain: *const LibfwChain,
+    ) -> LibfwResult::Type,
+    pub libfw_configure_chain_v2: unsafe extern "C" fn(
+        fw: *mut LibfwFirewall,
+        ffi_chain: *const LibfwChainV2,
     ) -> LibfwResult::Type,
     pub libfw_trigger_stale_connection_close: unsafe extern "C" fn(
         firewall: *mut LibfwFirewall,
@@ -243,7 +294,7 @@ pub struct Libfirewall {
     ) -> LibfwVerdict,
     pub libfw_process_outbound_packet: unsafe extern "C" fn(
         firewall: *mut LibfwFirewall,
-        packet: *const u8,
+        packet: *mut u8,
         packet_len: usize,
         associated_data: *const u8,
         associated_data_len: usize,
@@ -252,7 +303,6 @@ pub struct Libfirewall {
     ) -> LibfwVerdict,
     pub libfw_deinit: unsafe extern "C" fn(firewall: *mut LibfwFirewall),
 }
-
 #[cfg_attr(test, mockall::automock)]
 impl Libfirewall {
     pub unsafe fn new<P>(path: P) -> Result<Self, ::libloading::Error>
@@ -284,6 +334,9 @@ impl Libfirewall {
             .get(b"libfw_disable_tp_lite_stats_collection\0")
             .map(|sym| *sym)?;
         let libfw_configure_chain = __library.get(b"libfw_configure_chain\0").map(|sym| *sym)?;
+        let libfw_configure_chain_v2 = __library
+            .get(b"libfw_configure_chain_v2\0")
+            .map(|sym| *sym)?;
         let libfw_trigger_stale_connection_close = __library
             .get(b"libfw_trigger_stale_connection_close\0")
             .map(|sym| *sym)?;
@@ -301,6 +354,7 @@ impl Libfirewall {
             libfw_enable_tp_lite_stats_collection,
             libfw_disable_tp_lite_stats_collection,
             libfw_configure_chain,
+            libfw_configure_chain_v2,
             libfw_trigger_stale_connection_close,
             libfw_process_inbound_packet,
             libfw_process_outbound_packet,
@@ -346,6 +400,14 @@ impl Libfirewall {
     ) -> LibfwResult::Type {
         (self.libfw_configure_chain)(fw, ffi_chain)
     }
+    #[doc = " Same as `libfw_configure_chain` but accepts the V2 chain shape. V2 rules\n carry an `action_data` pointer alongside the action byte, allowing DNAT\n rules to specify a target via `LibfwDnatTarget`.\n\n # Safety\n\n Same as `libfw_configure_chain`."]
+    pub unsafe fn libfw_configure_chain_v2(
+        &self,
+        fw: *mut LibfwFirewall,
+        ffi_chain: *const LibfwChainV2,
+    ) -> LibfwResult::Type {
+        (self.libfw_configure_chain_v2)(fw, ffi_chain)
+    }
     #[doc = " A function which triggers stale connection closing\n\n @param fw - pointer returned by @ref libfw_init\n @param associated_data - identifier of peer. Should contain peer's public key\n                          for NordLynx and be Null for other protcols\n @param associated_data_len - size of @param associated_data in bytes\n @param inject_packet_cb_data - a pointer which will be passed in the\n                                inject_packet callback unmodified\n @param inject_inbound_packet_cb - callback which will be used by libfw to inject\n                           packets into virtual tunnel interface\n @param inject_outbound_packet_cb - callback which will be used by libfw to inject\n                          packets back towards VPN server. May be NULL if integrators\n                          accepts that libfirewall will only reject connections from\n                          inbound direction.\n\n # Safety\n\n This function dereferences pointer to firewall - user must ensure that this is\n the pointer returned by `libfw_init`."]
     pub unsafe fn libfw_trigger_stale_connection_close(
         &self,
@@ -390,7 +452,7 @@ impl Libfirewall {
     pub unsafe fn libfw_process_outbound_packet(
         &self,
         firewall: *mut LibfwFirewall,
-        packet: *const u8,
+        packet: *mut u8,
         packet_len: usize,
         associated_data: *const u8,
         associated_data_len: usize,

--- a/crates/telio-firewall/tests/firewall_integration_tests.rs
+++ b/crates/telio-firewall/tests/firewall_integration_tests.rs
@@ -319,12 +319,160 @@ fn make_icmp6(src: &str, dst: &str, icmp_type: GenericIcmpType) -> Vec<u8> {
     make_icmp6_with_body(src, dst, icmp_type, &[])
 }
 
+const DNS_HEADER_SIZE: usize = 12;
+
+// Strings in the DNS message format are encoded as a list of labels followed by a null byte.
+// A label starts with a "len byte" denoting how long the label is, followed by the bytes of the string.
+// DNS labels can only contain ascii code points.
+//
+// This explanation and function does not include the "root record" or compression pointers.
+fn encode_domain_name(name: &str) -> Vec<u8> {
+    let mut out = Vec::new();
+    for label in name.split('.') {
+        out.push(label.len() as u8);
+        out.extend_from_slice(label.as_bytes());
+    }
+    out.push(0x00);
+    out
+}
+
+enum PacketType {
+    Query,
+    Response,
+    BlockedResponse,
+}
+
+fn dns_packet(tx_id: u16, name: &str, packet_type: PacketType) -> Vec<u8> {
+    use pnet_packet::dns::{MutableDnsPacket, Retcode};
+
+    let mut buf = vec![0; DNS_HEADER_SIZE];
+    let mut packet =
+        MutableDnsPacket::new(&mut buf).expect("Creating MutableDnsPacket should be successful");
+
+    packet.set_id(tx_id);
+    packet.set_is_recursion_desirable(1);
+    packet.set_query_count(1);
+    match packet_type {
+        PacketType::Query => {}
+        PacketType::Response => {
+            packet.set_is_response(1);
+            packet.set_is_recursion_available(1);
+            packet.set_response_count(1);
+        }
+        PacketType::BlockedResponse => {
+            packet.set_is_response(1);
+            packet.set_is_recursion_available(1);
+            packet.set_rcode(Retcode::RecordNotExists);
+            packet.set_authority_rr_count(1);
+        }
+    };
+
+    buf.extend_from_slice(&dns_query(name));
+    match packet_type {
+        PacketType::Query => {}
+        PacketType::Response => buf.extend_from_slice(&dns_a_record()),
+        PacketType::BlockedResponse => buf.extend_from_slice(&dns_soa_record()),
+    }
+
+    buf
+}
+
+fn dns_query(name: &str) -> Vec<u8> {
+    use pnet_packet::dns::{DnsClasses, DnsTypes};
+    let mut buf = encode_domain_name(name);
+    buf.extend_from_slice(&DnsTypes::A.0.to_be_bytes());
+    buf.extend_from_slice(&DnsClasses::IN.0.to_be_bytes());
+    buf
+}
+
+fn dns_rr(rtype: pnet_packet::dns::DnsType, rdata: Vec<u8>) -> Vec<u8> {
+    use pnet_packet::dns::{DnsClasses, MutableDnsResponsePacket};
+
+    let mut buf = vec![0; DNS_HEADER_SIZE];
+    let mut packet = MutableDnsResponsePacket::new(&mut buf).unwrap();
+
+    packet.set_name_tag(u16::from_be_bytes([0xC0, 0x0C]));
+    packet.set_rtype(rtype);
+    packet.set_rclass(DnsClasses::IN);
+    packet.set_ttl(3600);
+    packet.set_data_len(rdata.len() as u16);
+
+    buf.extend_from_slice(&rdata);
+
+    buf
+}
+
+fn dns_a_record() -> Vec<u8> {
+    use pnet_packet::dns::DnsTypes;
+    // For A records the rdata just contains an IPv4 address
+    let rdata = vec![93, 184, 216, 34];
+    dns_rr(DnsTypes::A, rdata)
+}
+
+fn dns_soa_record() -> Vec<u8> {
+    use pnet_packet::dns::DnsTypes;
+    let mut rdata = Vec::new();
+
+    rdata.extend_from_slice(&encode_domain_name(
+        "dns-malware-cybersec.nordthreatprotection.com",
+    )); // MNAME
+    rdata.extend_from_slice(&encode_domain_name("hostmaster.example.com")); // RNAME
+
+    // Some fields that are irrelevant for testing purposes. They can all be set to 0
+    rdata.extend_from_slice(&[0, 0, 0, 0, 0, 0, 0, 0]); // Serial number
+    rdata.extend_from_slice(&[0, 0, 0, 0]); // Refresh interval
+    rdata.extend_from_slice(&[0, 0, 0, 0]); // Retry interval
+    rdata.extend_from_slice(&[0, 0, 0, 0]); // Expiry
+    rdata.extend_from_slice(&[0, 0, 0, 0]); // Minimum
+
+    dns_rr(DnsTypes::SOA, rdata)
+}
+
+fn make_dns_request_to(src: SocketAddrV4, dst: SocketAddrV4, tx_id: u16, name: &str) -> Vec<u8> {
+    let dns_payload = dns_packet(tx_id, name, PacketType::Query);
+    make_udp_with_body(&src.to_string(), &dst.to_string(), &dns_payload)
+}
+
+fn make_dns_request(tx_id: u16, name: &str) -> Vec<u8> {
+    make_dns_request_to(
+        "127.0.0.1:12345".parse().unwrap(),
+        "10.5.0.53:53".parse().unwrap(),
+        tx_id,
+        name,
+    )
+}
+
+fn make_dns_response_to(
+    src: SocketAddrV4,
+    dst: SocketAddrV4,
+    tx_id: u16,
+    name: &str,
+    is_blocked: bool,
+) -> Vec<u8> {
+    let dns_payload = if is_blocked {
+        dns_packet(tx_id, name, PacketType::BlockedResponse)
+    } else {
+        dns_packet(tx_id, name, PacketType::Response)
+    };
+    make_udp_with_body(&src.to_string(), &dst.to_string(), &dns_payload)
+}
+
+fn make_dns_response(tx_id: u16, name: &str, is_blocked: bool) -> Vec<u8> {
+    make_dns_response_to(
+        "10.5.0.53:53".parse().unwrap(),
+        "127.0.0.1:12345".parse().unwrap(),
+        tx_id,
+        name,
+        is_blocked,
+    )
+}
+
 trait FirewallExt {
-    fn process_outbound_packet_sink(&self, public_key: &[u8; 32], buffer: &[u8]) -> bool;
+    fn process_outbound_packet_sink(&self, public_key: &[u8; 32], buffer: &mut [u8]) -> bool;
 }
 
 impl FirewallExt for StatefulFirewall {
-    fn process_outbound_packet_sink(&self, public_key: &[u8; 32], buffer: &[u8]) -> bool {
+    fn process_outbound_packet_sink(&self, public_key: &[u8; 32], buffer: &mut [u8]) -> bool {
         Firewall::process_outbound_packet(self, public_key, buffer, &mut &io::sink())
     }
 }
@@ -377,13 +525,13 @@ fn ipv6_blocked() {
         assert_eq!(fw.process_inbound_packet(&make_peer(), &mut make_udp(dst1, src4)), false);
 
         // Should PASS (adds 1111..4444 and drops 2222)
-        assert_eq!(fw.process_outbound_packet_sink(&make_peer(), &make_udp(src1, dst1)), is_ipv4);
-        assert_eq!(fw.process_outbound_packet_sink(&make_peer(), &make_udp(src2, dst1)), is_ipv4);
-        assert_eq!(fw.process_outbound_packet_sink(&make_peer(), &make_udp(src1, dst1)), is_ipv4);
-        assert_eq!(fw.process_outbound_packet_sink(&make_peer(), &make_udp(src3, dst1)), is_ipv4);
-        assert_eq!(fw.process_outbound_packet_sink(&make_peer(), &make_udp(src1, dst1)), is_ipv4);
-        assert_eq!(fw.process_outbound_packet_sink(&make_peer(), &make_udp(src4, dst1)), is_ipv4);
-        assert_eq!(fw.process_outbound_packet_sink(&make_peer(), &make_udp(src1, dst1)), is_ipv4);
+        assert_eq!(fw.process_outbound_packet_sink(&make_peer(), &mut make_udp(src1, dst1)), is_ipv4);
+        assert_eq!(fw.process_outbound_packet_sink(&make_peer(), &mut make_udp(src2, dst1)), is_ipv4);
+        assert_eq!(fw.process_outbound_packet_sink(&make_peer(), &mut make_udp(src1, dst1)), is_ipv4);
+        assert_eq!(fw.process_outbound_packet_sink(&make_peer(), &mut make_udp(src3, dst1)), is_ipv4);
+        assert_eq!(fw.process_outbound_packet_sink(&make_peer(), &mut make_udp(src1, dst1)), is_ipv4);
+        assert_eq!(fw.process_outbound_packet_sink(&make_peer(), &mut make_udp(src4, dst1)), is_ipv4);
+        assert_eq!(fw.process_outbound_packet_sink(&make_peer(), &mut make_udp(src1, dst1)), is_ipv4);
 
         // Should PASS (matching outgoing connections exist in LRUCache)
         assert_eq!(fw.process_inbound_packet(&make_peer(), &mut make_udp(dst1, src3)), is_ipv4);
@@ -433,8 +581,8 @@ fn outgoing_blacklist() {
             ..Default::default()
         });
 
-        assert_eq!(fw.process_outbound_packet_sink(&make_peer(), &make_udp(src, dst)), false);
-        assert_eq!(fw.process_outbound_packet_sink(&make_peer(), &make_tcp(src, dst, TcpFlags::ACK)), false);
+        assert_eq!(fw.process_outbound_packet_sink(&make_peer(), &mut make_udp(src, dst)), false);
+        assert_eq!(fw.process_outbound_packet_sink(&make_peer(), &mut make_tcp(src, dst, TcpFlags::ACK)), false);
     }
 }
 
@@ -570,7 +718,7 @@ fn firewall_vpn_peer() {
             assert_eq!(fw.process_inbound_packet(&peer2.0, &mut make_udp(src2, dst1,)), false);
 
             assert_eq!(fw.process_inbound_packet(&peer1.0, &mut make_tcp(src1, dst1, syn)), true);
-            assert_eq!(fw.process_outbound_packet_sink(&peer1.0, &make_tcp(dst1, src1, synack)), true);
+            assert_eq!(fw.process_outbound_packet_sink(&peer1.0, &mut make_tcp(dst1, src1, synack)), true);
 
             state.whitelist.vpn_peer = None;
             fw.apply_state(state.clone());
@@ -650,7 +798,7 @@ fn firewall_whitelist_change_udp_allow() {
         assert_eq!(fw.process_inbound_packet(&them_peer.0, &mut make_udp(them, us)), false);
         state.whitelist.port_whitelist.insert(them_peer, 8888);
         fw.apply_state(state.clone()); // NOTE: this doesn't change anything about this test
-        assert_eq!(fw.process_outbound_packet_sink(&them_peer.0, &make_udp(us, them)), true);
+        assert_eq!(fw.process_outbound_packet_sink(&them_peer.0, &mut make_udp(us, them)), true);
         assert_eq!(fw.process_inbound_packet(&them_peer.0, &mut make_udp(them, us)), true);
 
         // Should PASS because we started the session
@@ -682,7 +830,7 @@ fn firewall_whitelist_change_udp_block() {
         state.whitelist.port_whitelist.insert(them_peer, 1111);
         fw.apply_state(state.clone());
         assert_eq!(fw.process_inbound_packet(&them_peer.0, &mut make_udp(them, us)), true);
-        assert_eq!(fw.process_outbound_packet_sink(&them_peer.0, &make_udp(us, them)), true);
+        assert_eq!(fw.process_outbound_packet_sink(&them_peer.0, &mut make_udp(us, them)), true);
 
         // The already started connection should still work
         assert_eq!(fw.process_inbound_packet(&them_peer.0, &mut make_udp(them, us)), true);
@@ -711,7 +859,7 @@ fn firewall_whitelist_change_tcp_allow() {
         state.whitelist.port_whitelist.insert(them_peer, 8888);
         fw.apply_state(state.clone()); // NOTE: this doesn't change anything about the test
         assert_eq!(fw.process_inbound_packet(&them_peer.0, &mut make_tcp(them, us, TcpFlags::SYN | TcpFlags::ACK)), false);
-        assert_eq!(fw.process_outbound_packet_sink(&them_peer.0, &make_tcp(us, them, TcpFlags::SYN)), true);
+        assert_eq!(fw.process_outbound_packet_sink(&them_peer.0, &mut make_tcp(us, them, TcpFlags::SYN)), true);
         assert_eq!(fw.process_inbound_packet(&them_peer.0, &mut make_tcp(them, us, TcpFlags::SYN | TcpFlags::ACK)), true);
 
 
@@ -744,7 +892,7 @@ fn firewall_whitelist_change_tcp_block() {
         state.whitelist.port_whitelist.insert(them_peer, 1111);
         fw.apply_state(state.clone());
         assert_eq!(fw.process_inbound_packet(&them_peer.0, &mut make_tcp(them, us, TcpFlags::SYN)), true);
-        assert_eq!(fw.process_outbound_packet_sink(&them_peer.0, &make_tcp(us, them, TcpFlags::SYN | TcpFlags::ACK)), true);
+        assert_eq!(fw.process_outbound_packet_sink(&them_peer.0, &mut make_tcp(us, them, TcpFlags::SYN | TcpFlags::ACK)), true);
 
 
         // Firewall allows already established connections
@@ -1084,7 +1232,7 @@ fn firewall_outbound_packet_with_wrong_src_ip_rejected() {
     assert!(
         fw.process_outbound_packet_sink(
             &vpn_peer.0,
-            &make_tcp(
+            &mut make_tcp(
                 &format!("{wlan_ip}:12345"),
                 &format!("{remote_ip}:443"),
                 TcpFlags::SYN
@@ -1106,7 +1254,7 @@ fn firewall_outbound_packet_with_wrong_src_ip_rejected() {
     assert!(
         !fw.process_outbound_packet_sink(
             &vpn_peer.0,
-            &make_tcp(
+            &mut make_tcp(
                 &format!("{wlan_ip}:12345"),
                 &format!("{remote_ip}:443"),
                 TcpFlags::SYN
@@ -1117,7 +1265,7 @@ fn firewall_outbound_packet_with_wrong_src_ip_rejected() {
     assert!(
         fw.process_outbound_packet_sink(
             &vpn_peer.0,
-            &make_tcp(
+            &mut make_tcp(
                 &format!("{tunnel_ip}:54321"),
                 &format!("{remote_ip}:443"),
                 TcpFlags::SYN
@@ -1135,7 +1283,7 @@ fn firewall_outbound_packet_with_wrong_src_ip_rejected() {
     assert!(
         fw.process_outbound_packet_sink(
             &vpn_peer.0,
-            &make_tcp(
+            &mut make_tcp(
                 &format!("{wlan_ip}:12345"),
                 &format!("{remote_ip}:443"),
                 TcpFlags::SYN
@@ -1149,130 +1297,11 @@ mod tp_lite_stats {
     use std::sync::Arc;
 
     use parking_lot::Mutex;
-    use pnet_packet::dns::{
-        DnsClasses, DnsType, DnsTypes, MutableDnsPacket, MutableDnsResponsePacket, Retcode,
-    };
     use telio_model::tp_lite_stats::{
         BlockedDomain, DnsMetrics, TpLiteStatsCallback, TpLiteStatsOptions,
     };
 
     use super::*;
-
-    const DNS_HEADER_SIZE: usize = 12;
-
-    // Strings in the DNS message format are encoded as a list of labels followed by a null byte.
-    // A label starts with a "len byte" denoting how long the label is, followed by the bytes of the string.
-    // DNS labels can only contain ascii code points.
-    //
-    // This explanation and function does not include the "root record" or compression pointers.
-    fn encode_domain_name(name: &str) -> Vec<u8> {
-        let mut out = Vec::new();
-        for label in name.split('.') {
-            out.push(label.len() as u8);
-            out.extend_from_slice(label.as_bytes());
-        }
-        out.push(0x00);
-        out
-    }
-
-    enum PacketType {
-        Query,
-        Response,
-        BlockedResponse,
-    }
-
-    fn dns_packet(tx_id: u16, name: &str, packet_type: PacketType) -> Vec<u8> {
-        let mut buf = vec![0; DNS_HEADER_SIZE];
-        let mut packet = MutableDnsPacket::new(&mut buf)
-            .expect("Creating MutableDnsPacket should be successful");
-
-        packet.set_id(tx_id);
-        packet.set_is_recursion_desirable(1);
-        packet.set_query_count(1);
-        match packet_type {
-            PacketType::Query => {}
-            PacketType::Response => {
-                packet.set_is_response(1);
-                packet.set_is_recursion_available(1);
-                packet.set_response_count(1);
-            }
-            PacketType::BlockedResponse => {
-                packet.set_is_response(1);
-                packet.set_is_recursion_available(1);
-                packet.set_rcode(Retcode::RecordNotExists);
-                packet.set_authority_rr_count(1);
-            }
-        };
-
-        buf.extend_from_slice(&dns_query(name));
-        match packet_type {
-            PacketType::Query => {}
-            PacketType::Response => buf.extend_from_slice(&dns_a_record()),
-            PacketType::BlockedResponse => buf.extend_from_slice(&dns_soa_record()),
-        }
-
-        buf
-    }
-
-    fn dns_query(name: &str) -> Vec<u8> {
-        let mut buf = encode_domain_name(name);
-        buf.extend_from_slice(&DnsTypes::A.0.to_be_bytes());
-        buf.extend_from_slice(&DnsClasses::IN.0.to_be_bytes());
-        buf
-    }
-
-    fn dns_rr(rtype: DnsType, rdata: Vec<u8>) -> Vec<u8> {
-        let mut buf = vec![0; DNS_HEADER_SIZE];
-        let mut packet = MutableDnsResponsePacket::new(&mut buf).unwrap();
-
-        packet.set_name_tag(u16::from_be_bytes([0xC0, 0x0C]));
-        packet.set_rtype(rtype);
-        packet.set_rclass(DnsClasses::IN);
-        packet.set_ttl(3600);
-        packet.set_data_len(rdata.len() as u16);
-
-        buf.extend_from_slice(&rdata);
-
-        buf
-    }
-
-    fn dns_a_record() -> Vec<u8> {
-        // For A records the rdata just contains an IPv4 address
-        let rdata = vec![93, 184, 216, 34];
-        dns_rr(DnsTypes::A, rdata)
-    }
-
-    fn dns_soa_record() -> Vec<u8> {
-        let mut rdata = Vec::new();
-
-        rdata.extend_from_slice(&encode_domain_name(
-            "dns-malware-cybersec.nordthreatprotection.com",
-        )); // MNAME
-        rdata.extend_from_slice(&encode_domain_name("hostmaster.example.com")); // RNAME
-
-        // Some fields that are irrelevant for testing purposes. They can all be set to 0
-        rdata.extend_from_slice(&[0, 0, 0, 0, 0, 0, 0, 0]); // Serial number
-        rdata.extend_from_slice(&[0, 0, 0, 0]); // Refresh interval
-        rdata.extend_from_slice(&[0, 0, 0, 0]); // Retry interval
-        rdata.extend_from_slice(&[0, 0, 0, 0]); // Expiry
-        rdata.extend_from_slice(&[0, 0, 0, 0]); // Minimum
-
-        dns_rr(DnsTypes::SOA, rdata)
-    }
-
-    fn make_dns_request(tx_id: u16, name: &str) -> Vec<u8> {
-        let dns_payload = dns_packet(tx_id, name, PacketType::Query);
-        make_udp_with_body("127.0.0.1:12345", "10.5.0.53:53", &dns_payload)
-    }
-
-    fn make_dns_response(tx_id: u16, name: &str, is_blocked: bool) -> Vec<u8> {
-        let dns_payload = if is_blocked {
-            dns_packet(tx_id, name, PacketType::BlockedResponse)
-        } else {
-            dns_packet(tx_id, name, PacketType::Response)
-        };
-        make_udp_with_body("10.5.0.53:53", "127.0.0.1:12345", &dns_payload)
-    }
 
     #[derive(Debug, Default)]
     struct Stats {
@@ -1319,7 +1348,9 @@ mod tp_lite_stats {
         fw.enable_tp_lite_stats_collection(config, Box::new(callback))
             .unwrap();
 
-        assert!(fw.process_outbound_packet_sink(&make_peer(), &make_dns_request(1, "example.com")));
+        assert!(
+            fw.process_outbound_packet_sink(&make_peer(), &mut make_dns_request(1, "example.com"))
+        );
         assert!(fw.process_inbound_packet(
             &make_peer(),
             &mut make_dns_response(1, "example.com", false)
@@ -1327,7 +1358,7 @@ mod tp_lite_stats {
 
         assert!(fw.process_outbound_packet_sink(
             &make_peer(),
-            &make_dns_request(2, "blocked1.example.com")
+            &mut make_dns_request(2, "blocked1.example.com")
         ));
         assert!(fw.process_inbound_packet(
             &make_peer(),
@@ -1336,7 +1367,7 @@ mod tp_lite_stats {
 
         assert!(fw.process_outbound_packet_sink(
             &make_peer(),
-            &make_dns_request(3, "blocked2.example.com")
+            &mut make_dns_request(3, "blocked2.example.com")
         ));
         // Small sleep to make sure stats collection happens
         std::thread::sleep(std::time::Duration::from_secs(1));
@@ -1388,11 +1419,13 @@ mod tp_lite_stats {
         // regardless of destination IP or port.
         //
         // Packet 1: different IP, non-53 port (DoT port 853) — accepted
-        assert!(fw.process_outbound_packet_sink(&make_peer(), &make_udp(SRC_ADDR, OTHER_ADDR)));
+        assert!(fw.process_outbound_packet_sink(&make_peer(), &mut make_udp(SRC_ADDR, OTHER_ADDR)));
         // Packet 2: configured DNS IP, port 53 — accepted
-        assert!(fw.process_outbound_packet_sink(&make_peer(), &make_udp(SRC_ADDR, PT_DNS_ADDR)));
+        assert!(fw.process_outbound_packet_sink(&make_peer(), &mut make_udp(SRC_ADDR, PT_DNS_ADDR)));
         // Packet 3: configured DNS IP, non-53 port (DoT port 853) — accepted (flag not set)
-        assert!(fw.process_outbound_packet_sink(&make_peer(), &make_udp(SRC_ADDR, DOT_DNS_ADDR)));
+        assert!(
+            fw.process_outbound_packet_sink(&make_peer(), &mut make_udp(SRC_ADDR, DOT_DNS_ADDR))
+        );
 
         // Re-enable TP-Lite stats collection with force_plaintext_dns = true
         let config = TpLiteStatsOptions {
@@ -1410,10 +1443,145 @@ mod tp_lite_stats {
         // After enabling with force_plaintext_dns = true:
         //
         // Packet 1: different IP, non-53 port — still accepted (only the configured DNS IP is restricted)
-        assert!(fw.process_outbound_packet_sink(&make_peer(), &make_udp(SRC_ADDR, OTHER_ADDR)));
+        assert!(fw.process_outbound_packet_sink(&make_peer(), &mut make_udp(SRC_ADDR, OTHER_ADDR)));
         // Packet 2: configured DNS IP, port 53 — accepted (standard DNS is allowed)
-        assert!(fw.process_outbound_packet_sink(&make_peer(), &make_udp(SRC_ADDR, PT_DNS_ADDR)));
+        assert!(fw.process_outbound_packet_sink(&make_peer(), &mut make_udp(SRC_ADDR, PT_DNS_ADDR)));
         // Packet 3: configured DNS IP, non-53 port (DoT port 853) — rejected
-        assert!(!fw.process_outbound_packet_sink(&make_peer(), &make_udp(SRC_ADDR, DOT_DNS_ADDR)));
+        assert!(
+            !fw.process_outbound_packet_sink(&make_peer(), &mut make_udp(SRC_ADDR, DOT_DNS_ADDR))
+        );
+    }
+}
+
+mod dns_whitelisting {
+    use pnet_packet::ipv4::Ipv4Packet;
+    use pnet_packet::udp::UdpPacket;
+    use telio_model::features::{DnsRedirect, DnsWhitelisting};
+
+    use super::*;
+
+    fn parse_dst_v4(packet: &[u8]) -> (Ipv4Addr, u16) {
+        let ip = Ipv4Packet::new(packet).expect("ipv4 parse");
+        let udp = UdpPacket::new(&packet[IPV4_HEADER_MIN..]).expect("udp parse");
+        (ip.get_destination(), udp.get_destination())
+    }
+
+    fn parse_src_v4(packet: &[u8]) -> (Ipv4Addr, u16) {
+        let ip = Ipv4Packet::new(packet).expect("ipv4 parse");
+        let udp = UdpPacket::new(&packet[IPV4_HEADER_MIN..]).expect("udp parse");
+        (ip.get_source(), udp.get_source())
+    }
+
+    fn fw_with_dns_whitelist(
+        domains: Vec<String>,
+        redirects: Vec<DnsRedirect>,
+    ) -> StatefulFirewall {
+        let feature = FeatureFirewall {
+            dns_whitelisting: Some(DnsWhitelisting { domains, redirects }),
+            ..Default::default()
+        };
+        StatefulFirewall::new(false, feature).expect("libfirewall.so available")
+    }
+
+    #[test]
+    fn dns_whitelisting_redirects_matching_query() {
+        let blocking: SocketAddrV4 = "10.5.0.53:53".parse().unwrap();
+        let standard: SocketAddrV4 = "8.8.8.8:53".parse().unwrap();
+        let fw = fw_with_dns_whitelist(
+            vec!["example.com".into()],
+            vec![DnsRedirect { blocking, standard }],
+        );
+
+        let src: SocketAddrV4 = "127.0.0.1:12345".parse().unwrap();
+        let mut buf = make_dns_request_to(src, blocking, 1, "example.com");
+
+        let accepted = fw.process_outbound_packet(&make_peer(), &mut buf, &mut io::sink());
+        assert!(accepted, "DNAT rule should accept the packet");
+
+        let (dst_ip, dst_port) = parse_dst_v4(&buf);
+        assert_eq!(dst_ip, *standard.ip(), "destination IP must be rewritten");
+        assert_eq!(
+            dst_port,
+            standard.port(),
+            "destination port must be rewritten"
+        );
+    }
+
+    #[test]
+    fn dns_whitelisting_leaves_non_matching_query_alone() {
+        let blocking: SocketAddrV4 = "10.5.0.53:53".parse().unwrap();
+        let standard: SocketAddrV4 = "8.8.8.8:53".parse().unwrap();
+        let fw = fw_with_dns_whitelist(
+            vec!["example.com".into()],
+            vec![DnsRedirect { blocking, standard }],
+        );
+
+        let src: SocketAddrV4 = "127.0.0.1:12345".parse().unwrap();
+        let mut buf = make_dns_request_to(src, blocking, 2, "notwhitelisted.com");
+
+        let accepted = fw.process_outbound_packet(&make_peer(), &mut buf, &mut io::sink());
+        assert!(accepted, "catch-all outbound-accept rule should accept");
+
+        let (dst_ip, dst_port) = parse_dst_v4(&buf);
+        assert_eq!(dst_ip, *blocking.ip(), "dst IP must NOT be rewritten");
+        assert_eq!(dst_port, blocking.port(), "dst port must NOT be rewritten");
+    }
+
+    #[test]
+    fn dns_whitelisting_scopes_to_configured_blocking_dst() {
+        let blocking: SocketAddrV4 = "10.5.0.53:53".parse().unwrap();
+        let standard: SocketAddrV4 = "8.8.8.8:53".parse().unwrap();
+        let fw = fw_with_dns_whitelist(
+            vec!["example.com".into()],
+            vec![DnsRedirect { blocking, standard }],
+        );
+
+        let src: SocketAddrV4 = "127.0.0.1:12345".parse().unwrap();
+        let other_dst: SocketAddrV4 = "1.1.1.1:53".parse().unwrap();
+        let mut buf = make_dns_request_to(src, other_dst, 3, "example.com");
+
+        let accepted = fw.process_outbound_packet(&make_peer(), &mut buf, &mut io::sink());
+        assert!(accepted, "catch-all outbound-accept rule should accept");
+
+        let (dst_ip, dst_port) = parse_dst_v4(&buf);
+        assert_eq!(dst_ip, *other_dst.ip());
+        assert_eq!(dst_port, other_dst.port());
+    }
+
+    #[test]
+    fn dns_whitelisting_un_dnats_response() {
+        let blocking: SocketAddrV4 = "10.5.0.53:53".parse().unwrap();
+        let standard: SocketAddrV4 = "8.8.8.8:53".parse().unwrap();
+        let fw = fw_with_dns_whitelist(
+            vec!["example.com".into()],
+            vec![DnsRedirect { blocking, standard }],
+        );
+
+        let client: SocketAddrV4 = "127.0.0.1:12345".parse().unwrap();
+        let peer = make_peer();
+
+        fw.apply_state(FirewallState {
+            ip_addresses: vec![IpAddr::V4(*client.ip())],
+            ..Default::default()
+        });
+
+        let mut query = make_dns_request_to(client, blocking, 42, "example.com");
+        assert!(fw.process_outbound_packet(&peer, &mut query, &mut io::sink()));
+
+        let mut response = make_dns_response_to(standard, client, 42, "example.com", false);
+        let accepted = fw.process_inbound_packet(&peer, &mut response);
+        assert!(accepted, "response packet should be accepted via conntrack");
+
+        let (src_ip, src_port) = parse_src_v4(&response);
+        assert_eq!(
+            src_ip,
+            *blocking.ip(),
+            "src IP must be un-DNATed to blocking"
+        );
+        assert_eq!(
+            src_port,
+            blocking.port(),
+            "src port must be un-DNATed to blocking"
+        );
     }
 }

--- a/crates/telio-model/src/features.rs
+++ b/crates/telio-model/src/features.rs
@@ -1,7 +1,13 @@
 //! Object descriptions of various
 //! telio configurable features via API
 
-use std::{collections::HashSet, fmt, net::IpAddr, str::FromStr, time::Duration};
+use std::{
+    collections::HashSet,
+    fmt,
+    net::{IpAddr, SocketAddrV4},
+    str::FromStr,
+    time::Duration,
+};
 
 use base64::{prelude::BASE64_STANDARD, Engine};
 use num_enum::{IntoPrimitive, TryFromPrimitive};
@@ -440,6 +446,33 @@ fn ipv4_net_strategy() -> impl proptest::strategy::Strategy<Value = ipnet::Ipv4N
     (addr, prefix).prop_map(|(addr, prefix)| ipnet::Ipv4Net::new(addr.into(), prefix).unwrap())
 }
 
+/// Pair of DNS server endpoints describing how a single DNS-redirect rule
+/// should rewrite outbound DNS traffic.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(test, derive(proptest_derive::Arbitrary))]
+pub struct DnsRedirect {
+    /// DNS server that would otherwise drop non-whitelisted queries.
+    pub blocking: SocketAddrV4,
+    /// DNS server to which whitelisted queries are redirected.
+    pub standard: SocketAddrV4,
+}
+
+/// DNS query whitelisting via DNAT redirect.
+///
+/// Outbound DNS queries (UDP) destined to a `blocking` endpoint whose QNAME
+/// matches one of `domains` are rewritten to the corresponding `standard`
+/// endpoint. Non-matching queries continue to the blocking server.
+#[derive(Default, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(test, derive(proptest_derive::Arbitrary))]
+pub struct DnsWhitelisting {
+    /// Domain patterns to whitelist (matched against DNS query QNAMEs).
+    #[serde(default)]
+    pub domains: Vec<String>,
+    /// Pairs of (blocking, standard) DNS server endpoints.
+    #[serde(default)]
+    pub redirects: Vec<DnsRedirect>,
+}
+
 /// Feature config for firewall
 #[derive(Default, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
@@ -456,6 +489,9 @@ pub struct FeatureFirewall {
     /// Blackist for outgoing connections
     #[serde(default)]
     pub outgoing_blacklist: Vec<FirewallBlacklistTuple>,
+    /// DNS query whitelisting (DNAT redirect of whitelisted queries away from
+    /// the blocking DNS server to the standard one).
+    pub dns_whitelisting: Option<DnsWhitelisting>,
 }
 
 impl FeatureFirewall {
@@ -844,6 +880,7 @@ mod tests {
                             ip: IpAddr::from_str("8.8.4.4").unwrap(),
                             port: 30,
                         }],
+                        dns_whitelisting: None,
                     }),
                     flush_events_on_stop_timeout_seconds: Some(15),
                     post_quantum_vpn: FeaturePostQuantumVPN {
@@ -961,6 +998,26 @@ mod tests {
                 r#"{"firewall": {}}"#,
                 Some(FeatureFirewall::default()),
                 firewall
+            );
+        }
+
+        #[test]
+        fn test_firewall_dns_whitelisting() {
+            assert_json!(
+                r#"{"firewall": {"dns_whitelisting": {
+                    "domains": ["example.com", "foo.bar"],
+                    "redirects": [
+                        {"blocking": "1.2.3.4:53", "standard": "8.8.8.8:53"}
+                    ]
+                }}}"#,
+                Some(DnsWhitelisting {
+                    domains: vec!["example.com".into(), "foo.bar".into()],
+                    redirects: vec![DnsRedirect {
+                        blocking: "1.2.3.4:53".parse().unwrap(),
+                        standard: "8.8.8.8:53".parse().unwrap(),
+                    }],
+                }),
+                firewall.unwrap().dns_whitelisting
             );
         }
 

--- a/crates/telio-wg/src/adapter.rs
+++ b/crates/telio-wg/src/adapter.rs
@@ -36,7 +36,7 @@ pub type FirewallInboundCb = Option<Arc<dyn Fn(&[u8; 32], &mut [u8]) -> bool + S
 
 /// Function pointer to Firewall Outbound Callback
 pub type FirewallOutboundCb =
-    Option<Arc<dyn Fn(&[u8; 32], &[u8], &mut dyn io::Write) -> bool + Send + Sync>>;
+    Option<Arc<dyn Fn(&[u8; 32], &mut [u8], &mut dyn io::Write) -> bool + Send + Sync>>;
 
 /// Function pointer for reseting all the connections
 pub type FirewallResetConnsCb = Option<Arc<dyn Fn(&PublicKey, &mut dyn io::Write) + Send + Sync>>;

--- a/crates/telio-wg/src/wg.rs
+++ b/crates/telio-wg/src/wg.rs
@@ -201,7 +201,7 @@ impl DynamicWg {
     ///     };
     ///     let firewall_filter_outbound_packets = {
     ///         let fw = firewall.clone();
-    ///         move |peer: &[u8; 32], packet: &[u8], sink: &mut dyn io::Write| {
+    ///         move |peer: &[u8; 32], packet: &mut [u8], sink: &mut dyn io::Write| {
     ///             fw.process_outbound_packet(peer, packet, sink)
     ///         }
     ///     };

--- a/nat-lab/tests/test_features_builder.py
+++ b/nat-lab/tests/test_features_builder.py
@@ -3,6 +3,8 @@ from tests.uniffi import (
     FeaturesDefaultsBuilder,
     deserialize_feature_config,
     FirewallBlacklistTuple,
+    DnsRedirect,
+    DnsWhitelisting,
     IpProtocol,
 )
 
@@ -36,6 +38,10 @@ def test_telio_features_builder_firewall():
         outgoing_blacklist=[
             FirewallBlacklistTuple(protocol=IpProtocol.UDP, ip="8.8.4.4", port=30)
         ],
+        dns_whitelisting=DnsWhitelisting(
+            domains=["a.b.c"],
+            redirects=[DnsRedirect(blocking="1.2.3.4:30", standard="5.6.7.8:40")],
+        ),
     )
 
     json = """
@@ -49,7 +55,14 @@ def test_telio_features_builder_firewall():
                     "ip": "8.8.4.4",
                     "port": 30
             }],
-            "neptun_reset_conns": false
+            "neptun_reset_conns": false,
+            "dns_whitelisting": {
+                "domains": ["a.b.c"],
+                "redirects": [{
+                    "blocking": "1.2.3.4:30",
+                    "standard": "5.6.7.8:40"
+                }]
+            }
         },
         "direct": null,
         "derp": null,

--- a/nat-lab/tests/test_tp_lite_stats.py
+++ b/nat-lab/tests/test_tp_lite_stats.py
@@ -8,6 +8,8 @@ from tests.utils.bindings import (
     TelioAdapterType,
     TpLiteStatsOptions,
     FeatureFirewall,
+    DnsRedirect,
+    DnsWhitelisting,
 )
 from tests.utils.connection import ConnectionTag
 from tests.utils.dns import query_dns
@@ -22,6 +24,12 @@ BLOCKED_NULL_IP = "blocked-ads.com"
 # Resolves normally on the TP-Lite server
 ALLOWED_DOMAIN = "google.com"
 
+# Standard (non-blocking) DNS server. Unlike the TP-Lite server it resolves
+# blocked-malware.com instead of returning NXDOMAIN.
+STANDARD_DNS_IP = config.LAN_ADDR_MAP[ConnectionTag.DOCKER_DNS_SERVER_1]["primary"]
+# Address the standrd dns-server returns for blocked-malware.com
+WHITELIST_RESOLVED_IP = "123.123.123.123"
+
 CALLBACK_INTERVAL_S = 1  # Use short interval for all tests
 
 
@@ -33,6 +41,21 @@ def _features_with_firewall():
         exclude_private_ip_range=None,
         outgoing_blacklist=[],
         dns_whitelisting=None,
+    )
+    return features
+
+
+def _features_with_dns_whitelisting(domains: list[str], blocking: str, standard: str):
+    features = default_features()
+    features.firewall = FeatureFirewall(
+        neptun_reset_conns=False,
+        boringtun_reset_conns=False,
+        exclude_private_ip_range=None,
+        outgoing_blacklist=[],
+        dns_whitelisting=DnsWhitelisting(
+            domains=domains,
+            redirects=[DnsRedirect(blocking=blocking, standard=standard)],
+        ),
     )
     return features
 
@@ -289,3 +312,70 @@ class TestTpLiteStats:
         # Attempt to enable TP-Lite stats without firewall feature, gives an exception
         with pytest.raises(Exception):
             await client.enable_tp_lite_stats_collection(_tp_lite_config())
+
+
+class TestDnsWhitelisting:
+    """DNS whitelisting redirects whitelisted queries away from the blocking
+    (TP-Lite) DNS server to a standard one via libfirewall DNAT."""
+
+    @pytest.fixture(name="vpn_tags")
+    def _vpn_tags(self) -> list:
+        return [ConnectionTag.DOCKER_VPN_1]
+
+    @pytest.mark.parametrize(
+        "alpha_setup_params",
+        [
+            pytest.param(
+                SetupParameters(
+                    connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
+                    adapter_type_override=TelioAdapterType.NEP_TUN,
+                    features=_features_with_dns_whitelisting(
+                        [BLOCKED_NXDOMAIN],
+                        f"{TP_LITE_DNS_IP}:53",
+                        f"{STANDARD_DNS_IP}:53",
+                    ),
+                )
+            )
+        ],
+    )
+    @pytest.mark.asyncio
+    @pytest.mark.libfirewall
+    async def test_dns_whitelisting_redirects_blocked_domain(
+        self,
+        alpha_setup_params: SetupParameters,  # pylint: disable=unused-argument
+        env: Environment,
+    ) -> None:
+        [alpha] = env.nodes
+        [client] = env.clients
+        [connection] = [c.connection for c in env.connections]
+
+        await connect_vpn(
+            connection,
+            None,
+            client,
+            alpha.ip_addresses[0],
+            config.WG_SERVER,
+        )
+
+        # blocked-malware.com is NXDOMAIN at the TP-Lite (blocking) server, but it
+        # is whitelisted, so the firewall DNATs the query to the standard DNS
+        # server, which resolves it to WHITELIST_RESOLVED_IP. Getting that address
+        # back proves the query was redirected.
+        await query_dns(
+            connection,
+            BLOCKED_NXDOMAIN,
+            dns_server=TP_LITE_DNS_IP,
+            expected_output=[WHITELIST_RESOLVED_IP],
+            options=["-type=a"],
+        )
+
+        # A domain that is NOT whitelisted still hits the blocking server, which
+        # returns NXDOMAIN for it, confirming the redirect is scoped to the
+        # whitelisted domains only.
+        with pytest.raises(Exception):
+            await query_dns(
+                connection,
+                "not-whitelisted.com",
+                dns_server=TP_LITE_DNS_IP,
+                options=["-type=a"],
+            )

--- a/nat-lab/tests/test_tp_lite_stats.py
+++ b/nat-lab/tests/test_tp_lite_stats.py
@@ -32,6 +32,7 @@ def _features_with_firewall():
         boringtun_reset_conns=False,
         exclude_private_ip_range=None,
         outgoing_blacklist=[],
+        dns_whitelisting=None,
     )
     return features
 

--- a/nat-lab/tests/test_vpn.py
+++ b/nat-lab/tests/test_vpn.py
@@ -149,6 +149,7 @@ def _make_blacklist_features(protocol: IpProtocol, ip: str, port: int) -> Featur
         outgoing_blacklist=[
             FirewallBlacklistTuple(protocol=protocol, ip=ip, port=port)
         ],
+        dns_whitelisting=None,
     )
     return features
 

--- a/nat-lab/tests/utils/bindings.py
+++ b/nat-lab/tests/utils/bindings.py
@@ -74,6 +74,7 @@ def default_features(
                 boringtun_reset_conns=False,
                 exclude_private_ip_range=enable_firewall_exclusion_range,
                 outgoing_blacklist=[],
+                dns_whitelisting=None,
             )
         else:
             features.firewall.exclude_private_ip_range = enable_firewall_exclusion_range

--- a/src/device.rs
+++ b/src/device.rs
@@ -1101,10 +1101,11 @@ impl Runtime {
         #[cfg(feature = "enable_firewall")]
         let firewall_process_outbound_callback = firewall.clone().map(|fw| {
             Arc::new(
-                move |peer: &[u8; 32], packet: &[u8], sink: &mut dyn io::Write| {
+                move |peer: &[u8; 32], packet: &mut [u8], sink: &mut dyn io::Write| {
                     fw.process_outbound_packet(peer, packet, sink)
                 },
-            ) as Arc<dyn Fn(&[u8; 32], &[u8], &mut dyn io::Write) -> bool + Send + Sync>
+            )
+                as Arc<dyn Fn(&[u8; 32], &mut [u8], &mut dyn io::Write) -> bool + Send + Sync>
         });
         #[cfg(not(feature = "enable_firewall"))]
         let firewall_process_outbound_callback = None;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@ pub use uniffi_libtelio::*;
     clippy::empty_line_after_doc_comments
 )]
 mod uniffi_libtelio {
-    use std::net::{IpAddr, SocketAddr};
+    use std::net::{IpAddr, SocketAddr, SocketAddrV4};
 
     use super::crypto::{PublicKey, SecretKey};
     use super::*;
@@ -197,6 +197,19 @@ mod uniffi_libtelio {
             Ok(val.parse().map_err(|_| TelioError::UnknownError {
                 inner: "Invalid IP address".to_owned(),
             })?)
+        }
+
+        fn from_custom(obj: Self) -> Self::Builtin {
+            obj.to_string()
+        }
+    }
+
+    impl UniffiCustomTypeConverter for SocketAddrV4 {
+        type Builtin = String;
+
+        fn into_custom(val: Self::Builtin) -> uniffi::Result<Self> {
+            val.parse()
+                .map_err(|e| anyhow::anyhow!(format!("Invalid SocketAddrV4 '{val}': {e}")))
         }
 
         fn from_custom(obj: Self) -> Self::Builtin {

--- a/src/libtelio.udl
+++ b/src/libtelio.udl
@@ -143,6 +143,9 @@ typedef string Ipv4Addr;
 typedef string SocketAddr;
 
 [Custom]
+typedef string SocketAddrV4;
+
+[Custom]
 typedef string HiddenString;
 
 [Custom]
@@ -815,6 +818,23 @@ dictionary FirewallBlacklistTuple {
     u16 port;
 };
 
+/// Pair of DNS server endpoints describing how a single DNS-redirect rule
+/// should rewrite outbound DNS traffic.
+dictionary DnsRedirect {
+    /// DNS server that would otherwise drop non-whitelisted queries.
+    SocketAddrV4 blocking;
+    /// DNS server to which whitelisted queries are redirected.
+    SocketAddrV4 standard;
+};
+
+/// DNS query whitelisting via DNAT redirect.
+dictionary DnsWhitelisting {
+    /// Domain patterns to whitelist (matched against DNS query QNAMEs).
+    sequence<string> domains;
+    /// Pairs of (blocking, standard) DNS server endpoints.
+    sequence<DnsRedirect> redirects;
+};
+
 /// Feature config for firewall
 dictionary FeatureFirewall {
     /// Turns on connection resets upon VPN server change
@@ -825,6 +845,9 @@ dictionary FeatureFirewall {
     Ipv4Net? exclude_private_ip_range;
     /// Blackist for outgoing connections
     sequence<FirewallBlacklistTuple> outgoing_blacklist;
+    /// DNS query whitelisting (DNAT redirect of whitelisted queries away
+    /// from the blocking DNS server to the standard one).
+    DnsWhitelisting? dns_whitelisting;
 };
 
 /// Link detection mechanism


### PR DESCRIPTION
Add feature config that allows apps to configure domains that are whitelisted from tplite dns. The whitelisting itself is implemented in libfirewall by redirecting DNS queries from tplite servers to the standard servers.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
