### PR TITLE
Fix performance metrics

### DIFF
--- a/nat-lab/docker-compose.yml
+++ b/nat-lab/docker-compose.yml
@@ -230,7 +230,7 @@ services:
       PASSWORD: "jobs"
       NETWORK: "bridge"
       RAM_SIZE: "2G"
-      CPU_CORES: "1"
+      CPU_CORES: "4"
       EXTRA_SCRIPT: "/libtelio/nat-lab/bin/mac-client"
       CLIENT_GATEWAY_PRIMARY: 192.168.154.254
       CLIENT_GATEWAY_SECONDARY: 192.168.155.254

--- a/nat-lab/tests/utils/iperf3.py
+++ b/nat-lab/tests/utils/iperf3.py
@@ -9,6 +9,7 @@ from tests.utils.connection import Connection, TargetOS
 from tests.utils.logger import log
 from tests.utils.output_notifier import OutputNotifier
 from tests.utils.process import Process
+from tests.utils.process.process import ProcessExecError
 from typing import AsyncIterator, Any, Dict
 
 
@@ -125,8 +126,19 @@ class IperfServer:
 
     @asynccontextmanager
     async def run(self) -> AsyncIterator["IperfServer"]:
-        async with self._process.run(stdout_callback=self.on_stdout):
-            yield self
+        try:
+            async with self._process.run(stdout_callback=self.on_stdout):
+                yield self
+        except ProcessExecError as e:
+            # iperf3 server catches SIGTERM internally and exits with code 1
+            # ("iperf3: interrupt - the server has terminated"), which is normal
+            # shutdown behaviour — not a real error.
+            if e.returncode != 1:
+                raise
+            log.debug(
+                "[%s] iperf3 server exited with code 1 (interrupted by signal) — handled",
+                self._log_prefix,
+            )
 
 
 class IperfClient:


### PR DESCRIPTION
### Problem
- `iperf3` server catches `SIGTERM` internally and exits with code `1` instead of `143`, causing `DockerProcess` to raise `ProcessExecError` after a tightening change in exit code handling
- `CPU_CORES: "1"` starved `NepTUN` by sharing the single `vCPU` with `QEMU` and `macOS` daemons


### Solution
- Catch and suppress `ProcessExecError` with `returncode == 1` in `IperfServer.run()`
- `CPU_CORES: "4"` gives `NepTUN` a dedicated core, matching real hardware behavior

Tested on: `31422842`


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
