### PR TITLE
Remove SEC_CONTAINER_REGISTRY from natlab

### DIFF
--- a/nat-lab/docker-compose.yml
+++ b/nat-lab/docker-compose.yml
@@ -691,7 +691,7 @@ services:
       context: .
       dockerfile: openwrt.Dockerfile
       args:
-        SEC_CONTAINER_REGISTRY: $LIBTELIO_ENV_SEC_CONTAINER_REGISTRY
+        LIBTELIO_ENV_SEC_CONTAINER_REGISTRY: $LIBTELIO_ENV_SEC_CONTAINER_REGISTRY
         OPENWRT_IMAGE: natlab-openwrt-25.12.2-x86-64:v0.8.0
         OPENWRT_IMG_GZ: openwrt-25.12.2-x86-64-generic-ext4-combined.img.gz
     cap_drop:
@@ -742,7 +742,7 @@ services:
       context: .
       dockerfile: openwrt.Dockerfile
       args:
-        SEC_CONTAINER_REGISTRY: $LIBTELIO_ENV_SEC_CONTAINER_REGISTRY
+        LIBTELIO_ENV_SEC_CONTAINER_REGISTRY: $LIBTELIO_ENV_SEC_CONTAINER_REGISTRY
         OPENWRT_IMAGE: natlab-openwrt-24.10.4-armsr-armv8:v0.8.0
         OPENWRT_IMG_GZ: openwrt-24.10.4-armsr-armv8-generic-ext4-combined-efi.img.gz
     devices:
@@ -780,7 +780,7 @@ services:
       context: .
       dockerfile: openwrt.Dockerfile
       args:
-        SEC_CONTAINER_REGISTRY: $LIBTELIO_ENV_SEC_CONTAINER_REGISTRY
+        LIBTELIO_ENV_SEC_CONTAINER_REGISTRY: $LIBTELIO_ENV_SEC_CONTAINER_REGISTRY
         OPENWRT_IMAGE: natlab-openwrt-24.10.4-malta-le:v0.8.0
         OPENWRT_IMG_GZ: rootfs.raw
     devices:

--- a/nat-lab/openwrt.Dockerfile
+++ b/nat-lab/openwrt.Dockerfile
@@ -1,7 +1,7 @@
-ARG SEC_CONTAINER_REGISTRY
+ARG LIBTELIO_ENV_SEC_CONTAINER_REGISTRY
 ARG OPENWRT_IMAGE=natlab-openwrt-24.10.4-x86-64:v0.6.0
 
-FROM ${SEC_CONTAINER_REGISTRY}/nord-projects/nordvpn/infra/llt/third-party-build/openwrt_image/${OPENWRT_IMAGE}
+FROM ${LIBTELIO_ENV_SEC_CONTAINER_REGISTRY}/nord-projects/nordvpn/infra/llt/third-party-build/openwrt_image/${OPENWRT_IMAGE}
 
 ARG OPENWRT_IMG_GZ=openwrt-24.10.4-x86-64-generic-ext4-combined.img.gz
 


### PR DESCRIPTION
### Problem
`SEC_CONTAINER_REGISTRY` was created during gitlab migration. But now it has the same value as `LIBTELIO_ENV_SEC_CONTAINER_REGISTRY`

### Solution
Replace `SEC_CONTAINER_REGISTRY` with `LIBTELIO_ENV_SEC_CONTAINER_REGISTRY`


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
