### PR TITLE
Deny ignore: RUSTSEC-2026-0173

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -16,6 +16,7 @@ ignore = [
     "RUSTSEC-2025-0141", # bincode is unmaintained
     "RUSTSEC-2026-0162", # pqcrypto-traits is unmaintained
     "RUSTSEC-2026-0163", # pqcrypto-internals is unmaintained
+    "RUSTSEC-2026-0173", # proc-macro-error2 is unmaintained
 ]
 
 


### PR DESCRIPTION
## Problem

The `linters / deny` (cargo-deny) check is failing on `main` with a newly published advisory:

```
error[unmaintained]: proc-macro-error2 is unmaintained
    ├ ID: RUSTSEC-2026-0173
    └ Advisory: https://rustsec.org/advisories/RUSTSEC-2026-0173
advisories FAILED, bans ok, licenses ok, sources ok
```

`proc-macro-error2` is a fork of `proc-macro-error` (already ignored as `RUSTSEC-2024-0370`); both are now unmaintained. This advisory was published recently and is unrelated to any code change — it fails CI for every open PR.

## Solution

Add `RUSTSEC-2026-0173` to the `[advisories].ignore` list in `deny.toml`, matching the existing handling of the parent crate and the prior `RUSTSEC-2026-0162`/`0163` entries.

Verified locally with `cargo deny check advisories` → `advisories ok`.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean
- [x] README.md is updated (n/a)
- [x] Functionality is covered by unit or integration tests (n/a — CI config change)
