### PR TITLE
LLT-7321: backport block packets with wrong src ip from entering tunnel

### DIFF
--- a/.unreleased/LLT-7321
+++ b/.unreleased/LLT-7321
@@ -1,0 +1,1 @@
+Block outgoing packets with wrong source IP

--- a/crates/telio-firewall/src/firewall.rs
+++ b/crates/telio-firewall/src/firewall.rs
@@ -159,6 +159,8 @@ pub struct FirewallState {
     pub whitelist: Whitelist,
     /// Local node ip addresses
     pub ip_addresses: Vec<StdIpAddr>,
+    /// Whether an exit node is currently active
+    pub exit_node_present: bool,
 }
 
 /// Configuration for firewall initialization.
@@ -181,7 +183,7 @@ pub struct StatefulFirewall {
     config: FirewallConfig,
     /// Current firewall state
     state: RwLock<FirewallState>,
-    /// Last known host interface IPs reported by network monitor.
+    /// Last known host interfaces reported by network monitor.
     interface_ips: RwLock<Vec<StdIpAddr>>,
     /// Chain configuration function
     configure_chain_fn: ConfigureChainFn,
@@ -196,7 +198,6 @@ unsafe impl Send for StatefulFirewall {}
 impl LocalInterfacesObserver for StatefulFirewall {
     fn notify(&self, addrs: &[StdIpAddr]) {
         telio_log_debug!("Firewall notified about network changes: {:?}", addrs);
-
         *self.interface_ips.write() = addrs.to_vec();
         self.refresh_chain();
     }
@@ -376,9 +377,19 @@ impl StatefulFirewall {
     }
 }
 
-fn dst_net_all_ports_filter(net: IpNet, inverted: bool) -> Filter {
+fn filter_dst_ip_all_ports(net: IpNet, inverted: bool) -> Filter {
     Filter {
         filter_data: FilterData::DstNetwork(NetworkFilterData {
+            network: net,
+            port_range: (0, 65535),
+        }),
+        inverted,
+    }
+}
+
+fn filter_src_ip_all_ports(net: IpNet, inverted: bool) -> Filter {
+    Filter {
+        filter_data: FilterData::SrcNetwork(NetworkFilterData {
             network: net,
             port_range: (0, 65535),
         }),
@@ -399,18 +410,18 @@ fn get_local_area_networks_filters(
 
     // Include packets which are going to local IPv4 networks
     let mut ipv4_local_area_network_filters = ipv4_local_area_networks
-        .map(|network| vec![dst_net_all_ports_filter(IpNet::V4(network), false)]);
+        .map(|network| vec![filter_dst_ip_all_ports(IpNet::V4(network), false)]);
 
     // Exclude packets from the exclude range
     if let Some(exclude_range) = exclude_ip_range {
         for local_net_filters in ipv4_local_area_network_filters.iter_mut() {
-            local_net_filters.push(dst_net_all_ports_filter(IpNet::V4(exclude_range), true));
+            local_net_filters.push(filter_dst_ip_all_ports(IpNet::V4(exclude_range), true));
         }
     }
 
     let mut ipv6_local_area_network_filters = vec![
         // Include packets which are going to local network
-        dst_net_all_ports_filter(
+        filter_dst_ip_all_ports(
             IpNet::V6(Ipv6Net::new_assert(
                 // TODO: Actually it Unique Local Address range should be (from what I found) fc00::/7,
                 // but it seems that we assume (and our tests do) that it is fc00::/6
@@ -420,7 +431,7 @@ fn get_local_area_networks_filters(
             false,
         ),
         // Exclude packets which are going to local interfaces
-        dst_net_all_ports_filter(
+        filter_dst_ip_all_ports(
             IpNet::V6(Ipv6Net::new_assert(
                 StdIpv6Addr::new(0xfd74, 0x656c, 0x696f, 0, 0, 0, 0, 0),
                 64,
@@ -432,10 +443,10 @@ fn get_local_area_networks_filters(
     for ip in local_ifs_addrs.iter() {
         if ip.is_ipv4() {
             for local_network_filters in ipv4_local_area_network_filters.iter_mut() {
-                local_network_filters.push(dst_net_all_ports_filter(IpNet::from(*ip), true));
+                local_network_filters.push(filter_dst_ip_all_ports(IpNet::from(*ip), true));
             }
         } else {
-            ipv6_local_area_network_filters.push(dst_net_all_ports_filter(IpNet::from(*ip), true));
+            ipv6_local_area_network_filters.push(filter_dst_ip_all_ports(IpNet::from(*ip), true));
         }
     }
 
@@ -444,19 +455,20 @@ fn get_local_area_networks_filters(
     result
 }
 
-/// Configures the firewall chain based on the provided configuration.
-pub(crate) fn configure_chain(
+/// Builds the rule list for the firewall chain. Separated from configure_chain
+/// so tests can inspect the Rule vec directly.
+pub(crate) fn build_chain_rules(
     config: &FirewallConfig,
     state: &FirewallState,
     local_ifs_addrs: &[StdIpAddr],
-) -> FfiChainGuard {
+) -> Vec<Rule> {
     let mut rules = vec![];
 
     // Drop all IPv6 packets when we don't allow ipv6 traffic
     const ALL_IP_V6_ADDRS: IpNet = IpNet::V6(Ipv6Net::new_assert(StdIpv6Addr::UNSPECIFIED, 0));
     if !config.allow_ipv6 {
         rules.push(Rule {
-            filters: vec![dst_net_all_ports_filter(ALL_IP_V6_ADDRS, false)],
+            filters: vec![filter_dst_ip_all_ports(ALL_IP_V6_ADDRS, false)],
             action: LibfwVerdict::LibfwVerdictDrop,
         });
     }
@@ -477,8 +489,24 @@ pub(crate) fn configure_chain(
                     filter_data: FilterData::NextLevelProtocol(next_level_protocol),
                     inverted: false,
                 },
-                dst_net_all_ports_filter(IpNet::from(blacklist_entry.ip), false),
+                filter_dst_ip_all_ports(IpNet::from(blacklist_entry.ip), false),
             ],
+            action: LibfwVerdict::LibfwVerdictReject,
+        });
+    }
+
+    // LLT-7321: reject outbound packets whose src is not a known tunnel IP.
+    // Filters within a rule are ANDed (see LibfwRule docs).
+    if state.exit_node_present && !state.ip_addresses.is_empty() {
+        let mut filters = vec![Filter {
+            filter_data: FilterData::Direction(Direction::Outbound),
+            inverted: false,
+        }];
+        for ip in &state.ip_addresses {
+            filters.push(filter_src_ip_all_ports(IpNet::from(*ip), true));
+        }
+        rules.push(Rule {
+            filters,
             action: LibfwVerdict::LibfwVerdictReject,
         });
     }
@@ -541,7 +569,7 @@ pub(crate) fn configure_chain(
                         filter_data: FilterData::AssociatedData(Some(peer.to_vec())),
                         inverted: false,
                     },
-                    dst_net_all_ports_filter(IpNet::from(*ip), false),
+                    filter_dst_ip_all_ports(IpNet::from(*ip), false),
                 ],
                 action: LibfwVerdict::LibfwVerdictAccept,
             });
@@ -554,7 +582,7 @@ pub(crate) fn configure_chain(
                     filter_data: FilterData::ConntrackState(ConnectionState::Established),
                     inverted: false,
                 },
-                dst_net_all_ports_filter(IpNet::from(*ip), false),
+                filter_dst_ip_all_ports(IpNet::from(*ip), false),
             ],
             action: LibfwVerdict::LibfwVerdictAccept,
         });
@@ -566,7 +594,7 @@ pub(crate) fn configure_chain(
                     filter_data: FilterData::ConntrackState(ConnectionState::Related),
                     inverted: false,
                 },
-                dst_net_all_ports_filter(IpNet::from(*ip), false),
+                filter_dst_ip_all_ports(IpNet::from(*ip), false),
             ],
             action: LibfwVerdict::LibfwVerdictAccept,
         });
@@ -599,7 +627,7 @@ pub(crate) fn configure_chain(
 
         // Drop rest of the packets going to local interfaces
         rules.push(Rule {
-            filters: vec![dst_net_all_ports_filter(IpNet::from(*ip), false)],
+            filters: vec![filter_dst_ip_all_ports(IpNet::from(*ip), false)],
             action: LibfwVerdict::LibfwVerdictDrop,
         });
     }
@@ -615,7 +643,18 @@ pub(crate) fn configure_chain(
         });
     }
 
-    (rules.as_slice()).into()
+    rules
+}
+
+/// Configures the firewall chain based on the provided configuration.
+pub(crate) fn configure_chain(
+    config: &FirewallConfig,
+    state: &FirewallState,
+    local_ifs_addrs: &[StdIpAddr],
+) -> FfiChainGuard {
+    build_chain_rules(config, state, local_ifs_addrs)
+        .as_slice()
+        .into()
 }
 
 extern "C" fn write_to_sink(
@@ -766,11 +805,11 @@ mod tests {
 
     #[test]
     fn test_notify_triggers_refresh_with_callback_addrs() {
-        let captured_addrs = Arc::new(ParkingLotMutex::new(Vec::<Vec<StdIpAddr>>::new()));
-        let addrs_clone = captured_addrs.clone();
+        let captured = Arc::new(ParkingLotMutex::new(Vec::<Vec<StdIpAddr>>::new()));
+        let captured_clone = captured.clone();
         let spy_fn =
             move |_config: &FirewallConfig, _state: &FirewallState, addrs: &[StdIpAddr]| {
-                addrs_clone.lock().push(addrs.to_vec());
+                captured_clone.lock().push(addrs.to_vec());
                 (Vec::<Rule>::new().as_slice()).into()
             };
 
@@ -789,29 +828,194 @@ mod tests {
             .once()
             .returning(|_| {});
 
-        firewall.notify(&[StdIpAddr::V4(Ipv4Addr::new(192, 168, 0, 11))]);
-        firewall.notify(&[StdIpAddr::V4(Ipv4Addr::new(192, 168, 0, 12))]);
+        let ip1 = StdIpAddr::V4(Ipv4Addr::new(192, 168, 0, 11));
+        let ip2 = StdIpAddr::V4(Ipv4Addr::new(192, 168, 0, 12));
+        firewall.notify(&[ip1]);
+        firewall.notify(&[ip2]);
 
-        let calls = captured_addrs.lock();
+        let calls = captured.lock();
         assert_eq!(calls.len(), 3);
         assert_eq!(calls[0], Vec::<StdIpAddr>::new());
-        assert_eq!(
-            calls[1],
-            vec![StdIpAddr::V4(Ipv4Addr::new(192, 168, 0, 11))]
-        );
-        assert_eq!(
-            calls[2],
-            vec![StdIpAddr::V4(Ipv4Addr::new(192, 168, 0, 12))]
+        assert_eq!(calls[1], vec![ip1]);
+        assert_eq!(calls[2], vec![ip2]);
+    }
+
+    #[test]
+    fn test_allowlist_rule_not_emitted_without_exit_node() {
+        let config = FirewallConfig {
+            allow_ipv6: false,
+            feature: FeatureFirewall::default(),
+        };
+        let state = FirewallState {
+            ip_addresses: vec![StdIpAddr::V4(Ipv4Addr::new(10, 5, 0, 1))],
+            exit_node_present: false,
+            ..Default::default()
+        };
+        let rules = build_chain_rules(&config, &state, &[]);
+        assert!(
+            rules
+                .iter()
+                .all(|r| r.action != LibfwVerdict::LibfwVerdictReject),
+            "found Reject rule without exit_node_present"
         );
     }
 
     #[test]
+    fn test_allowlist_rule_not_emitted_with_empty_ip_addresses() {
+        let config = FirewallConfig {
+            allow_ipv6: false,
+            feature: FeatureFirewall::default(),
+        };
+        let state = FirewallState {
+            ip_addresses: vec![],
+            exit_node_present: true,
+            ..Default::default()
+        };
+        let rules = build_chain_rules(&config, &state, &[]);
+        assert!(
+            rules
+                .iter()
+                .all(|r| r.action != LibfwVerdict::LibfwVerdictReject),
+            "found Reject rule with empty ip_addresses"
+        );
+    }
+
+    #[test]
+    fn test_allowlist_rule_emitted_as_single_rule_with_inverted_src_filters() {
+        let config = FirewallConfig {
+            allow_ipv6: false,
+            feature: FeatureFirewall::default(),
+        };
+        let tunnel_ip = StdIpAddr::V4(Ipv4Addr::new(10, 5, 0, 1));
+        let state = FirewallState {
+            ip_addresses: vec![tunnel_ip],
+            exit_node_present: true,
+            ..Default::default()
+        };
+        let rules = build_chain_rules(&config, &state, &[]);
+
+        let _rule = rules
+            .iter()
+            .filter(|r| r.action == LibfwVerdict::LibfwVerdictReject)
+            .find(|r| {
+                let has_outbound = r.filters.iter().any(|f| {
+                    f.filter_data == FilterData::Direction(Direction::Outbound) && !f.inverted
+                });
+                let has_inverted_src = r.filters.iter().any(|f| {
+                    matches!(&f.filter_data, FilterData::SrcNetwork(n)
+                        if n.network == IpNet::from(tunnel_ip))
+                        && f.inverted
+                });
+                has_outbound && has_inverted_src
+            })
+            .expect(
+                "expected a Reject rule with Direction::Outbound filter \
+                 and inverted SrcNetwork filter for tunnel IP",
+            );
+    }
+
+    #[test]
+    fn test_allowlist_rule_ordering_before_vpn_accept() {
+        let vpn_pk = PublicKey::new([0xAB; 32]);
+        let config = FirewallConfig {
+            allow_ipv6: false,
+            feature: FeatureFirewall::default(),
+        };
+        let tunnel_ip = StdIpAddr::V4(Ipv4Addr::new(10, 5, 0, 1));
+        let state = FirewallState {
+            ip_addresses: vec![tunnel_ip],
+            exit_node_present: true,
+            whitelist: Whitelist {
+                vpn_peer: Some(vpn_pk),
+                ..Default::default()
+            },
+        };
+        let rules = build_chain_rules(&config, &state, &[]);
+
+        let reject_pos = rules.iter().position(|r| {
+            r.action == LibfwVerdict::LibfwVerdictReject
+                && r.filters.iter().any(|f| {
+                    f.filter_data == FilterData::Direction(Direction::Outbound) && !f.inverted
+                })
+                && r.filters
+                    .iter()
+                    .any(|f| matches!(&f.filter_data, FilterData::SrcNetwork(_)) && f.inverted)
+        });
+        let accept_pos = rules.iter().position(|r| {
+            r.action == LibfwVerdict::LibfwVerdictAccept
+                && r.filters.iter().any(|f| {
+                    matches!(&f.filter_data, FilterData::AssociatedData(Some(k))
+                        if k == &vpn_pk.to_vec())
+                })
+        });
+        assert!(reject_pos.is_some(), "reject rule must exist");
+        assert!(accept_pos.is_some(), "vpn accept rule must exist");
+        assert!(
+            reject_pos.unwrap() < accept_pos.unwrap(),
+            "reject rule must come before vpn accept rule"
+        );
+    }
+
+    #[test]
+    fn test_allowlist_rule_two_ips_both_inverted_src_filters_in_one_rule() {
+        let config = FirewallConfig {
+            allow_ipv6: false,
+            feature: FeatureFirewall::default(),
+        };
+        let ip1 = StdIpAddr::V4(Ipv4Addr::new(10, 5, 0, 1));
+        let ip2 = StdIpAddr::V4(Ipv4Addr::new(100, 64, 0, 1));
+        let state = FirewallState {
+            ip_addresses: vec![ip1, ip2],
+            exit_node_present: true,
+            ..Default::default()
+        };
+        let rules = build_chain_rules(&config, &state, &[]);
+
+        let rule = rules
+            .iter()
+            .filter(|r| r.action == LibfwVerdict::LibfwVerdictReject)
+            .find(|r| {
+                r.filters.iter().any(|f| {
+                    f.filter_data == FilterData::Direction(Direction::Outbound) && !f.inverted
+                }) && r
+                    .filters
+                    .iter()
+                    .any(|f| matches!(&f.filter_data, FilterData::SrcNetwork(_)) && f.inverted)
+            })
+            .expect(
+                "expected a Reject rule with Direction::Outbound and inverted SrcNetwork filters",
+            );
+
+        let inverted_src_count = rule
+            .filters
+            .iter()
+            .filter(|f| matches!(&f.filter_data, FilterData::SrcNetwork(_)) && f.inverted)
+            .count();
+        assert_eq!(
+            inverted_src_count, 2,
+            "one inverted SrcNetwork filter per tunnel IP"
+        );
+
+        for ip in [ip1, ip2] {
+            assert!(
+                rule.filters.iter().any(|f| {
+                    matches!(&f.filter_data, FilterData::SrcNetwork(n)
+                        if n.network == IpNet::from(ip))
+                        && f.inverted
+                }),
+                "inverted SrcNetwork filter for {} must be present",
+                ip
+            );
+        }
+    }
+
+    #[test]
     fn test_notify_addrs_are_used_by_subsequent_refreshes() {
-        let captured_addrs = Arc::new(ParkingLotMutex::new(Vec::<Vec<StdIpAddr>>::new()));
-        let addrs_clone = captured_addrs.clone();
+        let captured = Arc::new(ParkingLotMutex::new(Vec::<Vec<StdIpAddr>>::new()));
+        let captured_clone = captured.clone();
         let spy_fn =
             move |_config: &FirewallConfig, _state: &FirewallState, addrs: &[StdIpAddr]| {
-                addrs_clone.lock().push(addrs.to_vec());
+                captured_clone.lock().push(addrs.to_vec());
                 (Vec::<Rule>::new().as_slice()).into()
             };
 
@@ -830,15 +1034,15 @@ mod tests {
             .once()
             .returning(|_| {});
 
-        let notify_addrs = vec![StdIpAddr::V4(Ipv4Addr::new(192, 168, 77, 7))];
-        firewall.notify(&notify_addrs);
+        let notify_ips = vec![StdIpAddr::V4(Ipv4Addr::new(192, 168, 77, 7))];
+        firewall.notify(&notify_ips);
         firewall.apply_state(FirewallState {
             ip_addresses: vec![StdIpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))],
             ..Default::default()
         });
 
-        assert_eq!(captured_addrs.lock().len(), 3);
-        assert_eq!(captured_addrs.lock()[1], notify_addrs);
-        assert_eq!(captured_addrs.lock()[2], notify_addrs);
+        assert_eq!(captured.lock().len(), 3);
+        assert_eq!(captured.lock()[1], notify_ips);
+        assert_eq!(captured.lock()[2], notify_ips);
     }
 }

--- a/crates/telio-firewall/tests/firewall_integration_tests.rs
+++ b/crates/telio-firewall/tests/firewall_integration_tests.rs
@@ -1063,6 +1063,87 @@ fn firewall_whitelist_port() {
     }
 }
 
+// When a VPN peer is set, outbound packets with a stale physical src IP
+//  must be rejected to prevent exit-node NAT pollution. [LLT-7321]
+#[test]
+fn firewall_outbound_packet_with_wrong_src_ip_rejected() {
+    let vpn_peer = make_random_peer();
+    let wlan_ip = Ipv4Addr::new(192, 168, 1, 5);
+    let tunnel_ip = Ipv4Addr::new(10, 5, 0, 2);
+    let remote_ip = Ipv4Addr::new(203, 0, 113, 1);
+
+    let fw = StatefulFirewall::new(true, FeatureFirewall::default())
+        .expect("Failed to load libfirewall");
+
+    // No exit node: outbound from any src should pass.
+    fw.apply_state(FirewallState {
+        ip_addresses: vec![IpAddr::V4(tunnel_ip)],
+        exit_node_present: false,
+        ..Default::default()
+    });
+    assert!(
+        fw.process_outbound_packet_sink(
+            &vpn_peer.0,
+            &make_tcp(
+                &format!("{wlan_ip}:12345"),
+                &format!("{remote_ip}:443"),
+                TcpFlags::SYN
+            )
+        ),
+        "outbound from physical IP should pass when no exit node"
+    );
+
+    // Exit node active + ip_addresses set: non-tunnel src rejected.
+    fw.apply_state(FirewallState {
+        ip_addresses: vec![IpAddr::V4(tunnel_ip)],
+        exit_node_present: true,
+        whitelist: telio_firewall::firewall::Whitelist {
+            vpn_peer: Some(vpn_peer),
+            ..Default::default()
+        },
+    });
+    assert!(
+        !fw.process_outbound_packet_sink(
+            &vpn_peer.0,
+            &make_tcp(
+                &format!("{wlan_ip}:12345"),
+                &format!("{remote_ip}:443"),
+                TcpFlags::SYN
+            )
+        ),
+        "outbound from physical IP should be rejected when exit node active"
+    );
+    assert!(
+        fw.process_outbound_packet_sink(
+            &vpn_peer.0,
+            &make_tcp(
+                &format!("{tunnel_ip}:54321"),
+                &format!("{remote_ip}:443"),
+                TcpFlags::SYN
+            )
+        ),
+        "outbound from tunnel IP should still pass"
+    );
+
+    // Exit node disconnected: rule gone.
+    fw.apply_state(FirewallState {
+        ip_addresses: vec![IpAddr::V4(tunnel_ip)],
+        exit_node_present: false,
+        ..Default::default()
+    });
+    assert!(
+        fw.process_outbound_packet_sink(
+            &vpn_peer.0,
+            &make_tcp(
+                &format!("{wlan_ip}:12345"),
+                &format!("{remote_ip}:443"),
+                TcpFlags::SYN
+            )
+        ),
+        "outbound from physical IP should pass after exit node disconnected"
+    );
+}
+
 mod tp_lite_stats {
     use std::sync::Arc;
 

--- a/crates/telio-network-monitors/src/monitor.rs
+++ b/crates/telio-network-monitors/src/monitor.rs
@@ -1,13 +1,12 @@
 //! Module to monitor changes in network.
 //! Get notified when network paths change
 //! and update local IP address cache
-use crate::{local_interfaces::gather_local_interfaces, local_interfaces::GetIfAddrs};
+use crate::local_interfaces::{gather_local_interfaces, GetIfAddrs};
 use if_addrs::Interface;
 use once_cell::sync::Lazy;
 use parking_lot::Mutex;
 use std::{
     io,
-    net::IpAddr,
     sync::{Arc, Weak},
 };
 use telio_utils::{telio_log_debug, telio_log_info, telio_log_trace, telio_log_warn};
@@ -28,8 +27,8 @@ struct PausedState {
 
 /// Trait which should be implemented to receive local address change notifications
 pub trait LocalInterfacesObserver: Sync + Send {
-    /// Callback which allows to take certain actions when local interfaces changed
-    fn notify(&self, addrs: &[IpAddr]);
+    /// Callback which allows to take certain actions when local interfaces changed.
+    fn notify(&self, addrs: &[std::net::IpAddr]);
 }
 
 #[derive(Debug)]
@@ -45,9 +44,9 @@ pub struct NetworkMonitor {
     paused_state: Arc<Mutex<PausedState>>,
 }
 
-/// Result of a gather operation containing interface IPs and change status.
+/// Result of a gather operation containing IPs and change status.
 struct GatheredInterfaceIps {
-    addrs: Vec<IpAddr>,
+    addrs: Vec<std::net::IpAddr>,
     changed: bool,
 }
 
@@ -229,8 +228,7 @@ mod tests {
     use if_addrs::IfOperStatus;
     use serial_test::serial;
     use std::{
-        net::IpAddr,
-        net::Ipv4Addr,
+        net::{IpAddr, Ipv4Addr},
         sync::atomic::{AtomicU8, Ordering},
     };
 

--- a/nat-lab/tests/test_mesh_firewall.py
+++ b/nat-lab/tests/test_mesh_firewall.py
@@ -4,7 +4,15 @@ import asyncio
 import pytest
 from contextlib import AsyncExitStack
 from tests import config
-from tests.helpers import SetupParameters, setup_mesh_nodes, setup_api
+from tests.config import LAN_ADDR_MAP
+from tests.helpers import (
+    SetupParameters,
+    setup_api,
+    setup_environment,
+    setup_mesh_nodes,
+    setup_connections,
+)
+from tests.helpers_vpn import connect_vpn
 from tests.mesh_api import Node
 from tests.utils import testing, stun
 from tests.utils.bindings import default_features, Features, TelioAdapterType
@@ -20,6 +28,7 @@ from tests.utils.logger import log
 from tests.utils.netcat import NetCatServer, NetCatClient
 from tests.utils.ping import ping
 from tests.utils.router import IPProto, IPStack
+from tests.utils.tcpdump import TcpDump
 from typing import Tuple, Optional
 
 
@@ -698,3 +707,170 @@ async def test_mesh_firewall_tcp_stuck_in_last_ack_state_conn_kill_from_client_s
                 # if everything is correct -> conntrack should show LAST_ACK -> TIME_WAIT
                 # if something goes wrong, it will be stuck at LAST_ACK state
                 await conntrack.wait_for_no_violations()
+
+
+# LLT-7321: a TCP connection established BEFORE being connected to VPN
+# carries the client's physical interface IP as its source.
+#
+# After connecting to VPN, the kernel reroutes it through the tunnel
+# but still with the wrong source IP. Exit node's receive this packet,
+# poisoning their NAT table which causes return traffic to be misrouted.
+@pytest.mark.xfail(reason="LLT-7321")
+@pytest.mark.asyncio
+async def test_stale_src_ip_persist_after_connection() -> None:
+    async with AsyncExitStack() as exit_stack:
+        setup_params = SetupParameters(
+            connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
+            adapter_type_override=TelioAdapterType.NEP_TUN,
+            ip_stack=IPStack.IPv4,
+            is_meshnet=False,
+            features=default_features(enable_firewall_exclusion_range="10.0.0.0/8"),
+        )
+
+        env = await exit_stack.enter_async_context(
+            setup_environment(
+                exit_stack,
+                [setup_params],
+                vpn=[ConnectionTag.DOCKER_VPN_1],
+            )
+        )
+
+        alpha, *_ = env.nodes
+        connection, *_ = [conn.connection for conn in env.connections]
+        client, *_ = env.clients
+
+        client_lan_ip = LAN_ADDR_MAP[ConnectionTag.DOCKER_CONE_CLIENT_1]["primary"]
+
+        await client.set_meshnet_config(env.api.get_meshnet_config(alpha.id))
+
+        # Open a TCP connection
+        pre_vpn_nc = await exit_stack.enter_async_context(
+            NetCatClient(
+                connection,
+                config.PHOTO_ALBUM_IP,
+                80,
+                source_ip=client_lan_ip,
+            ).run()
+        )
+        await pre_vpn_nc.connection_succeeded()
+
+        vpn_connection, *_ = await setup_connections(
+            exit_stack, [ConnectionTag.DOCKER_VPN_1]
+        )
+        await connect_vpn(
+            connection,
+            vpn_connection.connection,
+            client,
+            alpha.ip_addresses[0],
+            config.WG_SERVER,
+        )
+
+        # A fresh connection through the tunnel (src = tunnel IP) must work.
+        await ping(connection, config.PHOTO_ALBUM_IP)
+
+        # Widen the VPN peer's AllowedIPs so WireGuard passes all inner-src IPs
+        # through to wg0, isolating the libtelio firewall.
+        await vpn_connection.connection.create_process([
+            "wg",
+            "set",
+            "wg0",
+            "peer",
+            alpha.public_key,
+            "allowed-ips",
+            "0.0.0.0/0",
+        ]).execute()
+
+        stale_ip_capture = TcpDump(
+            vpn_connection.connection,
+            interfaces=["wg0"],
+            expressions=[f"src host {client_lan_ip}"],
+            count=1,
+        )
+
+        # Send data through the stale connection and check the source ip
+        async with stale_ip_capture.run():
+            await pre_vpn_nc.send_data("GET / HTTP/1.0\r\n\r\n")
+            try:
+                await asyncio.wait_for(stale_ip_capture.execute(), timeout=5)
+                raise AssertionError(
+                    f"Packet with stale source IP {client_lan_ip} reached the"
+                    " VPN's wg0 interface."
+                )
+            except asyncio.TimeoutError:
+                pass
+
+
+# LLT-7321: same stale-src-IP scenario but using a meshnet peer as exit node.
+@pytest.mark.asyncio
+@pytest.mark.libfirewall
+async def test_stale_src_ip_persist_after_meshnet_exit_node_connection() -> None:
+    async with AsyncExitStack() as exit_stack:
+        env = await setup_mesh_nodes(
+            exit_stack,
+            [
+                SetupParameters(
+                    connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
+                    adapter_type_override=TelioAdapterType.NEP_TUN,
+                    ip_stack=IPStack.IPv4,
+                    features=default_features(
+                        enable_firewall_exclusion_range="10.0.0.0/8"
+                    ),
+                ),
+                SetupParameters(
+                    connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2,
+                    ip_stack=IPStack.IPv4,
+                    features=default_features(
+                        enable_firewall_exclusion_range="10.0.0.0/8"
+                    ),
+                ),
+            ],
+        )
+
+        api = env.api
+        alpha, beta = env.nodes
+        connection_alpha, connection_beta = [
+            conn.connection for conn in env.connections
+        ]
+        client_alpha, client_beta = env.clients
+
+        alpha_lan_ip = LAN_ADDR_MAP[ConnectionTag.DOCKER_CONE_CLIENT_1]["primary"]
+
+        beta.set_peer_firewall_settings(
+            alpha.id,
+            allow_incoming_connections=True,
+            allow_peer_traffic_routing=True,
+        )
+        await client_beta.set_meshnet_config(api.get_meshnet_config(beta.id))
+        await client_beta.get_router().create_exit_node_route()
+
+        pre_exit_nc = await exit_stack.enter_async_context(
+            NetCatClient(
+                connection_alpha,
+                config.PHOTO_ALBUM_IP,
+                80,
+                source_ip=alpha_lan_ip,
+            ).run()
+        )
+        await pre_exit_nc.connection_succeeded()
+
+        await client_alpha.connect_to_exit_node(beta.public_key)
+
+        await ping(connection_alpha, config.PHOTO_ALBUM_IP)
+
+        stale_ip_capture = TcpDump(
+            connection_beta,
+            interfaces=["tun10"],
+            expressions=[f"src host {alpha_lan_ip}"],
+            count=1,
+        )
+
+        async with stale_ip_capture.run():
+            await pre_exit_nc.send_data("GET / HTTP/1.0\r\n\r\n")
+            try:
+                await asyncio.wait_for(stale_ip_capture.execute(), timeout=5)
+                raise AssertionError(
+                    f"Packet with stale source IP {alpha_lan_ip} reached the"
+                    " meshnet exit node's interface."
+                )
+            except asyncio.TimeoutError:
+                pass

--- a/nat-lab/tests/test_mesh_firewall.py
+++ b/nat-lab/tests/test_mesh_firewall.py
@@ -715,7 +715,6 @@ async def test_mesh_firewall_tcp_stuck_in_last_ack_state_conn_kill_from_client_s
 # After connecting to VPN, the kernel reroutes it through the tunnel
 # but still with the wrong source IP. Exit node's receive this packet,
 # poisoning their NAT table which causes return traffic to be misrouted.
-@pytest.mark.xfail(reason="LLT-7321")
 @pytest.mark.asyncio
 async def test_stale_src_ip_persist_after_connection() -> None:
     async with AsyncExitStack() as exit_stack:

--- a/src/device/wg_controller.rs
+++ b/src/device/wg_controller.rs
@@ -628,14 +628,16 @@ async fn consolidate_firewall<F: Firewall>(
         state.whitelist.peer_whitelists[Permissions::RoutingConnections].insert(key);
     }
 
-    if let Some(exit_node) = &requested_state.exit_node {
-        let is_vpn_exit_node =
-            !iter_peers(requested_state).any(|p| p.public_key == exit_node.public_key);
-
-        if is_vpn_exit_node {
+    let is_vpn_exit_node = if let Some(exit_node) = &requested_state.exit_node {
+        let is_vpn = !iter_peers(requested_state).any(|p| p.public_key == exit_node.public_key);
+        if is_vpn {
             state.whitelist.vpn_peer = Some(exit_node.public_key);
         }
-    }
+        state.exit_node_present = true;
+        is_vpn
+    } else {
+        false
+    };
 
     if let Some(meshnet_config) = &requested_state.meshnet_config {
         state.ip_addresses = meshnet_config
@@ -644,6 +646,15 @@ async fn consolidate_firewall<F: Firewall>(
             .clone()
             .ok_or(Error::IpNotSet)?;
     }
+
+    if is_vpn_exit_node {
+        state
+            .ip_addresses
+            .push(IpAddr::V4(Ipv4Addr::new(10, 5, 0, 2)));
+    }
+
+    state.ip_addresses.sort_unstable();
+    state.ip_addresses.dedup();
 
     firewall.apply_state(state);
 
@@ -1551,6 +1562,14 @@ mod tests {
             ..Default::default()
         });
 
+        let mut expected_ips = vec![
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            IpAddr::V6(Ipv6Addr::LOCALHOST),
+            IpAddr::V4(Ipv4Addr::new(10, 5, 0, 2)),
+        ];
+        expected_ips.sort_unstable();
+        expected_ips.dedup();
+
         firewall
             .expect_apply_state()
             .once()
@@ -1564,9 +1583,101 @@ mod tests {
                     port_whitelist: Default::default(),
                     vpn_peer: Some(pub_key_2),
                 },
-                ip_addresses: vec![IpAddr::V4(Ipv4Addr::LOCALHOST), IpAddr::V6(Ipv6Addr::LOCALHOST)],
-                ..Default::default()
+                ip_addresses: expected_ips,
+                exit_node_present: true,
             }))
+            .return_const(());
+
+        consolidate_firewall(
+            &requested_state,
+            &firewall,
+            Some(pub_key_starcast_vpeer),
+            None,
+        )
+        .await
+        .unwrap();
+    }
+
+    #[cfg(feature = "enable_firewall")]
+    #[tokio::test]
+    async fn vpn_exit_node_sets_exit_node_present_and_vpn_ip_addresses() {
+        let mut firewall = MockFirewall::new();
+        let pub_key_starcast_vpeer = SecretKey::gen().public();
+        let pub_key_vpn = SecretKey::gen().public();
+
+        let mut requested_state = create_requested_state(vec![]);
+        requested_state.exit_node = Some(ExitNode {
+            public_key: pub_key_vpn,
+            ..Default::default()
+        });
+
+        let mut expected_ips = vec![
+            IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+            IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)),
+            IpAddr::V4(Ipv4Addr::new(10, 5, 0, 2)),
+        ];
+        expected_ips.sort_unstable();
+        expected_ips.dedup();
+
+        firewall
+            .expect_apply_state()
+            .once()
+            .with(eq(FirewallState {
+                whitelist: Whitelist {
+                    peer_whitelists: enum_map! {
+                        Permissions::IncomingConnections => FwHashSet::from_iter([pub_key_starcast_vpeer]),
+                        Permissions::RoutingConnections => FwHashSet::from_iter([pub_key_starcast_vpeer]),
+                        Permissions::LocalAreaConnections => FwHashSet::default(),
+                    },
+                    port_whitelist: Default::default(),
+                    vpn_peer: Some(pub_key_vpn),
+                },
+                ip_addresses: expected_ips,
+                exit_node_present: true,
+            }))
+            .return_const(());
+
+        consolidate_firewall(
+            &requested_state,
+            &firewall,
+            Some(pub_key_starcast_vpeer),
+            None,
+        )
+        .await
+        .unwrap();
+    }
+
+    #[cfg(feature = "enable_firewall")]
+    #[tokio::test]
+    async fn meshnet_exit_node_sets_exit_node_present_without_vpn_ips() {
+        let mut firewall = MockFirewall::new();
+        let pub_key_starcast_vpeer = SecretKey::gen().public();
+        let pub_key_meshnet_peer = SecretKey::gen().public();
+
+        // Peer is in mesh AND used as exit node → is_vpn_exit_node = false
+        let mut requested_state = create_requested_state(vec![(
+            pub_key_meshnet_peer,
+            vec![],
+            false,
+            false,
+            false,
+            false,
+        )]);
+        requested_state.exit_node = Some(ExitNode {
+            public_key: pub_key_meshnet_peer,
+            ..Default::default()
+        });
+
+        firewall
+            .expect_apply_state()
+            .once()
+            .withf(|state: &FirewallState| {
+                state.exit_node_present
+                    && state.whitelist.vpn_peer.is_none()
+                    // VPN constants must NOT be in ip_addresses for meshnet exit
+                    && !state.ip_addresses.contains(&IpAddr::V4(VPN_INTERNAL_IPV4))
+                    && !state.ip_addresses.contains(&IpAddr::V4(VPN_EXTERNAL_IPV4))
+            })
             .return_const(());
 
         consolidate_firewall(
@@ -1595,6 +1706,13 @@ mod tests {
             ..Default::default()
         });
 
+        let mut expected_ips = vec![
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            IpAddr::V6(Ipv6Addr::LOCALHOST),
+        ];
+        expected_ips.sort_unstable();
+        expected_ips.dedup();
+
         firewall
             .expect_apply_state()
             .once()
@@ -1608,8 +1726,8 @@ mod tests {
                     port_whitelist: Default::default(),
                     vpn_peer: None,
                 },
-                ip_addresses: vec![IpAddr::V4(Ipv4Addr::LOCALHOST), IpAddr::V6(Ipv6Addr::LOCALHOST)],
-                ..Default::default()
+                ip_addresses: expected_ips,
+                exit_node_present: true,
             }))
             .return_const(());
 
@@ -1640,6 +1758,13 @@ mod tests {
             ..Default::default()
         });
 
+        let mut expected_ips = vec![
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            IpAddr::V6(Ipv6Addr::LOCALHOST),
+        ];
+        expected_ips.sort_unstable();
+        expected_ips.dedup();
+
         firewall
             .expect_apply_state()
             .once()
@@ -1653,8 +1778,8 @@ mod tests {
                     port_whitelist: Default::default(),
                     vpn_peer: None,
                 },
-                ip_addresses: vec![IpAddr::V4(Ipv4Addr::LOCALHOST), IpAddr::V6(Ipv6Addr::LOCALHOST)],
-                ..Default::default()
+                ip_addresses: expected_ips,
+                exit_node_present: true,
             }))
             .return_const(());
 


### PR DESCRIPTION
### Problem
Fix was merged to main, but we need to backport it to v7.0 releases

### Solution
Do backport, but skip some unimportant commits to keep hotfix small. All skipped commits relate to natlab tests and are non-critical. Additionally, had to slightly adjust natlab tests to use standard `setup_mesh_nodes` and `setup_connections` instead of using the newly introduced factories, as well as creating the exit stack in the test instead of providing it as a fixture.

Skipped commits: 
- 7625b7a: Hardcode tunnel local ipv4 - 10.5.0.2
- 370bef7: Add *.so files to .gitignore
- 2e0bf2c: Add libfirewall pytest mark
- 59139df: Fix tcpdump syntax error from unjoined filter predicates
- e0064db: Fail fast in netcat helpers when process exits early


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
