### PR TITLE
Add config to enable firewall at nordvpnlite

### DIFF
--- a/clis/nordvpnlite/src/config.rs
+++ b/clis/nordvpnlite/src/config.rs
@@ -140,6 +140,10 @@ pub struct NordVpnLiteConfig {
 
     /// Path to a http pem certificate to be used when connecting to CoreApi
     pub http_certificate_file_path: Option<PathBuf>,
+
+    /// Enables the libtelio firewall that processes packets.
+    #[serde(default)]
+    pub enable_firewall: bool,
 }
 
 impl NordVpnLiteConfig {
@@ -266,6 +270,7 @@ impl Default for NordVpnLiteConfig {
             override_default_wg_port: None,
             authentication_token: Default::default(),
             http_certificate_file_path: None,
+            enable_firewall: false,
         }
     }
 }
@@ -401,6 +406,7 @@ mod tests {
             override_default_wg_port: None,
             authentication_token: Default::default(),
             http_certificate_file_path: None,
+            enable_firewall: false,
         };
         {
             let json = r#"{

--- a/clis/nordvpnlite/src/daemon.rs
+++ b/clis/nordvpnlite/src/daemon.rs
@@ -152,9 +152,13 @@ impl TelioContext {
 
         // TODO: Make telio features configurable from nordvpnlite config: LLT-6587
         // Create default features with direct connections enabled
-        let features = Arc::new(FeaturesDefaultsBuilder::new())
+        let mut features = Arc::new(FeaturesDefaultsBuilder::new())
             .enable_direct()
             .build();
+
+        if config.enable_firewall {
+            features.firewall = Some(Default::default());
+        }
 
         let mut telio = Device::new(features, handle_telio_event, None)?;
         Self::start_telio(&mut telio, &config, nordlynx_private_key)?;


### PR DESCRIPTION
Until now telio-firewall has been disabled with nordvpnlite connections.

This PR adds a config to enable firewall at nordvpnlite CLI.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
