### PR TITLE
Exclude ARP requests from tcpdump in test_openwrt_ip_leaks

### DIFF
--- a/nat-lab/tests/test_openwrt.py
+++ b/nat-lab/tests/test_openwrt.py
@@ -338,6 +338,7 @@ async def test_openwrt_ip_leaks(
                 "-i",
                 "eth0",
                 "-nn",
+                "not arp",
             ]).run() as tcp_dump:
                 await ping(gateway_connection, PHOTO_ALBUM_IP, enable_strace=True)
                 await ping(client_connection, PHOTO_ALBUM_IP, enable_strace=True)


### PR DESCRIPTION
### Problem
ARP requests are irrelevant for the ip leaks testing.

### Solution
Exclude ARP from openwrt ip leak test.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
