### PR TITLE
refactor(nordvpnlite): remove unnecessary async from setup_logging

### DIFF
--- a/clis/nordvpnlite/src/logging.rs
+++ b/clis/nordvpnlite/src/logging.rs
@@ -8,7 +8,7 @@ use tracing_appender::{
 
 use crate::NordVpnLiteError;
 
-pub async fn setup_logging<P: AsRef<Path>>(
+pub fn setup_logging<P: AsRef<Path>>(
     log_file_path: P,
     log_level: LevelFilter,
     log_file_count: usize,

--- a/clis/nordvpnlite/src/main.rs
+++ b/clis/nordvpnlite/src/main.rs
@@ -82,19 +82,15 @@ fn main() -> Result<(), NordVpnLiteError> {
             }
         }
 
+        let _tracing_worker_guard = logging::setup_logging(
+            &config.log_file_path,
+            config.log_level,
+            config.log_file_count,
+        )?;
+
         // Run the daemon event loop
         let rt = tokio::runtime::Runtime::new()?;
-        rt.block_on(async {
-            // Setup daemon logging
-            let _tracing_worker_guard = logging::setup_logging(
-                &config.log_file_path,
-                config.log_level,
-                config.log_file_count,
-            )
-            .await?;
-
-            Box::pin(daemon::daemon_event_loop(config)).await
-        })
+        rt.block_on(daemon::daemon_event_loop(config))
     } else {
         client_main(cmd)
     }


### PR DESCRIPTION
## Problem

`setup_logging` is defined as async function but in in fact it is synchronous function as it does not do any async operations.

## Solution
* Removed async keyword from `setup_logging`
* Moved `setup_logging` call before runtime `block_on()`
* Removed `Box::pin` wrapper from `daemon_event_loop` as the future returned from `daemon_event_loop` does not contain recursion, self-referential structure and pinning is not required by the API. There is no clear reason why this future should be pinned.



### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
