### PR TITLE
LLT-6736: Add command 'reload' and support SIGHUP

### DIFF
--- a/clis/nordvpnlite/README.md
+++ b/clis/nordvpnlite/README.md
@@ -88,6 +88,7 @@ And following cli commands:
 * `nordvpnlite status` - returns the status of nordvpnlite and the VPN connection
 * `nordvpnlite is-alive` - query if the daemon is running
 * `nordvpnlite stop` - stop daemon execution
+* `nordvpnlite reload` - reload the configuration file and restart the daemon
 * `nordvpnlite countries` - list countries with available VPN servers
 
 ## OpenWRT

--- a/clis/nordvpnlite/openwrt/feed/net/nordvpnlite/files/nordvpnlite.init
+++ b/clis/nordvpnlite/openwrt/feed/net/nordvpnlite/files/nordvpnlite.init
@@ -22,7 +22,6 @@ stop_service() {
 }
 
 reload_service() {
-  stop
-  sleep 1
-  start
+  echo "Reloading nordvpnlite configuration"
+  /usr/sbin/nordvpnlite reload
 }

--- a/clis/nordvpnlite/src/command_listener.rs
+++ b/clis/nordvpnlite/src/command_listener.rs
@@ -4,11 +4,11 @@ use clap::Parser;
 use serde::{Deserialize, Serialize};
 use telio_core::telio_task::io::chan;
 use tokio::sync::oneshot;
-use tracing::{error, trace};
+use tracing::{error, info, trace};
 
 use crate::{
     comms::{DaemonConnection, DaemonSocket},
-    config::Endpoint,
+    config::{Endpoint, RunningConfig},
     daemon::{NordVpnLiteError, TelioStatusReport},
 };
 
@@ -24,6 +24,8 @@ pub enum ClientCmd {
     IsAlive,
     #[clap(name = "stop", about = "Stop daemon execution")]
     QuitDaemon,
+    #[clap(name = "reload", about = "Reload config file and restart the daemon")]
+    Reload,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -126,14 +128,27 @@ pub struct CommandListener {
     socket: DaemonSocket,
     /// Channel to send commands to telio task
     telio_task_tx: chan::Tx<TelioTaskCmd>,
+    config: RunningConfig,
+    /// Holds the new running config from a client triggered reload
+    pending_config: Option<RunningConfig>,
 }
 
 impl CommandListener {
-    pub fn new(socket: DaemonSocket, telio_task_tx: chan::Tx<TelioTaskCmd>) -> CommandListener {
+    pub fn new(
+        socket: DaemonSocket,
+        telio_task_tx: chan::Tx<TelioTaskCmd>,
+        config: RunningConfig,
+    ) -> CommandListener {
         CommandListener {
             socket,
             telio_task_tx,
+            config,
+            pending_config: None,
         }
+    }
+
+    pub fn take_pending_config(&mut self) -> Option<RunningConfig> {
+        self.pending_config.take()
     }
 
     // Main command handling communicating with telio task
@@ -175,6 +190,33 @@ impl CommandListener {
                 // cleanup
                 handle_response(response_rx, |_| Ok(CommandResponse::Ok)).await
             }
+            ClientCmd::Reload => {
+                match RunningConfig::from_file(&self.config.path) {
+                    Err(e) => {
+                        error!("Config file changed but failed to parse: {e}");
+                        Ok(CommandResponse::Err(e.to_string()))
+                    }
+                    Ok(new_config) if new_config.hash == self.config.hash => {
+                        info!("Config file unchanged, ignoring reload request");
+                        Ok(CommandResponse::Ok)
+                    }
+                    Ok(new_config) => {
+                        trace!("Config file changed, proceeding with reload");
+                        self.pending_config = Some(new_config);
+                        let (response_tx, response_rx) = oneshot::channel();
+                        #[allow(mpsc_blocking_send)]
+                        self.telio_task_tx
+                            .send(TelioTaskCmd::Quit(response_tx))
+                            .await
+                            .map_err(|e| {
+                                error!("Error sending command: {}", e);
+                                NordVpnLiteError::CommandFailed(ClientCmd::Reload)
+                            })?;
+                        // Wait for teardown to complete before responding to the client
+                        handle_response(response_rx, |_| Ok(CommandResponse::Ok)).await
+                    }
+                }
+            }
             ClientCmd::IsAlive => Ok(CommandResponse::Ok),
         }
     }
@@ -211,7 +253,9 @@ impl CommandListener {
                     match &command {
                         ClientCmd::QuitDaemon => CommandResponse::Ok,
                         ClientCmd::IsAlive => CommandResponse::Ok,
-                        ClientCmd::GetStatus => CommandResponse::DaemonInitializing,
+                        ClientCmd::GetStatus | ClientCmd::Reload => {
+                            CommandResponse::DaemonInitializing
+                        }
                     }
                 };
                 connection.respond(response.serialize()).await?;
@@ -236,6 +280,7 @@ mod tests {
     use crate::{CommandResponse, DaemonSocket};
     use assert_matches::assert_matches;
     use std::path::Path;
+    use temp_file::TempFile;
     use tokio::{
         io::{AsyncReadExt, AsyncWriteExt},
         net::UnixStream,
@@ -245,13 +290,34 @@ mod tests {
 
     const TEST_SOCKET_PATH: &str = "test_socket";
 
+    // A minimal valid NordVpnLiteConfig JSON used across reload tests.
+    const VALID_CONFIG_JSON: &str = r#"{
+        "log_level": "Info",
+        "log_file_path": "test.log",
+        "adapter_type": "linux-native",
+        "interface": { "name": "utun10", "config_provider": "manual" },
+        "authentication_token": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+    }"#;
+
     // Create a random socket path for the test, since tests run in parallel they can deadlock
     fn make_socket_path() -> String {
         format!("{}_{}", TEST_SOCKET_PATH, rand::random::<u16>())
     }
 
-    // Helper to create a fake command listener
-    fn make_command_listener(path: &str) -> CommandListener {
+    // Write VALID_CONFIG_JSON to a temp file and load it as a RunningConfig.
+    // Returns both so the TempFile stays alive (and thus the file exists) for the duration of the test.
+    fn make_running_config() -> (RunningConfig, TempFile) {
+        let file = TempFile::new()
+            .unwrap()
+            .with_contents(VALID_CONFIG_JSON.as_bytes())
+            .unwrap();
+        let config = RunningConfig::from_file(file.path()).unwrap();
+        (config, file)
+    }
+
+    // Helper to create a fake command listener.
+    // Returns the listener and the TempFile backing its RunningConfig so the file stays alive.
+    fn make_command_listener(path: &str) -> (CommandListener, TempFile) {
         let (tx, mut task_rx) = mpsc::channel(1);
 
         // spawn a fake telio task
@@ -270,7 +336,34 @@ mod tests {
 
         let socket = DaemonSocket::new(Path::new(path)).unwrap();
 
-        CommandListener::new(socket, tx)
+        let (config, config_file) = make_running_config();
+        (CommandListener::new(socket, tx, config), config_file)
+    }
+
+    fn make_reload_listener(
+        path: &str,
+    ) -> (CommandListener, mpsc::Receiver<TelioTaskCmd>, TempFile) {
+        let (tx, task_rx) = mpsc::channel(1);
+        let socket = DaemonSocket::new(Path::new(path)).unwrap();
+        let (config, config_file) = make_running_config();
+        (
+            CommandListener::new(socket, tx, config),
+            task_rx,
+            config_file,
+        )
+    }
+
+    fn spawn_quit_responder(
+        mut task_rx: mpsc::Receiver<TelioTaskCmd>,
+    ) -> tokio::task::JoinHandle<bool> {
+        tokio::spawn(async move {
+            if let Some(TelioTaskCmd::Quit(tx)) = task_rx.recv().await {
+                tx.send(()).unwrap();
+                true
+            } else {
+                false
+            }
+        })
     }
 
     // Simulate client sending command and waiting for response
@@ -305,7 +398,7 @@ mod tests {
         Result<ClientCmd, NordVpnLiteError>,
     ) {
         let path = make_socket_path();
-        let mut listener = make_command_listener(&path);
+        let (mut listener, _config_file) = make_command_listener(&path);
 
         let command = serde_json::to_string(&command).unwrap();
         let daemon = tokio::spawn(async move {
@@ -364,7 +457,7 @@ mod tests {
     #[tokio::test]
     async fn test_command_invalid() {
         let path = make_socket_path();
-        let mut listener = make_command_listener(&path);
+        let (mut listener, _config_file) = make_command_listener(&path);
 
         let command = "garbage";
         let daemon = tokio::spawn(async move {
@@ -381,7 +474,7 @@ mod tests {
     #[tokio::test]
     async fn test_command_invalid_broken() {
         let path = make_socket_path();
-        let mut listener = make_command_listener(&path);
+        let (mut listener, _config_file) = make_command_listener(&path);
 
         let command = "garbage";
         let daemon = tokio::spawn(async move {
@@ -423,5 +516,95 @@ mod tests {
 
         assert_eq!(cmd.unwrap(), ClientCmd::GetStatus);
         assert_eq!(response.unwrap(), CommandResponse::DaemonInitializing);
+    }
+
+    #[tokio::test]
+    async fn test_command_reload() {
+        let (response, cmd) = test_command_helper(ClientCmd::Reload, true, false).await;
+
+        assert_eq!(response.unwrap(), CommandResponse::Ok);
+        assert_eq!(cmd.unwrap(), ClientCmd::Reload);
+    }
+
+    #[tokio::test]
+    async fn test_command_early_reload() {
+        let (response, cmd) = test_command_helper(ClientCmd::Reload, false, false).await;
+
+        assert_eq!(cmd.unwrap(), ClientCmd::Reload);
+        assert_eq!(response.unwrap(), CommandResponse::DaemonInitializing);
+    }
+
+    #[tokio::test]
+    async fn test_command_reload_unchanged() {
+        use tokio::time::{timeout, Duration};
+
+        let path = make_socket_path();
+        let (mut listener, task_rx, _config_file) = make_reload_listener(&path);
+
+        let command = serde_json::to_string(&ClientCmd::Reload).unwrap();
+        let daemon = tokio::spawn(async move {
+            let connection = listener.accept_client_connection().await.unwrap();
+            listener.handle_client_command(true, connection).await
+        });
+
+        let responder = spawn_quit_responder(task_rx);
+
+        let response = timeout(Duration::from_secs(3), client_send_command(&path, &command))
+            .await
+            .expect("test timed out waiting for client response");
+        let cmd = timeout(Duration::from_secs(3), daemon)
+            .await
+            .expect("test timed out — daemon task hung")
+            .unwrap();
+        let quit_was_incorrectly_sent = responder.await.unwrap();
+
+        assert_eq!(response.unwrap(), CommandResponse::Ok);
+        assert_eq!(cmd.unwrap(), ClientCmd::Reload);
+        assert!(
+            !quit_was_incorrectly_sent,
+            "TelioTaskCmd::Quit must not be sent when config is unchanged"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_command_reload_changed() {
+        use tokio::time::{timeout, Duration};
+
+        let socket_path = make_socket_path();
+        let (mut listener, task_rx, config_file) = make_reload_listener(&socket_path);
+
+        let alt_config = VALID_CONFIG_JSON.replace("utun10", "utun11");
+        std::fs::write(config_file.path(), alt_config.as_bytes()).unwrap();
+
+        let command = serde_json::to_string(&ClientCmd::Reload).unwrap();
+        let daemon = tokio::spawn(async move {
+            let connection = listener.accept_client_connection().await.unwrap();
+            let result = listener.handle_client_command(true, connection).await;
+            let has_pending = listener.take_pending_config().is_some();
+            (result, has_pending)
+        });
+
+        let responder = spawn_quit_responder(task_rx);
+
+        let response = client_send_command(&socket_path, &command).await;
+        let (cmd, had_pending) = timeout(Duration::from_secs(3), daemon)
+            .await
+            .expect("test timed out — daemon task hung")
+            .unwrap();
+        let quit_was_sent = timeout(Duration::from_secs(3), responder)
+            .await
+            .expect("test timed out — responder task hung")
+            .unwrap();
+
+        assert_eq!(response.unwrap(), CommandResponse::Ok);
+        assert_eq!(cmd.unwrap(), ClientCmd::Reload);
+        assert!(
+            quit_was_sent,
+            "TelioTaskCmd::Quit must be sent when config has changed"
+        );
+        assert!(
+            had_pending,
+            "pending_config must be set after a successful reload"
+        );
     }
 }

--- a/clis/nordvpnlite/src/config.rs
+++ b/clis/nordvpnlite/src/config.rs
@@ -1,6 +1,6 @@
 use std::{
     fs,
-    io::Write,
+    io::{BufReader, Write},
     net::IpAddr,
     net::Ipv4Addr,
     os::unix::fs::PermissionsExt,
@@ -19,6 +19,47 @@ use telio_core::{
 };
 
 use crate::{interface::InterfaceConfig, NordVpnLiteError};
+
+#[derive(Clone, Debug)]
+pub struct RunningConfig {
+    pub parsed: NordVpnLiteConfig,
+    pub path: PathBuf,
+    pub hash: u64,
+}
+
+impl RunningConfig {
+    pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Self, NordVpnLiteError> {
+        let path = path.as_ref().to_path_buf();
+        let parsed = NordVpnLiteConfig::from_file(&path)?;
+        let path = path.canonicalize()?;
+        let hash = Self::hash_file(&path).unwrap_or(0);
+        Ok(Self { parsed, path, hash })
+    }
+
+    fn hash_file(path: &Path) -> Result<u64, std::io::Error> {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+        use std::io::BufRead;
+
+        const CHUNK_SIZE: usize = 8 * 1024; // 8 KiB
+
+        let file = fs::File::open(path)?;
+        let mut reader = BufReader::with_capacity(CHUNK_SIZE, file);
+        let mut hasher = DefaultHasher::new();
+
+        loop {
+            let chunk = reader.fill_buf()?;
+            if chunk.is_empty() {
+                break;
+            }
+            chunk.hash(&mut hasher);
+            let len = chunk.len();
+            reader.consume(len);
+        }
+
+        Ok(hasher.finish())
+    }
+}
 
 // These IPs are documented but the documentation is not publicly available
 fn dns_default() -> Vec<IpAddr> {
@@ -710,13 +751,16 @@ mod tests {
     }
 
     #[test]
-    fn test_invalid_log_path_error() {
+    fn test_invalid_log_path_returns_error() {
         let config_json = config_json_for_log("");
 
         let file = temp_config(&config_json);
         let err = NordVpnLiteConfig::from_file(file.path().to_str().unwrap()).unwrap_err();
 
-        matches!(err, NordVpnLiteError::InvalidConfigOption { .. });
+        assert!(
+            matches!(err, NordVpnLiteError::InvalidConfigOption { ref key, .. } if key == "log_file_path"),
+            "expected InvalidConfigOption for log_file_path, got: {err:?}"
+        );
     }
 
     #[test]
@@ -750,5 +794,115 @@ mod tests {
         );
 
         std::env::remove_var("NORD_TOKEN");
+    }
+
+    #[test]
+    fn running_config_valid_file_loads_parsed_config() {
+        let log_path = std::env::current_dir().unwrap().join("test.log");
+        let json = format!(
+            r#"{{
+                "log_level": "Info",
+                "log_file_path": "{}",
+                "adapter_type": "linux-native",
+                "interface": {{ "name": "utun10", "config_provider": "manual" }},
+                "authentication_token": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+            }}"#,
+            log_path.display()
+        );
+        let file = temp_config(&json);
+
+        let rc = RunningConfig::from_file(file.path()).unwrap();
+
+        assert_eq!(rc.parsed.adapter_type, AdapterType::LinuxNativeWg);
+        assert_eq!(rc.parsed.interface.name, "utun10");
+    }
+
+    #[test]
+    fn running_config_valid_file_canonicalizes_path() {
+        let json = config_json_for_log("test.log");
+        let file = temp_config(&json);
+
+        let rc = RunningConfig::from_file(file.path()).unwrap();
+
+        assert!(
+            rc.path.is_absolute(),
+            "path should be absolute after canonicalization"
+        );
+        assert_eq!(rc.path, file.path().canonicalize().unwrap());
+    }
+
+    #[test]
+    fn running_config_valid_file_produces_nonzero_hash() {
+        let json = config_json_for_log("test.log");
+        let file = temp_config(&json);
+
+        let rc = RunningConfig::from_file(file.path()).unwrap();
+
+        assert_ne!(rc.hash, 0, "hash should be non-zero for a non-empty file");
+    }
+
+    #[test]
+    fn running_config_same_content_produces_same_hash() {
+        let json = config_json_for_log("test.log");
+
+        let file_a = temp_config(&json);
+        let file_b = temp_config(&json);
+
+        let rc_a = RunningConfig::from_file(file_a.path()).unwrap();
+        let rc_b = RunningConfig::from_file(file_b.path()).unwrap();
+
+        assert_eq!(
+            rc_a.hash, rc_b.hash,
+            "identical file contents must produce the same hash"
+        );
+    }
+
+    #[test]
+    fn running_config_different_content_produces_different_hash() {
+        let json_a = config_json_for_log("a.log");
+        let json_b: String = config_json_for_log("b.log");
+
+        let file_a = temp_config(&json_a);
+        let file_b = temp_config(&json_b);
+
+        let rc_a = RunningConfig::from_file(file_a.path()).unwrap();
+        let rc_b = RunningConfig::from_file(file_b.path()).unwrap();
+
+        assert_ne!(
+            rc_a.hash, rc_b.hash,
+            "different file contents should produce different hashes"
+        );
+    }
+
+    #[test]
+    fn running_config_invalid_json_returns_error() {
+        let file = temp_config("this is not json {{ }}");
+
+        let err = RunningConfig::from_file(file.path())
+            .expect_err("RunningConfig::from_file should fail on malformed JSON");
+
+        assert!(
+            matches!(err, NordVpnLiteError::ParsingError(_)),
+            "expected ParsingError for invalid JSON, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn running_config_file_not_found_creates_default_and_returns_token_error() {
+        let dir = temp_dir::TempDir::new().expect("failed to create temp dir");
+        let nonexistent = dir.path().join("does_not_exist.json");
+
+        let err = RunningConfig::from_file(&nonexistent)
+            .expect_err("RunningConfig::from_file should fail when config file is missing");
+
+        assert!(
+            matches!(err, NordVpnLiteError::InvalidConfigToken { .. }),
+            "expected InvalidConfigToken when config file is absent, got: {err:?}"
+        );
+
+        assert!(
+            nonexistent.exists(),
+            "default config file should have been created"
+        );
     }
 }

--- a/clis/nordvpnlite/src/config.rs
+++ b/clis/nordvpnlite/src/config.rs
@@ -275,6 +275,12 @@ impl NordVpnLiteConfig {
         Ok(final_path.to_string_lossy().to_string())
     }
 
+    pub fn logging_params_changed(&self, other: &Self) -> bool {
+        self.log_file_path != other.log_file_path
+            || self.log_level != other.log_level
+            || self.log_file_count != other.log_file_count
+    }
+
     /// Checks if NORD_TOKEN env var is set and contains a valid token.
     pub fn resolve_env_token(&mut self) -> bool {
         if let Ok(token) = std::env::var("NORD_TOKEN") {

--- a/clis/nordvpnlite/src/daemon.rs
+++ b/clis/nordvpnlite/src/daemon.rs
@@ -37,7 +37,7 @@ use crate::core_api::get_server_endpoints_list;
 use crate::{
     command_listener::CommandListener,
     comms::DaemonSocket,
-    config::NordVpnLiteConfig,
+    config::{NordVpnLiteConfig, RunningConfig},
     core_api::{request_nordlynx_key, Error as ApiError, DEFAULT_WIREGUARD_PORT},
     interface::ConfigureInterface,
 };
@@ -354,8 +354,8 @@ async fn handle_exit_node_connection(config: &NordVpnLiteConfig, tx: mpsc::Sende
     }
 }
 
-pub async fn daemon_event_loop(mut config: NordVpnLiteConfig) -> Result<(), NordVpnLiteError> {
-    debug!("started with config: {config:?}");
+pub async fn daemon_event_loop(mut config: RunningConfig) -> Result<(), NordVpnLiteError> {
+    debug!("started with config: {:?}", config.parsed);
 
     let mut signals = Signals::new([SIGHUP, SIGTERM, SIGINT, SIGQUIT])?;
 
@@ -366,8 +366,8 @@ pub async fn daemon_event_loop(mut config: NordVpnLiteConfig) -> Result<(), Nord
 
     let nordlynx_private_key = {
         let api_request_future = request_nordlynx_key(
-            &config.authentication_token,
-            config.http_certificate_file_path.as_deref(),
+            &config.parsed.authentication_token,
+            config.parsed.http_certificate_file_path.as_deref(),
         );
         pin_mut!(api_request_future);
         loop {
@@ -402,9 +402,9 @@ pub async fn daemon_event_loop(mut config: NordVpnLiteConfig) -> Result<(), Nord
         }
     };
 
-    config.authentication_token.zeroize();
+    config.parsed.authentication_token.zeroize();
 
-    let config_clone = config.clone();
+    let config_clone = config.parsed.clone();
     let (init_done_tx, init_done_rx) = oneshot::channel::<()>();
     let mut telio_task_handle = tokio::task::spawn_blocking(move || {
         let mut context = TelioContext::new(config_clone, nordlynx_private_key)?;
@@ -415,7 +415,7 @@ pub async fn daemon_event_loop(mut config: NordVpnLiteConfig) -> Result<(), Nord
     // Wait for interface setup to complete before making API calls.
     if init_done_rx.await.is_ok() {
         // TODO: This can be triggered through nordvpnlite command to allow the user to stop/restart.
-        let config_clone = config.clone();
+        let config_clone = config.parsed.clone();
         let tx_clone = telio_tx.clone();
         tokio::spawn(async move {
             handle_exit_node_connection(&config_clone, tx_clone).await;

--- a/clis/nordvpnlite/src/daemon.rs
+++ b/clis/nordvpnlite/src/daemon.rs
@@ -18,7 +18,9 @@ use tokio::{
 use tracing::{debug, error, info, trace, warn};
 use tracing_appender::rolling::InitError;
 
+use crate::logging;
 use telio_core::telio_utils::select;
+
 #[cfg(target_os = "linux")]
 use telio_core::telio_utils::LIBTELIO_FWMARK;
 use telio_core::{
@@ -82,6 +84,8 @@ pub enum NordVpnLiteError {
     LogAppenderError(#[from] InitError),
     #[error(transparent)]
     DaemonizeError(#[from] daemonize::Error),
+    #[error("Failed to configure tracing subscriber: {0}")]
+    TracingError(String),
     #[error("Could not configure IP rules")]
     IpRule,
     #[error("Could not configure IP routing")]
@@ -361,14 +365,36 @@ enum LoopOutcome {
     Reload(Box<RunningConfig>),
 }
 
-pub async fn daemon_event_loop(mut config: RunningConfig) -> Result<(), NordVpnLiteError> {
+pub async fn daemon_event_loop(
+    mut config: RunningConfig,
+    logging_handle: &mut logging::LoggingHandle,
+) -> Result<(), NordVpnLiteError> {
     loop {
         match run_daemon(config.clone()).await? {
             LoopOutcome::Exit => break,
             LoopOutcome::Reload(new_config) => {
                 info!("Reloading config from {}", config.path.display());
+
+                let logging_configuration_changed =
+                    config.parsed.logging_params_changed(&new_config.parsed);
+
                 config = *new_config;
                 config.parsed.resolve_env_token();
+
+                if logging_configuration_changed {
+                    if let Err(e) = logging::reload_logging(
+                        logging_handle,
+                        &config.parsed.log_file_path,
+                        config.parsed.log_level,
+                        config.parsed.log_file_count,
+                    ) {
+                        error!("Failed to reload logging configuration: {e}, continue with previous logging configuration");
+                    } else {
+                        info!("Logging reconfigured successfully");
+                    }
+                } else {
+                    info!("Logging configuration unchanged");
+                }
 
                 info!("Config reloaded, restarting daemon");
                 // loop continues and run_daemon called again with new config

--- a/clis/nordvpnlite/src/daemon.rs
+++ b/clis/nordvpnlite/src/daemon.rs
@@ -362,7 +362,7 @@ pub async fn daemon_event_loop(mut config: RunningConfig) -> Result<(), NordVpnL
     let (telio_tx, telio_rx) = mpsc::channel(10);
 
     let socket = DaemonSocket::new(&DaemonSocket::get_ipc_socket_path()?)?;
-    let mut cmd_listener = CommandListener::new(socket, telio_tx.clone());
+    let mut cmd_listener = CommandListener::new(socket, telio_tx.clone(), config.clone());
 
     let nordlynx_private_key = {
         let api_request_future = request_nordlynx_key(

--- a/clis/nordvpnlite/src/daemon.rs
+++ b/clis/nordvpnlite/src/daemon.rs
@@ -354,7 +354,31 @@ async fn handle_exit_node_connection(config: &NordVpnLiteConfig, tx: mpsc::Sende
     }
 }
 
+/// Outcome of a single daemon run
+enum LoopOutcome {
+    Exit,
+    /// Carries new confguration
+    Reload(Box<RunningConfig>),
+}
+
 pub async fn daemon_event_loop(mut config: RunningConfig) -> Result<(), NordVpnLiteError> {
+    loop {
+        match run_daemon(config.clone()).await? {
+            LoopOutcome::Exit => break,
+            LoopOutcome::Reload(new_config) => {
+                info!("Reloading config from {}", config.path.display());
+                config = *new_config;
+                config.parsed.resolve_env_token();
+
+                info!("Config reloaded, restarting daemon");
+                // loop continues and run_daemon called again with new config
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn run_daemon(mut config: RunningConfig) -> Result<LoopOutcome, NordVpnLiteError> {
     debug!("started with config: {:?}", config.parsed);
 
     let mut signals = Signals::new([SIGHUP, SIGTERM, SIGINT, SIGQUIT])?;
@@ -379,7 +403,7 @@ pub async fn daemon_event_loop(mut config: RunningConfig) -> Result<(), NordVpnL
                             match cmd_listener.handle_client_command(false, connection).await {
                                 Ok(ClientCmd::QuitDaemon) => {
                                     info!("Received quit command, exiting");
-                                    return Ok(())
+                                    return Ok(LoopOutcome::Exit)
                                 },
                                 Ok(command) => {
                                     debug!("Received command {command:?} while obtaining service credentials, ignoring");
@@ -396,7 +420,7 @@ pub async fn daemon_event_loop(mut config: RunningConfig) -> Result<(), NordVpnL
                 },
                 _ = signals.next() => {
                     warn!("Interrupted while obtaining service credentials - stopping");
-                    return Ok(());
+                    return Ok(LoopOutcome::Exit);
                 }
             };
         }
@@ -430,8 +454,13 @@ pub async fn daemon_event_loop(mut config: RunningConfig) -> Result<(), NordVpnL
             join_result = &mut telio_task_handle => {
                 match join_result {
                     Ok(Ok(_)) => {
-                        info!("Telio task thread completed, exiting");
-                        break Ok(())
+                        if let Some(new_config) = cmd_listener.take_pending_config() {
+                            trace!("Telio task thread completed after reload request, restarting");
+                            break Ok(LoopOutcome::Reload(Box::new(new_config)))
+                        } else {
+                            trace!("Telio task thread completed, exiting");
+                            break Ok(LoopOutcome::Exit)
+                        }
                     }
                     Ok(Err(err)) => {
                         error!("Telio task failed with error: {:?}", err);
@@ -461,10 +490,31 @@ pub async fn daemon_event_loop(mut config: RunningConfig) -> Result<(), NordVpnL
                     }
                 }
             },
-            // Handle interrupt signals for clean shutdown
+            // Handle interrupt signals for clean shutdown or reload
             signal = signals.next() => {
                 match signal {
-                    Some(s @ SIGHUP | s @ SIGTERM | s @ SIGINT | s @ SIGQUIT) => {
+                    Some(SIGHUP) => {
+                        info!("Received signal SIGHUP, reloading");
+                        match RunningConfig::from_file(&config.path) {
+                            Err(e) => {
+                                error!("Config file changed but failed to parse: {e}. Ignoring reload.");
+                            }
+                            Ok(new_config) if new_config.hash == config.hash => {
+                                info!("Config file unchanged, ignoring reload request");
+                            }
+                            Ok(new_config) => {
+                                let (response_tx, response_rx) = oneshot::channel();
+                                if let Err(e) = telio_tx.send_timeout(TelioTaskCmd::Quit(response_tx), Duration::from_secs(2)).await {
+                                    error!("Unable to send QUIT due to {e} during reload");
+                                };
+                                if let Err(e) = response_rx.await {
+                                    error!("Error receiving quit response from telio task: {e}");
+                                }
+                                break Ok(LoopOutcome::Reload(Box::new(new_config)));
+                            }
+                        }
+                    }
+                    Some(s @ SIGTERM | s @ SIGINT | s @ SIGQUIT) => {
                         info!("Received signal {:?}, exiting", Signal::try_from(s));
                         let (response_tx, response_rx) = oneshot::channel();
                         if let Err(e) = telio_tx.send_timeout(TelioTaskCmd::Quit(response_tx), Duration::from_secs(2)).await {
@@ -474,7 +524,7 @@ pub async fn daemon_event_loop(mut config: RunningConfig) -> Result<(), NordVpnL
                             error!("Error receiving quit response from telio task: {e}");
                         }
 
-                        break Ok(());
+                        break Ok(LoopOutcome::Exit);
                     }
                     Some(s) => {
                         info!("Received unexpected signal {s:?}, ignoring");

--- a/clis/nordvpnlite/src/logging.rs
+++ b/clis/nordvpnlite/src/logging.rs
@@ -2,18 +2,26 @@ use std::path::Path;
 
 use tracing::level_filters::LevelFilter;
 use tracing_appender::{
-    non_blocking::WorkerGuard,
-    rolling::{Builder, Rotation},
+    non_blocking::{NonBlocking, WorkerGuard},
+    rolling::{Builder, RollingFileAppender, Rotation},
 };
+use tracing_subscriber::{reload, Layer, Registry};
 
 use crate::NordVpnLiteError;
 
-pub fn setup_logging<P: AsRef<Path>>(
+type DynLayer = Box<dyn Layer<Registry> + Send + Sync>;
+
+pub struct LoggingHandle {
+    _worker_guard: WorkerGuard,
+    fmt_layer_reload_handle: reload::Handle<DynLayer, Registry>,
+    filter_reload_handle: reload::Handle<LevelFilter, Registry>,
+}
+
+fn build_appender<P: AsRef<Path>>(
     log_file_path: P,
-    log_level: LevelFilter,
     log_file_count: usize,
-) -> Result<WorkerGuard, NordVpnLiteError> {
-    let log_appender = Builder::new()
+) -> Result<RollingFileAppender, NordVpnLiteError> {
+    Builder::new()
         .filename_prefix(
             log_file_path
                 .as_ref()
@@ -37,18 +45,68 @@ pub fn setup_logging<P: AsRef<Path>>(
                 msg: "needs to contain both directory and file name".to_owned(),
                 value: log_file_path.as_ref().to_string_lossy().into_owned(),
             }
-        })?)?;
+        })?)
+        .map_err(Into::into)
+}
 
-    let (non_blocking_writer, tracing_worker_guard) = tracing_appender::non_blocking(log_appender);
-    tracing_subscriber::fmt()
-        .with_max_level(log_level)
-        .with_writer(non_blocking_writer)
-        .with_ansi(false)
-        .with_line_number(true)
-        .with_level(true)
-        .init();
+fn build_fmt_layer(writer: NonBlocking) -> DynLayer {
+    Box::new(
+        tracing_subscriber::fmt::layer()
+            .with_writer(writer)
+            .with_ansi(false)
+            .with_line_number(true)
+            .with_level(true),
+    )
+}
 
-    Ok(tracing_worker_guard)
+pub fn setup_logging<P: AsRef<Path>>(
+    log_file_path: P,
+    log_level: LevelFilter,
+    log_file_count: usize,
+) -> Result<LoggingHandle, NordVpnLiteError> {
+    use tracing_subscriber::prelude::*;
+
+    let appender = build_appender(&log_file_path, log_file_count)?;
+    let (writer, guard) = tracing_appender::non_blocking(appender);
+    let fmt_layer: DynLayer = build_fmt_layer(writer);
+
+    let (layer_reload, fmt_layer_reload_handle) = reload::Layer::new(fmt_layer);
+    let (filter_reload, filter_reload_handle) = reload::Layer::new(log_level);
+
+    let subscriber = Registry::default().with(layer_reload.with_filter(filter_reload));
+    tracing::subscriber::set_global_default(subscriber)
+        .map_err(|e| NordVpnLiteError::TracingError(e.to_string()))?;
+
+    Ok(LoggingHandle {
+        _worker_guard: guard,
+        fmt_layer_reload_handle,
+        filter_reload_handle,
+    })
+}
+
+pub fn reload_logging<P: AsRef<Path>>(
+    handle: &mut LoggingHandle,
+    log_file_path: P,
+    log_level: LevelFilter,
+    log_file_count: usize,
+) -> Result<(), NordVpnLiteError> {
+    let appender = build_appender(&log_file_path, log_file_count)?;
+    let (new_writer, new_guard) = tracing_appender::non_blocking(appender);
+    let new_layer: DynLayer = build_fmt_layer(new_writer);
+
+    handle
+        .filter_reload_handle
+        .modify(|level| *level = log_level)
+        .map_err(|e| NordVpnLiteError::TracingError(e.to_string()))?;
+
+    handle
+        .fmt_layer_reload_handle
+        .modify(|layer| *layer = new_layer)
+        .map_err(|e| NordVpnLiteError::TracingError(e.to_string()))?;
+
+    handle._worker_guard = new_guard;
+
+    Ok(())
 }
 
 #[macro_export]

--- a/clis/nordvpnlite/src/main.rs
+++ b/clis/nordvpnlite/src/main.rs
@@ -82,15 +82,15 @@ fn main() -> Result<(), NordVpnLiteError> {
             }
         }
 
-        let _tracing_worker_guard = logging::setup_logging(
+        let mut logging_handle = logging::setup_logging(
             &config.parsed.log_file_path,
             config.parsed.log_level,
             config.parsed.log_file_count,
         )?;
 
-        // Run the daemon event loop
+        // Run the daemon event loop.
         let rt = tokio::runtime::Runtime::new()?;
-        rt.block_on(daemon::daemon_event_loop(config))
+        rt.block_on(daemon::daemon_event_loop(config, &mut logging_handle))
     } else {
         client_main(cmd)
     }

--- a/clis/nordvpnlite/src/main.rs
+++ b/clis/nordvpnlite/src/main.rs
@@ -16,7 +16,7 @@ mod logging;
 use crate::{
     command_listener::{ClientCmd, Cmd, CommandResponse, TIMEOUT_SEC},
     comms::DaemonSocket,
-    config::NordVpnLiteConfig,
+    config::RunningConfig,
     core_api::get_countries_with_exp_backoff,
     daemon::NordVpnLiteError,
 };
@@ -35,10 +35,10 @@ fn main() -> Result<(), NordVpnLiteError> {
         }
 
         // Parse config file
-        let mut config = NordVpnLiteConfig::from_file(&opts.config_path)?;
-        config.resolve_env_token();
+        let mut config = RunningConfig::from_file(&opts.config_path)?;
+        config.parsed.resolve_env_token();
 
-        println!("Saving logs to: {}", config.log_file_path);
+        println!("Saving logs to: {}", config.parsed.log_file_path);
         println!("Starting daemon");
 
         // Fork the process before starting Tokio runtime.
@@ -83,9 +83,9 @@ fn main() -> Result<(), NordVpnLiteError> {
         }
 
         let _tracing_worker_guard = logging::setup_logging(
-            &config.log_file_path,
-            config.log_level,
-            config.log_file_count,
+            &config.parsed.log_file_path,
+            config.parsed.log_level,
+            config.parsed.log_file_count,
         )?;
 
         // Run the daemon event loop

--- a/nat-lab/tests/nordvpnlite.py
+++ b/nat-lab/tests/nordvpnlite.py
@@ -357,6 +357,14 @@ class NordVpnLite:
                 raise IgnoreableError() from exc
             raise exc
 
+    async def reload(self) -> None:
+        """Trigger a config reload on the running daemon and wait for it to reconnect."""
+        stdout, stderr = await self.execute_command(["reload"])
+        assert (
+            "Command executed successfully" in stdout
+        ), f"Reload failed: stdout={stdout!r}, stderr={stderr!r}"
+        await self.wait_for_nordvpnlite_start()
+
     async def quit(self) -> None:
         stdout, stderr = await self.execute_command(["stop"])
         assert (

--- a/nat-lab/tests/test_nordvpnlite.py
+++ b/nat-lab/tests/test_nordvpnlite.py
@@ -1,4 +1,5 @@
 import asyncio
+import copy
 import pytest
 from contextlib import AsyncExitStack
 from pathlib import Path
@@ -148,6 +149,78 @@ async def test_nordvpnlite_vpn_country_connection(
                     hostname in report
                     for hostname in ["pl128.nordvpn.com", "de1263.nordvpn.com"]
                 ), report
+
+
+async def test_nordvpnlite_reload_country_change() -> None:
+    async with AsyncExitStack() as exit_stack:
+        # Start connected to PL
+        initial_config = NordVpnLiteConfig(vpn=VPNConfig(country="pl"))
+        nordvpnlite = await NordVpnLite.new(exit_stack, initial_config)
+        await nordvpnlite.request_credentials_from_core()
+
+        async with nordvpnlite.start():
+            # Verify initial PL connection
+            log.debug("Waiting for initial PL VPN connection...")
+            await nordvpnlite.wait_for_vpn_connected_state()
+
+            ip = await stun.get(nordvpnlite.connection, STUN_SERVER)
+            assert ip == WG_SERVER["ipv4"], f"Expected PL server IP, got {ip}"
+            report = await nordvpnlite.get_status()
+            assert "pl128.nordvpn.com" in report, report
+
+            # Rewrite config on disk to DE and trigger reload
+            log.debug("Updating config to DE and reloading...")
+            nordvpnlite.config.config_data = NordVpnLiteConfig(
+                vpn=VPNConfig(country="de")
+            )
+            await nordvpnlite.save_config()
+            await nordvpnlite.reload()
+
+            # Verify new DE connection
+            log.debug("Waiting for DE VPN connection after reload...")
+            await nordvpnlite.wait_for_vpn_connected_state()
+
+            ip = await stun.get(nordvpnlite.connection, STUN_SERVER)
+            assert (
+                ip == WG_SERVER_2["ipv4"]
+            ), f"Expected DE server IP after reload, got {ip}"
+            report = await nordvpnlite.get_status()
+            assert "de1263.nordvpn.com" in report, report
+
+
+async def test_nordvpnlite_reload_no_config_change() -> None:
+    """Reload without changing the config file should be a no-op (daemon keeps running)."""
+    async with AsyncExitStack() as exit_stack:
+        config = copy.deepcopy(CONFIG_PRESETS[ConfigPresetName.DEFAULT])
+        nordvpnlite = await NordVpnLite.new(exit_stack, config_data=config)
+
+        async with nordvpnlite.start():
+            await nordvpnlite.wait_for_telio_running_status()
+
+            # Trigger reload without modifying the config file on disk
+            stdout, stderr = await nordvpnlite.execute_command(["reload"])
+            assert (
+                "Command executed successfully" in stdout
+            ), f"Reload command failed: stdout={stdout!r}, stderr={stderr!r}"
+
+            # Force filesystem sync to ensure logs are flushed to disk before checking
+            await nordvpnlite.connection.create_process(["sync"]).execute()
+
+            try:
+                await nordvpnlite.connection.create_process([
+                    "grep",
+                    "-q",
+                    "Config reloaded, restarting daemon",
+                    str(nordvpnlite.config.paths.daemon_log),
+                ]).execute()
+                pytest.fail("Daemon restarted after reload with unchanged config")
+            except ProcessExecError:
+                pass  # Expected: restart message absent
+
+            # Daemon must still be alive after the no-op reload
+            assert (
+                await nordvpnlite.is_alive()
+            ), "Daemon is no longer alive after no-op reload"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Problem
Currently to change the nordvpnlite configuration while the deamon is running we need to stop it, change the config file and restart the daemon.

```
./nordvpnlite stop
// change config.json file
./nordvpnlite start -c ~/config.json
```

The packets may leak during this operation.


### Solution
This PR doesn't address the packets leak problem yet but prepares a base for future changes.
It introduces:
* CLI `reload` command support
* SIGHUP signal support

Both triggers causes the the daemon to restart with a new configuration.

### Verification

Happy path verification

### 

* CLI reload
```
nordvpnlite start -c ~/config.json
nordvpnlite status
// change anything in the config.json (i.e. country code/log level)
nordvpnlite reload
nordvpnliste status

```

* SIGHUP signal
```
nordvpnlite start -c ~/config.json
nordvpnlite status
// change anything in the config.json
kill -HUP $(pidof nordvpnlite)
nordvpnliste status
```

Daemon does not restart when config.json not changed
 ```
nordvpnlite start -c ~/config.json
kill -HUP $(pidof nordvpnlite) // nordvpnlite reload
// check /var/log/nordvpnlite.log if telio daemon did not restart
```

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
