### PR TITLE
Allow disabling forcing plaintext DNS for TP-Lite

### DIFF
--- a/crates/telio-firewall/src/firewall.rs
+++ b/crates/telio-firewall/src/firewall.rs
@@ -366,11 +366,11 @@ impl StatefulFirewall {
             let mut cb = self.tp_lite_stats_cb.callback.write();
             std::mem::swap(&mut old_cb, &mut cb);
         }
-        if let Some(server_ips) = force_plaintext_dns_for_servers {
-            let mut state = self.get_state();
-            state.force_plaintext_dns_for_servers = Some(server_ips);
-            self.apply_state(state);
-        }
+
+        let mut state = self.get_state();
+        state.force_plaintext_dns_for_servers = force_plaintext_dns_for_servers;
+        self.apply_state(state);
+
         let res = unsafe {
             self.firewall_lib.libfw_enable_tp_lite_stats_collection(
                 self.firewall,

--- a/crates/telio-firewall/tests/firewall_integration_tests.rs
+++ b/crates/telio-firewall/tests/firewall_integration_tests.rs
@@ -1368,6 +1368,28 @@ mod tp_lite_stats {
         assert!(
             !fw.process_outbound_packet_sink(&make_peer(), &mut make_udp(SRC_ADDR, DOT_DNS_ADDR))
         );
+
+        // Re-enable TP-Lite stats collection with force_plaintext_dns = false
+        let config = TpLiteStatsOptions {
+            dns_server_ips: vec![IpAddr::from([10, 5, 0, 53])],
+            ..Default::default()
+        };
+        let callback = Callback {
+            stats: stats.clone(),
+        };
+        fw.enable_tp_lite_stats_collection(config, Box::new(callback))
+            .unwrap();
+
+        // After enabling with force_plaintext_dns = false:
+        //
+        // Packet 1: different IP, non-53 port — still accepted (only the configured DNS IP is restricted)
+        assert!(fw.process_outbound_packet_sink(&make_peer(), &mut make_udp(SRC_ADDR, OTHER_ADDR)));
+        // Packet 2: configured DNS IP, port 53 — accepted (standard DNS is allowed)
+        assert!(fw.process_outbound_packet_sink(&make_peer(), &mut make_udp(SRC_ADDR, PT_DNS_ADDR)));
+        // Packet 3: configured DNS IP, non-53 port (DoT port 853) should be allowed again
+        assert!(
+            fw.process_outbound_packet_sink(&make_peer(), &mut make_udp(SRC_ADDR, DOT_DNS_ADDR))
+        );
     }
 }
 


### PR DESCRIPTION
### Problem
When enabling force plaintext DNS for TP-Lite stats, the firewall rule would only be set if there was a set of servers provided to force plaintext for. What that means is that if you first enable stats collection with force plaintext enabled and then enable collection again with force plaintext disabled, without disabling stats collection in between, plaintext will still be forced for the initial set of servers.

### Solution
Update firewall if either there is a new set of servers provided, or if there previously a set of servers


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
