### PR TITLE
Do not start ENS when routing through meshnet peer

### DIFF
--- a/.unreleased/meshnet_peer_ens_fix
+++ b/.unreleased/meshnet_peer_ens_fix
@@ -1,0 +1,1 @@
+ENS starts only, when routing through VPN sever (and not through meshnet peer).

--- a/nat-lab/tests/test_ens.py
+++ b/nat-lab/tests/test_ens.py
@@ -3,7 +3,12 @@ import base64
 import pytest
 from contextlib import AsyncExitStack
 from tests import config
-from tests.helpers import SetupParameters, setup_environment, setup_connections
+from tests.helpers import (
+    SetupParameters,
+    setup_api,
+    setup_environment,
+    setup_connections,
+)
 from tests.helpers_ens import (
     get_grpc_tls_fingerprint_from_server,
     get_grpc_tls_root_certificate_from_server,
@@ -21,6 +26,7 @@ from tests.utils.bindings import (
     default_features,
     PathType,
     NodeState,
+    RelayState,
     TelioAdapterType,
     VpnConnectionError,
     generate_secret_key,
@@ -30,9 +36,12 @@ from tests.utils.connection_util import (
     generate_connection_tracker_config,
     new_connection_by_tag,
 )
+from tests.utils.ping import ping
+from tests.utils.router import IPProto, IPStack
 from typing import cast
 
 ENS_PORT = 993
+ENS_LOG_STR = "Will start ENS monitoring"
 
 
 @pytest.mark.nlx
@@ -579,6 +588,135 @@ async def test_ens_superseded(
             is_vpn=True,
             vpn_connection_error=VpnConnectionError.SUPERSEDED,
         )
+
+
+@pytest.mark.parametrize(
+    "alpha_setup_params",
+    [
+        pytest.param(
+            SetupParameters(
+                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
+                adapter_type_override=TelioAdapterType.NEP_TUN,
+                connection_tracker_config=generate_connection_tracker_config(
+                    ConnectionTag.DOCKER_CONE_CLIENT_1,
+                    nlx_1_limits=(0, 0),
+                    derp_1_limits=(1, 1),
+                ),
+                features=default_features(
+                    enable_error_notification_service=True,
+                    enable_direct=True,
+                ),
+            )
+        ),
+        pytest.param(
+            SetupParameters(
+                connection_tag=ConnectionTag.VM_WINDOWS_1,
+                adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
+                connection_tracker_config=generate_connection_tracker_config(
+                    ConnectionTag.VM_WINDOWS_1,
+                    nlx_1_limits=(0, 0),
+                    derp_1_limits=(1, 1),
+                ),
+                features=default_features(
+                    enable_error_notification_service=True,
+                    enable_direct=True,
+                ),
+            ),
+            marks=pytest.mark.windows,
+        ),
+        pytest.param(
+            SetupParameters(
+                connection_tag=ConnectionTag.VM_MAC,
+                adapter_type_override=TelioAdapterType.NEP_TUN,
+                connection_tracker_config=generate_connection_tracker_config(
+                    ConnectionTag.VM_MAC,
+                    nlx_1_limits=(0, 0),
+                    derp_1_limits=(1, 1),
+                ),
+                features=default_features(
+                    enable_error_notification_service=True,
+                    enable_direct=True,
+                ),
+            ),
+            marks=pytest.mark.mac,
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "beta_setup_params",
+    [
+        pytest.param(
+            SetupParameters(
+                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2,
+                connection_tracker_config=generate_connection_tracker_config(
+                    ConnectionTag.DOCKER_CONE_CLIENT_2,
+                    nlx_1_limits=(0, 0),
+                    derp_1_limits=(1, 1),
+                ),
+                features=default_features(
+                    enable_error_notification_service=True,
+                    enable_direct=True,
+                    enable_firewall_exclusion_range="10.0.0.0/8",
+                ),
+            )
+        )
+    ],
+)
+async def test_ens_not_started_for_meshnet_exit_peer(
+    alpha_setup_params: SetupParameters,
+    beta_setup_params: SetupParameters,
+) -> None:
+    async with AsyncExitStack() as exit_stack:
+        api, (alpha, beta) = setup_api([(False, IPStack.IPv4), (False, IPStack.IPv4)])
+        beta.set_peer_firewall_settings(
+            alpha.id,
+            allow_incoming_connections=True,
+            allow_peer_traffic_routing=True,
+        )
+
+        env = await exit_stack.enter_async_context(
+            setup_environment(exit_stack, [alpha_setup_params, beta_setup_params], api)
+        )
+
+        client_alpha, client_beta = env.clients
+        connection_alpha, _ = [conn.connection for conn in env.connections]
+
+        await asyncio.gather(
+            client_alpha.wait_for_state_on_any_derp([RelayState.CONNECTED]),
+            client_beta.wait_for_state_on_any_derp([RelayState.CONNECTED]),
+        )
+
+        await client_alpha.set_meshnet_config(api.get_meshnet_config(alpha.id))
+        await client_beta.set_meshnet_config(api.get_meshnet_config(beta.id))
+
+        await asyncio.gather(
+            client_alpha.wait_for_state_peer(
+                beta.public_key, [NodeState.CONNECTED], [PathType.DIRECT]
+            ),
+            client_beta.wait_for_state_peer(
+                alpha.public_key, [NodeState.CONNECTED], [PathType.DIRECT]
+            ),
+        )
+
+        await ping(connection_alpha, cast(str, beta.get_ip_address(IPProto.IPv4)))
+        await client_beta.get_router().create_exit_node_route()
+
+        logs_before = await client_alpha.get_log()
+        ens_starts_before = logs_before.count(ENS_LOG_STR)
+
+        await client_alpha.connect_to_exit_node(beta.public_key)
+        await client_alpha.wait_for_state_peer(
+            beta.public_key,
+            [NodeState.CONNECTED],
+            list(PathType),
+            is_exit=True,
+            is_vpn=False,
+        )
+
+        logs_after = await client_alpha.get_log()
+        assert (
+            logs_after.count(ENS_LOG_STR) == ens_starts_before == 0
+        ), "ENS started while routing through a meshnet peer"
 
 
 @pytest.mark.parametrize(

--- a/src/device.rs
+++ b/src/device.rs
@@ -2196,11 +2196,15 @@ impl Runtime {
                 self.reconfigure_dns_peer(dns, &dns.get_default_dns_servers())
                     .await?;
             }
-        } else if exit_node.endpoint.is_none() {
-            return Err(Error::EndpointNotProvided);
-        }
-        if let Some(endpoint) = exit_node.endpoint {
-            let vpn_ip = endpoint.ip();
+        } else {
+            // ENS provides no real value, when routing through meshnet's peer
+            let vpn_ip = match exit_node.endpoint {
+                Some(ep) => ep.ip(),
+                None => {
+                    return Err(Error::EndpointNotProvided);
+                }
+            };
+
             let client_pk = self.get_private_key().await?;
             if let Some(ens) = self.entities.error_notification_service.as_mut() {
                 telio_log_info!("Starting ENS monitoring");


### PR DESCRIPTION
### Problem
ENS starts its monitoring, when app start routing either through VPN server or meshnet's peer. We are not interested in enabling ENS, when routing through the later.

### Solution
`ens.start_monitoring()` is called only when routing through VPN server.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
