### PR TITLE
Warning on stdout/stderr about using a recommended server

### DIFF
--- a/clis/nordvpnlite/src/core_api.rs
+++ b/clis/nordvpnlite/src/core_api.rs
@@ -19,6 +19,7 @@ use telio::telio_utils::exponential_backoff::{
 
 use crate::config::{Endpoint, NordToken, NordVpnLiteConfig, NordlynxKeyResponse, VpnConfig};
 use crate::NordVpnLiteError;
+use crate::{nordvpnlite_logstd_error, nordvpnlite_logstd_warn};
 
 const API_BASE: &str = "https://api.nordvpn.com/v1";
 const WIREGUARD_ID: u64 = 35;
@@ -432,44 +433,62 @@ async fn get_recommended_servers(
 }
 
 pub async fn get_server_endpoints_list(config: &NordVpnLiteConfig) -> Result<Vec<Endpoint>, Error> {
-    let country_id: Option<u64> = match &config.vpn {
+    enum CountryResolution {
+        Recommended,
+        Found(u64),
+        FallbackToRecommended,
+    }
+
+    let resolution = match &config.vpn {
         // Use the endpoint directly if provided in the config
         VpnConfig::Server(endpoint) => return Ok(vec![endpoint.clone()]),
         // Find VPN exit node based on country
         VpnConfig::Country(target_country) => {
             if !target_country.chars().all(|c| c.is_ascii_alphabetic()) {
-                warn!("Invalid country format: '{target_country}', non-ascii characters used");
-                None
+                nordvpnlite_logstd_warn!(
+                    "Invalid country format: '{target_country}', non-ascii characters used. To list supported countries/country codes, run: nordvpnlite countries"
+                );
+                CountryResolution::FallbackToRecommended
             } else {
                 match get_countries_with_exp_backoff(config.http_certificate_file_path.as_deref())
                     .await
                 {
-                    Ok(countries_list) => countries_list
-                        .iter()
-                        .find_map(|country| {
-                            // search for country full name or iso code
-                            if country.matches(target_country) {
-                                Some(country.id)
-                            } else {
-                                None
-                            }
-                        })
-                        .or_else(|| {
-                            warn!("Servers not found for '{target_country}' country code.");
+                    Ok(countries_list) => match countries_list.iter().find_map(|country| {
+                        // search for country full name or iso code
+                        if country.matches(target_country) {
+                            Some(country.id)
+                        } else {
                             None
-                        }),
+                        }
+                    }) {
+                        Some(id) => CountryResolution::Found(id),
+                        None => {
+                            nordvpnlite_logstd_warn!(
+                                "Servers not found for '{target_country}' country code. To list supported countries/country codes, run: nordvpnlite countries"
+                            );
+                            CountryResolution::FallbackToRecommended
+                        }
+                    },
                     Err(e) => {
-                        error!("Getting countries failed due to: {e}");
-                        None
+                        nordvpnlite_logstd_error!("Getting countries failed due to: {e}");
+                        CountryResolution::FallbackToRecommended
                     }
                 }
             }
         }
-        VpnConfig::Recommended => None,
+        VpnConfig::Recommended => CountryResolution::Recommended,
     };
 
-    if country_id.is_none() {
-        info!("Using a recommended server");
+    let country_id = match resolution {
+        CountryResolution::Found(id) => Some(id),
+        CountryResolution::Recommended => {
+            info!("Using a recommended server");
+            None
+        }
+        CountryResolution::FallbackToRecommended => {
+            nordvpnlite_logstd_warn!("Falling back to a recommended server");
+            None
+        }
     };
 
     // Fetch the list of recommended server from the API

--- a/clis/nordvpnlite/src/logging.rs
+++ b/clis/nordvpnlite/src/logging.rs
@@ -50,3 +50,19 @@ pub async fn setup_logging<P: AsRef<Path>>(
 
     Ok(tracing_worker_guard)
 }
+
+#[macro_export]
+macro_rules! nordvpnlite_logstd_warn {
+    ($($arg:tt)*) => {
+        ::tracing::warn!($($arg)*);
+        eprintln!("WARNING: {}", format_args!($($arg)*));
+    };
+}
+
+#[macro_export]
+macro_rules! nordvpnlite_logstd_error {
+    ($($arg:tt)*) => {
+        ::tracing::error!($($arg)*);
+        eprintln!("ERROR: {}", format_args!($($arg)*));
+    };
+}


### PR DESCRIPTION
## Problem

NordVPNLite users are not informed via the stdout/stderr about the recommended server being used when a non-existent country/country code is requested, or when there is a problem obtaining the countries list.

## Solution

Add a message to notify users that the recommended server is being used. Warn about the invalid country/country code, and explain how to list valid options.

## Changes
* `logging.rs` defined `nordvpnlite_logstd_<warn|error>` macros
* `core_api.rs ` used  `nordvpnlite_logstd_<warn|error>` and improved the logging for a scenario with a fallback to a recommended server

## Verification

Create a `config.json` file (with valid authentication_token) i.e.: 
```
{
  "authentication_token": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
  "vpn": {
    "country": "UNSUPPORTED"
  },
  "log_level": "info",
  "log_file_path": "/var/log/nordvpnlite_log_file.log",
  "log_file_count": 0,
  "adapter_type": "linux-native",
  "interface": {
    "name": "utun10",
    "config_provider": "manual"
  }
}
```
Launch nordvpnlite in `no-detach` mode.
```
 ./nordvpnlite start --config-file ~/config.json --no-detach
```
Check that the following logs are visible on the terminal
```
WARNING: Servers not found for 'UNSUPPORTED' country code. To list supported countries/country codes, run: nordvpnlite countries
WARNING: Falling back to a recommended server

```

Change in `config.json` the `country` to unsupported country code with non--ASCII character i.e.: PL_LS and check that the a message in visible on the terminal.

In `detach` mode the `stdout`/`stderr` outputs are redirected by default to `/var/log/nordvpnlite.log` and the logs mentioned above will be written there.

 

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
