### PR TITLE
LLT-6920: Remove explicit defaults from FeaturesDefaultsBuilder constructor

### DIFF
--- a/crates/telio-model/src/features.rs
+++ b/crates/telio-model/src/features.rs
@@ -199,7 +199,7 @@ pub enum RttType {
 pub struct FeatureLana {
     /// Path of the file where events will be stored. If such file does not exist, it will be created, otherwise reused
     pub event_path: String,
-    /// Whether the events should be sent to produciton or not
+    /// Whether the events should be sent to production or not
     pub prod: bool,
 }
 
@@ -254,7 +254,7 @@ pub enum PathType {
     Direct,
 }
 
-/// Enable meshent direct connection
+/// Enable meshnet direct connection
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, SmartDefault)]
 #[serde(default)]
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
@@ -453,7 +453,7 @@ pub struct FeatureFirewall {
     /// Customizable private IP range to treat certain private IP ranges
     /// as public IPs for testing purposes.
     pub exclude_private_ip_range: Option<Ipv4Net>,
-    /// Blackist for outgoing connections
+    /// Blacklist for outgoing connections
     #[serde(default)]
     pub outgoing_blacklist: Vec<FirewallBlacklistTuple>,
 }

--- a/src/ffi/defaults_builder.rs
+++ b/src/ffi/defaults_builder.rs
@@ -8,34 +8,13 @@ pub struct FeaturesDefaultsBuilder {
 }
 
 impl FeaturesDefaultsBuilder {
+    /// Create a new builder with default values
     pub fn new() -> Self {
-        let config = Features {
-            wireguard: default(),
-            validate_keys: default(),
-            firewall: default(),
-            post_quantum_vpn: default(),
-            dns: default(),
-            nurse: None,
-            lana: None,
-            paths: None,
-            direct: None,
-            is_test_env: None,
-            hide_user_data: true,
-            hide_thread_id: true,
-            // All inner values of derp are None's or false's
-            // and as it does not actualy control derp
-            // builder part is not added
-            derp: None,
-            link_detection: None,
-            flush_events_on_stop_timeout_seconds: None,
-            multicast: false,
-            ipv6: false,
-            nicknames: false,
-            error_notification_service: None,
-        };
-
         Self {
-            config: Mutex::new(config),
+            config: Mutex::new(Features {
+                nurse: None,
+                ..default()
+            }),
         }
     }
 
@@ -82,7 +61,7 @@ impl FeaturesDefaultsBuilder {
             cfg.wireguard.persistent_keepalive.proxying = Some(125);
             cfg.wireguard.persistent_keepalive.stun = Some(125);
 
-            // Preseve any previous values if those were set.
+            // Preserve any previous values if those were set.
             let prev = cfg.derp.as_ref().cloned().unwrap_or_default();
             cfg.derp = Some(FeatureDerp {
                 tcp_keepalive: Some(125),
@@ -94,7 +73,7 @@ impl FeaturesDefaultsBuilder {
         self
     }
 
-    /// Enable key valiation in set_config call with defaults
+    /// Enable key validation in set_config call with defaults
     pub fn enable_validate_keys(self: Arc<Self>) -> Arc<Self> {
         self.config.lock().validate_keys = FeatureValidateKeys(true);
         self
@@ -112,7 +91,7 @@ impl FeaturesDefaultsBuilder {
         self
     }
 
-    /// Enable blocking event flush with timout on stop with defaults
+    /// Enable blocking event flush with timeout on stop with defaults
     pub fn enable_flush_events_on_stop_timeout_seconds(self: Arc<Self>) -> Arc<Self> {
         self.config.lock().flush_events_on_stop_timeout_seconds = Some(0);
         self
@@ -124,7 +103,7 @@ impl FeaturesDefaultsBuilder {
         self
     }
 
-    /// Eanable multicast with defaults
+    /// Enable multicast with defaults
     pub fn enable_multicast(self: Arc<Self>) -> Arc<Self> {
         self.config.lock().multicast = true;
         self
@@ -171,4 +150,22 @@ impl Default for FeaturesDefaultsBuilder {
 
 fn default<T: Default>() -> T {
     T::default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_builder_default_features() {
+        let expected_features = Features {
+            nurse: None,
+            ..default()
+        };
+
+        let builder = Arc::new(FeaturesDefaultsBuilder::new());
+        let features = builder.build();
+
+        assert_eq!(features, expected_features);
+    }
 }

--- a/src/libtelio.udl
+++ b/src/libtelio.udl
@@ -563,7 +563,7 @@ callback interface TelioProtectCb {
 };
 
 /// A [Features] builder that allows a simpler initialization of
-/// features with defaults comming from libtelio lib.
+/// features with defaults coming from libtelio lib.
 ///
 /// !!! Should only be used then remote config is inaccessible !!!
 ///
@@ -594,7 +594,7 @@ interface FeaturesDefaultsBuilder {
     [Self=ByArc]
     FeaturesDefaultsBuilder enable_battery_saving_defaults();
 
-    /// Enable key valiation in set_config call with defaults
+    /// Enable key validation in set_config call with defaults
     [Self=ByArc]
     FeaturesDefaultsBuilder enable_validate_keys();
 
@@ -606,7 +606,7 @@ interface FeaturesDefaultsBuilder {
     [Self=ByArc]
     FeaturesDefaultsBuilder enable_nicknames();
 
-    /// Enable blocking event flush with timout on stop with defaults
+    /// Enable blocking event flush with timeout on stop with defaults
     [Self=ByArc]
     FeaturesDefaultsBuilder enable_flush_events_on_stop_timeout_seconds();
 
@@ -614,7 +614,7 @@ interface FeaturesDefaultsBuilder {
     [Self=ByArc]
     FeaturesDefaultsBuilder enable_link_detection();
 
-    /// Eanable multicast with defaults
+    /// Enable multicast with defaults
     [Self=ByArc]
     FeaturesDefaultsBuilder enable_multicast();
 


### PR DESCRIPTION
### Problem
Default `Features` config explicitly redefined inside `FeaturesDefaultsBuilder` constructor.

### Solution
`FeaturesDefaultsBuilder` constructor reuses `Features::default()` as a base line, and redefines only needed fields.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
