### PR TITLE
LLT-4142: wire Android client tools + guest-side process kill in nat-lab

### DIFF
--- a/nat-lab/tests/config.py
+++ b/nat-lab/tests/config.py
@@ -283,6 +283,10 @@ UNIFFI_PATH_VM_MAC = "/var/root/workspace/uniffi/"
 ANDROID_DEVICE_TMP = "/data/local/tmp/"
 LIBTELIO_BINARY_PATH_VM_ANDROID = "/data/data/com.termux/files/home/work/"
 UNIFFI_PATH_VM_ANDROID = "/data/data/com.termux/files/home/work/"
+# Termux's bin dir, where the baked CLI tools live. Used to invoke a baked tool
+# by absolute path when a same-named system (toybox) tool would otherwise shadow
+# it on PATH (e.g. nc) - see tests/utils/netcat.py.
+TERMUX_BIN_VM_ANDROID = "/data/data/com.termux/files/usr/bin/"
 
 LIBTELIO_LOCAL_IP = "10.5.0.2"
 

--- a/nat-lab/tests/utils/iperf3.py
+++ b/nat-lab/tests/utils/iperf3.py
@@ -61,7 +61,9 @@ class ThroughputUnit(Enum):
 
 
 def get_iperf_binary(target_os: TargetOS) -> str:
-    if target_os == TargetOS.Linux:
+    # Linux and Android resolve the baked iperf3 by bare name (Termux's bin is on
+    # the guest PATH; there is no system iperf3 to shadow it).
+    if target_os in (TargetOS.Linux, TargetOS.Android):
         return "iperf3"
 
     if target_os == TargetOS.Windows:

--- a/nat-lab/tests/utils/netcat.py
+++ b/nat-lab/tests/utils/netcat.py
@@ -1,6 +1,6 @@
 import asyncio
 from contextlib import asynccontextmanager
-from tests.config import LIBTELIO_BINARY_PATH_VM_MAC
+from tests.config import LIBTELIO_BINARY_PATH_VM_MAC, TERMUX_BIN_VM_ANDROID
 from tests.utils.connection import Connection, TargetOS
 from tests.utils.logger import log
 from tests.utils.output_notifier import OutputNotifier
@@ -22,6 +22,11 @@ def _get_netcat_base_command(connection: Connection) -> list[str]:
             get_python_binary(connection),
             LIBTELIO_BINARY_PATH_VM_MAC + "netcat.py",
         ]
+    if connection.target_os == TargetOS.Android:
+        # The baked OpenBSD nc, by absolute path: the netcat flags below (-v/-z)
+        # aren't supported by Android's system toybox nc, which would otherwise
+        # win on PATH (Termux's bin is only appended as a fallback).
+        return [TERMUX_BIN_VM_ANDROID + "nc"]
     # use the built in netcat command on linux
     return ["nc"]
 

--- a/nat-lab/tests/utils/process/adb_process.py
+++ b/nat-lab/tests/utils/process/adb_process.py
@@ -1,3 +1,5 @@
+import asyncio
+import secrets
 import shlex
 from .docker_process import DockerProcess, _EXIT_CODE_SIGKILL, _EXIT_CODE_SIGTERM
 from .process import ProcessExecError, StreamCallback
@@ -5,6 +7,18 @@ from aiodocker.containers import DockerContainer
 from contextlib import asynccontextmanager
 from tests.utils.logger import log
 from typing import AsyncIterator, List, Optional
+
+# Guest-side analog of bin/kill_process_by_natlab_id. The base class kills the
+# in-container adb *client* by KILL_ID, but adb can orphan the `su 0` child on
+# the guest when that stream closes, so the actual tool (ping/iperf3/nc/...) would
+# leak. Scan the guest's /proc for the matching KILL_ID and kill it. Pure toybox
+# sh: glob /proc, grep -a the NUL-separated environ; $1 is the id.
+_GUEST_KILL_SCRIPT = (
+    'id="$1"; [ -n "$id" ] || exit 2; '
+    "for d in /proc/[0-9]*; do "
+    'grep -aq "KILL_ID=$id" "$d/environ" 2>/dev/null && kill "${d#/proc/}" 2>/dev/null; '
+    "done; exit 0"
+)
 
 
 class AdbProcess(DockerProcess):
@@ -32,15 +46,52 @@ class AdbProcess(DockerProcess):
         kill_id=None,
         extra_path: Optional[str] = None,
     ) -> None:
+        # Fix the id here (mirroring DockerProcess's default) so we can export it
+        # into the *guest* env below - DockerProcess only puts KILL_ID on the
+        # in-container adb-client exec, which the guest process never sees.
+        kill_id = kill_id if kill_id else secrets.token_hex(8).upper()
+        self._serial = serial
         # adb passes a single string to the device shell, so quote each arg and
-        # join. `extra_path` is appended to PATH (so the system/toybox tools keep
-        # priority and Termux's baked binaries resolve only as a fallback).
+        # join. KILL_ID is exported so the guest process carries it (see
+        # _kill_exec_if_running). `extra_path` is appended to PATH (so the
+        # system/toybox tools keep priority and Termux's baked binaries resolve
+        # only as a fallback).
         guest_cmd = " ".join(shlex.quote(arg) for arg in command)
+        guest_cmd = f"export KILL_ID={shlex.quote(kill_id)}; {guest_cmd}"
         if extra_path:
             guest_cmd = f'export PATH="$PATH":{shlex.quote(extra_path)}; {guest_cmd}'
         shell_cmd = f"su 0 sh -c {shlex.quote(guest_cmd)}"
         adb_command = ["adb", "-s", serial, "shell", shell_cmd]
         super().__init__(container, container_name, adb_command, kill_id)
+
+    async def _kill_guest_process(self) -> None:
+        """Best-effort: terminate the guest process carrying our KILL_ID."""
+        inner = f"su 0 sh -c {shlex.quote(_GUEST_KILL_SCRIPT)} _ {shlex.quote(self._kill_id)}"
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                "docker",
+                "exec",
+                self._container.id,
+                "adb",
+                "-s",
+                self._serial,
+                "shell",
+                inner,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            await proc.communicate()
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            log.debug(
+                "[%s] guest kill-by-id failed (ignored): %s", self._container_name, e
+            )
+
+    async def _kill_exec_if_running(self) -> None:
+        # Kill the guest process first (adb may orphan the su child when the exec
+        # stream closes), then let the base class kill the in-container adb client
+        # to end the exec and record the intentional kill.
+        await self._kill_guest_process()
+        await super()._kill_exec_if_running()
 
     @asynccontextmanager
     async def run(


### PR DESCRIPTION
Followup tools work, tracked under LLT-4142. Base is `LLT-4138-android-natlab` (the parent PR branch, not `main`) until the parent PRs merge.

## Problem
nat-lab could not run several client tools on the Android guest: `iperf3` asserted, `netcat` fell back to the feature-thin toybox `nc`, and guest tool processes could be orphaned on teardown (adb orphans the `su 0` child; the container kill script only reaches the in-container adb client).

## Solution
- `get_iperf_binary`: handle Android — the baked `iperf3` resolves by bare name.
- `netcat`: use the baked OpenBSD `nc` by absolute Termux path (toybox `nc` lacks `-v`/`-z`, and Termux's bin is only a PATH fallback).
- `AdbProcess`: export `KILL_ID` into the guest env and kill the guest process by id on teardown — the guest-side analog of `bin/kill_process_by_natlab_id`.

Tools with no system shadow (`dig`/`nslookup`/`curl`/`wget`/`stunclient`/`tcpdump`) need no code change; they resolve via the existing PATH-append.

## Depends on
Client tools being baked into the emulator image — `android-emulator-docker` MR !4 (LLT-4142).

## Notes
- Could not run the emulator locally; the guest-kill is defensive against the known adb-orphans-`su`-children behavior. The `/proc`-scan kill logic is verified locally (same Linux `/proc/environ` semantics as the guest).
- Pre-existing pylint findings (`raise-missing-from`, too-many-args) left untouched.

### :ballot_box_with_check: Definition of Done checklist
- [ ] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [ ] README.md is updated
- [ ] Functionality is covered by unit or integration tests
