### PR TITLE
nat-lab: minor build, startup, VM and CLI improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,6 @@ tcli.log
 /nat-lab/data/nordvpnlite/data.json
 /nat-lab/logs
 /nat-lab/coredumps
-/nat-lab/docker-compose.yml.bak
 /src/telio.py
 /build/
 /dist/

--- a/nat-lab/README.md
+++ b/nat-lab/README.md
@@ -299,8 +299,6 @@ Libtelio emits boths logs and events during runtime that are potentially relevan
 
 ## Troubleshooting
 
-- Docker version < 28.0 and nat-unprotected
-  - Nat-Lab prefers the “nat-unprotected” bridge mode. On Docker Server < 28.0, Nat-Lab will warn and patch compose to use “nat” instead, creating a backup compose file. See [python.check_docker_version_compatibility()](natlab.py).
 - Containers failed to start
   - Use:
 
@@ -453,19 +451,27 @@ export NATLAB_SKIP_SETUP_CHECKS=1
 - TELIO_BIN_PROFILE
   - Controls which libtelio binaries paths are used by tests (release|debug). Automatically set by [python.get_pytest_arguments()](run_local.py:180) based on --telio-debug; may be overridden manually if needed.
 - GITLAB_CI
-  - CI toggle that modifies behavior in a few places (for example, disabling the [docker-compose.yml](docker-compose.yml) port mapping for cone-client-01 and using quiet pulls). See [python.start()](natlab.py:38) and [python.check_docker_version_compatibility()](natlab.py:170).
+  - CI toggle that modifies behavior in a few places (for example using quiet pulls, and disabling the client host-port binding in [docker-compose.yml](docker-compose.yml)). See [python.start()](natlab.py).
 
 ## Rebuild and apply changes efficiently
 
 ### Base image and scripts
 
-- natlab start always rebuilds the “base” image profile with BuildKit:
+- natlab start builds the “base” image profile with BuildKit using the layer cache, so repeated starts with no changes are fast:
 
 ```bash
 uv run python3 natlab.py start
 ```
 
-Implementation: [python.start()](natlab.py:38) issues docker compose build for the base profile.
+- Force a clean (no-cache) rebuild of the base image with `--rebuild` (or `NATLAB_BUILD_NO_CACHE=1`):
+
+```bash
+uv run python3 natlab.py start --rebuild
+```
+
+In CI (`GITLAB_CI`) the build always runs with `--no-cache` for fully reproducible images; the layer cache is a local-dev convenience only.
+
+Implementation: [python.start()](natlab.py) issues docker compose build for the base profile.
 
 ### Recreate vs restart
 
@@ -527,7 +533,7 @@ docker container prune          # will remove stopped containers
 - IPv6
   - The “internet” network has IPv6 enabled in [docker-compose.yml](docker-compose.yml:934). Ensure Docker daemon has IPv6 enabled if running IPv6 tests; otherwise disable IPv6-related markers.
 - Security and networking impact
-  - On newer Docker versions natlab prefers a special “nat-unprotected” bridge mode; on older Docker it falls back to “nat”. This adjusts NAT/masquerade behavior and may affect firewalling/routing on your workstation. See [python.check_docker_version_compatibility()](natlab.py:170) and comments in [docker-compose.yml](docker-compose.yml).
+  - natlab uses Docker bridge networks with custom NAT/masquerade behavior that may affect firewalling/routing on your workstation. See comments in [docker-compose.yml](docker-compose.yml).
 - Windows as host
   - Full env (with nested virtualization) is not supported on native Windows hosts. Use a Linux host for full coverage or run the lite-mode.
 

--- a/nat-lab/bin/openwrt/run-vm.sh
+++ b/nat-lab/bin/openwrt/run-vm.sh
@@ -56,9 +56,18 @@ case "${QEMU_ARCH}" in
         -drive file=/var/lib/qemu/image.raw,format=raw,if=ide
     ;;
   x86_64)
+    # Use hardware acceleration when /dev/kvm is usable; otherwise fall back to
+    # TCG software emulation (e.g. CI runners without nested virt). KVM is both
+    # much faster and lighter on host CPU than TCG.
+    if [ -r /dev/kvm ] && [ -w /dev/kvm ]; then
+        ACCEL_ARGS="-enable-kvm -cpu host"
+    else
+        ACCEL_ARGS="-cpu max"
+    fi
     exec /usr/bin/qemu-system-x86_64 \
         -nodefaults \
         -display none \
+        ${ACCEL_ARGS} \
         -m 256M \
         -smp 2 \
         -netdev tap,id=hostnet0,ifname=qemu1,script=no,downscript=no \

--- a/nat-lab/docker-compose.yml
+++ b/nat-lab/docker-compose.yml
@@ -1,3 +1,13 @@
+# Fast polling for lightweight docker services. Without this, a bare healthcheck
+# uses Docker's 30s default interval, so `docker compose up --wait` blocks ~30s on
+# services that are actually ready in well under a second. VM healthchecks set their
+# own (slower) timings and intentionally do not use this.
+x-fast-healthcheck: &fast-hc
+  interval: 2s
+  timeout: 2s
+  retries: 15
+  start_period: 2s
+
 services:
   base:
     image: nat-lab:base
@@ -105,6 +115,7 @@ services:
       - ../:/libtelio
       - ./data/core_api/test.pem:/etc/ssl/server_certificate/test.pem
     healthcheck:
+      <<: *fast-hc
       test: "ls /ready"
 
   windows-client-01: &windows-client
@@ -461,6 +472,7 @@ services:
     security_opt:
       - no-new-privileges:true
     healthcheck:
+      <<: *fast-hc
       test: "ls /ready"
     networks:
       internet:
@@ -811,7 +823,7 @@ services:
       start_period: 120s
       retries: 5
 
-  windows-gw-01: &windows-gw
+  windows-gw-01:
     hostname: windows-gw-01
     <<: *common-gw
     networks:
@@ -902,6 +914,7 @@ services:
       - ./data/nordderper/config1.yml:/etc/nordderper/config.yml
     working_dir: /etc/nordderper
     healthcheck:
+      <<: *fast-hc
       test: "curl http://localhost:8765" # Here the port comes from nat-lab/data/nordderper/config*.yml
 
   derp-02:
@@ -945,6 +958,7 @@ services:
       options:
         max-size: 50m
     healthcheck:
+      <<: *fast-hc
       test: "stunclient 10.0.1.1 3478 | grep success"
 
   # Two VPN servers
@@ -953,6 +967,7 @@ services:
     image: nat-lab:base
     entrypoint: /opt/bin/vpn-server
     healthcheck:
+      <<: *fast-hc
       test: "ls /ready"
     cap_drop:
       - ALL
@@ -1007,6 +1022,7 @@ services:
         target: /srv/www/photo.png
         read_only: true
     healthcheck:
+      <<: *fast-hc
       test: "curl http://localhost"
 
   # Just some publicly-routable UDP server. To access
@@ -1026,6 +1042,7 @@ services:
         ipv4_address: 10.0.80.81
         ipv6_address: 2001:db8:85a4::adda:edde:6
     healthcheck:
+      <<: *fast-hc
       test: "netstat -ul | grep 2000"
 
   dns-server-1:
@@ -1043,6 +1060,7 @@ services:
         ipv4_address: 10.0.80.82
         ipv6_address: 2001:db8:85a4::adda:edde:7
     healthcheck:
+      <<: *fast-hc
       test: "nslookup google.com localhost"
 
   dns-server-2:
@@ -1060,6 +1078,7 @@ services:
         ipv4_address: 10.0.80.83
         ipv6_address: 2001:db8:85a4::adda:edde:8
     healthcheck:
+      <<: *fast-hc
       test: "nslookup google.com localhost"
 
   tp-lite-dns-server:
@@ -1076,6 +1095,7 @@ services:
       internet:
         ipv4_address: 10.0.80.90
     healthcheck:
+      <<: *fast-hc
       test: "nslookup -type=a google.com localhost"
 
   mqtt-broker:

--- a/nat-lab/natlab.py
+++ b/nat-lab/natlab.py
@@ -310,9 +310,7 @@ def _report_container_failures(
     raise RuntimeError(f"Containers failed to start: {failed}; see docker logs above")
 
 
-def check_containers(
-    services_to_start, check_only=False
-) -> Tuple[List[str], List[str]]:
+def find_failing_containers(services_to_start) -> Tuple[List[str], List[str]]:
     missing_services: List[str] = []
     unhealthy_services: List[str] = []
 
@@ -327,45 +325,30 @@ def check_containers(
                     unhealthy_services.append(service)
                 break
 
-    if check_only:
-        _report_container_failures(missing_services, unhealthy_services)
-
     return missing_services, unhealthy_services
+
+
+def check_containers(services_to_start) -> None:
+    missing, unhealthy = find_failing_containers(services_to_start)
+    _report_container_failures(missing, unhealthy)
 
 
 def manage_containers(services_to_start) -> None:
     restart_attempts = 0
-    missing: List[str] = []
-    unhealthy: List[str] = []
     while restart_attempts < NATLAB_CONTAINER_RESTART_ATTEMPTS:
-        missing, unhealthy = check_containers(services_to_start, False)
+        missing, unhealthy = find_failing_containers(services_to_start)
         failed = missing + [s for s in unhealthy if s not in missing]
-        if failed:
-            print("Missing services: ", missing)
-            print("Unhealthy services: ", unhealthy)
-            quick_restart_container(
-                failed, env={"COMPOSE_DOCKER_CLI_BUILD": "1", "DOCKER_BUILDKIT": "1"}
-            )
-        else:
+        if not failed:
             return
+        print("Missing services: ", missing)
+        print("Unhealthy services: ", unhealthy)
+        quick_restart_container(
+            failed, env={"COMPOSE_DOCKER_CLI_BUILD": "1", "DOCKER_BUILDKIT": "1"}
+        )
         restart_attempts += 1
 
-    # Final check after all restart attempts exhausted
-    missing, unhealthy = check_containers(services_to_start, False)
-    failed = missing + [s for s in unhealthy if s not in missing]
-
-    print(f"missing services: {missing}, unhealthy services: {unhealthy}")
-
-    if failed:
-        # Dump logs only at the very end, only for still-failing containers
-        for service in missing:
-            dump_docker_logs(service)
-        for service in unhealthy:
-            dump_docker_logs(service)
-            dump_journal_logs(service)
-        raise RuntimeError(
-            f"Containers failed to start: {failed}; see docker logs above"
-        )
+    # Dump logs and raise for any containers still failing after all attempts.
+    check_containers(services_to_start)
 
 
 def generate_grpc(path):
@@ -542,7 +525,7 @@ def main():
     elif args.command == "kill":
         kill()
     elif args.command == "check-containers":
-        check_containers(services_to_start=list_services(), check_only=True)
+        check_containers(services_to_start=list_services())
 
 
 if __name__ == "__main__":

--- a/nat-lab/natlab.py
+++ b/nat-lab/natlab.py
@@ -431,17 +431,22 @@ def _resolve_skip_keywords(args) -> set:
     return skip_keywords
 
 
-def main():
-    all_services = run_command_with_output(
+def list_services() -> List[str]:
+    output = run_command_with_output(
         ["docker", "compose", "config", "--services"], hide_output=True
     )
-    valid_services = [service.strip() for service in all_services.splitlines()]
-    parser = argparse.ArgumentParser()
+    return [service.strip() for service in output.splitlines() if service.strip()]
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Build, start and manage the nat-lab docker/VM test environment."
+    )
     subparsers = parser.add_subparsers(dest="command", help="Available commands")
 
     start_parser = subparsers.add_parser(
         "start",
-        help="Build and start the environment [--skip-fullcone] [--skip-windows] [--skip-windows-client-02] [--skip-mac] [--skip-nlx] [--lite-mode]",
+        help="Build and start the environment (run `start --help` for skip/scope flags)",
     )
     start_parser.add_argument(
         "--skip-fullcone",
@@ -485,8 +490,8 @@ def main():
     start_parser.add_argument(
         "--services-to-start",
         nargs="+",
-        choices=valid_services,
-        help="List of services to start",
+        metavar="SERVICE",
+        help="Start only these services (validated against the compose file)",
     )
     start_parser.add_argument(
         "--rebuild",
@@ -511,6 +516,14 @@ def main():
     if args.command == "start":
         skip_keywords = _resolve_skip_keywords(args)
         if args.services_to_start:
+            valid_services = list_services()
+            invalid = [s for s in args.services_to_start if s not in valid_services]
+            if invalid:
+                start_parser.error(
+                    "unknown service(s) for --services-to-start: "
+                    f"{', '.join(invalid)}\n"
+                    f"valid services: {', '.join(sorted(valid_services))}"
+                )
             start(
                 skip_keywords,
                 services_to_start=args.services_to_start,
@@ -529,7 +542,7 @@ def main():
     elif args.command == "kill":
         kill()
     elif args.command == "check-containers":
-        check_containers(services_to_start=valid_services, check_only=True)
+        check_containers(services_to_start=list_services(), check_only=True)
 
 
 if __name__ == "__main__":

--- a/nat-lab/natlab.py
+++ b/nat-lab/natlab.py
@@ -4,11 +4,8 @@ import argparse
 import errno
 import json
 import os
-import shutil
 import subprocess
 import sys
-import warnings
-from packaging import version
 from typing import List, Tuple
 
 # isort: off
@@ -17,6 +14,49 @@ sys.path += [f"{PROJECT_ROOT}/ci"]
 from env import LIBTELIO_ENV_NAT_LAB_DEPS_TAG  # type: ignore # pylint: disable=import-error, wrong-import-position
 
 NATLAB_CONTAINER_RESTART_ATTEMPTS = 5
+
+
+def disable_client_host_ports():
+    """Drop the client host-port binding in CI by editing docker-compose.yml in place.
+
+    Idempotent: a no-op if the binding is already disabled, so repeated runs on the
+    same checkout don't fail.
+    """
+    with open("docker-compose.yml", "r", encoding="utf-8") as file:
+        filedata = file.read()
+    enabled = 'ports: ["58001"]'
+    disabled = "ports: []"
+    if enabled in filedata:
+        filedata = filedata.replace(enabled, disabled)
+        with open("docker-compose.yml", "w", encoding="utf-8") as file:
+            file.write(filedata)
+    elif disabled not in filedata:
+        raise RuntimeError("Cannot find expected client port mapping in compose file")
+
+
+def compose_container_ids(service: str, running_only: bool = False) -> List[str]:
+    """Resolve a compose service to its concrete container IDs (exact, no substring match)."""
+    command = ["docker", "compose", "ps", "-q"]
+    command += ["--status", "running"] if running_only else ["--all"]
+    command.append(service)
+    output = run_command_with_output(command, hide_output=True)
+    return [cid.strip() for cid in output.splitlines() if cid.strip()]
+
+
+def inspect_health(container_id: str):
+    raw = run_command_with_output(
+        ["docker", "inspect", container_id, "--format", "{{json .State.Health}}"],
+        hide_output=True,
+    ).strip()
+    if not raw or raw.lower() == "null":
+        return None
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    if isinstance(data, dict):
+        return (data.get("Status") or "").lower()
+    return None
 
 
 def run_command(command, env=None):
@@ -120,27 +160,25 @@ def dump_journal_logs(service_name):
         )
 
 
-def start(skip_keywords=None, force_recreate=False, services_to_start=None):
+def start(
+    skip_keywords=None, force_recreate=False, services_to_start=None, rebuild=False
+):
     if skip_keywords is None:
         skip_keywords = []
-
-    check_docker_version_compatibility()
 
     generate_grpc("../dist/linux/ens.proto")
 
     if "GITLAB_CI" in os.environ:
-        with open("docker-compose.yml", "r", encoding="utf-8") as file:
-            filedata = file.read()
-        original_port_mapping = 'ports: ["58001"]'
-        disabled_port_mapping = "ports: []"
-        if original_port_mapping not in filedata:
-            raise RuntimeError("Cannot find expected port mapping compose file")
-        filedata = filedata.replace(original_port_mapping, disabled_port_mapping)
-        with open("docker-compose.yml", "w", encoding="utf-8") as file:
-            file.write(filedata)
+        disable_client_host_ports()
+
+    build_command = ["docker", "compose", "--profile", "base", "build"]
+    # Build from cache locally for fast iteration. In CI always force a clean
+    # rebuild so images are fully reproducible and never reuse a persisted layer.
+    if rebuild or "NATLAB_BUILD_NO_CACHE" in os.environ or "GITLAB_CI" in os.environ:
+        build_command.append("--no-cache")
 
     run_command(
-        ["docker", "compose", "--profile", "base", "build", "--no-cache"],
+        build_command,
         env={
             "COMPOSE_DOCKER_CLI_BUILD": "1",
             "DOCKER_BUILDKIT": "1",
@@ -228,20 +266,11 @@ def kill():
 def quick_restart_container(names: List[str], env=None):
     if env:
         env = {**os.environ.copy(), **env}
-    docker_status = [
-        line.strip().strip("'")
-        for line in subprocess.check_output(
-            ["docker", "ps", "--filter", "status=running", "--format", "'{{.Names}}'"],
-            env=env,
-        )
-        .decode("utf-8")
-        .splitlines()
-    ]
 
-    for container in docker_status:
-        if any(name for name in names if name in container):
-            print("Killing container: ", container)
-            run_command(["docker", "container", "kill", container], env=env)
+    for service in names:
+        for cid in compose_container_ids(service, running_only=True):
+            print("Killing container: ", cid)
+            run_command(["docker", "container", "kill", cid], env=env)
     print("Restarting services: ", names)
     try:
         run_command(
@@ -252,13 +281,16 @@ def quick_restart_container(names: List[str], env=None):
                 "-d",
                 "--wait",
                 "--force-recreate",
+                # Recreate only the failed services, not their healthy dependencies
+                # (which include the slow-to-boot VMs).
+                "--no-deps",
             ]
             + names
             + ["--quiet-pull"],
             env=env,
         )
-    except subprocess.CalledProcessError:
-        print(f"Restart of services '{names}' failed...")
+    except subprocess.CalledProcessError as e:
+        print(f"Restart of services '{names}' failed with exit code {e.returncode}")
 
 
 def _report_container_failures(
@@ -281,60 +313,20 @@ def _report_container_failures(
 def check_containers(
     services_to_start, check_only=False
 ) -> Tuple[List[str], List[str]]:
-    docker_status = run_command_with_output(
-        ["docker", "ps", "--filter", "status=running"]
-    )
-    docker_status = [line.strip() for line in docker_status.splitlines()]
-
     missing_services: List[str] = []
     unhealthy_services: List[str] = []
 
-    # Identify missing containers
-    running_services = []
     for service in services_to_start:
-        if not find_container(service, docker_status):
+        running_ids = compose_container_ids(service, running_only=True)
+        if not running_ids:
             missing_services.append(service)
-        else:
-            running_services.append(service)
+            continue
+        for cid in running_ids:
+            if inspect_health(cid) == "unhealthy":
+                if service not in unhealthy_services:
+                    unhealthy_services.append(service)
+                break
 
-    # Check health status of running containers
-    for service in running_services:
-        container_ids_raw = run_command_with_output(
-            ["docker", "compose", "ps", "-q", "--all", service], hide_output=True
-        ).strip()
-        container_ids = [
-            cid.strip() for cid in container_ids_raw.splitlines() if cid.strip()
-        ]
-
-        # If no containers are found for the service, consider it a problem and add it to missing_services
-        if not container_ids:
-            missing_services.append(service)
-
-        for cid in container_ids:
-            container_state_raw = run_command_with_output(
-                ["docker", "inspect", cid, "--format", "{{json .State.Health}}"],
-                hide_output=True,
-            ).strip()
-
-            try:
-                container_state_json = (
-                    None
-                    if not container_state_raw or container_state_raw.lower() == "null"
-                    else json.loads(container_state_raw)
-                )
-            except json.JSONDecodeError:
-                container_state_json = None
-
-            if isinstance(container_state_json, dict):
-                status = (container_state_json.get("Status") or "").lower()
-                if status == "unhealthy":
-                    logs = container_state_json.get("Log") or []
-                    print(f"Container {cid} is unhealthy.\nLogs: {logs}")
-                    if service not in unhealthy_services:
-                        unhealthy_services.append(service)
-                    break
-
-    # Used to call from cli
     if check_only:
         _report_container_failures(missing_services, unhealthy_services)
 
@@ -374,47 +366,6 @@ def manage_containers(services_to_start) -> None:
         raise RuntimeError(
             f"Containers failed to start: {failed}; see docker logs above"
         )
-
-
-def find_container(service: str, docker_status: List[str]) -> bool:
-    for line in docker_status:
-        if service in line:
-            return True
-
-    return False
-
-
-def check_docker_version_compatibility():
-    docker_version = version.parse(get_docker_version())
-
-    with open("docker-compose.yml", "r", encoding="utf-8") as compose_file:
-        compose_content = compose_file.read()
-    if docker_version < version.parse("28.0") and "nat-unprotected" in compose_content:
-        warnings.warn(
-            f"Nat-lab uses 'unprotected nat' bridge mode which require Docker >= v28.0 (detected: v{docker_version})"
-        )
-
-        compose_content = compose_content.replace("nat-unprotected", "nat")
-        shutil.copy("docker-compose.yml", "docker-compose.yml.bak")
-        with open("docker-compose.yml", "w", encoding="utf-8") as compose_file:
-            compose_file.write(compose_content)
-
-        print("Docker compose backup file created: ./docker-compose.yml.bak")
-        print("Changed to 'nat' bridge gateway mode")
-
-
-def get_docker_version():
-    try:
-        result = subprocess.run(
-            ["docker", "version", "--format", "{{.Server.Version}}"],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-    except subprocess.CalledProcessError:
-        print("Error: Docker is not installed or not running.")
-        sys.exit(1)
-    return result.stdout.strip()
 
 
 def generate_grpc(path):
@@ -537,6 +488,11 @@ def main():
         choices=valid_services,
         help="List of services to start",
     )
+    start_parser.add_argument(
+        "--rebuild",
+        action="store_true",
+        help="Force a no-cache rebuild of the base image (same as NATLAB_BUILD_NO_CACHE=1)",
+    )
 
     subparsers.add_parser("restart", help="Restart (already existing) containers")
     subparsers.add_parser("recreate", help="Recreate (already existing) containers")
@@ -555,9 +511,13 @@ def main():
     if args.command == "start":
         skip_keywords = _resolve_skip_keywords(args)
         if args.services_to_start:
-            start(skip_keywords, services_to_start=args.services_to_start)
+            start(
+                skip_keywords,
+                services_to_start=args.services_to_start,
+                rebuild=args.rebuild,
+            )
         else:
-            start(skip_keywords)
+            start(skip_keywords, rebuild=args.rebuild)
     elif args.command == "restart":
         restart()
     elif args.command == "recreate":

--- a/nat-lab/openwrt.Dockerfile
+++ b/nat-lab/openwrt.Dockerfile
@@ -7,8 +7,6 @@ ARG OPENWRT_IMG_GZ=openwrt-24.10.4-x86-64-generic-ext4-combined.img.gz
 
 ENV QEMU_CONFIG_TIMEOUT="300"
 
-COPY --chmod=0755 bin/ /opt/bin/
-
 WORKDIR /ipk-source
 COPY data/core_api/test.pem /ipk-source/
 
@@ -24,6 +22,10 @@ RUN mkdir -p /var/lib/qemu && \
 
 RUN mkdir -p /usr/local/share/vmconfig/container.d /usr/local/share/vmconfig/vm.d
 RUN mkdir -p /var/lib/vmconfig/container.d /var/lib/vmconfig/vm.d
+
+# bin/ changes far more often than the image; copy it (and the symlinks below that
+# point into it) last so editing a script does not re-trigger the gunzip above.
+COPY --chmod=0755 bin/ /opt/bin/
 
 RUN ln -s /opt/bin/openwrt/10-usbmount-initsh.sh    /usr/local/share/vmconfig/vm.d/10-usbmount-initsh.sh && \
     ln -s /opt/bin/openwrt/20-firewall.sh           /usr/local/share/vmconfig/vm.d/20-firewall.sh && \

--- a/nat-lab/run_local.py
+++ b/nat-lab/run_local.py
@@ -64,7 +64,7 @@ def run_command(
 def _build_arg_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "-o", type=str, default="linux", help="Pass the host OS [default: linux])"
+        "-o", type=str, default="linux", help="Pass the host OS [default: linux]"
     )
     parser.add_argument(
         "--restart", action="store_true", help="Restart build container"

--- a/nat-lab/tests/conftest.py
+++ b/nat-lab/tests/conftest.py
@@ -196,8 +196,33 @@ def pytest_runtestloop(session):
     asyncio.run(copy_vm_binaries_if_needed(_SESSION.vm_marks))
 
 
-def pytest_runtest_setup():
-    asyncio.run(perform_pretest_cleanups())
+def _test_uses_upnp(item) -> bool:
+    """Whether the test exercises a UPNP gateway, so miniupnpd needs a pre-reset.
+
+    Errs on the side of running the reset: only confidently-non-UPNP tests skip it.
+    """
+
+    def contains_upnp(value) -> bool:
+        if isinstance(value, ConnectionTag):
+            return "UPNP" in value.name
+        if isinstance(value, SetupParameters):
+            tag = getattr(value, "connection_tag", None)
+            return isinstance(tag, ConnectionTag) and "UPNP" in tag.name
+        if isinstance(value, (list, tuple, set)):
+            return any(contains_upnp(v) for v in value)
+        return False
+
+    try:
+        params = getattr(getattr(item, "callspec", None), "params", {}) or {}
+        if any(contains_upnp(v) for v in params.values()):
+            return True
+        return "upnp" in item.nodeid.lower()
+    except Exception:  # pylint: disable=broad-exception-caught
+        return True
+
+
+def pytest_runtest_setup(item):
+    asyncio.run(perform_pretest_cleanups(reset_upnp=_test_uses_upnp(item)))
 
 
 def pytest_runtest_teardown(item, nextitem):  # pylint: disable=unused-argument

--- a/nat-lab/tests/conftest_helpers/pretest.py
+++ b/nat-lab/tests/conftest_helpers/pretest.py
@@ -10,7 +10,11 @@ from tests.config import LAN_ADDR_MAP, CORE_API_IP, CORE_API_CREDENTIALS
 from tests.conftest_helpers.setup_checks import OPENWRT_VM_TAGS
 from tests.utils.connection import ConnectionTag, clear_ephemeral_setups_set
 from tests.utils.connection.ssh_connection import SshConnection
-from tests.utils.connection_util import new_connection_raw, is_running
+from tests.utils.connection_util import (
+    new_connection_raw,
+    is_running,
+    running_container_names,
+)
 from tests.utils.logger import log, setup_log
 from tests.utils.router import IPStack, new_router
 from tests.utils.tcpdump import make_tcpdump, make_local_tcpdump
@@ -55,7 +59,9 @@ async def reset_service_credentials_cache():
         headers=headers,
     )
     try:
-        with urllib.request.urlopen(request, context=ssl_context) as response:
+        with urllib.request.urlopen(
+            request, context=ssl_context, timeout=5
+        ) as response:
             if response.status == HTTPStatus.OK:
                 setup_log.debug("Service credentials cache reset successfully")
             else:
@@ -67,20 +73,19 @@ async def reset_service_credentials_cache():
         setup_log.warning(
             "Failed to reset service credentials cache: HTTP %s - %s", e.code, e.reason
         )
-        raise
     except Exception as e:  # pylint: disable=broad-exception-caught
         setup_log.warning("Error resetting service credentials cache: %s", e)
-        raise
 
 
 async def reset_upnpd_on_upnp_gateways():
     setup_log.info("Resetting miniupnpd on UPNP gateways..")
     async with AsyncExitStack() as exit_stack:
+        names = await running_container_names()
         for gw_tag in ConnectionTag:
             if "UPNP_GW" not in gw_tag.name:
                 continue
             try:
-                if not await is_running(gw_tag):
+                if not await is_running(gw_tag, names):
                     continue
                 conn = await exit_stack.enter_async_context(new_connection_raw(gw_tag))
                 router = new_router(conn, IPStack.IPv4v6)
@@ -136,10 +141,14 @@ PRETEST_CLEANUPS = [
 ]
 
 
-async def perform_pretest_cleanups():
+async def perform_pretest_cleanups(reset_upnp: bool = True):
     for cleanup in PRETEST_CLEANUPS:
         await cleanup()
-    await reset_upnpd_on_upnp_gateways()
+    # miniupnpd only accumulates stale mappings during UPNP tests, so the reset is
+    # only needed ahead of those; skipping it for everything else removes two
+    # gateway round-trips from the majority of tests.
+    if reset_upnp:
+        await reset_upnpd_on_upnp_gateways()
 
 
 async def _copy_vm_binaries(tag: ConnectionTag):
@@ -172,11 +181,12 @@ async def start_tcpdump_processes(
     exit_stack: AsyncExitStack,
 ):
     connections = []
+    names = await running_container_names()
     for gw_tag in ConnectionTag:
         if gw_tag in OPENWRT_VM_TAGS:
             continue
         if "_GW" in gw_tag.name:
-            if not await is_running(gw_tag):
+            if not await is_running(gw_tag, names):
                 continue
             connection = await exit_stack.enter_async_context(
                 new_connection_raw(gw_tag)
@@ -186,7 +196,7 @@ async def start_tcpdump_processes(
         ConnectionTag.DOCKER_DNS_SERVER_1,
         ConnectionTag.DOCKER_DNS_SERVER_2,
     ]:
-        if await is_running(conn_tag):
+        if await is_running(conn_tag, names):
             connection = await exit_stack.enter_async_context(
                 new_connection_raw(conn_tag)
             )

--- a/nat-lab/tests/conftest_helpers/setup_checks.py
+++ b/nat-lab/tests/conftest_helpers/setup_checks.py
@@ -10,7 +10,11 @@ from tests.config import LAN_ADDR_MAP
 from tests.interderp_cli import InterDerpClient
 from tests.utils.connection import ConnectionTag, TargetOS
 from tests.utils.connection.docker_connection import DockerConnection
-from tests.utils.connection_util import new_connection_raw, is_running
+from tests.utils.connection_util import (
+    new_connection_raw,
+    is_running,
+    running_container_names,
+)
 from tests.utils.logger import log, setup_log
 from tests.utils.process import ProcessExecError
 from tests.utils.tcpdump import make_tcpdump
@@ -423,9 +427,10 @@ async def check_gateway_connectivity(exit_stack: AsyncExitStack) -> bool:
     current_gateway = None
     for _ in range(GW_CHECK_CONNECTIVITY_RETRIES + 1):
         try:
+            names = await running_container_names()
             for gw_tag in ConnectionTag:
                 if "_GW" in gw_tag.name:
-                    if not await is_running(gw_tag):
+                    if not await is_running(gw_tag, names):
                         continue
                     current_gateway = gw_tag
                     await exit_stack.enter_async_context(new_connection_raw(gw_tag))
@@ -447,8 +452,9 @@ async def check_all_containers_running() -> dict[ConnectionTag, bool]:
     setup_log.info("Checking running containers..")
 
     tags = list(ConnectionTag)
+    names = await running_container_names()
     is_running_results = await asyncio.gather(
-        *[is_running(conn_tag) for conn_tag in tags]
+        *[is_running(conn_tag, names) for conn_tag in tags]
     )
 
     for conn_tag, is_running_res in zip(tags, is_running_results):

--- a/nat-lab/tests/log_collector.py
+++ b/nat-lab/tests/log_collector.py
@@ -146,7 +146,7 @@ async def get_system_log(connection: Connection) -> Optional[str]:
     return None
 
 
-async def save_logs(connection: Connection) -> None:
+async def save_logs(connection: Connection, log_content: Optional[str] = None) -> None:
     """
     Save the logs from libtelio.
     In order to collect all of the logs this function must be called
@@ -160,11 +160,12 @@ async def save_logs(connection: Connection) -> None:
     log_dir = get_current_test_log_path()
     os.makedirs(log_dir, exist_ok=True)
 
-    try:
-        log_content = await get_log_without_flush(connection)
-    except ProcessExecError as err:
-        err.print()
-        return
+    if log_content is None:
+        try:
+            log_content = await get_log_without_flush(connection)
+        except ProcessExecError as err:
+            err.print()
+            return
 
     system_log_content = await get_system_log(connection)
 
@@ -435,13 +436,22 @@ class LogCollector:
         log.info("[%s] Saving moose dbs", self.node_name)
         await save_moose_db()
 
-        log.info("[%s] Checking logs", self.node_name)
-        await self._check_logs_for_errors(connection)
+        # Fetch the libtelio log once and feed both the error check and the save,
+        # instead of pulling it from the node twice.
+        try:
+            log_content = await get_log_without_flush(connection)
+        except ProcessExecError as err:
+            err.print()
+            log_content = None
 
-        log.info("[%s] Saving logs", self.node_name)
-        await save_logs(connection)
+        if log_content is not None:
+            log.info("[%s] Checking logs", self.node_name)
+            self._check_logs_for_errors(log_content)
 
-    async def _check_logs_for_errors(self, connection: Connection) -> None:
+            log.info("[%s] Saving logs", self.node_name)
+            await save_logs(connection, log_content)
+
+    def _check_logs_for_errors(self, log_content: str) -> None:
         """
         Check logs for error and raise error/warning if unexpected errors
         has been found
@@ -451,7 +461,6 @@ class LogCollector:
         at least after logs has been flushed.
         """
 
-        log_content = await get_log_without_flush(connection)
         for line in log_content.splitlines():
             if "TelioLogLevel.ERROR" in line:
                 if not self.allowed_errors or not any(

--- a/nat-lab/tests/test_openwrt.py
+++ b/nat-lab/tests/test_openwrt.py
@@ -10,6 +10,7 @@ from tests.config import (
     PHOTO_ALBUM_IP,
     STUN_SERVER,
     LAN_ADDR_MAP,
+    CORE_API_URL,
 )
 from tests.helpers import (
     print_network_state,
@@ -35,6 +36,7 @@ from tests.utils.openwrt import (
 from tests.utils.ping import ping
 from tests.utils.process import ProcessExecError
 from typing import Optional
+from urllib.parse import urlparse
 
 NETWORK_RESTART_LOG_LINE = "netifd: Network device 'eth1' link is up"
 OPENWRT_GW_WAN_IP = {
@@ -155,6 +157,31 @@ async def check_gateway_and_client_ip(
     ), f"LuCi UI isn't available. Response status: {luci_ui_response_status}"
 
 
+async def wait_for_router_dns(
+    connection: Connection, host: str, attempts: int = 20, interval: float = 2.0
+) -> None:
+    """Wait until the OpenWrt router's dnsmasq can resolve `host`.
+
+    After a WAN-down or reboot the router's resolver needs a moment to recover,
+    so probe it with a light nslookup before issuing requests that depend on it.
+    """
+    for attempt in range(1, attempts + 1):
+        try:
+            await connection.create_process(["nslookup", host], quiet=True).execute()
+            return
+        except ProcessExecError:
+            if attempt == attempts:
+                raise
+            log.warning(
+                "[%s] router cannot resolve %s yet (attempt %d/%d), waiting...",
+                connection.tag.name,
+                host,
+                attempt,
+                attempts,
+            )
+            await asyncio.sleep(interval)
+
+
 async def setup_openwrt_test_environment(
     country_config: ConfigPresetName,
     exit_stack: AsyncExitStack,
@@ -211,6 +238,10 @@ async def setup_openwrt_test_environment(
         exit_stack=exit_stack,
         config=config,
     )
+    # OpenWrt tests exercise router network events (WAN down, reboot); make sure
+    # the router's dnsmasq can resolve core-api again before we query it.
+    core_api_host = urlparse(CORE_API_URL).hostname or CORE_API_URL
+    await wait_for_router_dns(gateway_connection, core_api_host)
     await nordvpnlite.request_credentials_from_core()
     return client_connection, gateway_connection, nordvpnlite
 

--- a/nat-lab/tests/utils/connection_util.py
+++ b/nat-lab/tests/utils/connection_util.py
@@ -31,7 +31,7 @@ from tests.utils.network_switcher import (
 )
 from typing import AsyncIterator, Tuple, Optional, List, Union
 
-IS_VM_RUNNING_PING_TIMEOUT = 10.0
+IS_VM_RUNNING_PING_TIMEOUT = 3.0
 
 
 @dataclass
@@ -423,18 +423,56 @@ async def toggle_secondary_adapter(connection: Connection, enable: bool):
         await set_secondary_ifc_state(connection, not enable, secondary_ifc)
 
 
-async def is_running(tag: ConnectionTag) -> bool:
+async def running_container_names(docker: Optional[Docker] = None) -> set[str]:
+    """Snapshot the names of all running docker containers in one API call.
+
+    `containers.list()` already returns only running containers and includes their
+    names, so callers that check many tags can fetch this once instead of opening a
+    Docker client and inspecting every container per tag.
+    """
+
+    async def _collect(client: Docker) -> set[str]:
+        names: set[str] = set()
+        for container in await client.containers.list():
+            names.update(container["Names"])
+        return names
+
+    if docker is not None:
+        return await _collect(docker)
+    async with Docker() as client:
+        return await _collect(client)
+
+
+async def is_running(
+    tag: ConnectionTag, running_names: Optional[set[str]] = None
+) -> bool:
     if tag in DOCKER_SERVICE_IDS:
-        cid = container_id(tag)
-        async with Docker() as docker:
-            clist = await docker.containers.list()
-            for c in clist:
-                name = (await c.show())["Name"]
-                if name == f"/{cid}":
-                    return True
-    else:
-        primary_ip = LAN_ADDR_MAP[tag]["primary"]
-        assert primary_ip != ""
+        if running_names is None:
+            running_names = await running_container_names()
+        return f"/{container_id(tag)}" in running_names
+
+    primary_ip = LAN_ADDR_MAP[tag]["primary"]
+    assert primary_ip != ""
+    proc = await asyncio.wait_for(
+        asyncio.create_subprocess_exec(
+            "ping",
+            "-c",
+            "1",
+            "-W",
+            "1",
+            primary_ip,
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        ),
+        timeout=IS_VM_RUNNING_PING_TIMEOUT,
+    )
+    returncode = await asyncio.wait_for(proc.wait(), timeout=2.0)
+    if returncode == 0:
+        return True
+    log.debug("%s haven't replied to ICMP request at %s", tag, primary_ip)
+
+    secondary_ip = LAN_ADDR_MAP[tag]["secondary"]
+    if secondary_ip != "":
         proc = await asyncio.wait_for(
             asyncio.create_subprocess_exec(
                 "ping",
@@ -442,7 +480,7 @@ async def is_running(tag: ConnectionTag) -> bool:
                 "1",
                 "-W",
                 "1",
-                primary_ip,
+                secondary_ip,
                 stdout=asyncio.subprocess.DEVNULL,
                 stderr=asyncio.subprocess.DEVNULL,
             ),
@@ -451,28 +489,6 @@ async def is_running(tag: ConnectionTag) -> bool:
         returncode = await asyncio.wait_for(proc.wait(), timeout=2.0)
         if returncode == 0:
             return True
-        else:
-            log.debug("%s haven't replied to ICMP request at %s", tag, primary_ip)
-
-        secondary_ip = LAN_ADDR_MAP[tag]["secondary"]
-        if secondary_ip != "":
-            proc = await asyncio.wait_for(
-                asyncio.create_subprocess_exec(
-                    "ping",
-                    "-c",
-                    "1",
-                    "-W",
-                    "1",
-                    secondary_ip,
-                    stdout=asyncio.subprocess.DEVNULL,
-                    stderr=asyncio.subprocess.DEVNULL,
-                ),
-                timeout=IS_VM_RUNNING_PING_TIMEOUT,
-            )
-            returncode = await asyncio.wait_for(proc.wait(), timeout=2.0)
-            if returncode == 0:
-                return True
-            else:
-                log.debug("%s haven't replied to ICMP request at %s", tag, primary_ip)
+        log.debug("%s haven't replied to ICMP request at %s", tag, secondary_ip)
 
     return False

--- a/nat-lab/tests/utils/diagnostics.py
+++ b/nat-lab/tests/utils/diagnostics.py
@@ -1,3 +1,4 @@
+import os
 from contextlib import asynccontextmanager
 from tests.log_collector import clear_core_dumps, clear_system_log
 from tests.utils.connection import Connection
@@ -13,7 +14,10 @@ async def connection_diagnostics(
 ) -> AsyncIterator[None]:
     await clear_core_dumps(connection)
     await clear_system_log(connection)
-    if run_tcpdump:
+    # Per-test packet captures are only useful when logs are collected (CI sets
+    # NATLAB_SAVE_LOGS). Skipping the per-connection tcpdump spawn locally removes
+    # a process + pcap download from every test's connection setup.
+    if run_tcpdump and os.environ.get("NATLAB_SAVE_LOGS"):
         async with make_tcpdump([connection]):
             yield
     else:

--- a/nat-lab/tests/utils/tcpdump.py
+++ b/nat-lab/tests/utils/tcpdump.py
@@ -394,7 +394,7 @@ async def make_tcpdump(
                 await _start_capture(exit_stack, conn, session)
             yield
     finally:
-        if download:
+        if download and os.environ.get("NATLAB_SAVE_LOGS"):
             log_dir = get_current_test_log_path()
             os.makedirs(log_dir, exist_ok=True)
             for conn in connection_list:


### PR DESCRIPTION
### Problem

A handful of nat-lab rough edges slowed local dev and CI and risked incorrect orchestration:

- The base image was rebuilt with `--no-cache` on every `./natlab.py start`.
- Lightweight services had bare healthchecks, so `docker compose up --wait` sat on Docker's 30s default interval for services that are ready in well under a second.
- The x86 OpenWrt VM ran under TCG software emulation even though `/dev/kvm` was already mapped into the container.
- Health/restart logic matched containers by substring, so `cone-gw-01` also matched `fullcone-gw-01` (and `symmetric`/`internal-symmetric`): health could read the wrong container and restarts could kill the wrong sibling.
- Per-test tcpdump capture + downloads and redundant Docker-API calls ran even locally, where the captures are never collected.
- `natlab.py --help` (and no-args, invalid command, bad flag) required a running docker daemon and dumped the entire ~58-service list inline.

### Solution

Minor, self-contained improvements — one commit per concern:

- **Build / orchestration** — cache the base image build for fast local iteration (`--rebuild` / `NATLAB_BUILD_NO_CACHE` to force a clean rebuild). **CI keeps `--no-cache`**, so CI images stay fully reproducible and never reuse a persisted layer — BuildKit's cache is content-addressed anyway, so a changed `Dockerfile`/`bin/` script can't serve a stale image. Resolve services to exact container IDs via `docker compose ps -q` (fixes `cone-gw-01`⊂`fullcone-gw-01` substring collisions); `--no-deps` on the recovery recreate; remove dead version-compat code.
- **Startup** — fast healthcheck anchor (2s interval/start, 15 retries) for lightweight services (~30s off the parallel startup floor); drop an unused anchor. VM/openwrt healthchecks keep their own timings.
- **OpenWrt VM** — enable KVM for x86 (probe + `-cpu host`, TCG fallback for runners without nested virt); reorder `openwrt.Dockerfile` so editing a script no longer re-triggers the image decompression.
- **Test setup/teardown** — gate per-test tcpdump capture/download on `NATLAB_SAVE_LOGS`; snapshot running containers once instead of inspecting every container per tag; reset miniupnpd only before tests that use a UPNP gateway (with a conservative fallback); dedupe the per-node log fetch; tighten two timeouts.
- **CLI** — `--help`/errors no longer require docker and read cleanly; helpful `--services-to-start` validation; fixed a stale help reference and a `-o` typo.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
