### PR TITLE
Hardcode tunnel local IPv4 as a shared constant

### DIFF
--- a/clis/nordvpnlite/src/config.rs
+++ b/clis/nordvpnlite/src/config.rs
@@ -1,5 +1,7 @@
 use std::{
+    fs,
     io::Write,
+    net::IpAddr,
     net::Ipv4Addr,
     os::unix::fs::PermissionsExt,
     path::{Path, PathBuf},
@@ -8,16 +10,15 @@ use std::{
 };
 
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
-use std::fs;
 use tracing::{level_filters::LevelFilter, Level};
 
-use telio::{crypto::SecretKey, device::AdapterType, telio_utils::Hidden};
+use telio::{
+    crypto::{PublicKey, SecretKey},
+    device::AdapterType,
+    telio_utils::Hidden,
+};
 
 use crate::{interface::InterfaceConfig, NordVpnLiteError};
-use std::net::IpAddr;
-use telio::crypto::PublicKey;
-
-pub(crate) const LOCAL_IP: Ipv4Addr = Ipv4Addr::new(10, 5, 0, 2);
 
 // These IPs are documented but the documentation is not publicly available
 fn dns_default() -> Vec<IpAddr> {

--- a/clis/nordvpnlite/src/daemon.rs
+++ b/clis/nordvpnlite/src/daemon.rs
@@ -25,8 +25,11 @@ use telio::{
     crypto::SecretKey,
     device::{Device, DeviceConfig, Error as DeviceError},
     ffi::defaults_builder::FeaturesDefaultsBuilder,
-    telio_model::event::{ErrorLevel, Event},
-    telio_model::mesh::NodeState,
+    telio_model::{
+        constants::LOCAL_TUNNEL_IPV4,
+        event::{ErrorLevel, Event},
+        mesh::NodeState,
+    },
 };
 
 use crate::command_listener::{ClientCmd, ExitNodeConfig, TelioTaskCmd, TIMEOUT_SEC};
@@ -34,7 +37,7 @@ use crate::core_api::get_server_endpoints_list;
 use crate::{
     command_listener::CommandListener,
     comms::DaemonSocket,
-    config::{NordVpnLiteConfig, LOCAL_IP},
+    config::NordVpnLiteConfig,
     core_api::{request_nordlynx_key, Error as ApiError, DEFAULT_WIREGUARD_PORT},
     interface::ConfigureInterface,
 };
@@ -159,7 +162,7 @@ impl TelioContext {
         let mut interface_config_provider = config.interface.get_config_provider();
         interface_config_provider.initialize()?;
         interface_config_provider
-            .set_ip(&LOCAL_IP.into())
+            .set_ip(&LOCAL_TUNNEL_IPV4.into())
             .inspect_err(|e| error!("Failed to set interface IP with error '{e:?}'"))?;
 
         Ok(Self {

--- a/crates/telio-model/src/constants.rs
+++ b/crates/telio-model/src/constants.rs
@@ -9,6 +9,8 @@ pub const VPN_INTERNAL_IPV4: Ipv4Addr = Ipv4Addr::new(100, 64, 0, 1);
 pub const VPN_INTERNAL_IPV6: Ipv6Addr = Ipv6Addr::new(0xfd74, 0x656c, 0x696f, 0, 0, 0, 0, 1);
 /// VPN IPv4 Non-Meshnet Address
 pub const VPN_EXTERNAL_IPV4: Ipv4Addr = Ipv4Addr::new(10, 5, 0, 1);
+/// Local address for tunnel interface when VPN without meshnet is enabled
+pub const LOCAL_TUNNEL_IPV4: Ipv4Addr = Ipv4Addr::new(10, 5, 0, 2);
 /// Ipv4 multicast range
 pub const IPV4_MULTICAST_NETWORK: ConstIpv4Net = ConstIpv4Net::new(Ipv4Addr::new(224, 0, 0, 0), 4);
 /// Ipv6 multicast range

--- a/crates/telio-pq/src/proto.rs
+++ b/crates/telio-pq/src/proto.rs
@@ -20,12 +20,13 @@ use pnet_packet::{
 use pqcrypto_kyber::{ffi::PQCLEAN_KYBER768_CLEAN_CRYPTO_SECRETKEYBYTES, kyber768};
 use pqcrypto_traits::kem::{Ciphertext, PublicKey, SecretKey, SharedSecret};
 use rand::{rand_core::UnwrapErr, rngs::SysRng};
-use telio_utils::{telio_log_debug, telio_log_error, telio_log_warn, Hidden};
 use tokio::net::{ToSocketAddrs, UdpSocket};
+
+use telio_model::constants::LOCAL_TUNNEL_IPV4;
+use telio_utils::{telio_log_debug, telio_log_error, telio_log_warn, Hidden};
 
 const SERVICE_PORT: u16 = 6480;
 const LOCAL_PORT_RANGE: RangeInclusive<u16> = 49152..=u16::MAX; // dynamic port range
-const LOCAL_IP: Ipv4Addr = Ipv4Addr::new(10, 5, 0, 2);
 const REMOTE_IP: Ipv4Addr = Ipv4Addr::new(10, 5, 0, 1);
 const CIPHERTEXT_LEN: u32 = kyber768::ciphertext_bytes() as _;
 const REKEY_METHOD_ID: u32 = 1;
@@ -362,7 +363,7 @@ fn validate_get_response_ip(ip: &Ipv4Packet) -> Result<(), String> {
     if ip.get_source() != REMOTE_IP {
         return Err("invalid src IP".to_owned());
     }
-    if ip.get_destination() != LOCAL_IP {
+    if ip.get_destination() != LOCAL_TUNNEL_IPV4 {
         return Err("invalid dst IP".to_owned());
     }
     let next_level_protocol = ip.get_next_level_protocol();
@@ -751,7 +752,7 @@ fn fill_get_packet_headers(pkgbuf: &mut [u8], local_port: u16) {
     udppkg.set_length((pkg_len - IPV4_HEADER_LEN) as _);
     udppkg.set_checksum(udp::ipv4_checksum(
         &udppkg.to_immutable(),
-        &LOCAL_IP,
+        &LOCAL_TUNNEL_IPV4,
         &REMOTE_IP,
     ));
     drop(udppkg);
@@ -766,7 +767,7 @@ fn fill_get_packet_headers(pkgbuf: &mut [u8], local_port: u16) {
     ippkg.set_flags(Ipv4Flags::DontFragment);
     ippkg.set_ttl(0xFF);
     ippkg.set_next_level_protocol(IpNextHeaderProtocols::Udp);
-    ippkg.set_source(LOCAL_IP);
+    ippkg.set_source(LOCAL_TUNNEL_IPV4);
     ippkg.set_destination(REMOTE_IP);
     ippkg.set_checksum(ipv4::checksum(&ippkg.to_immutable()));
 }

--- a/src/device/wg_controller.rs
+++ b/src/device/wg_controller.rs
@@ -1,20 +1,26 @@
-use super::{Entities, RequestedState, Result};
+use std::{
+    collections::{BTreeMap, HashMap, HashSet},
+    iter::FromIterator,
+    net::{IpAddr, Ipv4Addr},
+    sync::Arc,
+    time::Duration,
+};
+
 use futures::FutureExt;
 use ipnet::IpNet;
-use std::collections::{BTreeMap, HashMap, HashSet};
-use std::iter::FromIterator;
-use std::net::{IpAddr, Ipv4Addr};
-use std::sync::Arc;
-use std::time::Duration;
+use thiserror::Error as TError;
+use tokio::sync::Mutex;
+
 use telio_crypto::PublicKey;
 use telio_dns::DnsResolver;
 #[cfg(feature = "enable_firewall")]
 use telio_firewall::firewall::{Firewall, FirewallState, Permissions, FILE_SEND_PORT};
-use telio_model::constants::{VPN_EXTERNAL_IPV4, VPN_INTERNAL_IPV4, VPN_INTERNAL_IPV6};
-use telio_model::features::Features;
-use telio_model::mesh::{LinkState, NodeState};
-use telio_model::EndpointMap;
-use telio_model::SocketAddr;
+use telio_model::{
+    constants::{VPN_EXTERNAL_IPV4, VPN_INTERNAL_IPV4, VPN_INTERNAL_IPV6},
+    features::Features,
+    mesh::{LinkState, NodeState},
+    EndpointMap, SocketAddr,
+};
 use telio_nurse::aggregator::ConnectivityDataAggregator;
 use telio_proto::{PeersStatesMap, Session};
 use telio_proxy::Proxy;
@@ -24,10 +30,12 @@ use telio_traversal::{
     SessionKeeperTrait, UpgradeSyncTrait, WireGuardEndpointCandidateChangeEvent,
 };
 use telio_utils::{build_ping_endpoint, telio_log_debug, telio_log_info, telio_log_warn, Instant};
-use telio_wg::uapi::{AnalyticsEvent, UpdateReason};
-use telio_wg::{uapi::Peer, WireGuard};
-use thiserror::Error as TError;
-use tokio::sync::Mutex;
+use telio_wg::{
+    uapi::{AnalyticsEvent, Peer, UpdateReason},
+    WireGuard,
+};
+
+use super::{Entities, RequestedState, Result};
 
 pub const DEFAULT_PEER_UPGRADE_WINDOW: u64 = 15;
 


### PR DESCRIPTION
### Problem
The tunnel local address 10.5.0.2 is duplicated as a private LOCAL_IP constant in both nordvpnlite and telio-pq.

### Solution
Define it once as LOCAL_TUNNEL_IPV4 and removes the duplicated definitions.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
