### PR TITLE
Ignore pre-existing ip rule when adding fwmark rule

### DIFF
--- a/nat-lab/tests/utils/router/linux_router.py
+++ b/nat-lab/tests/utils/router/linux_router.py
@@ -145,20 +145,25 @@ class LinuxRouter(Router):
                         raise exception
                     log.warning(exception.stderr)
 
-            await self._connection.create_process([
-                "ip",
-                "rule",
-                "add",
-                "priority",
-                ROUTING_PRIORITY,
-                "not",
-                "from",
-                "all",
-                "fwmark",
-                FWMARK_VALUE,
-                "lookup",
-                ROUTING_TABLE_ID,
-            ]).execute()
+            try:
+                await self._connection.create_process([
+                    "ip",
+                    "rule",
+                    "add",
+                    "priority",
+                    ROUTING_PRIORITY,
+                    "not",
+                    "from",
+                    "all",
+                    "fwmark",
+                    FWMARK_VALUE,
+                    "lookup",
+                    ROUTING_TABLE_ID,
+                ]).execute()
+            except ProcessExecError as exception:
+                if exception.stderr.find("File exists") < 0:
+                    raise exception
+                log.warning(exception.stderr)
 
         if self.ip_stack in [IPStack.IPv6, IPStack.IPv4v6]:
             for network in [
@@ -184,21 +189,26 @@ class LinuxRouter(Router):
                         raise exception
                     log.warning(exception.stderr)
 
-            await self._connection.create_process([
-                "ip",
-                "-6",
-                "rule",
-                "add",
-                "priority",
-                ROUTING_PRIORITY,
-                "not",
-                "from",
-                "all",
-                "fwmark",
-                FWMARK_VALUE,
-                "lookup",
-                ROUTING_TABLE_ID,
-            ]).execute()
+            try:
+                await self._connection.create_process([
+                    "ip",
+                    "-6",
+                    "rule",
+                    "add",
+                    "priority",
+                    ROUTING_PRIORITY,
+                    "not",
+                    "from",
+                    "all",
+                    "fwmark",
+                    FWMARK_VALUE,
+                    "lookup",
+                    ROUTING_TABLE_ID,
+                ]).execute()
+            except ProcessExecError as exception:
+                if exception.stderr.find("File exists") < 0:
+                    raise exception
+                log.warning(exception.stderr)
 
     async def delete_interface(self, name=None) -> None:
         try:


### PR DESCRIPTION
### Problem
Adding the fwmark routing rule fails when the rule already exists.

### Solution
Catch ProcessExecError and ignore the "File exists" case (logging a warning) for both the IPv4 and IPv6 rules, matching how existing routes are handled.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
