### PR TITLE
fix(nat-lab): retry event request loop on lost proxy connection (LLT-5223)

### DIFF
--- a/nat-lab/tests/telio.py
+++ b/nat-lab/tests/telio.py
@@ -1,5 +1,6 @@
 import asyncio
 import platform
+import Pyro5.errors  # type: ignore
 import re
 import time
 import uuid
@@ -1131,6 +1132,23 @@ class Client:
                         self._runtime.handle_event(event[1], event[0])
                         event = await self.get_proxy().next_event()
                 await asyncio.sleep(0.1)
+            except (ProxyConnectionError, Pyro5.errors.CommunicationError) as e:
+                # The remote can briefly become unreachable mid-test (e.g. the
+                # device/VM was suspended). next_event() runs in a worker thread
+                # that asyncio cannot cancel, so such a failure otherwise only
+                # surfaces when this task is awaited at teardown - failing the
+                # whole test's teardown (a race between this loop and the proxy
+                # shutdown, LLT-5223). Treat a lost connection as transient and
+                # keep retrying until the remote responds again or the task is
+                # cancelled.
+                if self._quit:
+                    return
+                log.debug(
+                    "[%s] event request loop: remote unreachable, retrying (%s)",
+                    self._node.name,
+                    e,
+                )
+                await asyncio.sleep(0.5)
             except:
                 if self._quit:
                     return


### PR DESCRIPTION
### Problem

nat-lab tests that suspend/freeze a client (the LLT-4961 no-burst tests) intermittently **ERROR at teardown**, and in the worst case cascade into every later test sharing the environment. Tonight's `natlab-tests 6/9` (job 32523213) shows `test_no_burst_after_monotonic_jump[VM_WINDOWS_1]` **pass its body, then ERROR at teardown**:

```
Pyro5.errors.CommunicationError: cannot connect to ('192.168.150.54', 35980): [Errno 113] No route to host
```

Traceback: `_exit_stack` → `stack.aclose()` → `Client.run` → `cancel_future(self._event_request_loop())` → `await self.get_proxy().next_event()` → Pyro reconnect → `CommunicationError`.

Root cause: `Client._event_request_loop` polls `next_event()` over Pyro inside `asyncio.to_thread` — a worker thread asyncio cannot cancel. When the remote briefly becomes unreachable mid-test (a device/VM suspended), the blocking call raises `CommunicationError`; `self._quit` is not set yet, so the loop re-raises, and racing the teardown cancellation it surfaces as a failure for the whole test's teardown. This is the event-loop vs proxy-shutdown race (LLT-5223), surfaced by the LLT-4961 suspend/freeze tests.

### Solution

Treat a lost proxy connection in `_event_request_loop` as transient: keep retrying `next_event()` until the remote responds again or the task is cancelled at shutdown (the existing `_quit` / `CancelledError` paths), instead of propagating the error and failing teardown.

No user-facing change (nat-lab test framework) → empty `.unreleased` entry.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
