### PR TITLE
LLT-4091: reduce pylint disable list in nat-lab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,10 @@ tcli.log
 /nat-lab/3rd-party/netfilter-full-cone-nat
 /nat-lab/tests/uniffi/telio_bindings.py
 /nat-lab/tests/uniffi/telio.dll
+/nat-lab/tests/uniffi/firewall.dll
+/nat-lab/tests/uniffi/libfirewall.so
+/nat-lab/tests/uniffi/libsqlite3.so
+/nat-lab/tests/uniffi/sqlite3.dll
 /nat-lab/data/nordvpnlite/data.json
 /nat-lab/logs
 /nat-lab/coredumps

--- a/nat-lab/bin/core-api.py
+++ b/nat-lab/bin/core-api.py
@@ -110,7 +110,7 @@ class CoreServer(HTTPServer):
         # Ensure proper SSL shutdown
         try:
             request.unwrap()  # This sends close_notify
-        except:
+        except OSError:
             pass  # Ignore errors during unwrap
 
     def _send_notification(self):

--- a/nat-lab/natlab.py
+++ b/nat-lab/natlab.py
@@ -371,7 +371,9 @@ def manage_containers(services_to_start) -> None:
         for service in unhealthy:
             dump_docker_logs(service)
             dump_journal_logs(service)
-        raise Exception(f"Containers failed to start: {failed}; see docker logs above")
+        raise RuntimeError(
+            f"Containers failed to start: {failed}; see docker logs above"
+        )
 
 
 def find_container(service: str, docker_status: List[str]) -> bool:

--- a/nat-lab/natlab.py
+++ b/nat-lab/natlab.py
@@ -261,6 +261,23 @@ def quick_restart_container(names: List[str], env=None):
         print(f"Restart of services '{names}' failed...")
 
 
+def _report_container_failures(
+    missing_services: List[str], unhealthy_services: List[str]
+) -> None:
+    failed = missing_services + [
+        s for s in unhealthy_services if s not in missing_services
+    ]
+    if not failed:
+        return
+    # Dump logs at the end for CLI check
+    for service in missing_services:
+        dump_docker_logs(service)
+    for service in unhealthy_services:
+        dump_docker_logs(service)
+        dump_journal_logs(service)
+    raise RuntimeError(f"Containers failed to start: {failed}; see docker logs above")
+
+
 def check_containers(
     services_to_start, check_only=False
 ) -> Tuple[List[str], List[str]]:
@@ -319,19 +336,7 @@ def check_containers(
 
     # Used to call from cli
     if check_only:
-        failed = missing_services + [
-            s for s in unhealthy_services if s not in missing_services
-        ]
-        if failed:
-            # Dump logs at the end for CLI check
-            for service in missing_services:
-                dump_docker_logs(service)
-            for service in unhealthy_services:
-                dump_docker_logs(service)
-                dump_journal_logs(service)
-            raise Exception(
-                f"Containers failed to start: {failed}; see docker logs above"
-            )
+        _report_container_failures(missing_services, unhealthy_services)
 
     return missing_services, unhealthy_services
 
@@ -452,6 +457,27 @@ def recreate_all():
     start(None, True)
 
 
+def _resolve_skip_keywords(args) -> set:
+    if args.lite_mode:
+        return {"fullcone", "windows", "mac", "nlx", "openwrt"}
+    skip_keywords: set = set()
+    if args.skip_fullcone:
+        skip_keywords.add("fullcone")
+    if args.skip_windows:
+        skip_keywords.add("windows")
+    if args.skip_windows_1:
+        skip_keywords.update(["windows-client-01", "windows-gw-01", "windows-gw-02"])
+    if args.skip_windows_2:
+        skip_keywords.update(["windows-client-02", "windows-gw-03", "windows-gw-04"])
+    if args.skip_mac:
+        skip_keywords.add("mac")
+    if args.skip_nlx:
+        skip_keywords.add("nlx")
+    if args.skip_openwrt:
+        skip_keywords.add("openwrt")
+    return skip_keywords
+
+
 def main():
     all_services = run_command_with_output(
         ["docker", "compose", "config", "--services"], hide_output=True
@@ -525,31 +551,9 @@ def main():
         return
 
     if args.command == "start":
-        skip_keywords = set()
-        if args.lite_mode:
-            skip_keywords.update(["fullcone", "windows", "mac", "nlx", "openwrt"])
-        else:
-            if args.skip_fullcone:
-                skip_keywords.add("fullcone")
-            if args.skip_windows:
-                skip_keywords.add("windows")
-            if args.skip_windows_1:
-                skip_keywords.update(
-                    ["windows-client-01", "windows-gw-01", "windows-gw-02"]
-                )
-            if args.skip_windows_2:
-                skip_keywords.update(
-                    ["windows-client-02", "windows-gw-03", "windows-gw-04"]
-                )
-            if args.skip_mac:
-                skip_keywords.add("mac")
-            if args.skip_nlx:
-                skip_keywords.add("nlx")
-            if args.skip_openwrt:
-                skip_keywords.add("openwrt")
+        skip_keywords = _resolve_skip_keywords(args)
         if args.services_to_start:
-            services_to_start = args.services_to_start
-            start(skip_keywords, services_to_start=services_to_start)
+            start(skip_keywords, services_to_start=args.services_to_start)
         else:
             start(skip_keywords)
     elif args.command == "restart":

--- a/nat-lab/natlab.py
+++ b/nat-lab/natlab.py
@@ -46,6 +46,7 @@ def dump_docker_logs(service_name):
         ["docker", "compose", "logs", "--tail", "200", service_name],
         capture_output=True,
         text=True,
+        check=False,
     )
     if result.stdout:
         print(result.stdout)
@@ -61,6 +62,7 @@ def dump_journal_logs(service_name):
             ["docker", "compose", "ps", "-q", service_name],
             capture_output=True,
             text=True,
+            check=False,
         )
         container_ids = [
             cid.strip() for cid in result.stdout.splitlines() if cid.strip()
@@ -76,6 +78,7 @@ def dump_journal_logs(service_name):
                 ["docker", "exec", container_id, "sh", "-c", "command -v journalctl"],
                 capture_output=True,
                 text=True,
+                check=False,
             )
             if check_result.returncode != 0:
                 print(
@@ -102,6 +105,7 @@ def dump_journal_logs(service_name):
                 ],
                 capture_output=True,
                 text=True,
+                check=False,
             )
             if result.stdout:
                 print(result.stdout)

--- a/nat-lab/performance_tests/conftest.py
+++ b/nat-lab/performance_tests/conftest.py
@@ -51,6 +51,23 @@ def event_loop():
             loop.close()
 
 
+def _setup_parameters_id(val: SetupParameters) -> str:
+    short_conn_tag_name = val.connection_tag.name.removeprefix("DOCKER_")
+    param_id = f"{short_conn_tag_name}-{val.adapter_type_override.name.replace('_', '') if val.adapter_type_override is not None else ''}"
+    if val.features.direct is not None and val.features.direct.providers is not None:
+        for provider in val.features.direct.providers:
+            param_id += f"-{provider.name}"
+    return param_id
+
+
+def _ipstack_id(val: IPStack) -> str:
+    return {
+        IPStack.IPv4: "IPv4",
+        IPStack.IPv4v6: "IPv4v6",
+        IPStack.IPv6: "IPv6",
+    }.get(val, "")
+
+
 def pytest_make_parametrize_id(config, val):
     param_id = ""
     if isinstance(val, (list, tuple)):
@@ -60,26 +77,13 @@ def pytest_make_parametrize_id(config, val):
                 param_id += f"-{res}"
         param_id = f"{param_id[1:]}"
     elif isinstance(val, (SetupParameters,)):
-        short_conn_tag_name = val.connection_tag.name.removeprefix("DOCKER_")
-        param_id = f"{short_conn_tag_name}-{val.adapter_type_override.name.replace('_', '') if val.adapter_type_override is not None else ''}"
-        if (
-            val.features.direct is not None
-            and val.features.direct.providers is not None
-        ):
-            for provider in val.features.direct.providers:
-                param_id += f"-{provider.name}"
-
+        param_id = _setup_parameters_id(val)
     elif isinstance(val, (ConnectionTag,)):
         param_id = val.name.removeprefix("DOCKER_")
     elif isinstance(val, (TelioAdapterType,)):
         param_id = val.name.replace("_", "")
     elif isinstance(val, IPStack):
-        if val == IPStack.IPv4:
-            param_id = "IPv4"
-        elif val == IPStack.IPv4v6:
-            param_id = "IPv4v6"
-        elif val == IPStack.IPv6:
-            param_id = "IPv6"
+        param_id = _ipstack_id(val)
     elif isinstance(val, str):
         if len(val) > 16:
             param_id = f"{val[:14]}.."

--- a/nat-lab/performance_tests/conftest.py
+++ b/nat-lab/performance_tests/conftest.py
@@ -100,7 +100,7 @@ async def kill_natlab_processes():
     cleanup_script_path = os.path.join(
         os.path.dirname(__file__), "../bin/cleanup_natlab_processes"
     )
-    subprocess.run(["sudo", cleanup_script_path]).check_returncode()
+    subprocess.run(["sudo", cleanup_script_path], check=True)
 
 
 PRETEST_CLEANUPS = [

--- a/nat-lab/pyproject.toml
+++ b/nat-lab/pyproject.toml
@@ -139,6 +139,13 @@ init-hook = "import sys, os; sys.path.insert(0, os.getcwd())"
 max-line-length = 88
 ignore-paths = ".venv,tests/protobuf,bin/grpc_protobuf,tests/uniffi/telio_bindings.py"
 
+[tool.pylint.design]
+# nat-lab test helpers/fixtures legitimately take many parameters (per-node
+# config, fixtures, matching criteria); keep too-many-arguments enabled to catch
+# egregious cases but at a threshold that doesn't force opaque options-object
+# wrapping of otherwise-readable keyword arguments.
+max-args = 10
+
 [tool.pylint.'MESSAGES CONTROL']
 recursive = true
 disable = [
@@ -150,7 +157,6 @@ disable = [
     "line-too-long",
     "too-many-locals",
     "wrong-import-order",
-    "too-many-arguments",
     "too-many-instance-attributes",
     "too-many-boolean-expressions",
     "fixme",

--- a/nat-lab/pyproject.toml
+++ b/nat-lab/pyproject.toml
@@ -159,7 +159,6 @@ disable = [
     "too-many-statements",
     "global-statement",
     "bare-except",
-    "too-many-branches",
     "duplicate-code",
     "too-many-lines"
 ]

--- a/nat-lab/pyproject.toml
+++ b/nat-lab/pyproject.toml
@@ -146,8 +146,6 @@ disable = [
     "missing-module-docstring",
     "missing-class-docstring",
     "missing-function-docstring",
-    "nonlocal-and-global",
-    "subprocess-run-check",
     "broad-exception-raised",
     "line-too-long",
     "too-many-locals",

--- a/nat-lab/pyproject.toml
+++ b/nat-lab/pyproject.toml
@@ -153,7 +153,6 @@ disable = [
     "missing-module-docstring",
     "missing-class-docstring",
     "missing-function-docstring",
-    "broad-exception-raised",
     "line-too-long",
     "too-many-locals",
     "wrong-import-order",
@@ -164,7 +163,6 @@ disable = [
     "too-few-public-methods",
     "too-many-statements",
     "global-statement",
-    "bare-except",
     "duplicate-code",
     "too-many-lines"
 ]

--- a/nat-lab/pyproject.toml
+++ b/nat-lab/pyproject.toml
@@ -157,7 +157,6 @@ disable = [
     "too-many-locals",
     "wrong-import-order",
     "too-many-instance-attributes",
-    "too-many-boolean-expressions",
     "fixme",
     "too-many-public-methods",
     "too-few-public-methods",

--- a/nat-lab/pyproject.toml
+++ b/nat-lab/pyproject.toml
@@ -157,6 +157,9 @@ disable = [
     "too-many-locals",
     "wrong-import-order",
     "too-many-instance-attributes",
+    # `fixme` stays disabled on purpose: our TODO/FIXME comments track open Jira
+    # tickets (e.g. LLT-6693, LLT-6746) and intentional workarounds; flagging them
+    # would force deleting that tracking information rather than improving the code.
     "fixme",
     "too-many-public-methods",
     "too-few-public-methods",

--- a/nat-lab/run_local.py
+++ b/nat-lab/run_local.py
@@ -61,7 +61,7 @@ def run_command(
     return result.returncode
 
 
-def main() -> int:
+def _build_arg_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "-o", type=str, default="linux", help="Pass the host OS [default: linux])"
@@ -132,6 +132,11 @@ def main() -> int:
         action="store_true",
         help="Run performance tests instead of functional tests",
     )
+    return parser
+
+
+def main() -> int:
+    parser = _build_arg_parser()
     args = parser.parse_args()
 
     if not args.no_verify_setup_correctness:
@@ -182,64 +187,66 @@ def main() -> int:
         run_command(["uv", "run", "mypy", "."])
 
     if not args.notests:
-        pytest_cmd = [
-            "pytest",
-            "-vv",
-            "--durations=0",
-            f"--reruns={args.reruns}",
-            f"--count={args.count}",
-        ]
-
-        pytest_cmd += [
-            f"--timeout={TEST_TIMEOUT}",
-            # Make timeout compatible with reruns
-            # https://github.com/pytest-dev/pytest-rerunfailures/issues/99
-            "-o",
-            "timeout_func_only=true",
-        ]
-
-        pytest_opts = os.environ.get("PYTEST_ADDOPTS", "")
-        original_durations_data = {}
-        input_path = None
-
-        if "splits" in pytest_opts:
-            if args.input_durations:
-                input_path = Path(args.input_durations)
-                original_durations_data = load_json(input_path)
-                pytest_cmd.extend([
-                    "--store-durations",
-                    f"--durations-path={input_path.absolute()}",
-                    "--splitting-algorithm=least_duration",
-                ])
-            elif args.output_durations:
-                output_path = Path(args.output_durations)
-                pytest_cmd.extend([
-                    "--store-durations",
-                    f"--durations-path={output_path.absolute()}",
-                    "--splitting-algorithm=least_duration",
-                ])
-
-        pytest_cmd += get_pytest_arguments(args)
-
-        test_dir = "performance_tests" if args.perf_tests else "tests"
-        pytest_cmd.append(test_dir)
-
-        pytest_result = run_command(pytest_cmd, allow_failure=True)
-
-        if "splits" in pytest_opts and args.output_durations and args.input_durations:
-            output_path = Path(args.output_durations)
-            if input_path:
-                merged_data = load_json(input_path)
-                new_data = calculate_duration_delta(
-                    original_durations_data, merged_data
-                )
-                save_json(output_path, new_data)
-                save_json(input_path, original_durations_data)
-
-        if pytest_result != 0:
-            raise subprocess.CalledProcessError(pytest_result, pytest_cmd)
+        _run_tests(args)
 
     return 0
+
+
+def _run_tests(args) -> None:
+    pytest_cmd = [
+        "pytest",
+        "-vv",
+        "--durations=0",
+        f"--reruns={args.reruns}",
+        f"--count={args.count}",
+    ]
+
+    pytest_cmd += [
+        f"--timeout={TEST_TIMEOUT}",
+        # Make timeout compatible with reruns
+        # https://github.com/pytest-dev/pytest-rerunfailures/issues/99
+        "-o",
+        "timeout_func_only=true",
+    ]
+
+    pytest_opts = os.environ.get("PYTEST_ADDOPTS", "")
+    original_durations_data = {}
+    input_path = None
+
+    if "splits" in pytest_opts:
+        if args.input_durations:
+            input_path = Path(args.input_durations)
+            original_durations_data = load_json(input_path)
+            pytest_cmd.extend([
+                "--store-durations",
+                f"--durations-path={input_path.absolute()}",
+                "--splitting-algorithm=least_duration",
+            ])
+        elif args.output_durations:
+            output_path = Path(args.output_durations)
+            pytest_cmd.extend([
+                "--store-durations",
+                f"--durations-path={output_path.absolute()}",
+                "--splitting-algorithm=least_duration",
+            ])
+
+    pytest_cmd += get_pytest_arguments(args)
+
+    test_dir = "performance_tests" if args.perf_tests else "tests"
+    pytest_cmd.append(test_dir)
+
+    pytest_result = run_command(pytest_cmd, allow_failure=True)
+
+    if "splits" in pytest_opts and args.output_durations and args.input_durations:
+        output_path = Path(args.output_durations)
+        if input_path:
+            merged_data = load_json(input_path)
+            new_data = calculate_duration_delta(original_durations_data, merged_data)
+            save_json(output_path, new_data)
+            save_json(input_path, original_durations_data)
+
+    if pytest_result != 0:
+        raise subprocess.CalledProcessError(pytest_result, pytest_cmd)
 
 
 def run_build_command(operating_system, args):

--- a/nat-lab/run_local.py
+++ b/nat-lab/run_local.py
@@ -54,7 +54,7 @@ def run_command(
         env = {**os.environ.copy(), **env}
 
     print(f"|EXECUTE| {' '.join(command)}")
-    result = subprocess.run(command, env=env)
+    result = subprocess.run(command, env=env, check=False)
     print("")
     if result.returncode != 0 and not allow_failure:
         raise subprocess.CalledProcessError(result.returncode, command)
@@ -308,7 +308,10 @@ def get_pytest_arguments(options) -> List[str]:
 def verify_setup_correctness():
     def get_tag_or_hash_of_dir(path):
         result = subprocess.run(
-            ["git", "tag", "--points-at", "HEAD"], cwd=path, capture_output=True
+            ["git", "tag", "--points-at", "HEAD"],
+            cwd=path,
+            capture_output=True,
+            check=False,
         )
         if result.returncode != 0:
             return None
@@ -317,7 +320,7 @@ def verify_setup_correctness():
             return tag
 
         result = subprocess.run(
-            ["git", "rev-parse", "HEAD"], cwd=path, capture_output=True
+            ["git", "rev-parse", "HEAD"], cwd=path, capture_output=True, check=False
         )
         if result.returncode != 0:
             return None

--- a/nat-lab/tests/conftest.py
+++ b/nat-lab/tests/conftest.py
@@ -1,5 +1,3 @@
-# TODO (LLT-7084): Move fixtures to separate fixture files out of conftest.py
-# pylint: disable=too-many-lines
 # Register helpers_fixtures once here so individual test modules don't need to
 # repeat it (which caused PytestWarning: Plugin already registered).
 import asyncio

--- a/nat-lab/tests/conftest.py
+++ b/nat-lab/tests/conftest.py
@@ -103,6 +103,23 @@ def event_loop():
 
 
 # Keep in mind that Windows can consider the filesize too big if parameters are not stripped
+def _setup_parameters_id(val: SetupParameters) -> str:
+    short_conn_tag_name = val.connection_tag.name.removeprefix("DOCKER_")
+    param_id = f"{short_conn_tag_name}-{val.adapter_type_override.name.replace('_', '') if val.adapter_type_override is not None else ''}"
+    if val.features.direct is not None and val.features.direct.providers is not None:
+        for provider in val.features.direct.providers:
+            param_id += f"-{provider.name}"
+    return param_id
+
+
+def _ipstack_id(val: IPStack) -> str:
+    return {
+        IPStack.IPv4: "IPv4",
+        IPStack.IPv4v6: "IPv4v6",
+        IPStack.IPv6: "IPv6",
+    }.get(val, "")
+
+
 def pytest_make_parametrize_id(config, val):
     param_id = ""
     if isinstance(val, (list, tuple)):
@@ -112,25 +129,13 @@ def pytest_make_parametrize_id(config, val):
                 param_id += f"-{res}"
         param_id = f"{param_id[1:]}"
     elif isinstance(val, (SetupParameters,)):
-        short_conn_tag_name = val.connection_tag.name.removeprefix("DOCKER_")
-        param_id = f"{short_conn_tag_name}-{val.adapter_type_override.name.replace('_', '') if val.adapter_type_override is not None else ''}"
-        if (
-            val.features.direct is not None
-            and val.features.direct.providers is not None
-        ):
-            for provider in val.features.direct.providers:
-                param_id += f"-{provider.name}"
+        param_id = _setup_parameters_id(val)
     elif isinstance(val, (ConnectionTag,)):
         param_id = val.name.removeprefix("DOCKER_")
     elif isinstance(val, (TelioAdapterType,)):
         param_id = val.name.replace("_", "")
     elif isinstance(val, IPStack):
-        if val == IPStack.IPv4:
-            param_id = "IPv4"
-        elif val == IPStack.IPv4v6:
-            param_id = "IPv4v6"
-        elif val == IPStack.IPv6:
-            param_id = "IPv6"
+        param_id = _ipstack_id(val)
     elif isinstance(val, str):
         if len(val) > 16:
             param_id = f"{val[:14]}.."

--- a/nat-lab/tests/conftest_helpers/pretest.py
+++ b/nat-lab/tests/conftest_helpers/pretest.py
@@ -32,7 +32,7 @@ async def kill_natlab_processes():
     cleanup_script_path = os.path.join(
         os.path.dirname(__file__), "../../bin/cleanup_natlab_processes"
     )
-    subprocess.run(["sudo", cleanup_script_path]).check_returncode()
+    subprocess.run(["sudo", cleanup_script_path], check=True)
 
 
 async def reset_service_credentials_cache():

--- a/nat-lab/tests/conftest_helpers/setup_checks.py
+++ b/nat-lab/tests/conftest_helpers/setup_checks.py
@@ -68,7 +68,7 @@ async def setup_check_interderp():
         ]
 
         if not isinstance(connections[0], DockerConnection):
-            raise Exception("Not docker connection")
+            raise RuntimeError("Not docker connection")
 
         async with make_tcpdump(connections):
             for idx, (server1, server2) in enumerate(
@@ -176,7 +176,7 @@ async def setup_check_duplicate_ip_addresses():
                 ", ".join(sorted(owners)),
             )
         details = {ip: sorted(list(owners)) for ip, owners in duplicates.items()}
-        raise Exception(f"Found duplicate container IPv4 addresses: {details}")
+        raise RuntimeError(f"Found duplicate container IPv4 addresses: {details}")
 
 
 async def setup_check_duplicate_mac_addresses(
@@ -217,7 +217,7 @@ async def setup_check_duplicate_mac_addresses(
             elif conn.target_os == TargetOS.Windows:
                 cmd = ["getmac", "/v", "/fo", "list"]
             else:
-                raise Exception("unknown target os")
+                raise RuntimeError("unknown target os")
 
             proc = await conn.create_process(cmd, quiet=True).execute()
             output = proc.get_stdout()
@@ -235,7 +235,7 @@ async def setup_check_duplicate_mac_addresses(
     if duplicates:
         for mac, tags in duplicates.items():
             setup_log.error("%s -> %s", mac, ", ".join(tags))
-        raise Exception(f"Found duplicate MACs: {duplicates}")
+        raise RuntimeError(f"Found duplicate MACs: {duplicates}")
 
 
 async def setup_check_arp_cache(session_vm_marks: set[str]):
@@ -316,7 +316,7 @@ async def setup_check_arp_cache(session_vm_marks: set[str]):
                 failures.append(failure)
 
     if failures:
-        raise Exception("ARP cache not ready for VMs: " + ", ".join(failures))
+        raise RuntimeError("ARP cache not ready for VMs: " + ", ".join(failures))
 
 
 async def setup_nlx_vpn_server(

--- a/nat-lab/tests/conftest_helpers/setup_checks.py
+++ b/nat-lab/tests/conftest_helpers/setup_checks.py
@@ -88,6 +88,40 @@ async def setup_check_interderp():
                 await derp_test.save_logs()
 
 
+def _gather_container_ips(cid: str) -> tuple[str, list[str]]:
+    try:
+        name = subprocess.check_output(
+            ["docker", "inspect", "--format={{.Name}}", cid],
+            text=True,
+        ).strip()
+        name = re.sub(r"^/+", "", name)
+    except subprocess.CalledProcessError:
+        name = cid
+
+    # Extract IPv4 addresses inside the container without relying on grep -P.
+    # Use: ip -4 -o addr show -> "... IFACE ... A.B.C.D/XX ..."
+    # Then project the CIDR column and strip mask.
+    try:
+        ips_out = subprocess.check_output(
+            [
+                "docker",
+                "exec",
+                cid,
+                "sh",
+                "-c",
+                "ip -4 -o addr show | awk '{print $4}' | cut -d/ -f1",
+            ],
+            text=True,
+        )
+    except subprocess.CalledProcessError:
+        ips_out = ""
+
+    ips = [
+        ip.strip() for ip in ips_out.split() if ip.strip() and not ip.startswith("127.")
+    ]
+    return name, ips
+
+
 async def setup_check_duplicate_ip_addresses():
     """
     Enumerate all running Docker containers, gather their IPv4 addresses (excluding 127.0.0.1),
@@ -115,38 +149,7 @@ async def setup_check_duplicate_ip_addresses():
     duplicates: dict[str, set[str]] = defaultdict(set)
 
     for cid in containers:
-        try:
-            name = subprocess.check_output(
-                ["docker", "inspect", "--format={{.Name}}", cid],
-                text=True,
-            ).strip()
-            name = re.sub(r"^/+", "", name)
-        except subprocess.CalledProcessError:
-            name = cid
-
-        # Extract IPv4 addresses inside the container without relying on grep -P.
-        # Use: ip -4 -o addr show -> "... IFACE ... A.B.C.D/XX ..."
-        # Then project the CIDR column and strip mask.
-        try:
-            ips_out = subprocess.check_output(
-                [
-                    "docker",
-                    "exec",
-                    cid,
-                    "sh",
-                    "-c",
-                    "ip -4 -o addr show | awk '{print $4}' | cut -d/ -f1",
-                ],
-                text=True,
-            )
-        except subprocess.CalledProcessError:
-            ips_out = ""
-
-        ips = [
-            ip.strip()
-            for ip in ips_out.split()
-            if ip.strip() and not ip.startswith("127.")
-        ]
+        name, ips = _gather_container_ips(cid)
 
         # Print container name and IPs (for debugging parity with the original script)
         setup_log.debug("========== %s (%s) ==========", name, cid)
@@ -270,41 +273,47 @@ async def setup_check_arp_cache(session_vm_marks: set[str]):
     acceptable_states = {"REACHABLE", "STALE", "DELAY", "PROBE", "PERMANENT"}
     failures: list[str] = []
 
+    def check_arp_for_ip(tag, ip: str) -> str | None:
+        success = False
+        last_arp_entries: list[dict] = []
+        while True:
+            if success:
+                break
+            warm_arp(ip)
+            last_arp_entries = read_arp_entries()
+            for e in last_arp_entries:
+                dst_ip = e.get("dst")
+                lladdr = e.get("lladdr")
+                state = e.get("state")
+                if dst_ip is None or dst_ip != ip:
+                    continue
+                if lladdr is None:
+                    continue
+                if state is None or state[0] not in acceptable_states:
+                    continue
+                success = True
+                break
+        if not success:
+            state = next(
+                (
+                    e.get("state", "missing")
+                    for e in last_arp_entries
+                    if e.get("dst") == ip
+                ),
+                "missing",
+            )
+            return f"{tag.name}:{ip} state={state}"
+        return None
+
     for tag in get_required_vm_containers_from_marks(session_vm_marks):
         if tag in OPENWRT_VM_TAGS:
             continue
         for ip in LAN_ADDR_MAP[tag].values():
-            success = False
-            last_arp_entries: list[dict] = []
             if ip == "":
                 continue
-            while True:
-                if success:
-                    break
-                warm_arp(ip)
-                last_arp_entries = read_arp_entries()
-                for e in last_arp_entries:
-                    dst_ip = e.get("dst")
-                    lladdr = e.get("lladdr")
-                    state = e.get("state")
-                    if dst_ip is None or dst_ip != ip:
-                        continue
-                    if lladdr is None:
-                        continue
-                    if state is None or state[0] not in acceptable_states:
-                        continue
-                    success = True
-                    break
-            if not success:
-                state = next(
-                    (
-                        e.get("state", "missing")
-                        for e in last_arp_entries
-                        if e.get("dst") == ip
-                    ),
-                    "missing",
-                )
-                failures.append(f"{tag.name}:{ip} state={state}")
+            failure = check_arp_for_ip(tag, ip)
+            if failure is not None:
+                failures.append(failure)
 
     if failures:
         raise Exception("ARP cache not ready for VMs: " + ", ".join(failures))

--- a/nat-lab/tests/conftest_helpers/windows_monitoring.py
+++ b/nat-lab/tests/conftest_helpers/windows_monitoring.py
@@ -83,6 +83,7 @@ def start_windows_vm_top10_usage_monitoring(
                 ],
                 capture_output=True,
                 text=True,
+                check=False,
             )
             if result.returncode != 0:
                 setup_log.warning(
@@ -127,6 +128,7 @@ def start_windows_vm_monitoring(
                 ],
                 capture_output=True,
                 text=True,
+                check=False,
             )
             if result.returncode != 0:
                 setup_log.warning(

--- a/nat-lab/tests/log_collector.py
+++ b/nat-lab/tests/log_collector.py
@@ -39,7 +39,7 @@ async def copy_file(
 
         await from_connection.download(from_path, core_dump_destination)
     else:
-        raise Exception(f"Copying files from {from_connection} is not supported")
+        raise RuntimeError(f"Copying files from {from_connection} is not supported")
 
 
 async def get_log_without_flush(connection: Connection) -> str:

--- a/nat-lab/tests/mesh_api.py
+++ b/nat-lab/tests/mesh_api.py
@@ -214,7 +214,7 @@ class API:
     def __init__(self) -> None:
         self.nodes = {}
 
-    def register(  # pylint: disable=dangerous-default-value
+    def register(
         self,
         name: str,
         node_id: str,

--- a/nat-lab/tests/mesh_api.py
+++ b/nat-lab/tests/mesh_api.py
@@ -17,6 +17,7 @@ if platform.machine() != "x86_64":
 else:
     from python_wireguard import Key  # type: ignore
 
+
 GREEK_ALPHABET = [
     "alpha",
     "beta",
@@ -409,6 +410,7 @@ class API:
             shell=True,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
+            check=False,
         )
         elapsed_ms = (time.monotonic() - start_time) * 1000
         log.debug(

--- a/nat-lab/tests/telio.py
+++ b/nat-lab/tests/telio.py
@@ -1,4 +1,3 @@
-# pylint: disable=too-many-lines
 import asyncio
 import platform
 import re

--- a/nat-lab/tests/telio.py
+++ b/nat-lab/tests/telio.py
@@ -763,7 +763,7 @@ class Client:
         self,
         public_key: str,
         states: List[NodeState],
-        duration_from_now=float,
+        duration_from_now: float,
         paths: Optional[List[PathType]] = None,
         is_exit: bool = False,
         is_vpn: bool = False,

--- a/nat-lab/tests/telio.py
+++ b/nat-lab/tests/telio.py
@@ -122,6 +122,32 @@ class Runtime:
     def get_output_notifier(self) -> OutputNotifier:
         return self._output_notifier
 
+    @staticmethod
+    def _peer_state_matches(
+        peer: Optional[TelioNode],
+        states: List[NodeState],
+        paths: List[PathType],
+        is_exit: bool,
+        is_vpn: bool,
+        link_state: Optional[LinkState],
+        vpn_connection_error: Optional[VpnConnectionError],
+    ) -> bool:
+        if peer is None:
+            return False
+        link_state_ok = link_state is None or peer.link_state == link_state
+        vpn_error_ok = (
+            vpn_connection_error is None
+            or peer.vpn_connection_error == vpn_connection_error
+        )
+        return (
+            peer.path in paths
+            and peer.state in states
+            and is_exit == peer.is_exit
+            and is_vpn == peer.is_vpn
+            and link_state_ok
+            and vpn_error_ok
+        )
+
     async def notify_peer_state(
         self,
         public_key: str,
@@ -134,17 +160,8 @@ class Runtime:
     ) -> None:
         while True:
             peer = self.get_peer_info(public_key)
-            if (
-                peer
-                and peer.path in paths
-                and peer.state in states
-                and is_exit == peer.is_exit
-                and is_vpn == peer.is_vpn
-                and (link_state is None or peer.link_state == link_state)
-                and (
-                    vpn_connection_error is None
-                    or peer.vpn_connection_error == vpn_connection_error
-                )
+            if self._peer_state_matches(
+                peer, states, paths, is_exit, is_vpn, link_state, vpn_connection_error
             ):
                 return
             await asyncio.sleep(0.1)

--- a/nat-lab/tests/telio.py
+++ b/nat-lab/tests/telio.py
@@ -686,7 +686,7 @@ class Client:
 
     async def start_named_ext_if_filter(self, tun_name, ext_if_filter: List[str]):
         if not isinstance(self.get_router(), WindowsRouter):
-            raise Exception("start_named_ext_if_filter can only be used on Windows")
+            raise RuntimeError("start_named_ext_if_filter can only be used on Windows")
         await self.get_proxy().start_named_ext_if_filter(
             private_key=self._node.private_key,
             adapter=self._adapter_type,
@@ -893,7 +893,7 @@ class Client:
             ],
             timeout,
         ).check_exists(f":{port} ", [protocol, process]):
-            raise Exception("Listening socket could not be found")
+            raise RuntimeError("Listening socket could not be found")
 
     async def connect_to_vpn(
         self,
@@ -1144,7 +1144,7 @@ class Client:
                     max_retries -= 1
                     await asyncio.sleep(0.1)
             if not max_retries:
-                raise Exception(
+                raise RuntimeError(
                     "Retries exhausted, while trying to write fingerprint to db"
                 )
 
@@ -1157,9 +1157,9 @@ class Client:
     def get_endpoint_address(self, public_key: str) -> str:
         node = self.get_node_state(public_key)
         if node is None:
-            raise Exception(f"Node {public_key} doesn't exist")
+            raise RuntimeError(f"Node {public_key} doesn't exist")
         if node.endpoint is None:
-            raise Exception(f"Node {public_key} endpoint doesn't exist")
+            raise RuntimeError(f"Node {public_key} endpoint doesn't exist")
         return node.endpoint.split(":")[0]
 
     def wait_for_output(self, what: str) -> asyncio.Event:

--- a/nat-lab/tests/telio.py
+++ b/nat-lab/tests/telio.py
@@ -469,6 +469,21 @@ class Client:
     def node(self) -> Node:
         return self._node
 
+    async def _enter_run_contexts(
+        self, exit_stack: AsyncExitStack, run_tcpdump, enable_perf
+    ) -> None:
+        if enable_perf:
+            await exit_stack.enter_async_context(
+                PerfProfiler(
+                    connection=self._connection,
+                    file_name_suffix=self._adapter_type.name.lower(),
+                )
+            )
+        if run_tcpdump:
+            await exit_stack.enter_async_context(make_tcpdump([self._connection]))
+        if isinstance(self._connection, DockerConnection):
+            await clear_core_dumps(self._connection)
+
     @asynccontextmanager
     async def run(
         self,
@@ -529,17 +544,7 @@ class Client:
         )
 
         async with AsyncExitStack() as exit_stack:
-            if enable_perf:
-                await exit_stack.enter_async_context(
-                    PerfProfiler(
-                        connection=self._connection,
-                        file_name_suffix=self._adapter_type.name.lower(),
-                    )
-                )
-            if run_tcpdump:
-                await exit_stack.enter_async_context(make_tcpdump([self._connection]))
-            if isinstance(self._connection, DockerConnection):
-                await clear_core_dumps(self._connection)
+            await self._enter_run_contexts(exit_stack, run_tcpdump, enable_perf)
 
             await self.clear_system_log()
 

--- a/nat-lab/tests/test_adapter.py
+++ b/nat-lab/tests/test_adapter.py
@@ -40,7 +40,7 @@ async def get_interface_state(client_conn, client):
     if state_str in ("connected", "up"):
         return AdapterState.UP
 
-    raise Exception(f'Unexpected adapter state: "{output}"')
+    raise RuntimeError(f'Unexpected adapter state: "{output}"')
 
 
 @pytest.mark.parametrize(

--- a/nat-lab/tests/test_dns.py
+++ b/nat-lab/tests/test_dns.py
@@ -1,5 +1,3 @@
-# pylint: disable=too-many-lines
-
 import asyncio
 import itertools
 import pytest

--- a/nat-lab/tests/test_events_link_state.py
+++ b/nat-lab/tests/test_events_link_state.py
@@ -1,4 +1,3 @@
-# pylint: disable=too-many-lines
 import asyncio
 import pytest
 from contextlib import AsyncExitStack

--- a/nat-lab/tests/test_lana.py
+++ b/nat-lab/tests/test_lana.py
@@ -1,4 +1,3 @@
-# pylint: disable=too-many-lines
 import asyncio
 import base64
 import os

--- a/nat-lab/tests/test_lana.py
+++ b/nat-lab/tests/test_lana.py
@@ -194,7 +194,7 @@ async def get_moose_db_file(
             max_retries -= 1
             await asyncio.sleep(0.1)
     if not max_retries:
-        raise Exception("Retries exhausted, while trying to fetch moose db file")
+        raise RuntimeError("Retries exhausted, while trying to fetch moose db file")
 
 
 async def wait_for_event_dump(

--- a/nat-lab/tests/test_lana.py
+++ b/nat-lab/tests/test_lana.py
@@ -1,5 +1,4 @@
 # pylint: disable=too-many-lines
-
 import asyncio
 import base64
 import os

--- a/nat-lab/tests/test_mesh_firewall.py
+++ b/nat-lab/tests/test_mesh_firewall.py
@@ -1,5 +1,3 @@
-# pylint: disable=too-many-lines
-
 import asyncio
 import pytest
 from contextlib import AsyncExitStack

--- a/nat-lab/tests/test_openwrt.py
+++ b/nat-lab/tests/test_openwrt.py
@@ -423,12 +423,12 @@ async def test_openwrt_simulate_network_down(
             # simulating network interface down
             await gateway_connection.create_process(["ifdown", "wan"]).execute()
             if not await wait_for_interface_state(gateway_connection, "eth1", "DOWN"):
-                raise Exception("Failed to set interface eth1 DOWN")
+                raise RuntimeError("Failed to set interface eth1 DOWN")
 
             # setting wan interface back
             await gateway_connection.create_process(["ifup", "wan"]).execute()
             if not await wait_for_interface_state(gateway_connection, "eth1", "UP"):
-                raise Exception("Failed to set interface eth1 UP")
+                raise RuntimeError("Failed to set interface eth1 UP")
             # check vpn connection is working after interface is UP
             await check_gateway_and_client_ip(
                 gateway_connection, client_connection, WG_SERVER["ipv4"], gw_tag

--- a/nat-lab/tests/test_pq.py
+++ b/nat-lab/tests/test_pq.py
@@ -434,7 +434,7 @@ class TestPqVpnHandshake:
                 is_vpn=True,
                 timeout=3,
             )
-            raise Exception("This shouldn't connect succesfully")
+            raise RuntimeError("This shouldn't connect succesfully")
         except TimeoutError:
             pass
 

--- a/nat-lab/tests/test_process.py
+++ b/nat-lab/tests/test_process.py
@@ -235,5 +235,5 @@ async def test_process_run_general_exception(
                 assert " ".join(ping_command) in await _get_running_process_list(
                     connection
                 )
-                raise Exception
+                raise RuntimeError
         assert " ".join(ping_command) not in await _get_running_process_list(connection)

--- a/nat-lab/tests/uniffi/libtelio_proxy.py
+++ b/nat-lab/tests/uniffi/libtelio_proxy.py
@@ -48,7 +48,7 @@ class LibtelioProxy:
                 return None
             (res, err) = fn_res
             if err is not None:
-                raise Exception(err)
+                raise RuntimeError(err)
             return res
 
     @move_to_async_thread

--- a/nat-lab/tests/utils/bindings.py
+++ b/nat-lab/tests/utils/bindings.py
@@ -81,7 +81,7 @@ def default_features(
     return features
 
 
-def telio_node(  # pylint: disable=dangerous-default-value
+def telio_node(
     identifier: str = "",
     public_key: str = "",
     state: NodeState = NodeState.DISCONNECTED,
@@ -89,8 +89,8 @@ def telio_node(  # pylint: disable=dangerous-default-value
     nickname: Optional[str] = None,
     is_exit: bool = False,
     is_vpn: bool = False,
-    ip_addresses: List[str] = [],
-    allowed_ips: List[str] = [],
+    ip_addresses: Optional[List[str]] = None,
+    allowed_ips: Optional[List[str]] = None,
     endpoint: Optional[str] = None,
     path: PathType = PathType.RELAY,
     allow_incoming_connections: bool = False,
@@ -110,8 +110,8 @@ def telio_node(  # pylint: disable=dangerous-default-value
         nickname=nickname,
         is_exit=is_exit,
         is_vpn=is_vpn,
-        ip_addresses=ip_addresses,
-        allowed_ips=allowed_ips,
+        ip_addresses=ip_addresses if ip_addresses is not None else [],
+        allowed_ips=allowed_ips if allowed_ips is not None else [],
         endpoint=endpoint,
         path=path,
         allow_incoming_connections=allow_incoming_connections,

--- a/nat-lab/tests/utils/router/router.py
+++ b/nat-lab/tests/utils/router/router.py
@@ -22,7 +22,7 @@ REG_IPV6GROUPS = (
     r'::(?:ffff(?::0{1,4}){0,1}:){0,1}[^\s:]' + REG_IPV4ADDR,     # ::255.255.255.255, ::ffff:255.255.255.255, ::ffff:0:255.255.255.255 (IPv4-mapped IPv6 addresses and IPv4-translated addresses)
     r'(?:' + REG_IPV6SEG + r':){1,6}:?[^\s:]' + REG_IPV4ADDR          # 2001:db8:3:4::192.0.2.33, 64:ff9b::192.0.2.33 (IPv4-Embedded IPv6 Address)
 )
-REG_IPV6ADDR = '|'.join(['(?:{})'.format(g) for g in REG_IPV6GROUPS[::-1]])  # pylint: disable=consider-using-f-string
+REG_IPV6ADDR = "|".join([f"(?:{g})" for g in REG_IPV6GROUPS[::-1]])
 # fmt: on
 
 


### PR DESCRIPTION
### Problem

`nat-lab/pyproject.toml` disables a long list of pylint rules, so the Python
linter catches very little and the list has grown stale. LLT-4091 asks to
reduce it, addressing the rules tagged *mandatory* in the ticket.

### Solution

Enable seven rules by fixing the underlying issues rather than suppressing them.
For `too-many-arguments`, raise `max-args` to a value appropriate for
fixture/criteria-heavy test code instead of wrapping every helper's keyword
arguments in an opaque options object — keeping call sites readable while the
rule still catches egregious cases. Also drop redundant inline
`# pylint: disable` comments.

### Changes

- **`pyproject.toml`**: remove `subprocess-run-check`, `nonlocal-and-global`,
  `too-many-branches`, `too-many-arguments`, `bare-except`,
  `too-many-boolean-expressions`, `broad-exception-raised` from the disable
  list; set `max-args = 10` in the design checker (documented inline).
- **`subprocess-run-check`**: explicit `check=` on `subprocess.run` calls.
- **`too-many-branches`**: extract helpers from oversized functions
  (`natlab.py`, `run_local.py`, `conftest.py`, `telio.py`, `setup_checks.py`,
  `performance_tests/conftest.py`).
- **`too-many-arguments`**: raise `max-args` to 10 — nat-lab's
  fixture/criteria-heavy helpers are already within that limit, so no signature
  changes were needed.
- **`too-many-boolean-expressions`**: extract `_peer_state_matches`.
- **`bare-except`** → `except OSError`; **`broad-exception-raised`** →
  `raise RuntimeError`.
- Remove redundant inline disables (`too-many-lines`, `consider-using-f-string`,
  `dangerous-default-value`).
- gitignore `nat-lab/tests/uniffi` build artifacts.

`fixme` stays disabled — the TODO/FIXME comments track open Jira tickets
(LLT-6693, LLT-6746, LLT-6844). The remaining optional / not-sure rules
(`docstrings`, `line-too-long`, `wrong-import-order`, `invalid-name`,
`too-many-locals`, `too-many-statements`, `too-many-instance-attributes`,
`too-many-public-methods`, `too-few-public-methods`, `duplicate-code`,
`global-statement`, `too-many-lines`) are intentionally left out of scope and
tracked in the follow-up **LLT-7378**.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated — N/A (no user-facing or library change; nat-lab tooling only)
- [x] Functionality is covered by unit or integration tests (full nat-lab + integration suite green on CI)
