### PR TITLE
test(nat-lab): no burst after waking from sleep (LLT-4961)

### DIFF
--- a/nat-lab/tests/test_no_burst_after_sleep.py
+++ b/nat-lab/tests/test_no_burst_after_sleep.py
@@ -1,0 +1,287 @@
+"""Regression tests for LLT-4961 / LLT-4948 - libtelio must not replay the tokio
+interval ticks it missed while a device was asleep in a single burst.
+
+Two suspend mechanisms are exercised. tokio `Interval`/`Instant` run on
+CLOCK_MONOTONIC (QPC on Windows, mach_absolute_time on macOS), which - unlike
+CLOCK_BOOTTIME - does NOT count time the OS spent suspended (see telio-utils
+`instant.rs`, which keeps a separate boot_time clock exactly for that reason).
+Either the clock jumps forward on resume (tokio sees overdue ticks, which the
+Delay fix must not replay in a burst) or it freezes (no ticks missed, nothing to
+burst); both cases must be burst-free:
+
+* `test_no_burst_after_monotonic_jump` - the container/VM is frozen with the
+  cgroup freezer while the host keeps running, so CLOCK_MONOTONIC jumps forward
+  on resume and tokio sees many overdue ticks. This models process-freeze style
+  sleep (mobile background / Android Doze, VM pause / live-migration, CPU
+  starvation) and is the condition that actually triggered LLT-4947's burst, so
+  it is the real regression test for the Burst -> Delay fix. Runs on Linux,
+  Windows and macOS; the clock jump is verified, so it can never pass vacuously.
+
+* `test_no_burst_after_system_suspend` - the VM is genuinely suspended by
+  halting its vCPUs through the QEMU monitor (`stop`/`cont`, the same operation
+  as `virsh suspend`), then resumed. The clock behaviour is platform dependent
+  here - Windows QPC freezes (a genuine suspend-to-RAM, no missed ticks) while
+  macOS mach time jumps (missed ticks) - and neither may burst. VM-only (docker
+  containers have no hypervisor to suspend). ACPI S3 via the guest agent is not
+  usable in the dockur images, so the hypervisor-level suspend is used instead.
+"""
+
+import asyncio
+import pytest
+from tests.helpers import Environment, SetupParameters, ping_between_all_nodes
+from tests.utils.bindings import TelioAdapterType
+from tests.utils.connection import Connection, ConnectionTag
+from tests.utils.connection.docker_connection import (
+    backing_container_id,
+    paused_container,
+)
+from tests.utils.python import get_python_binary
+
+# Each tick of libtelio's 5s WireGuard-consolidation poll (src/device.rs) emits
+# this debug line. Before LLT-4948 the interval used the default tokio
+# `MissedTickBehavior::Burst`, so every tick missed while the device slept fired
+# immediately on wake, producing a burst of these lines (LLT-4947). With the
+# `Delay` fix only the single overdue tick fires and the 5s cadence resumes.
+CONSOLIDATION_LOG = "WG consolidation triggered by tick event"
+
+# The poll period is 5s, so a 60s freeze misses ~12 ticks. A regression would
+# replay all of them in a burst right after wake.
+SLEEP_DURATION_S = 60
+# Settle window after wake before counting. Kept below the 5s poll period so
+# that, with the fix, at most the single immediate tick lands in the window.
+SETTLE_AFTER_WAKE_S = 3
+# With the fix we expect ~1 consolidation right after wake; allow a small margin
+# for scheduling jitter. A burst would be far above this (~SLEEP/period ≈ 12).
+MAX_CONSOLIDATIONS_AFTER_WAKE = 4
+
+
+async def _read_guest_monotonic(connection: Connection) -> float:
+    """Read the guest's monotonic clock (seconds).
+
+    `time.monotonic()` maps to the same per-platform clock tokio's `Instant`
+    uses: CLOCK_MONOTONIC on Linux, QueryPerformanceCounter on Windows and
+    mach_absolute_time on macOS. All guests ship python3 (the libtelio test
+    proxy runs on it), so this works uniformly across docker and VM clients.
+    """
+    python = get_python_binary(connection)
+    process = connection.create_process(
+        [python, "-c", "import time;print(time.monotonic())"], quiet=True
+    )
+    await process.execute()
+    return float(process.get_stdout().strip())
+
+
+# --- VM suspend, driven through the dockur QEMU monitor ----------------------
+# A VM client runs its guest OS in QEMU inside the dockur container. The QEMU
+# monitor lives inside that container (telnet on localhost) and is reachable with
+# `docker exec`: `stop` suspends the VM (halts the vCPUs - the same operation as
+# `virsh suspend`) and `cont` resumes it. How the guest clock behaves across the
+# pause is platform dependent (Windows QPC freezes; macOS mach time jumps).
+# (ACPI S3 via the guest agent is not usable here: the dockur Windows guest
+# reports "suspend-to-ram not supported by OS" and the macOS guest agent has no
+# guest-suspend-ram command.)
+QEMU_MONITOR_PORT = "7100"
+# Real wall-clock time to stay suspended; only needs to clearly exceed the 5s
+# poll period.
+SUSPEND_DURATION_S = 30
+
+
+async def _container_exec(container: str, script: str) -> str:
+    proc = await asyncio.create_subprocess_exec(
+        "docker",
+        "exec",
+        container,
+        "sh",
+        "-c",
+        script,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+    )
+    out, _ = await proc.communicate()
+    return out.decode(errors="replace")
+
+
+async def _qemu_monitor(container: str, command: str) -> str:
+    """Send one HMP command to the QEMU monitor."""
+    return await _container_exec(
+        container,
+        f"printf '%s\\n' '{command}' | nc -w2 localhost {QEMU_MONITOR_PORT}",
+    )
+
+
+async def _wait_for_run_state(container: str, wanted: str, attempts: int = 30) -> bool:
+    """Poll the QEMU monitor until `info status` reports the wanted run state."""
+    for _ in range(attempts):
+        if wanted in (await _qemu_monitor(container, "info status")).lower():
+            return True
+        await asyncio.sleep(1)
+    return False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "alpha_setup_params, beta_setup_params",
+    [
+        pytest.param(
+            SetupParameters(connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1),
+            SetupParameters(connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2),
+        ),
+        pytest.param(
+            SetupParameters(
+                connection_tag=ConnectionTag.VM_WINDOWS_1,
+                adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
+            ),
+            SetupParameters(connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2),
+            marks=pytest.mark.windows,
+        ),
+        pytest.param(
+            SetupParameters(
+                connection_tag=ConnectionTag.VM_MAC,
+                adapter_type_override=TelioAdapterType.NEP_TUN,
+            ),
+            SetupParameters(connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2),
+            marks=pytest.mark.mac,
+        ),
+    ],
+)
+async def test_no_burst_after_monotonic_jump(
+    alpha_setup_params: SetupParameters,  # pylint: disable=unused-argument
+    beta_setup_params: SetupParameters,  # pylint: disable=unused-argument
+    env_mesh: Environment,
+) -> None:
+    """Regression test for LLT-4961 / LLT-4948.
+
+    Freezes a connected client with the cgroup freezer, wakes it, and asserts
+    libtelio does not replay the interval ticks missed while frozen in a single
+    burst. Runs on Linux, Windows and macOS clients.
+
+    This models process-freeze style sleep - mobile background / Android Doze, VM
+    pause / live-migration, CPU starvation: while the process (a VM's vCPUs) is
+    frozen the host keeps advancing CLOCK_MONOTONIC, so on resume the guest sees
+    ~SLEEP_DURATION_S/5s overdue ticks. That monotonic jump is exactly the
+    condition that triggered LLT-4947's burst. (A genuine VM suspend, where the
+    clock may instead freeze, is covered by test_no_burst_after_system_suspend.)
+    The test does not need to wait multiple days: even a handful of missed ticks
+    distinguishes `Burst` from the `Delay` fix. The jump is verified to actually
+    happen (below), so the no-burst check cannot pass vacuously.
+    """
+    client_alpha = env_mesh.clients[0]
+    connection_alpha = client_alpha.get_connection()
+    alpha_tag = connection_alpha.tag
+
+    # Make sure the mesh is up and the consolidation loop is running steadily.
+    await ping_between_all_nodes(env_mesh)
+
+    mono_before = await _read_guest_monotonic(connection_alpha)
+    consolidations_before = (await client_alpha.get_log()).count(CONSOLIDATION_LOG)
+
+    # Freeze the client: it does no work, but the monotonic clock keeps moving,
+    # so on unpause the poll interval has many overdue ticks.
+    async with paused_container(alpha_tag):
+        await asyncio.sleep(SLEEP_DURATION_S)
+
+    mono_after = await _read_guest_monotonic(connection_alpha)
+    slept = mono_after - mono_before
+
+    # Precondition: the freeze must look like a long sleep to the guest's
+    # monotonic clock, otherwise the no-burst check below would be vacuous.
+    assert slept >= SLEEP_DURATION_S * 0.5, (
+        f"guest monotonic clock advanced only {slept:.1f}s during a"
+        f" {SLEEP_DURATION_S}s freeze - the sleep was not simulated (the guest"
+        " clock did not jump), so the no-burst check would be meaningless."
+    )
+
+    # Give libtelio a moment to wake and process the (now overdue) timers.
+    await asyncio.sleep(SETTLE_AFTER_WAKE_S)
+
+    consolidations_after = (await client_alpha.get_log()).count(CONSOLIDATION_LOG)
+    burst = consolidations_after - consolidations_before
+    assert burst <= MAX_CONSOLIDATIONS_AFTER_WAKE, (
+        f"Detected a burst of {burst} WG consolidations within"
+        f" {SETTLE_AFTER_WAKE_S}s of waking from a {SLEEP_DURATION_S}s sleep"
+        f" (expected <= {MAX_CONSOLIDATIONS_AFTER_WAKE}); missed interval ticks"
+        " are being replayed in a burst - see LLT-4948."
+    )
+
+    # Sanity check: the consolidation loop must keep ticking after wake (i.e. we
+    # measured "no burst", not "interval died"). One more tick within ~2 periods.
+    await client_alpha.wait_for_log(CONSOLIDATION_LOG, count=consolidations_after + 1)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "alpha_setup_params, beta_setup_params",
+    [
+        pytest.param(
+            SetupParameters(
+                connection_tag=ConnectionTag.VM_WINDOWS_1,
+                adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
+            ),
+            SetupParameters(connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2),
+            marks=pytest.mark.windows,
+        ),
+        pytest.param(
+            SetupParameters(
+                connection_tag=ConnectionTag.VM_MAC,
+                adapter_type_override=TelioAdapterType.NEP_TUN,
+            ),
+            SetupParameters(connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_2),
+            marks=pytest.mark.mac,
+        ),
+    ],
+)
+async def test_no_burst_after_system_suspend(
+    alpha_setup_params: SetupParameters,  # pylint: disable=unused-argument
+    beta_setup_params: SetupParameters,  # pylint: disable=unused-argument
+    env_mesh: Environment,
+) -> None:
+    """VM-suspend counterpart of test_no_burst_after_monotonic_jump.
+
+    Genuinely suspends the guest by halting its vCPUs through the QEMU monitor
+    (`stop`, the same operation as `virsh suspend`) and resumes it (`cont`),
+    then asserts the mesh reconnects and there is no consolidation burst.
+
+    How the suspend looks to tokio's clock is platform dependent and both cases
+    must be burst-free: on Windows the guest QPC freezes across the pause (a
+    genuine suspend-to-RAM - no ticks are even missed), while on macOS mach time
+    jumps (missed ticks, which the Delay fix must not replay). The proof that the
+    VM was really suspended is the monitor's paused/running transition, so the
+    test does not depend on either clock behaviour.
+
+    VM-only: docker containers have no hypervisor to suspend. (ACPI S3 via the
+    guest agent is not usable in the dockur images - Windows reports
+    "suspend-to-ram not supported by OS" and the macOS guest agent has no
+    guest-suspend-ram command - so the hypervisor-level suspend is used instead.)
+    """
+    client_alpha = env_mesh.clients[0]
+    container = backing_container_id(client_alpha.get_connection().tag)
+
+    await ping_between_all_nodes(env_mesh)
+    consolidations_before = (await client_alpha.get_log()).count(CONSOLIDATION_LOG)
+
+    # Suspend the VM (halt vCPUs), hold it down, then resume. The paused/running
+    # transition reported by the monitor is the proof the VM really suspended.
+    await _qemu_monitor(container, "stop")
+    assert await _wait_for_run_state(
+        container, "paused"
+    ), f"{container} did not suspend (QEMU never reported 'paused')"
+    await asyncio.sleep(SUSPEND_DURATION_S)
+    await _qemu_monitor(container, "cont")
+    assert await _wait_for_run_state(
+        container, "running"
+    ), f"{container} did not resume after 'cont'"
+
+    # Let the guest settle and re-establish connectivity after the suspend.
+    await asyncio.sleep(SETTLE_AFTER_WAKE_S)
+    await ping_between_all_nodes(env_mesh)
+
+    # No burst either way: across this suspend the guest monotonic clock freezes
+    # on some platforms (e.g. Windows QPC - a real suspend, so no ticks are even
+    # missed) and jumps on others (e.g. macOS mach time - missed ticks, which the
+    # Delay fix must not replay in a burst).
+    consolidations_after = (await client_alpha.get_log()).count(CONSOLIDATION_LOG)
+    burst = consolidations_after - consolidations_before
+    assert burst <= MAX_CONSOLIDATIONS_AFTER_WAKE, (
+        f"Detected a burst of {burst} WG consolidations after a VM suspend"
+        f" (expected <= {MAX_CONSOLIDATIONS_AFTER_WAKE}) - see LLT-4948."
+    )

--- a/nat-lab/tests/utils/connection/docker_connection.py
+++ b/nat-lab/tests/utils/connection/docker_connection.py
@@ -242,3 +242,54 @@ def container_id(tag: ConnectionTag) -> str:
     if tag in DOCKER_SERVICE_IDS:
         return f"nat-lab-{DOCKER_SERVICE_IDS[tag]}-1"
     assert False, f"tag {tag} not a docker container"
+
+
+# VM clients run their guest OS inside a dockur QEMU container. The SSH-based VM
+# tag does not appear in DOCKER_SERVICE_IDS, so map it to the docker service that
+# hosts the guest, allowing the backing container to be controlled (e.g. paused).
+DOCKER_VM_SERVICE_IDS: Dict[ConnectionTag, str] = {
+    ConnectionTag.VM_WINDOWS_1: "windows-client-01",
+    ConnectionTag.VM_WINDOWS_2: "windows-client-02",
+    ConnectionTag.VM_MAC: "mac-client-01",
+}
+
+
+def backing_container_id(tag: ConnectionTag) -> str:
+    """Name of the docker container hosting the client for `tag`.
+
+    For docker tags this is the client container itself; for VM tags it is the
+    dockur QEMU container running the guest OS.
+    """
+    if tag in DOCKER_SERVICE_IDS:
+        return container_id(tag)
+    if tag in DOCKER_VM_SERVICE_IDS:
+        return f"nat-lab-{DOCKER_VM_SERVICE_IDS[tag]}-1"
+    assert False, f"tag {tag} has no backing docker container"
+
+
+@asynccontextmanager
+async def paused_container(tag: ConnectionTag) -> AsyncIterator[None]:
+    """Freeze the docker container hosting `tag` (cgroup freezer) for the scope.
+
+    While frozen the container's processes are suspended and do no work, but the
+    host keeps advancing CLOCK_MONOTONIC. This works for both docker clients and
+    VM clients: freezing the dockur QEMU container stops the guest vCPUs while
+    the host TSC keeps running, so on unpause the guest's monotonic clock (TSC /
+    QPC / mach_absolute_time - the same clock tokio's timers use) jumps forward
+    by the freeze duration. That is exactly how a long device sleep looks to
+    tokio, which makes the missed-tick (burst vs delay) behaviour reproducible
+    without actually waiting for the sleep duration.
+
+    Note: do not issue commands/RPC to the container while paused - they will
+    block until it is unpaused.
+    """
+    name = backing_container_id(tag)
+    async with Docker() as docker:
+        container = await docker.containers.get(name)
+        log.info("[%s] Pausing container %s", tag.name, name)
+        await container.pause()
+        try:
+            yield
+        finally:
+            await container.unpause()
+            log.info("[%s] Unpaused container %s", tag.name, name)


### PR DESCRIPTION
### Problem

[LLT-4961] There was no test guarding against libtelio bursting events/logs after a device wakes from sleep — the regression behind [LLT-4947] (excessive logs on wake), fixed in [LLT-4948] by switching the tokio interval missed-tick behaviour from `Burst` to `Delay`. Adding the test was deferred, and the ticket then sat blocked on "how to simulate a multi-day sleep instantly".

### Solution

Add `nat-lab/tests/test_no_burst_after_sleep.py` (parametrized for Linux, Windows and macOS) plus reusable `paused_container()` / `backing_container_id()` helpers in `docker_connection.py`.

Key insight that unblocked it: a multi-day sleep isn't needed. The `Burst`-vs-`Delay` difference is observable after missing just a handful of ticks of the 5s WireGuard-consolidation interval, and freezing a container advances `CLOCK_MONOTONIC` (the clock tokio's `Interval` uses) instantly while the process does no work.

Two complementary tests, both asserting the per-tick `WG consolidation triggered by tick event` log does **not** burst on wake:

- **`test_no_burst_after_monotonic_jump`** (Linux / Windows / macOS) — cgroup-freezes the client (`docker pause`), so `CLOCK_MONOTONIC` jumps forward and tokio sees the ticks missed while "asleep". Models process-freeze style sleep (mobile background / Android Doze, VM pause / live-migration, CPU starvation) — the real trigger of LLT-4947. Self-validating: reads the guest's `time.monotonic()` and asserts it actually jumped, so it cannot pass vacuously.
- **`test_no_burst_after_system_suspend`** (Windows / macOS VMs) — genuinely suspends the VM via the QEMU monitor (`stop`/`cont`, i.e. `virsh suspend`) and asserts the mesh reconnects with no burst. The guest clock freezes on Windows (true suspend-to-RAM, no missed ticks) and jumps on macOS (missed ticks); both must be burst-free. ACPI S3 via the guest agent is unsupported in the dockur images, so the hypervisor-level suspend is used.

No user-facing change → empty `.unreleased` entry.

Verified locally and in the nat-lab CI pipeline (green) on all three platforms.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
