### PR TITLE
Add libfirewall pytest marker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ tcli.log
 *.nix
 *.prepared*
 *.dylib
+*.so
 /nat-lab/data/tcli*
 /3rd-party/ci-helper-scripts/
 /3rd-party/libmoose
@@ -18,7 +19,6 @@ tcli.log
 /nat-lab/3rd-party/iptables
 /nat-lab/3rd-party/netfilter-full-cone-nat
 /nat-lab/tests/uniffi/telio_bindings.py
-/nat-lab/tests/uniffi/libtelio.so
 /nat-lab/tests/uniffi/telio.dll
 /nat-lab/tests/uniffi/firewall.dll
 /nat-lab/tests/uniffi/libfirewall.so

--- a/nat-lab/README.md
+++ b/nat-lab/README.md
@@ -195,6 +195,13 @@ Markers are defined in [pyproject.toml](pyproject.toml). Useful ones:
 - moose         requires build with “moose”
 - ipv4 / ipv6 / ipv4v6
 - utils
+- libfirewall   requires `libfirewall.so` (see below)
+
+### libfirewall tests
+
+Tests marked `libfirewall` depend on `tests/uniffi/libfirewall.so` being present. Without it, the firewall is a no-op and these tests are automatically skipped at collection time.
+
+In CI, `libfirewall.so` is downloaded and placed at `nat-lab/tests/uniffi/libfirewall.so` before tests run. For local runs, obtain the `.so` from the internal artifact registry and place it at that path manually.
 
 ### To include a marker
 

--- a/nat-lab/pyproject.toml
+++ b/nat-lab/pyproject.toml
@@ -197,6 +197,7 @@ markers = [
     "openwrt: tests that require OpenWrt VM to be running",
     "openwrt_ui: tests that check the OpenWrt LuCI UI",
     "perf_profiling: tests that profile execution with perf",
+    "libfirewall: tests that require libfirewall.so to be present in nat-lab/tests/uniffi/",
 ]
 
 [tool.pyright]

--- a/nat-lab/tests/conftest.py
+++ b/nat-lab/tests/conftest.py
@@ -56,6 +56,8 @@ SETUP_CHECK_DUPLICATE_IP_RETRIES = 1
 
 TASKS: List[asyncio.Task] = []
 END_TASKS: threading.Event = threading.Event()
+CURRENT_TEST_LOG_FILE = None
+_LIBFIREWALL_SO = os.path.join(os.path.dirname(__file__), "uniffi", "libfirewall.so")
 
 
 @dataclass
@@ -151,10 +153,13 @@ def pytest_make_parametrize_id(config, val):
 
 
 def pytest_collection_modifyitems(items):
+    libfirewall_missing = not os.path.exists(_LIBFIREWALL_SO)
     for item in items:
         # Apply 5 minutes timeout to windows tests (due to constant lag)
         if item.get_closest_marker("windows"):
             item.add_marker(pytest.mark.timeout(300))
+        if libfirewall_missing and item.get_closest_marker("libfirewall"):
+            item.add_marker(pytest.mark.skip(reason="libfirewall.so not available"))
 
 
 @pytest.hookimpl(hookwrapper=True)

--- a/nat-lab/tests/test_mesh_firewall.py
+++ b/nat-lab/tests/test_mesh_firewall.py
@@ -86,6 +86,7 @@ def _setup_params(
     ],
 )
 @pytest.mark.asyncio
+@pytest.mark.libfirewall
 async def test_mesh_firewall_successful_passthrough(
     setup_mesh_nodes_factory: Callable[..., Awaitable[Environment]],
     alpha_ip_stack: IPStack,
@@ -180,6 +181,7 @@ async def test_mesh_firewall_successful_passthrough(
     ],
 )
 @pytest.mark.asyncio
+@pytest.mark.libfirewall
 async def test_mesh_firewall_reject_packet(
     setup_mesh_nodes_factory: Callable[..., Awaitable[Environment]],
     alpha_ip_stack: IPStack,
@@ -236,6 +238,7 @@ async def test_mesh_firewall_reject_packet(
 
 # This test uses 'stun' and our stun client does not IPv6
 @pytest.mark.asyncio
+@pytest.mark.libfirewall
 async def test_blocking_incoming_connections_from_exit_node(
     setup_mesh_nodes_factory: Callable[..., Awaitable[Environment]],
 ) -> None:
@@ -342,6 +345,7 @@ async def test_blocking_incoming_connections_from_exit_node(
 
 
 @pytest.mark.asyncio
+@pytest.mark.libfirewall
 @pytest.mark.parametrize(
     "alpha_ip_stack,beta_ip_stack",
     [
@@ -470,6 +474,7 @@ async def test_mesh_firewall_file_share_port(
 
 
 @pytest.mark.asyncio
+@pytest.mark.libfirewall
 @pytest.mark.parametrize(
     "alpha_ip_stack,beta_ip_stack",
     [
@@ -567,6 +572,7 @@ async def test_mesh_firewall_tcp_stuck_in_last_ack_state_conn_kill_from_server_s
 
 
 @pytest.mark.asyncio
+@pytest.mark.libfirewall
 @pytest.mark.parametrize(
     "alpha_ip_stack,beta_ip_stack",
     [

--- a/nat-lab/tests/test_tp_lite_stats.py
+++ b/nat-lab/tests/test_tp_lite_stats.py
@@ -136,6 +136,7 @@ class TestTpLiteStats:
         [pytest.param(_alpha_setup_params_with_firewall())],
     )
     @pytest.mark.asyncio
+    @pytest.mark.libfirewall
     async def test_tp_lite_stats_basic(
         self,
         alpha_setup_params: SetupParameters,  # pylint: disable=unused-argument
@@ -215,6 +216,7 @@ class TestTpLiteStats:
         [pytest.param(_alpha_setup_params_with_firewall())],
     )
     @pytest.mark.asyncio
+    @pytest.mark.libfirewall
     async def test_tp_lite_stats_re_enable_with_new_callback(
         self,
         alpha_setup_params: SetupParameters,  # pylint: disable=unused-argument
@@ -255,6 +257,7 @@ class TestTpLiteStats:
         [pytest.param(_alpha_setup_params_with_firewall())],
     )
     @pytest.mark.asyncio
+    @pytest.mark.libfirewall
     async def test_tp_lite_stats_empty_dns_server_ips_disables(
         self,
         alpha_setup_params: SetupParameters,  # pylint: disable=unused-argument
@@ -283,6 +286,7 @@ class TestTpLiteStats:
         [pytest.param(_alpha_setup_params_default())],
     )
     @pytest.mark.asyncio
+    @pytest.mark.libfirewall
     async def test_tp_lite_stats_requires_firewall_feature(
         self,
         alpha_setup_params: SetupParameters,  # pylint: disable=unused-argument

--- a/nat-lab/tests/test_vpn.py
+++ b/nat-lab/tests/test_vpn.py
@@ -371,6 +371,7 @@ class TestDualVpn:
                     await conntrack.wait_for_no_violations()
 
     @pytest.mark.asyncio
+    @pytest.mark.libfirewall
     @pytest.mark.parametrize(
         "alpha_setup_params",
         [
@@ -562,6 +563,7 @@ class TestSingleVpn2Node:
             await conntrack.wait_for_no_violations()
 
     @pytest.mark.asyncio
+    @pytest.mark.libfirewall
     @pytest.mark.parametrize(
         "alpha_setup_params, beta_setup_params",
         [


### PR DESCRIPTION
### Problem
Libtelio doesn't panic if the libfirewall binary is not found, and when that happens consequent calls are no-op, so nat-lab tests can either fail or pass depending on their design.

### Solution
This commit registers a "libfirewall" pytest marker that skips any test when the binary is missing


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
