### PR TITLE
LLT-7321: Make firewall reject packets with non-tunnel src ips

### DIFF
--- a/.unreleased/LLT-7321_firewall_reject_wrong_src_ip
+++ b/.unreleased/LLT-7321_firewall_reject_wrong_src_ip
@@ -1,0 +1,4 @@
+Reject outbound packets whose source IP does not match the tunnel interface's configured source IP(s)
+Add new `set_tunnel_src_ip(src_ips)` API: apps pass the tunnel interface source IP(s) so the firewall can enforce the source-IP check. Pass an empty list to disable the check.
+
+Apps should call it set it once and re-call only if the IP change. Libtelio's chain rebuilds regenerate the rule from stored state.

--- a/crates/telio-firewall/Cargo.toml
+++ b/crates/telio-firewall/Cargo.toml
@@ -25,7 +25,7 @@ telio-crypto.workspace = true
 telio-utils.workspace = true
 telio-model.workspace = true
 telio-network-monitors.workspace = true
-libloading = { default-features = false, version = "0.9.0" }
+libloading = { default-features = false, features = ["std"], version = "0.9.0" }
 thiserror.workspace = true
 mockall_double.workspace = true
 

--- a/crates/telio-firewall/src/firewall.rs
+++ b/crates/telio-firewall/src/firewall.rs
@@ -159,6 +159,11 @@ pub struct FirewallState {
     pub whitelist: Whitelist,
     /// Local node ip addresses
     pub ip_addresses: Vec<StdIpAddr>,
+    /// Source address(es) of the tunnel interface, when known. When non-empty,
+    /// the firewall rejects outbound packets whose source IP is not one of
+    /// these addresses, protecting the VPN tunnel from accidental leaks.
+    /// When empty, this protection is disabled.
+    pub tunnel_ips: Vec<StdIpAddr>,
     /// List of DNS server IPs for which only plaintext DNS should be allowed
     pub force_plaintext_dns_for_servers: Option<Vec<StdIpAddr>>,
     /// Domain patterns whitelisted from TP-Lite DNS
@@ -190,7 +195,8 @@ pub struct StatefulFirewall {
     config: FirewallConfig,
     /// Current firewall state
     state: RwLock<FirewallState>,
-    /// Last known host interface IPs reported by network monitor.
+    /// IP addresses currently assigned to the host's local network interfaces,
+    /// as last reported by the network monitor.
     interface_ips: RwLock<Vec<StdIpAddr>>,
     /// Chain configuration function
     configure_chain_fn: ConfigureChainFn,
@@ -431,6 +437,16 @@ fn filter_dst_ip_single_port(net: IpNet, port: u16, inverted: bool) -> Filter {
     }
 }
 
+fn filter_src_ip_all_ports(net: IpNet, inverted: bool) -> Filter {
+    Filter {
+        filter_data: FilterData::SrcNetwork(NetworkFilterData {
+            network: net,
+            port_range: (0, 65535),
+        }),
+        inverted,
+    }
+}
+
 fn get_local_area_networks_filters(
     exclude_ip_range: Option<Ipv4Net>,
     local_ifs_addrs: &[StdIpAddr],
@@ -489,12 +505,13 @@ fn get_local_area_networks_filters(
     result
 }
 
-/// Configures the firewall chain based on the provided configuration.
-pub(crate) fn configure_chain(
+/// Builds the rule list for the firewall chain. Separated from configure_chain
+/// so tests can inspect the Rule vec directly.
+pub(crate) fn build_chain_rules(
     config: &FirewallConfig,
     state: &FirewallState,
     local_ifs_addrs: &[StdIpAddr],
-) -> FfiChainGuard {
+) -> Vec<Rule> {
     let mut rules = vec![];
 
     if let Some(dns_server_ips) = &state.force_plaintext_dns_for_servers {
@@ -572,6 +589,25 @@ pub(crate) fn configure_chain(
                 action: RuleAction::Dnat(redirect.standard),
             });
         }
+    }
+
+    // Reject outbound packets with a wrong source IP (not a tunnel IP).
+    // Has to be placed before the blanket outbound-accept rule below
+    // so it takes effect.
+    if !state.tunnel_ips.is_empty() {
+        let mut filters = vec![Filter {
+            filter_data: FilterData::Direction(Direction::Outbound),
+            inverted: false,
+        }];
+        for tunnel_ip in &state.tunnel_ips {
+            filters.push(filter_src_ip_all_ports(IpNet::from(*tunnel_ip), true));
+        }
+        let reject_rule = Rule {
+            filters,
+            action: RuleAction::Reject,
+        };
+
+        rules.push(reject_rule);
     }
 
     rules.push(Rule {
@@ -691,7 +727,18 @@ pub(crate) fn configure_chain(
         });
     }
 
-    (rules.as_slice()).into()
+    rules
+}
+
+/// Configures the firewall chain based on the provided configuration.
+pub(crate) fn configure_chain(
+    config: &FirewallConfig,
+    state: &FirewallState,
+    local_ifs_addrs: &[StdIpAddr],
+) -> FfiChainGuard {
+    build_chain_rules(config, state, local_ifs_addrs)
+        .as_slice()
+        .into()
 }
 
 extern "C" fn write_to_sink(
@@ -878,6 +925,154 @@ mod tests {
         assert_eq!(
             calls[2],
             vec![StdIpAddr::V4(Ipv4Addr::new(192, 168, 0, 12))]
+        );
+    }
+
+    fn reject_rule_for_outbound_src(rules: &[Rule], ip: StdIpAddr) -> Option<&Rule> {
+        let outbound = Filter {
+            filter_data: FilterData::Direction(Direction::Outbound),
+            inverted: false,
+        };
+        let inverted_src = filter_src_ip_all_ports(IpNet::from(ip), true);
+        rules
+            .iter()
+            .filter(|r| r.action == RuleAction::Reject)
+            .find(|r| r.filters.contains(&outbound) && r.filters.contains(&inverted_src))
+    }
+
+    #[test]
+    fn test_reject_rule_not_emitted_without_tunnel_ip() {
+        let config = FirewallConfig {
+            allow_ipv6: false,
+            feature: FeatureFirewall::default(),
+        };
+        let state = FirewallState {
+            tunnel_ips: vec![],
+            ..Default::default()
+        };
+        let rules = build_chain_rules(&config, &state, &[]);
+        assert!(
+            rules.iter().all(|r| r.action != RuleAction::Reject),
+            "no Reject rule should be emitted when tunnel_ips is empty"
+        );
+    }
+
+    #[test]
+    fn test_reject_rule_emitted_with_tunnel_ip() {
+        let config = FirewallConfig {
+            allow_ipv6: false,
+            feature: FeatureFirewall::default(),
+        };
+        let tunnel_ip = StdIpAddr::V4(Ipv4Addr::new(10, 5, 0, 2));
+        let state = FirewallState {
+            tunnel_ips: vec![tunnel_ip],
+            ..Default::default()
+        };
+        let rules = build_chain_rules(&config, &state, &[]);
+        let rule = reject_rule_for_outbound_src(&rules, tunnel_ip).expect(
+            "expected a Reject rule with Direction::Outbound and inverted SrcNetwork(tunnel_ip)",
+        );
+        let inverted_src_count = rule
+            .filters
+            .iter()
+            .filter(|f| matches!(&f.filter_data, FilterData::SrcNetwork(_)) && f.inverted)
+            .count();
+        assert_eq!(inverted_src_count, 1);
+    }
+
+    #[test]
+    fn test_reject_rule_dual_stack_one_rule_two_inverted_src_filters() {
+        let config = FirewallConfig {
+            allow_ipv6: true,
+            feature: FeatureFirewall::default(),
+        };
+        let v4 = StdIpAddr::V4(Ipv4Addr::new(10, 5, 0, 2));
+        let v6 = StdIpAddr::V6(std::net::Ipv6Addr::new(
+            0xfd74, 0x656c, 0x696f, 0, 0, 0, 0, 2,
+        ));
+        let state = FirewallState {
+            tunnel_ips: vec![v4, v6],
+            ..Default::default()
+        };
+        let rules = build_chain_rules(&config, &state, &[]);
+        // A single Reject rule must carry one inverted SrcNetwork filter per IP.
+        let rule = rules
+            .iter()
+            .find(|r| {
+                r.action == RuleAction::Reject
+                    && r.filters.iter().any(|f| {
+                        f.filter_data == FilterData::Direction(Direction::Outbound) && !f.inverted
+                    })
+            })
+            .expect("expected a single Reject rule for the tunnel IPs");
+        let inverted_src_count = rule
+            .filters
+            .iter()
+            .filter(|f| matches!(&f.filter_data, FilterData::SrcNetwork(_)) && f.inverted)
+            .count();
+        assert_eq!(
+            inverted_src_count, 2,
+            "one inverted SrcNetwork per tunnel IP"
+        );
+        for ip in [v4, v6] {
+            assert!(
+                rule.filters.iter().any(|f| matches!(&f.filter_data,
+                    FilterData::SrcNetwork(n) if n.network == IpNet::from(ip))
+                    && f.inverted),
+                "inverted SrcNetwork filter for {ip} must be present",
+                ip = ip
+            );
+        }
+    }
+
+    #[test]
+    fn test_reject_rule_ordered_before_blanket_outbound_accept_and_vpn_accept() {
+        let vpn_pk = PublicKey::new([0xAB; 32]);
+        let config = FirewallConfig {
+            allow_ipv6: false,
+            feature: FeatureFirewall::default(),
+        };
+        let tunnel_ip = StdIpAddr::V4(Ipv4Addr::new(10, 5, 0, 2));
+        let state = FirewallState {
+            tunnel_ips: vec![tunnel_ip],
+            whitelist: Whitelist {
+                vpn_peer: Some(vpn_pk),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let rules = build_chain_rules(&config, &state, &[]);
+
+        let reject_pos = rules.iter().position(|r| {
+            r.action == RuleAction::Reject
+                && r.filters.iter().any(|f| {
+                    f.filter_data == FilterData::Direction(Direction::Outbound) && !f.inverted
+                })
+                && r.filters
+                    .iter()
+                    .any(|f| matches!(&f.filter_data, FilterData::SrcNetwork(_)) && f.inverted)
+        });
+        let blanket_outbound_accept_pos = rules.iter().position(|r| {
+            r.action == RuleAction::Accept
+                && r.filters.len() == 1
+                && r.filters[0].filter_data == FilterData::Direction(Direction::Outbound)
+                && !r.filters[0].inverted
+        });
+        let vpn_accept_pos = rules.iter().position(|r| {
+            r.action == RuleAction::Accept
+                && r.filters.iter().any(|f| {
+                    matches!(&f.filter_data, FilterData::AssociatedData(Some(k))
+                        if k == &vpn_pk.to_vec())
+                })
+        });
+        let reject_pos = reject_pos.expect("reject rule must exist");
+        assert!(
+            reject_pos < blanket_outbound_accept_pos.expect("blanket outbound accept must exist"),
+            "reject rule must precede the blanket outbound-accept rule"
+        );
+        assert!(
+            reject_pos < vpn_accept_pos.expect("vpn accept rule must exist"),
+            "reject rule must precede the vpn accept rule"
         );
     }
 

--- a/crates/telio-firewall/tests/firewall_integration_tests.rs
+++ b/crates/telio-firewall/tests/firewall_integration_tests.rs
@@ -1834,3 +1834,96 @@ mod dns_whitelisting {
         );
     }
 }
+
+#[test]
+fn outbound_wrong_tunnel_src_ip_rejected() {
+    let tunnel_ip = "10.5.0.2";
+    let wrong_ip = "10.5.0.9";
+    let dst = "8.8.8.8:8888";
+
+    let fw = StatefulFirewall::new(false, FeatureFirewall::default())
+        .expect("Failed to load libfirewall");
+    fw.apply_state(FirewallState {
+        tunnel_ips: vec![IpAddr::V4(tunnel_ip.parse().unwrap())],
+        ..Default::default()
+    });
+
+    // Packets originating from the tunnel source IP are allowed out.
+    assert!(
+        fw.process_outbound_packet_sink(
+            &make_peer(),
+            &mut make_udp(&format!("{tunnel_ip}:1111"), dst)
+        ),
+        "packet from the tunnel src IP must be accepted"
+    );
+    // Packets with any other source IP are rejected to avoid poisoning NAT.
+    assert!(
+        !fw.process_outbound_packet_sink(
+            &make_peer(),
+            &mut make_udp(&format!("{wrong_ip}:1111"), dst)
+        ),
+        "packet with a non-tunnel src IP must be rejected"
+    );
+}
+
+#[test]
+fn outbound_wrong_src_ip_allowed_when_tunnel_ips_unset() {
+    let dst = "8.8.8.8:8888";
+
+    let fw = StatefulFirewall::new(false, FeatureFirewall::default())
+        .expect("Failed to load libfirewall");
+    // Empty tunnel_ips disables the protection: outbound is unrestricted.
+    fw.apply_state(FirewallState::default());
+
+    assert!(
+        fw.process_outbound_packet_sink(&make_peer(), &mut make_udp("10.5.0.9:1111", dst)),
+        "with tunnel_ips unset, any src IP must be accepted"
+    );
+}
+
+#[test]
+fn outbound_wrong_tunnel_src_ip_rejected_dual_stack() {
+    let tunnel_v4 = "10.5.0.2";
+    let tunnel_v6 = "fd74:656c:696f::2";
+    let dst4 = "8.8.8.8:8888";
+    let dst6 = "[2001:4860:4860::8888]:8888";
+
+    let fw = StatefulFirewall::new(true, FeatureFirewall::default())
+        .expect("Failed to load libfirewall");
+    fw.apply_state(FirewallState {
+        tunnel_ips: vec![
+            IpAddr::V4(tunnel_v4.parse().unwrap()),
+            IpAddr::V6(tunnel_v6.parse().unwrap()),
+        ],
+        ..Default::default()
+    });
+
+    // Both tunnel source IPs are allowed out on their respective stacks.
+    assert!(
+        fw.process_outbound_packet_sink(
+            &make_peer(),
+            &mut make_udp(&format!("{tunnel_v4}:1111"), dst4)
+        ),
+        "packet from the IPv4 tunnel src IP must be accepted"
+    );
+    assert!(
+        fw.process_outbound_packet_sink(
+            &make_peer(),
+            &mut make_udp6(&format!("[{tunnel_v6}]:1111"), dst6)
+        ),
+        "packet from the IPv6 tunnel src IP must be accepted"
+    );
+
+    // Wrong source IPs are rejected on both stacks.
+    assert!(
+        !fw.process_outbound_packet_sink(&make_peer(), &mut make_udp("10.5.0.9:1111", dst4)),
+        "IPv4 packet with a non-tunnel src IP must be rejected"
+    );
+    assert!(
+        !fw.process_outbound_packet_sink(
+            &make_peer(),
+            &mut make_udp6("[fd74:656c:696f::9]:1111", dst6)
+        ),
+        "IPv6 packet with a non-tunnel src IP must be rejected"
+    );
+}

--- a/nat-lab/tests/libtelio_client/client.py
+++ b/nat-lab/tests/libtelio_client/client.py
@@ -378,6 +378,9 @@ class Client:
     async def notify_network_change(self) -> None:
         await self.get_proxy().notify_network_change()
 
+    async def set_tunnel_src_ip(self, src_ips: List[str]) -> None:
+        await self.get_proxy().set_tunnel_src_ip(src_ips)
+
     async def configure_interface(self) -> bool:
         if not self._interface_configured:
             await self.get_router().setup_interface(self._node.ip_addresses)

--- a/nat-lab/tests/test_vpn.py
+++ b/nat-lab/tests/test_vpn.py
@@ -24,6 +24,7 @@ from tests.utils.netcat import NetCatClient
 from tests.utils.ping import ping
 from tests.utils.process import ProcessExecError
 from tests.utils.router import IPProto, IPStack
+from tests.utils.tcpdump import make_tcpdump
 
 
 class TestVpnConnection:
@@ -768,3 +769,95 @@ class TestSingleVpn1Node:
         assert (
             ip == config.WG_SERVER["ipv4"]
         ), f"wrong public IP when connected to VPN {ip}"
+
+    @pytest.mark.asyncio
+    # NEP_TUN only: the firewall outbound reject path is wired into the NepTUN
+    # adapter, not LinuxNativeWg. The feature is inactive on linux-native.
+    @pytest.mark.parametrize(
+        "alpha_setup_params",
+        [
+            pytest.param(
+                SetupParameters(
+                    connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
+                    adapter_type_override=TelioAdapterType.NEP_TUN,
+                    ip_stack=IPStack.IPv4,
+                    connection_tracker_config=generate_connection_tracker_config(
+                        ConnectionTag.DOCKER_CONE_CLIENT_1,
+                        vpn_1_limits=(1, 1),
+                    ),
+                    is_meshnet=False,
+                ),
+                id="neptun",
+            ),
+        ],
+    )
+    async def test_vpn_reject_wrong_tunnel_src_ip(
+        self,
+        alpha_setup_params: SetupParameters,  # pylint: disable=unused-argument
+        env,
+        single_vpn_server_connection,
+    ) -> None:
+        alpha_node = env.nodes[0]
+        alpha_conn = env.connections[0].connection
+        alpha_client = env.clients[0]
+        vpn_conn = single_vpn_server_connection.connection
+
+        node_ip = alpha_node.ip_addresses[0]
+        # this is not node's tunnel src IP, so the firewall must drop packets from it.
+        foreign_ip = "100.64.0.8"
+        serv_ip = config.PHOTO_ALBUM_IP
+        serv_port = 80
+
+        await connect_vpn(
+            alpha_conn,
+            vpn_conn,
+            alpha_client,
+            node_ip,
+            config.WG_SERVER,
+        )
+
+        # set tunnel IP so the firewall enforces the
+        # source-IP reject check.
+        await alpha_client.set_tunnel_src_ip(list(alpha_node.ip_addresses))
+
+        interface_name = alpha_client.get_router().get_interface_name()
+
+        await alpha_conn.create_process(
+            ["ip", "-4", "addr", "add", f"{foreign_ip}/32", "dev", interface_name],
+            quiet=True,
+        ).execute()
+        try:
+            async with make_tcpdump([vpn_conn]):
+                async with NetCatClient(
+                    alpha_conn,
+                    serv_ip,
+                    serv_port,
+                    source_ip=node_ip,
+                ).run() as good_client:
+                    await asyncio.wait_for(
+                        good_client.connection_succeeded(), timeout=10
+                    )
+
+                async with NetCatClient(
+                    alpha_conn,
+                    serv_ip,
+                    serv_port,
+                    source_ip=foreign_ip,
+                ).run() as bad_client:
+                    with pytest.raises(asyncio.TimeoutError):
+                        await asyncio.wait_for(
+                            bad_client.connection_succeeded(), timeout=10
+                        )
+        finally:
+            await alpha_conn.create_process(
+                [
+                    "ip",
+                    "-4",
+                    "addr",
+                    "del",
+                    f"{foreign_ip}/32",
+                    "dev",
+                    interface_name,
+                ],
+                quiet=True,
+            ).execute()

--- a/nat-lab/tests/uniffi/libtelio_proxy.py
+++ b/nat-lab/tests/uniffi/libtelio_proxy.py
@@ -142,6 +142,10 @@ class LibtelioProxy:
         self._handle_remote_error(lambda r: r.notify_network_change())
 
     @move_to_async_thread
+    def set_tunnel_src_ip(self, src_ips):
+        self._handle_remote_error(lambda r: r.set_tunnel_src_ip(src_ips))
+
+    @move_to_async_thread
     def connect_to_exit_node(self, public_key, allowed_ips, endpoint):
         self._handle_remote_error(
             lambda r: r.connect_to_exit_node(public_key, allowed_ips, endpoint)

--- a/nat-lab/tests/uniffi/libtelio_remote.py
+++ b/nat-lab/tests/uniffi/libtelio_remote.py
@@ -191,6 +191,10 @@ class LibtelioWrapper:
         self._libtelio.notify_network_change("")
 
     @serialize_error
+    def set_tunnel_src_ip(self, src_ips: List[str]):
+        self._libtelio.set_tunnel_src_ip(src_ips)
+
+    @serialize_error
     def connect_to_exit_node(self, public_key, allowed_ips: str, endpoint: str):
         self._libtelio.connect_to_exit_node_with_id(
             "natlab", public_key, allowed_ips, endpoint

--- a/src/device.rs
+++ b/src/device.rs
@@ -278,6 +278,11 @@ pub struct RequestedState {
 
     // Requested keepalive periods
     pub(crate) keepalive_periods: FeaturePersistentKeepalive,
+
+    // Tunnel source IPs supplied by the integrating app via set_tunnel_src_ip(...).
+    // When non-empty, the firewall rejects outbound packets whose source IP is
+    // not one of these.
+    pub tunnel_ips: Vec<IpAddr>,
 }
 
 pub struct MeshnetEntities {
@@ -802,6 +807,15 @@ impl Device {
         self.async_runtime()?.block_on(async {
             task_exec!(self.rt()?, async move |rt| {
                 Ok(rt.notify_network_change().await)
+            })
+            .await?
+        })
+    }
+
+    pub fn set_tunnel_src_ip(&self, src_ips: Vec<IpAddr>) -> Result {
+        self.async_runtime()?.block_on(async {
+            task_exec!(self.rt()?, async move |rt| {
+                Ok(rt.set_tunnel_src_ip(src_ips).await)
             })
             .await?
         })
@@ -1824,6 +1838,14 @@ impl Runtime {
         #[cfg(target_os = "android")]
         PATH_CHANGE_BROADCAST.send(());
 
+        Ok(())
+    }
+
+    async fn set_tunnel_src_ip(&mut self, src_ips: Vec<IpAddr>) -> Result {
+        self.requested_state.tunnel_ips = src_ips;
+        // re-consolidate so the firewall picks up tunnel_ips when building rules chain.
+        wg_controller::consolidate_wg_state(&self.requested_state, &self.entities, &self.features)
+            .await?;
         Ok(())
     }
 

--- a/src/device/wg_controller.rs
+++ b/src/device/wg_controller.rs
@@ -1658,6 +1658,86 @@ mod tests {
 
     #[cfg(feature = "enable_firewall")]
     #[tokio::test]
+    async fn app_supplied_tunnel_ip_survives_exit_node_reconnect() {
+        let mut firewall = MockFirewall::new();
+        let pub_key_starcast_vpeer = SecretKey::gen().public();
+        let pub_key_1 = SecretKey::gen().public();
+        let pub_key_2 = SecretKey::gen().public();
+
+        let mut requested_state =
+            create_requested_state(vec![(pub_key_1, vec![], false, false, false, false)]);
+        // The app supplies the tunnel source IP only once; it must be retained
+        // in the requested state and reapplied on every exit-node reconnect.
+        requested_state.tunnel_ips = vec![IpAddr::V4(Ipv4Addr::new(10, 5, 0, 2))];
+
+        let mut seq = mockall::Sequence::new();
+        // 1) Exit node up: tunnel IP protection applied.
+        firewall
+            .expect_apply_state()
+            .once()
+            .in_sequence(&mut seq)
+            .withf(|state| state.tunnel_ips == vec![IpAddr::V4(Ipv4Addr::new(10, 5, 0, 2))])
+            .return_const(());
+        // 2) Exit node down: protection cleared from the firewall state.
+        firewall
+            .expect_apply_state()
+            .once()
+            .in_sequence(&mut seq)
+            .withf(|state| state.tunnel_ips.is_empty())
+            .return_const(());
+        // 3) Exit node back up: tunnel IP reapplied without the app re-supplying it.
+        firewall
+            .expect_apply_state()
+            .once()
+            .in_sequence(&mut seq)
+            .withf(|state| state.tunnel_ips == vec![IpAddr::V4(Ipv4Addr::new(10, 5, 0, 2))])
+            .return_const(());
+
+        requested_state.exit_node = Some(ExitNode {
+            public_key: pub_key_2,
+            ..Default::default()
+        });
+        consolidate_firewall(
+            &requested_state,
+            &firewall,
+            Some(pub_key_starcast_vpeer),
+            None,
+        )
+        .await
+        .unwrap();
+
+        requested_state.exit_node = None;
+        consolidate_firewall(
+            &requested_state,
+            &firewall,
+            Some(pub_key_starcast_vpeer),
+            None,
+        )
+        .await
+        .unwrap();
+
+        requested_state.exit_node = Some(ExitNode {
+            public_key: pub_key_2,
+            ..Default::default()
+        });
+        consolidate_firewall(
+            &requested_state,
+            &firewall,
+            Some(pub_key_starcast_vpeer),
+            None,
+        )
+        .await
+        .unwrap();
+
+        // The app never re-supplied the IP; the requested state must still hold it.
+        assert_eq!(
+            requested_state.tunnel_ips,
+            vec![IpAddr::V4(Ipv4Addr::new(10, 5, 0, 2))]
+        );
+    }
+
+    #[cfg(feature = "enable_firewall")]
+    #[tokio::test]
     async fn do_not_add_meshnet_exit_node_to_firewall_if_it_does_not_allow_incoming_connections() {
         let mut firewall = MockFirewall::new();
 

--- a/src/device/wg_controller.rs
+++ b/src/device/wg_controller.rs
@@ -653,6 +653,15 @@ async fn consolidate_firewall<F: Firewall>(
             .ok_or(Error::IpNotSet)?;
     }
 
+    state.tunnel_ips = if requested_state.exit_node.is_some() {
+        if requested_state.tunnel_ips.is_empty() {
+            telio_log_warn!("Exit node connected but no tunnel source IP was supplied.");
+        }
+        requested_state.tunnel_ips.clone()
+    } else {
+        Vec::new()
+    };
+
     firewall.apply_state(state);
 
     Ok(())
@@ -1576,6 +1585,65 @@ mod tests {
                 force_plaintext_dns_for_servers: None,
                 ..Default::default()
             }))
+            .return_const(());
+
+        consolidate_firewall(
+            &requested_state,
+            &firewall,
+            Some(pub_key_starcast_vpeer),
+            None,
+        )
+        .await
+        .unwrap();
+    }
+
+    #[cfg(feature = "enable_firewall")]
+    #[tokio::test]
+    async fn app_supplied_tunnel_ip_is_set_for_vpn_exit() {
+        let mut firewall = MockFirewall::new();
+        let pub_key_starcast_vpeer = SecretKey::gen().public();
+        let pub_key_1 = SecretKey::gen().public();
+        let pub_key_2 = SecretKey::gen().public();
+
+        let mut requested_state =
+            create_requested_state(vec![(pub_key_1, vec![], false, false, false, false)]);
+        requested_state.exit_node = Some(ExitNode {
+            public_key: pub_key_2,
+            ..Default::default()
+        });
+        requested_state.tunnel_ips = vec![IpAddr::V4(Ipv4Addr::new(10, 5, 0, 2))];
+
+        firewall
+            .expect_apply_state()
+            .once()
+            .withf(|state| state.tunnel_ips == vec![IpAddr::V4(Ipv4Addr::new(10, 5, 0, 2))])
+            .return_const(());
+
+        consolidate_firewall(
+            &requested_state,
+            &firewall,
+            Some(pub_key_starcast_vpeer),
+            None,
+        )
+        .await
+        .unwrap();
+    }
+
+    #[cfg(feature = "enable_firewall")]
+    #[tokio::test]
+    async fn app_supplied_tunnel_ip_ignored_without_exit_node() {
+        let mut firewall = MockFirewall::new();
+        let pub_key_starcast_vpeer = SecretKey::gen().public();
+        let pub_key_1 = SecretKey::gen().public();
+
+        let mut requested_state =
+            create_requested_state(vec![(pub_key_1, vec![], false, false, false, false)]);
+        requested_state.tunnel_ips = vec![IpAddr::V4(Ipv4Addr::new(10, 5, 0, 2))];
+
+        firewall
+            .expect_apply_state()
+            .once()
+            .withf(|state| state.tunnel_ips.is_empty())
             .return_const(());
 
         consolidate_firewall(

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -680,6 +680,26 @@ impl Telio {
         })
     }
 
+    /// Set the source IP address(es) currently configured on the tunnel
+    /// interface. When set, the firewall rejects outbound packets whose source
+    /// IP is not one of these.
+    ///
+    /// # Parameters
+    /// - `src_ips`: tunnel interface source IPs, empty to disable.
+    pub fn set_tunnel_src_ip(&self, src_ips: Vec<IpAddr>) -> FfiResult<()> {
+        telio_log_info!(
+            "Telio::set_tunnel_src_ip entry with instance id: {}. src_ips: {:?}",
+            self.id,
+            src_ips
+        );
+        catch_ffi_panic(|| {
+            self.device_op(true, |dev| {
+                dev.set_tunnel_src_ip(src_ips.clone())
+                    .log_result("Telio::set_tunnel_src_ip")
+            })
+        })
+    }
+
     /// Notify telio system is going to sleep.
     pub fn notify_sleep(&self) -> FfiResult<()> {
         telio_log_info!("telio_notify_sleep entry with instance id: {}.", self.id);

--- a/src/libtelio.udl
+++ b/src/libtelio.udl
@@ -362,6 +362,16 @@ interface Telio {
     [Throws=TelioError]
     void notify_network_change(string network_info);
 
+    /// Set the source IP address(es) currently configured on the tunnel
+    /// interface. When set, the firewall rejects outbound packets whose source
+    /// IP is not one of these.
+    ///
+    /// # Parameters
+    /// - `src_ips`: tunnel interface source IPs, empty to disable.
+    ///
+    [Throws=TelioError]
+    void set_tunnel_src_ip(sequence<IpAddr> src_ips);
+
     /// Notify telio when system goes to sleep.
     [Throws=TelioError]
     void notify_sleep();


### PR DESCRIPTION
### Problem
Connections opened before the VPN tunnel comes up (analytics, OS DNS, browser prefetch) are bound to the physical NIC's address. When those sockets later send through the now-active tunnel, the inner packet still carries that stale source IP. The exit node interprets this as a client-IP change and starts redirecting all subsequent return traffic to the wrong destination, tearing down active connections. This breaks NordWhisper and intermittently NordLynx shortly after startup.

  ### Solution
Once a VPN exit node is connected and the integrating app has supplied the tunnel interface's source IPs, the firewall rejects any outbound packet whose source IP is not one of those addresses. The check is opt-in and inert until the app provides IPs (passing an empty list disables it).


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
