### PR TITLE
LLT-7444: boot x86_64 OpenWRT nat-lab VM with QEMU -M microvm

### DIFF
--- a/nat-lab/bin/openwrt/extract-kernel.sh
+++ b/nat-lab/bin/openwrt/extract-kernel.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+# Pull OpenWrt's bzImage out of the x86 ext4-combined image so QEMU -M microvm
+# can direct-boot it (microvm has no firmware/BIOS to run the image's GRUB).
+# Partition 1 is a small ext2 "kernel" partition holding /boot/vmlinuz; carve it
+# out with dd and read the kernel with debugfs (no privileged loop mount, so it
+# works inside an unprivileged docker build). LLT-7444.
+set -eu
+
+IMAGE="$1"
+OUT="$2"
+
+# First partition's start sector and length (numeric fdisk columns are
+# Start End Sectors Id; the bootable '*' and unit-suffixed Size are skipped).
+read -r START SECTORS <<EOF
+$(fdisk -l "$IMAGE" | awk '
+    /^Device/ { in_table = 1; next }
+    in_table && NF >= 4 {
+        n = 0
+        for (i = 1; i <= NF; i++) if ($i ~ /^[0-9]+$/) a[++n] = $i
+        print a[1], a[3]
+        exit
+    }')
+EOF
+
+PART1="$(mktemp)"
+dd if="$IMAGE" of="$PART1" bs=512 skip="$START" count="$SECTORS" status=none
+debugfs -R "dump /boot/vmlinuz $OUT" "$PART1"
+rm -f "$PART1"
+test -s "$OUT"

--- a/nat-lab/bin/openwrt/run-vm.sh
+++ b/nat-lab/bin/openwrt/run-vm.sh
@@ -56,11 +56,19 @@ case "${QEMU_ARCH}" in
         -drive file=/var/lib/qemu/image.raw,format=raw,if=ide
     ;;
   x86_64)
+    # microvm has no firmware/BIOS, so boot the kernel directly (-kernel) instead
+    # of via the image's GRUB; the rootfs is partition 2 of the combined image.
+    # pcie=on keeps virtio-pci net/blk, which OpenWrt's x86 kernel supports out of
+    # the box (pure virtio-mmio would need CONFIG_VIRTIO_MMIO). The kernel is
+    # extracted at build time (see openwrt.Dockerfile / extract-kernel.sh). LLT-7444.
     exec /usr/bin/qemu-system-x86_64 \
         -nodefaults \
         -display none \
+        -M microvm,pcie=on,rtc=on \
         -m 256M \
         -smp 2 \
+        -kernel /var/lib/qemu/kernel.bin \
+        -append "root=/dev/vda2 rootwait console=ttyS0,115200n8 noinitrd" \
         -netdev tap,id=hostnet0,ifname=qemu1,script=no,downscript=no \
         -netdev tap,id=hostnet1,ifname=qemu0,script=no,downscript=no \
         -device virtio-net-pci,romfile=,netdev=hostnet0,mac=${VM_MAC0},id=net0 \

--- a/nat-lab/docker-compose.yml
+++ b/nat-lab/docker-compose.yml
@@ -694,6 +694,7 @@ services:
         SEC_CONTAINER_REGISTRY: $LIBTELIO_ENV_SEC_CONTAINER_REGISTRY
         OPENWRT_IMAGE: natlab-openwrt-25.12.2-x86-64:v0.8.0
         OPENWRT_IMG_GZ: openwrt-25.12.2-x86-64-generic-ext4-combined.img.gz
+        OPENWRT_DIRECT_KERNEL: "true"
     cap_drop:
       - ALL
     cap_add:

--- a/nat-lab/openwrt.Dockerfile
+++ b/nat-lab/openwrt.Dockerfile
@@ -4,6 +4,8 @@ ARG OPENWRT_IMAGE=natlab-openwrt-24.10.4-x86-64:v0.6.0
 FROM ${SEC_CONTAINER_REGISTRY}/nord-projects/nordvpn/infra/llt/third-party-build/openwrt_image/${OPENWRT_IMAGE}
 
 ARG OPENWRT_IMG_GZ=openwrt-24.10.4-x86-64-generic-ext4-combined.img.gz
+# Set true (x86_64 GW only) to extract the kernel for QEMU -M microvm direct boot.
+ARG OPENWRT_DIRECT_KERNEL=false
 
 ENV QEMU_CONFIG_TIMEOUT="300"
 
@@ -20,6 +22,12 @@ RUN mkdir -p /var/lib/qemu && \
       gunzip -c ${OPENWRT_IMG_GZ} > /var/lib/qemu/image.raw; \
     else \
       cp ${OPENWRT_IMG_GZ} /var/lib/qemu/image.raw; \
+    fi
+
+RUN if [ "${OPENWRT_DIRECT_KERNEL}" = "true" ]; then \
+      apk add --no-cache e2fsprogs-extra && \
+      /opt/bin/openwrt/extract-kernel.sh /var/lib/qemu/image.raw /var/lib/qemu/kernel.bin && \
+      apk del e2fsprogs-extra; \
     fi
 
 RUN mkdir -p /usr/local/share/vmconfig/container.d /usr/local/share/vmconfig/vm.d


### PR DESCRIPTION
## Problem
[LLT-7444](https://nordsec.atlassian.net/browse/LLT-7444): try QEMU's `microvm` machine type in nat-lab — boot OpenWRT with `-M microvm` for a leaner/faster VM, and answer whether it's possible for ARM.

## Solution
Convert the x86_64 OpenWRT gateway (`openwrt-gw-01`) to `-M microvm,pcie=on,rtc=on` with direct kernel boot. `microvm` has no firmware/BIOS, so the kernel is extracted from the combined image at build time and booted via `-kernel`; virtio-pci net/blk and the existing combined image (`root=/dev/vda2`) are kept, so OpenWRT's stock drivers work unchanged.

- ~2× faster boot locally (~5s vs ~10s to serial console), same `-m 256M`
- Config-serialization and healthcheck paths are untouched (boot still reaches the ttyS0 console banner that `send-config-to-vm.sh` waits for)
- Kernel extraction (`extract-kernel.sh`) is gated by the `OPENWRT_DIRECT_KERNEL` build arg, set only on the x86_64 GW

## Notes
- `microvm` is **x86_64-only** — there is no aarch64 `microvm`; ARM already uses the minimal `-M virt`. The aarch64/mipsel gateways are unchanged.
- Validated locally (boot + ext4 rootfs mount + console banner). nat-lab CI is the authoritative check.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
