### PR TITLE
Reset handshake timers on network change

### DIFF
--- a/.unreleased/fix_android_session_expired_loop
+++ b/.unreleased/fix_android_session_expired_loop
@@ -1,0 +1,1 @@
+Make session keeper and PQ restarts suspend-aware, and restart more things on network change

--- a/crates/telio-core/src/device.rs
+++ b/crates/telio-core/src/device.rs
@@ -37,7 +37,8 @@ use telio_traversal::{
     },
     last_rx_time_provider::{TimeSinceLastRxProvider, WireGuardTimeSinceLastRxProvider},
     ping_pong_handler::PingPongHandler,
-    SessionKeeper, UpgradeRequestChangeEvent, UpgradeSync, WireGuardEndpointCandidateChangeEvent,
+    SessionKeeper, SessionKeeperTrait, UpgradeRequestChangeEvent, UpgradeSync,
+    WireGuardEndpointCandidateChangeEvent,
 };
 
 #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
@@ -1832,7 +1833,20 @@ impl Runtime {
             }
 
             meshnet_entities.derp.reconnect().await;
+
+            // Fire all keepalive pings immediately so peers receive a fresh
+            // handshake after the network change rather than waiting up to one
+            // full keepalive interval
+            if let Some(sk) = &meshnet_entities.session_keeper {
+                let _ = sk.reset_keepalives().await;
+            }
         }
+
+        // Restart the PQ key-rotation task so it opens a fresh socket on the
+        // new network interface.  We keep the existing preshared key in place
+        // so the WireGuard peer remains configured and traffic is not
+        // interrupted while the new task performs its first rekey
+        self.entities.postquantum_wg.restart_rotation();
 
         #[cfg(target_os = "android")]
         PATH_CHANGE_BROADCAST.send(());

--- a/crates/telio-pq/src/conn.rs
+++ b/crates/telio-pq/src/conn.rs
@@ -4,7 +4,7 @@ use tokio::task::JoinHandle;
 
 use telio_model::features::FeaturePostQuantumVPN;
 use telio_task::io::chan;
-use telio_utils::{reset_after, telio_log_debug, telio_log_warn};
+use telio_utils::{telio_log_debug, telio_log_warn, SuspendAwareTicker};
 
 use crate::proto;
 
@@ -23,7 +23,11 @@ impl ConnKeyRotation {
     ) -> Self {
         telio_log_debug!("Starting PQ task");
 
-        let rekey_interval = Duration::from_secs(features.rekey_interval_s as _);
+        let mut rekey_interval = features.rekey_interval_s;
+        if rekey_interval == 0 {
+            rekey_interval = 1;
+        }
+        let rekey_interval = Duration::from_secs(rekey_interval as _);
         let request_retry = Duration::from_secs(features.handshake_retry_interval_s as _);
         let pq_version = features.version;
 
@@ -68,11 +72,10 @@ impl ConnKeyRotation {
                 .await;
 
             telio_log_debug!("Rekey interval: {}s", rekey_interval.as_secs());
-            let mut interval = telio_utils::interval(rekey_interval);
+            let mut ticker = SuspendAwareTicker::new_after(rekey_interval, rekey_interval);
 
-            interval.tick().await; // This call returns immedietly
             loop {
-                interval.tick().await;
+                ticker.tick().await;
 
                 // Dylint is unhappy about the `rekey` future size
                 // and asks for using `Box::pin` to move it on the heap
@@ -109,14 +112,14 @@ impl ConnKeyRotation {
                     }
                     Ok(Err(err)) => {
                         telio_log_warn!("Failed to perform PQ rekey: {err}");
-                        reset_after(&mut interval, request_retry);
+                        ticker.reset_after(request_retry);
                     }
                     Err(_timeout) => {
                         telio_log_warn!(
                             "Failed to perform PQ rekey: TIMEOUT({}s)",
                             request_retry.as_secs()
                         );
-                        interval.reset_immediately();
+                        ticker.reset_immediately();
                     }
                 }
             }

--- a/crates/telio-pq/src/entity.rs
+++ b/crates/telio-pq/src/entity.rs
@@ -114,6 +114,31 @@ impl Entity {
         self.start_impl(addr, wg_secret, peer).await;
     }
 
+    /// Restart the key-rotation task without clearing the existing keys.
+    ///
+    /// This is the preferred action on a network change.
+    /// The old `ConnKeyRotation` task is dropped and a new one is started immediately
+    /// so it can open a fresh socket on the current network interface.  The existing
+    /// `keys` and `last_key_fetch_ts` are preserved, so WireGuard continues to use the
+    /// current preshared key while the new task performs its first rekey - avoiding a
+    /// visible VPN disconnection.
+    ///
+    /// Does nothing if no PQ peer is currently active
+    pub fn restart_rotation(&self) {
+        let mut peer = self.peer.lock();
+        if let Some(p) = peer.as_mut() {
+            telio_log_debug!("Restarting PQ rotation task after network change");
+            p._rotation_task = super::conn::ConnKeyRotation::run(
+                self.chan.clone(),
+                self.sockets.clone(),
+                p.addr,
+                p.wg_secret.clone(),
+                p.pubkey,
+                &self.features,
+            );
+        }
+    }
+
     // Postquantum has a quirk that can cause VPN connections to fail due to the client having a preshared key when the server doesn't.
     // This can happen if there was a handshake established with a preshared key, then the connection is broken for more than 180s
     // (the time after which wireguard will abandon an inactive connection), and then the client tries to do a new handshake with the same

--- a/crates/telio-traversal/src/session_keeper.rs
+++ b/crates/telio-traversal/src/session_keeper.rs
@@ -46,6 +46,10 @@ pub trait SessionKeeperTrait {
         interval: Duration,
     ) -> Result<()>;
     async fn remove_node(&self, key: &PublicKey) -> Result<()>;
+    /// Reset all keepalive timers so they fire immediately on the next poll.
+    /// Call this after a network change to ensure peers receive a fresh
+    /// keepalive ping without waiting for the next scheduled interval
+    async fn reset_keepalives(&self) -> Result<()>;
 }
 
 pub struct SessionKeeper {
@@ -127,6 +131,15 @@ impl SessionKeeperTrait for SessionKeeper {
         .await?;
 
         Ok(())
+    }
+
+    async fn reset_keepalives(&self) -> Result<()> {
+        task_exec!(&self.task, async move |s| {
+            s.actions.reset_all_actions();
+            Ok(())
+        })
+        .await
+        .map_err(Error::Task)
     }
 }
 

--- a/crates/telio-utils/src/lib.rs
+++ b/crates/telio-utils/src/lib.rs
@@ -14,6 +14,10 @@ pub use map::*;
 pub mod sleep;
 pub use sleep::*;
 
+/// Suspend-aware interval ticker
+pub mod suspend_aware_ticker;
+pub use suspend_aware_ticker::*;
+
 /// Timed, repeated actions
 pub mod repeated_actions;
 pub use repeated_actions::*;

--- a/crates/telio-utils/src/repeated_actions.rs
+++ b/crates/telio-utils/src/repeated_actions.rs
@@ -5,13 +5,14 @@ use std::{
 };
 use thiserror::Error as ThisError;
 
-use crate::{interval, interval_after};
 use futures::{
     future::BoxFuture,
     stream::{FuturesUnordered, StreamExt},
     FutureExt,
 };
-use tokio::time::{Duration, Interval};
+use tokio::time::Duration;
+
+use crate::SuspendAwareTicker;
 
 /// Possible [RepeatedAction] errors.
 #[derive(ThisError, Debug)]
@@ -33,7 +34,7 @@ type Result<T> = std::result::Result<T, RepeatedActionError>;
 
 /// Main struct container, that hold all actions
 pub struct RepeatedActions<K, C, R> {
-    actions: HashMap<K, (Interval, RepeatedAction<C, R>)>,
+    actions: HashMap<K, (SuspendAwareTicker, RepeatedAction<C, R>)>,
 }
 
 impl<K, C, R> Default for RepeatedActions<K, C, R>
@@ -64,7 +65,7 @@ where
         action: RepeatedAction<C, R>,
     ) -> Result<()> {
         if let hash_map::Entry::Vacant(e) = self.actions.entry(key) {
-            e.insert((interval(dur), action));
+            e.insert((SuspendAwareTicker::new(dur), action));
             return Ok(());
         }
 
@@ -84,10 +85,21 @@ where
         self.actions.get_mut(key).map_or_else(
             || Err(RepeatedActionError::RepeatedActionNotFound),
             |a| {
-                a.0 = interval_after(dur, dur);
+                a.0 = SuspendAwareTicker::new_after(dur, dur);
                 Ok(())
             },
         )
+    }
+
+    /// Reset all action timers so they fire immediately on the next poll.
+    ///
+    /// This is useful after a network change: rather than waiting up to one full
+    /// period for the next scheduled keepalive, all peers receive a ping as soon
+    /// as `select_action` is polled again
+    pub fn reset_all_actions(&mut self) {
+        self.actions.values_mut().for_each(|(ticker, _)| {
+            ticker.reset_immediately();
+        });
     }
 
     /// Check if it contains action
@@ -105,11 +117,11 @@ where
         let a = self
             .actions
             .iter_mut()
-            .map(|(key, (interval, action))| (key, interval.tick(), action));
+            .map(|(key, (ticker, action))| (key, ticker.tick(), action));
 
         // Transform futures to `Output = (key, action)`
         let mut b: FuturesUnordered<_> = a
-            .map(|(key, interval, action)| interval.map(move |_| (key, action)).boxed())
+            .map(|(key, tick, action)| tick.map(move |_| (key, action)).boxed())
             .collect();
 
         b.next()
@@ -151,10 +163,6 @@ mod tests {
         pub async fn change(&mut self, str: String) -> Result {
             self.test = str;
             Ok(())
-        }
-
-        pub fn get(&self) -> &str {
-            &self.test
         }
     }
 

--- a/crates/telio-utils/src/suspend_aware_ticker.rs
+++ b/crates/telio-utils/src/suspend_aware_ticker.rs
@@ -1,0 +1,49 @@
+/// A suspend-aware interval ticker.
+///
+/// `tokio::time::Instant` and `std::time::Instant` are not suspend aware, which means
+/// that the timers that are driving periodic actions won't advance while a device is
+/// suspended. As a result of that, we might have to wait an entire `period` after waking
+/// up from sleep rather than firing immediately, which can cause slowdowns and nonets.
+/// `crate::Instant` is suspend-aware, and allows this ticker to also be suspend-aware,
+/// which let's other components restore connectivity much faster after waking up from
+/// suspend.
+///
+/// The next tick is always based on the current time, rather than just advancing
+/// `next` by `period`. That way, if the tick is happening after the device wakes
+/// up from a long sleep, the ticker won't fire multiple ticks to try to catch up
+pub struct SuspendAwareTicker {
+    period: tokio::time::Duration,
+    /// The wall-clock deadline for the next tick, measured with a suspend-aware clock.
+    next: crate::Instant,
+}
+
+impl SuspendAwareTicker {
+    /// Create a new ticker with a given period where the first tick happens immediately
+    pub fn new(period: tokio::time::Duration) -> Self {
+        Self::new_after(tokio::time::Duration::ZERO, period)
+    }
+
+    /// Create a new ticker with a given period where the first tick is `offset` time from now
+    pub fn new_after(offset: tokio::time::Duration, period: tokio::time::Duration) -> Self {
+        Self {
+            period,
+            next: crate::Instant::now() + offset,
+        }
+    }
+
+    /// Wait until the next tick, then advance the deadline
+    pub async fn tick(&mut self) {
+        crate::sleep_until(self.next).await;
+        self.next = crate::Instant::now() + self.period;
+    }
+
+    /// Reset the ticker so the next tick happens `offset` time from now
+    pub fn reset_after(&mut self, offset: tokio::time::Duration) {
+        self.next = crate::Instant::now() + offset;
+    }
+
+    /// Reset the ticker so the next tick happens immediately
+    pub fn reset_immediately(&mut self) {
+        self.next = crate::Instant::now();
+    }
+}


### PR DESCRIPTION
### Problem
Android reported some nonet scenarios and from reading the logs two things could be found: wireguard session were expired for longer than they should after waking up from doze mode and after a network change

### Solution
Make the timers for handshakes suspend-aware and reset all handshake timers on `notify_network_change`


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
