### PR TITLE
Fix clippy warnings for release build

### DIFF
--- a/crates/telio-dns/src/forward.rs
+++ b/crates/telio-dns/src/forward.rs
@@ -230,9 +230,9 @@ impl Authority for ForwardAuthority {
                 telio_log_debug!("DNS name resolution failed (no records): {:?}", e);
             }
 
-            Err(ref e) => {
+            Err(ref _e) => {
                 #[cfg(debug_assertions)]
-                telio_log_debug!("DNS name resolution failed: {:?}", e);
+                telio_log_debug!("DNS name resolution failed: {:?}", _e);
 
                 #[cfg(not(debug_assertions))]
                 telio_log_warn!("DNS name resolution failed");

--- a/crates/telio-pinger/src/lib.rs
+++ b/crates/telio-pinger/src/lib.rs
@@ -169,11 +169,11 @@ impl Pinger {
         Ok((pinger, socket))
     }
 
+    #[cfg(debug_assertions)]
     fn prepare_payload(&self) -> [u8; MAX_PING_PAYLOAD_SIZE] {
         let mut payload = [0; MAX_PING_PAYLOAD_SIZE];
 
         // Trace the compomnent that sent the ping for debugging purposes
-        #[cfg(debug_assertions)]
         {
             let data = self.module_name.as_bytes();
             for (dest, &src) in payload.iter_mut().zip(data) {
@@ -182,6 +182,11 @@ impl Pinger {
         }
 
         payload
+    }
+
+    #[cfg(not(debug_assertions))]
+    fn prepare_payload(&self) -> [u8; MAX_PING_PAYLOAD_SIZE] {
+        [0; MAX_PING_PAYLOAD_SIZE]
     }
 
     /// Helper for iOS/tvOS.


### PR DESCRIPTION
### Problem
There are few `clippy` warnings for release build - `cargo clippy --release`

### Solution
Updated code to fix those warnings


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
