### PR TITLE
LLT-7378: reduce pylint disable list in nat-lab (follow-up)

### DIFF
--- a/nat-lab/bin/core-api.py
+++ b/nat-lab/bin/core-api.py
@@ -45,9 +45,6 @@ MQTT_CREDENTIALS = {
     "password": "9-A'.:vUM3FPTCABorsK}J4mM}/3898_",
 }
 
-# Cache for service credentials to ensure consistency within a test run
-_SERVICE_CREDENTIALS_CACHE: dict[str, Any] = {}
-
 
 class CoreApiErrorCode(Enum):
     MACHINE_ALREADY_EXISTS = 101117
@@ -93,6 +90,7 @@ class CoreServer(HTTPServer):
     def __init__(self, server_address, RequestHandlerClass, mqttc: mqtt.Client) -> None:
         super().__init__(server_address, RequestHandlerClass)
         self._known_machines: Dict[str, Node] = {}
+        self._service_credentials: Dict[str, Any] = {}
         self._mqttc = mqttc
         self._id_counter = count(1)
 
@@ -145,6 +143,15 @@ class CoreServer(HTTPServer):
 
     def get_machines(self):
         return self._known_machines
+
+    def get_service_credentials(self):
+        return self._service_credentials
+
+    def set_service_credentials(self, credentials):
+        self._service_credentials = credentials
+
+    def clear_service_credentials(self):
+        self._service_credentials = {}
 
     def next_id(self):
         return next(self._id_counter)
@@ -502,10 +509,10 @@ class CoreApiHandler(BaseHTTPRequestHandler):
 
     @requires_basic_authentication
     def handle_service_credentials(self):
-        global _SERVICE_CREDENTIALS_CACHE
-        current_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-        if not _SERVICE_CREDENTIALS_CACHE:
-            _SERVICE_CREDENTIALS_CACHE = {
+        credentials = self.server.get_service_credentials()
+        if not credentials:
+            current_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+            credentials = {
                 "created_at": current_time,
                 "updated_at": current_time,
                 "username": "".join(
@@ -517,21 +524,21 @@ class CoreApiHandler(BaseHTTPRequestHandler):
                 "nordlynx_key": base64.b64encode(random.randbytes(32)).decode("utf-8"),
                 "id": random.randint(1, 10000),
             }
+            self.server.set_service_credentials(credentials)
 
         response = {
-            "id": _SERVICE_CREDENTIALS_CACHE["id"],
-            "created_at": _SERVICE_CREDENTIALS_CACHE["created_at"],
-            "updated_at": _SERVICE_CREDENTIALS_CACHE["updated_at"],
-            "username": _SERVICE_CREDENTIALS_CACHE["username"],
-            "password": _SERVICE_CREDENTIALS_CACHE["password"],
-            "nordlynx_private_key": _SERVICE_CREDENTIALS_CACHE["nordlynx_key"],
+            "id": credentials["id"],
+            "created_at": credentials["created_at"],
+            "updated_at": credentials["updated_at"],
+            "username": credentials["username"],
+            "password": credentials["password"],
+            "nordlynx_private_key": credentials["nordlynx_key"],
         }
         self._write_response(response, HTTPStatus.OK)
 
     @requires_basic_authentication
     def handle_reset_credentials(self):
-        global _SERVICE_CREDENTIALS_CACHE
-        _SERVICE_CREDENTIALS_CACHE = {}
+        self.server.clear_service_credentials()
         self._set_headers(status_code=HTTPStatus.OK)
         self.wfile.write(b"Credentials cache cleared")
 

--- a/nat-lab/pyproject.toml
+++ b/nat-lab/pyproject.toml
@@ -147,6 +147,10 @@ ignore-paths = ".venv,tests/protobuf,bin/grpc_protobuf,tests/uniffi/telio_bindin
 # egregious cases but at a threshold that doesn't force opaque options-object
 # wrapping of otherwise-readable keyword arguments.
 max-args = 10
+# Limits above current usage: catch egregious cases without forcing refactors.
+max-locals = 35
+max-statements = 90
+max-attributes = 21
 
 [tool.pylint.'MESSAGES CONTROL']
 recursive = true
@@ -155,19 +159,12 @@ disable = [
     "missing-module-docstring",
     "missing-class-docstring",
     "missing-function-docstring",
-    "line-too-long",
-    "too-many-locals",
-    "wrong-import-order",
-    "too-many-instance-attributes",
-    # `fixme` stays disabled on purpose: our TODO/FIXME comments track open Jira
-    # tickets (e.g. LLT-6693, LLT-6746) and intentional workarounds; flagging them
-    # would force deleting that tracking information rather than improving the code.
-    "fixme",
+    "line-too-long",          # owned by black
+    "wrong-import-order",     # owned by isort (no_sections)
     "too-many-public-methods",
     "too-few-public-methods",
-    "too-many-statements",
-    "global-statement",
     "duplicate-code",
+    "fixme",                  # intentional; tracks open tickets
     "too-many-lines"
 ]
 

--- a/nat-lab/tests/conftest.py
+++ b/nat-lab/tests/conftest.py
@@ -7,6 +7,7 @@ import Pyro5  # type: ignore
 import pytest
 import threading
 from contextlib import AsyncExitStack
+from dataclasses import dataclass, field
 from tests.conftest_helpers.log_collection import collect_logs, collect_kernel_logs
 from tests.conftest_helpers.pretest import (
     perform_pretest_cleanups,
@@ -53,13 +54,19 @@ SETUP_CHECK_ARP_CACHE_RETRIES = 1
 SETUP_CHECK_DUPLICATE_IP_TIMEOUT_S = 60
 SETUP_CHECK_DUPLICATE_IP_RETRIES = 1
 
-RUNNER: asyncio.Runner | None = None
-SESSION_SCOPE_EXIT_STACK: AsyncExitStack | None = None
 TASKS: List[asyncio.Task] = []
 END_TASKS: threading.Event = threading.Event()
-CURRENT_TEST_LOG_FILE = None
 
-SESSION_VM_MARKS: set[str] = set()
+
+@dataclass
+class _SessionState:
+    runner: asyncio.Runner | None = None
+    exit_stack: AsyncExitStack | None = None
+    current_test_log_file: logging.FileHandler | None = None
+    vm_marks: set[str] = field(default_factory=set)
+
+
+_SESSION = _SessionState()
 
 
 def _cancel_all_tasks(loop: asyncio.AbstractEventLoop):
@@ -158,12 +165,10 @@ def pytest_runtest_makereport(item, call):  # pylint: disable=unused-argument
 
 
 def pytest_runtestloop(session):
-    global SESSION_VM_MARKS
-
     if session.config.option.collectonly:
         return
 
-    SESSION_VM_MARKS = get_session_vm_marks(session.items)
+    _SESSION.vm_marks = get_session_vm_marks(session.items)
 
     if "NATLAB_SKIP_SETUP_CHECKS" not in os.environ:
         is_container_running: dict[ConnectionTag, bool] = asyncio.run(
@@ -171,7 +176,7 @@ def pytest_runtestloop(session):
         )
 
         if not asyncio.run(
-            perform_setup_checks(is_container_running, SESSION_VM_MARKS)
+            perform_setup_checks(is_container_running, _SESSION.vm_marks)
         ):
             pytest.exit("Setup checks failed, exiting ...")
 
@@ -179,11 +184,11 @@ def pytest_runtestloop(session):
         asyncio.run(
             collect_kernel_logs(
                 "before_tests",
-                SESSION_VM_MARKS,
+                _SESSION.vm_marks,
             )
         )
 
-    asyncio.run(copy_vm_binaries_if_needed(SESSION_VM_MARKS))
+    asyncio.run(copy_vm_binaries_if_needed(_SESSION.vm_marks))
 
 
 def pytest_runtest_setup():
@@ -200,7 +205,7 @@ def pytest_runtest_teardown(item, nextitem):  # pylint: disable=unused-argument
         len(LOG_COLLECTORS),
     )
 
-    assert RUNNER
+    assert _SESSION.runner
 
     async def collect_all_logs():
         async with AsyncExitStack() as stack:
@@ -220,17 +225,16 @@ def pytest_runtest_teardown(item, nextitem):  # pylint: disable=unused-argument
                     log_collector.tag,
                 )
 
-    RUNNER.run(collect_all_logs())
+    _SESSION.runner.run(collect_all_logs())
 
     LOG_COLLECTORS.clear()
-    global CURRENT_TEST_LOG_FILE
 
-    if CURRENT_TEST_LOG_FILE:
-        CURRENT_TEST_LOG_FILE.flush()
-        log.removeHandler(CURRENT_TEST_LOG_FILE)
-        CURRENT_TEST_LOG_FILE.close()
+    if _SESSION.current_test_log_file:
+        _SESSION.current_test_log_file.flush()
+        log.removeHandler(_SESSION.current_test_log_file)
+        _SESSION.current_test_log_file.close()
 
-    CURRENT_TEST_LOG_FILE = None
+    _SESSION.current_test_log_file = None
 
     log.info("Post-test log collection completed for %s", item.reportinfo()[2])
 
@@ -238,19 +242,18 @@ def pytest_runtest_teardown(item, nextitem):  # pylint: disable=unused-argument
 # Session-long AsyncExitStack is created at session start and closed at session finish.
 # pylint: disable=unused-argument
 def pytest_sessionstart(session):
-    global RUNNER, SESSION_SCOPE_EXIT_STACK
     setattr(Pyro5.config, "SERPENT_BYTES_REPR", True)
     if os.environ.get("NATLAB_SAVE_LOGS"):
-        RUNNER = asyncio.Runner()
-        SESSION_SCOPE_EXIT_STACK = AsyncExitStack()
-        if not RUNNER.run(check_gateway_connectivity(SESSION_SCOPE_EXIT_STACK)):
+        _SESSION.runner = asyncio.Runner()
+        _SESSION.exit_stack = AsyncExitStack()
+        if not _SESSION.runner.run(check_gateway_connectivity(_SESSION.exit_stack)):
             pytest.exit("Gateway nodes connectivity check failed, exiting ...")
-        RUNNER.run(
+        _SESSION.runner.run(
             start_tcpdump_processes(
-                SESSION_SCOPE_EXIT_STACK,
+                _SESSION.exit_stack,
             )
         )
-        RUNNER.run(start_windows_vms_resource_monitoring(TASKS, END_TASKS))
+        _SESSION.runner.run(start_windows_vms_resource_monitoring(TASKS, END_TASKS))
 
 
 # pylint: disable=unused-argument
@@ -260,14 +263,14 @@ def pytest_sessionfinish(session, exitstatus):
 
     END_TASKS.set()
 
-    if RUNNER is not None:
+    if _SESSION.runner is not None:
         try:
-            if SESSION_SCOPE_EXIT_STACK is not None:
-                RUNNER.run(SESSION_SCOPE_EXIT_STACK.aclose())
+            if _SESSION.exit_stack is not None:
+                _SESSION.runner.run(_SESSION.exit_stack.aclose())
         finally:
-            RUNNER.close()
+            _SESSION.runner.close()
 
-    asyncio.run(collect_logs(SESSION_VM_MARKS))
+    asyncio.run(collect_logs(_SESSION.vm_marks))
 
 
 @pytest.fixture(autouse=True)
@@ -285,8 +288,7 @@ def setup_logger(tmp_path, request):
         )
         log.addHandler(file_handler)
 
-        global CURRENT_TEST_LOG_FILE
-        CURRENT_TEST_LOG_FILE = file_handler
+        _SESSION.current_test_log_file = file_handler
     try:
         yield
     finally:


### PR DESCRIPTION
### Problem

`nat-lab/pyproject.toml` disables a batch of pylint rules left out of LLT-4091's scope. LLT-7378 asks to enable the ones worth enabling and document the rest.

### Solution

Enable `global-statement` (by removing the module globals it flagged, not suppressing them) and the complexity rules `too-many-locals` / `too-many-statements` / `too-many-instance-attributes` (via design thresholds). The remaining rules stay disabled — they conflict with black/isort or are test noise.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated — N/A (nat-lab tooling only)
- [x] Functionality is covered by unit or integration tests