### PR TITLE
LLT-6914, LLT-6917, LLT-6919: Remove obsolete entries from deny.toml

### DIFF
--- a/clis/nordvpnlite/openwrt/feed/net/nordvpnlite/THIRD-PARTY-NOTICES
+++ b/clis/nordvpnlite/openwrt/feed/net/nordvpnlite/THIRD-PARTY-NOTICES
@@ -411,10 +411,6 @@ The following dependencies are licensed under the Apache-2.0 license.
 
 - [proc-macro-crate](https://github.com/bkchr/proc-macro-crate) *(also available under: MIT)*
 
-- [proc-macro-error](https://gitlab.com/CreepySkeleton/proc-macro-error) *(also available under: MIT)*
-
-- [proc-macro-error-attr](https://gitlab.com/CreepySkeleton/proc-macro-error) *(also available under: MIT)*
-
 - [proc-macro2](https://github.com/dtolnay/proc-macro2) *(also available under: MIT)*
 
 - [proptest](https://github.com/proptest-rs/proptest) *(also available under: MIT)*
@@ -947,8 +943,6 @@ The following dependencies are licensed under the MIT license.
 
 - [atomic-waker](https://github.com/smol-rs/atomic-waker) *(also available under: Apache-2.0)*
 
-- [atty](https://github.com/softprops/atty)
-
 - [axum](https://github.com/tokio-rs/axum)
 
 - [axum-core](https://github.com/tokio-rs/axum)
@@ -1307,9 +1301,9 @@ The following dependencies are licensed under the MIT license.
 
 - [parking_lot](https://github.com/Amanieu/parking_lot) *(also available under: Apache-2.0)*
 
-- [parking_lot_core](https://github.com/Amanieu/parking_lot) *(also available under: Apache-2.0)*
-
 - [paste](https://github.com/dtolnay/paste) *(also available under: Apache-2.0)*
+
+- [parking_lot_core](https://github.com/Amanieu/parking_lot) *(also available under: Apache-2.0)*
 
 - [percent-encoding](https://github.com/servo/rust-url/) *(also available under: Apache-2.0)*
 
@@ -1358,10 +1352,6 @@ The following dependencies are licensed under the MIT license.
 - [predicates-tree](https://github.com/assert-rs/predicates-rs/tree/master/crates/tree) *(also available under: Apache-2.0)*
 
 - [proc-macro-crate](https://github.com/bkchr/proc-macro-crate) *(also available under: Apache-2.0)*
-
-- [proc-macro-error](https://gitlab.com/CreepySkeleton/proc-macro-error) *(also available under: Apache-2.0)*
-
-- [proc-macro-error-attr](https://gitlab.com/CreepySkeleton/proc-macro-error) *(also available under: Apache-2.0)*
 
 - [proc-macro2](https://github.com/dtolnay/proc-macro2) *(also available under: Apache-2.0)*
 
@@ -2703,7 +2693,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     means any form of the work other than Source Code Form.
 
 1.7. "Larger Work"
-    means a work that combines Covered Software with other material, in 
+    means a work that combines Covered Software with other material, in
     a separate file or files, that is not Covered Software.
 
 1.8. "License"

--- a/deny.toml
+++ b/deny.toml
@@ -7,10 +7,7 @@ db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
 yanked = "warn"
 ignore = [
-    "RUSTSEC-2024-0370", # proc-macro-error is unmaintained
     "RUSTSEC-2024-0436", # paste is unmaintained
-    "RUSTSEC-2024-0375", # atty is unmaintained
-    "RUSTSEC-2021-0145", # atty has potential unaligned read
     "RUSTSEC-2025-0141", # bincode is unmaintained
     "RUSTSEC-2026-0173", # proc-macro-error2 is unmaintained
 ]


### PR DESCRIPTION
### Problem
After nat-detect was updated to 1.9 we don't use proc-macro-error and atty anymore, so deny.toml entries are obsolete

### Solution
Remove the deny.toml entries, remove them also from THIRD-PARTY-NOTICES

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
