### PR TITLE
feat(nat-lab): replace WinDump with pktmon for Windows packet capture

### DIFF
--- a/nat-lab/README.md
+++ b/nat-lab/README.md
@@ -369,7 +369,7 @@ export NATLAB_SAVE_LOGS=1
 ### Tcpdump internals (useful when customizing)
 
 - Binary and host file paths are defined in [python.build_tcpdump_command()](tests/utils/tcpdump.py) and PCAP_FILE_PATH map at [python.PCAP_FILE_PATH](tests/utils/tcpdump.py)
-- Windows tcpdump in-tests is temporarily disabled (see TODO in [python.make_tcpdump()](tests/utils/tcpdump.py))
+- Windows captures use the in-box `pktmon` tool (full packet size, all adapters present at capture start); the .etl log is converted to pcapng on the VM before download (see [python.PktmonCapture](tests/utils/tcpdump.py)). pktmon cannot exclude the SSH control channel at capture time, so it is stripped from the pcap on the test runner right after download (requires local `tcpdump`; the file is kept unfiltered if that fails). Note: adapters created after capture start (e.g. libtelio's wintun/wireguard adapter) are not captured — decrypted tunnel traffic is only visible in the counterpart node's pcap, while the encrypted side is captured on the physical NICs.
 
 ### Example: run a single test and keep all logs
 

--- a/nat-lab/tests/config.py
+++ b/nat-lab/tests/config.py
@@ -237,8 +237,6 @@ STUN_BINARY_PATH_MAC = "/var/root/stunserver/stunclient"
 IPERF_BINARY_MAC = "/var/root/iperf3/iperf3"
 IPERF_BINARY_WINDOWS = "C:/workspace/iperf3/iperf3.exe".replace("/", "\\")
 
-WINDUMP_BINARY_WINDOWS = "C:/workspace/WinDump.exe".replace("/", "\\")
-
 # Network Adapter device setup class registry path
 # https://learn.microsoft.com/en-us/windows-hardware/drivers/install/system-defined-device-setup-classes-available-to-vendors
 WINDOWS_NETWORK_ADAPTER_REGISTRY_KEY = r"HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Class\{4d36e972-e325-11ce-bfc1-08002be10318}"

--- a/nat-lab/tests/utils/tcpdump.py
+++ b/nat-lab/tests/utils/tcpdump.py
@@ -2,15 +2,14 @@ import asyncio
 import os
 import secrets
 import subprocess
-from asyncio import Event, wait_for, sleep
+from asyncio import Event, wait_for
 from contextlib import asynccontextmanager, AsyncExitStack
 from datetime import datetime
-from tests.config import WINDUMP_BINARY_WINDOWS
 from tests.utils.connection import TargetOS, Connection
 from tests.utils.connection_util import ConnectionTag
 from tests.utils.logger import log
 from tests.utils.output_notifier import OutputNotifier
-from tests.utils.process import Process
+from tests.utils.process import Process, ProcessExecError
 from tests.utils.testing import get_current_test_log_path
 from typing import AsyncIterator, Optional
 
@@ -19,10 +18,16 @@ PCAP_FILE_PATH = {
     TargetOS.Mac: "/var/root/dump.pcap",
     TargetOS.Windows: "C:\\workspace\\dump.pcap",
 }
+PKTMON_LOG_FILE_WINDOWS = "C:\\workspace\\pktmon.etl"
+# Circular-buffer cap, raised from the 512 MB default so long captures don't
+# rotate away their start (VM has ~56 GB free).
+PKTMON_MAX_LOG_SIZE_MB = 16 * 1024
 TCPDUMP_START_EVENT_TIMEOUT_S = 10
 
 
 class TcpDump:
+    """tcpdump-based packet capture for Linux and Mac; use PktmonCapture on Windows."""
+
     interfaces: Optional[list[str]]
     connection: Connection
     process: Process
@@ -43,6 +48,9 @@ class TcpDump:
         count: Optional[int] = None,
         session: bool = False,
     ) -> None:
+        assert (
+            connection.target_os != TargetOS.Windows
+        ), "tcpdump is not available on Windows, use PktmonCapture instead"
         self.connection = connection
         self.interfaces = interfaces
         self.output_file = output_file
@@ -120,9 +128,93 @@ class TcpDump:
                 delta,
             )
             yield self
-            # Windump takes so long to flush packets to stdout/file
-            if self.connection.target_os == TargetOS.Windows:
-                await sleep(5)
+
+
+class PktmonCapture:
+    """Packet capture for Windows VMs using the in-box `pktmon` tool.
+
+    Captures all adapters present at start with full payloads, one session
+    per machine, and converts the .etl to pcapng on the VM. Known gap:
+    adapters created later (libtelio's wireguard/wintun adapter) are not
+    captured, so decrypted tunnel traffic is missing from Windows pcaps -
+    it is visible in the counterpart node's pcap instead. `--comp all` and
+    `netsh trace` share this. SSH can't be filtered at capture time and is
+    stripped after download (see strip_ssh_from_pcap).
+    """
+
+    connection: Connection
+    output_file: str
+
+    def __init__(
+        self, connection: Connection, output_file: Optional[str] = None
+    ) -> None:
+        assert connection.target_os == TargetOS.Windows
+        self.connection = connection
+        self.output_file = output_file or PCAP_FILE_PATH[TargetOS.Windows]
+
+    async def _exec_quiet(self, command: list[str], ignore_failure: bool) -> None:
+        try:
+            await self.connection.create_process(command, quiet=True).execute()
+        except ProcessExecError as e:
+            if not ignore_failure:
+                raise
+            log.debug(
+                "[%s] '%s' failed (ignored): %s",
+                self.connection.tag,
+                " ".join(command),
+                e.stderr or e.stdout,
+            )
+
+    @asynccontextmanager
+    async def run(self) -> AsyncIterator["PktmonCapture"]:
+        start_time = datetime.now()
+        # one session per machine: clear any leftover from a crashed run
+        await self._exec_quiet(["pktmon", "stop"], ignore_failure=True)
+        await self._exec_quiet(["pktmon", "filter", "remove"], ignore_failure=True)
+        await self._exec_quiet(
+            [
+                "pktmon",
+                "start",
+                "--capture",
+                "--comp",
+                "nics",
+                "--pkt-size",
+                "0",
+                "--log-mode",
+                "circular",
+                "--file-size",
+                str(PKTMON_MAX_LOG_SIZE_MB),
+                "--file-name",
+                PKTMON_LOG_FILE_WINDOWS,
+            ],
+            ignore_failure=False,
+        )
+        log.info(
+            "[%s] pktmon capture ready in %s",
+            self.connection.tag,
+            datetime.now() - start_time,
+        )
+        try:
+            yield self
+        finally:
+            try:
+                await self._exec_quiet(["pktmon", "stop"], ignore_failure=False)
+                await self._exec_quiet(
+                    [
+                        "pktmon",
+                        "etl2pcap",
+                        PKTMON_LOG_FILE_WINDOWS,
+                        "--out",
+                        self.output_file,
+                    ],
+                    ignore_failure=False,
+                )
+            except ProcessExecError as e:
+                log.warning(
+                    "[%s] failed to stop/convert pktmon capture: %s",
+                    self.connection.tag,
+                    e.stderr or e.stdout,
+                )
 
 
 def build_tcpdump_command(
@@ -135,20 +227,16 @@ def build_tcpdump_command(
     include_ssh: bool = False,
     using_sudo: bool = False,
 ):
-    def get_tcpdump_binary(target_os: TargetOS) -> str:
-        if target_os in [TargetOS.Linux, TargetOS.Mac]:
-            return "tcpdump"
-
-        if target_os == TargetOS.Windows:
-            return WINDUMP_BINARY_WINDOWS
-
-        raise ValueError(f"target_os not supported {target_os}")
+    if target_os not in [TargetOS.Linux, TargetOS.Mac]:
+        raise ValueError(
+            f"tcpdump is not supported on {target_os}, use PktmonCapture on Windows"
+        )
 
     if using_sudo:
         command = ["sudo"]
     else:
         command = []
-    command += [get_tcpdump_binary(target_os), "-n"]
+    command += ["tcpdump", "-n"]
 
     if output_file:
         command += ["-w", output_file]
@@ -156,21 +244,9 @@ def build_tcpdump_command(
         command += ["-w", PCAP_FILE_PATH[target_os]]
 
     if interfaces:
-        if target_os != TargetOS.Windows:
-            command += ["-i", ",".join(interfaces)]
-        else:
-            # TODO(gytsto). Windump itself only supports one interface at the time,
-            # but it supports multiple instances of Windump without any issues,
-            # so there is a workaround we can do for multiple interfaces:
-            # - create multiple process of windump for each interface
-            # - when finished with dump, just combine the pcap's with `mergecap` or smth
-            log.warning("Currently tcpdump for windows support only 1 interface")
-            command += ["-i", interfaces[0]]
+        command += ["-i", ",".join(interfaces)]
     else:
-        if target_os != TargetOS.Windows:
-            command += ["-i", "any"]
-        else:
-            command += ["-i", "2"]
+        command += ["-i", "any"]
 
     if count:
         command += ["-c", str(count)]
@@ -179,16 +255,53 @@ def build_tcpdump_command(
         command += flags
 
     if not include_ssh:
-        if target_os != TargetOS.Windows:
-            command += ["--immediate-mode"]
-            command += ["port not 22"]
-        else:
-            command += ["not port 22"]
+        command += ["--immediate-mode"]
+        command += ["port not 22"]
 
     if expressions:
         command += expressions
 
     return command
+
+
+async def strip_ssh_from_pcap(pcap_path: str) -> None:
+    """Rewrite 'pcap_path' without port-22 SSH traffic, best-effort.
+
+    pktmon can't filter at capture time, so the harness's own SSH chatter
+    (often most of the pcap) is dropped here. Original is kept on failure.
+    """
+    if not os.path.isfile(pcap_path):
+        return
+    filtered_path = f"{pcap_path}.filtered"
+    try:
+        process = await asyncio.create_subprocess_exec(
+            "tcpdump",
+            "-r",
+            pcap_path,
+            "-w",
+            filtered_path,
+            "port not 22",
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        _, stderr = await process.communicate()
+        if process.returncode == 0:
+            os.replace(filtered_path, pcap_path)
+        else:
+            log.warning(
+                "Failed to strip SSH traffic from %s, keeping it unfiltered: %s",
+                pcap_path,
+                stderr.decode(errors="replace"),
+            )
+    except OSError as e:
+        log.warning(
+            "Failed to strip SSH traffic from %s, keeping it unfiltered: %s",
+            pcap_path,
+            e,
+        )
+    finally:
+        if os.path.isfile(filtered_path):
+            os.remove(filtered_path)
 
 
 def find_unique_path_for_tcpdump(log_dir, guest_name):
@@ -241,6 +354,34 @@ async def make_local_tcpdump():
             await process.wait()
 
 
+async def _start_capture(
+    exit_stack: AsyncExitStack, conn: Connection, session: bool
+) -> None:
+    for attempt in range(1, 4):
+        try:
+            if conn.target_os == TargetOS.Windows:
+                await exit_stack.enter_async_context(PktmonCapture(conn).run())
+            else:
+                await exit_stack.enter_async_context(
+                    TcpDump(conn, session=session).run()
+                )
+            return
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            log.warning(
+                "Failed to start packet capture on %s (attempt %d/3): %s",
+                conn.tag,
+                attempt,
+                e,
+            )
+            if attempt >= 3:
+                if conn.target_os == TargetOS.Windows:
+                    # best-effort on Windows: capture already had to be
+                    # disabled once for destabilizing the VMs (LLT-5942)
+                    log.error("Continuing without packet capture on %s", conn.tag)
+                else:
+                    raise e
+
+
 @asynccontextmanager
 async def make_tcpdump(
     connection_list: list[Connection],
@@ -251,24 +392,7 @@ async def make_tcpdump(
     try:
         async with AsyncExitStack() as exit_stack:
             for conn in connection_list:
-                # TODO(LLT-5942): temporary disable windows tcpdump
-                if conn.target_os == TargetOS.Windows:
-                    continue
-                for attempt in range(1, 4):
-                    try:
-                        await exit_stack.enter_async_context(
-                            TcpDump(conn, session=session).run()
-                        )
-                        break
-                    except Exception as e:  # pylint: disable=broad-exception-caught
-                        log.warning(
-                            "Failed to start tcpdump on %s (attempt %d/3): %s",
-                            conn.tag,
-                            attempt,
-                            e,
-                        )
-                        if attempt >= 3:
-                            raise e
+                await _start_capture(exit_stack, conn, session)
             yield
     finally:
         if download:
@@ -280,11 +404,19 @@ async def make_tcpdump(
                 )
                 await conn.download(PCAP_FILE_PATH[conn.target_os], path)
 
+                if conn.target_os == TargetOS.Windows:
+                    await strip_ssh_from_pcap(path)
+
                 if conn.target_os in [TargetOS.Linux, TargetOS.Mac]:
                     await conn.create_process(
                         ["rm", "-f", PCAP_FILE_PATH[conn.target_os]], quiet=True
                     ).execute()
                 else:
                     await conn.create_process(
-                        ["del", PCAP_FILE_PATH[conn.target_os]]
+                        [
+                            "del",
+                            PCAP_FILE_PATH[conn.target_os],
+                            PKTMON_LOG_FILE_WINDOWS,
+                        ],
+                        quiet=True,
                     ).execute()


### PR DESCRIPTION
### Problem
Packet capture on Windows VMs has been disabled since LLT-5942 — WinDump (WinPcap driver) was suspected of destabilizing the VMs and only ever captured one hardcoded adapter.

### Solution
Drop WinDump, capture with the in-box `pktmon` instead (`PktmonCapture`):

- all adapters present at start, full payloads, no third-party driver
- .etl converted to pcapng on the VM; download/cleanup unchanged
- SSH can't be excluded at capture time, so it's stripped post-download with local tcpdump
- 16 GB circular buffer; capture failures are non-fatal to the test run
- `TcpDump`/`build_tcpdump_command` are now Linux/Mac-only

**Known limitation:** pktmon enumerates adapters at start, so libtelio's wireguard adapter (created later) isn't captured — decrypted tunnel traffic shows up in the counterpart node's pcap instead. `--comp all` and `netsh trace` share this; fixing needs a session roll, left out of scope.

Verified live and via this PR's CI artifacts.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
