### PR TITLE
Add support for post-quantum in nordvpnlite

### DIFF
--- a/.unreleased/LLT-6822
+++ b/.unreleased/LLT-6822
@@ -1,0 +1,1 @@
+Add support for post-quantum to nordvpnlite

--- a/clis/nordvpnlite/README.md
+++ b/clis/nordvpnlite/README.md
@@ -55,6 +55,8 @@ Currently supported configuration variables:
     * `public_key` - The public key of the server/peer to connect to
   * `country` - Full country name or ISO A2 code, of the desired VPN server location.
   * `recommended` - First server from the API recommendation list will be selected.
+* `post_quantum` - If `true`, use a post-quantum-secure (Kyber + X25519) key
+  exchange. Defaults to `false`.
 * `log_level` - filters the logged messages by priority, possible levels:
   * `error`
   * `warn`

--- a/clis/nordvpnlite/src/command_listener.rs
+++ b/clis/nordvpnlite/src/command_listener.rs
@@ -30,6 +30,7 @@ pub enum ClientCmd {
 pub struct ExitNodeConfig {
     pub endpoint: Endpoint,
     pub dns: Vec<IpAddr>,
+    pub post_quantum: bool,
 }
 
 #[derive(Debug)]

--- a/clis/nordvpnlite/src/config.rs
+++ b/clis/nordvpnlite/src/config.rs
@@ -144,6 +144,9 @@ pub struct NordVpnLiteConfig {
     /// Enables the libtelio firewall that processes packets.
     #[serde(default)]
     pub enable_firewall: bool,
+
+    #[serde(default)]
+    pub post_quantum: bool,
 }
 
 impl NordVpnLiteConfig {
@@ -271,6 +274,7 @@ impl Default for NordVpnLiteConfig {
             authentication_token: Default::default(),
             http_certificate_file_path: None,
             enable_firewall: false,
+            post_quantum: false,
         }
     }
 }
@@ -407,6 +411,7 @@ mod tests {
             authentication_token: Default::default(),
             http_certificate_file_path: None,
             enable_firewall: false,
+            post_quantum: false,
         };
         {
             let json = r#"{
@@ -418,7 +423,8 @@ mod tests {
                 "config_provider": "manual"
             },
             "vpn": "recommended",
-            "authentication_token": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+            "authentication_token": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+            "post_quantum": false
             }"#;
 
             assert_eq!(expected, serde_json::from_str(json).unwrap());
@@ -522,6 +528,26 @@ mod tests {
                 "config_provider": "manual"
             },
             "authentication_token": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+            }"#;
+
+        assert_eq!(expected_config, serde_json::from_str(json).unwrap());
+    }
+
+    #[test]
+    fn test_config_post_quantum() {
+        let mut expected_config = NordVpnLiteConfig::default();
+        expected_config.post_quantum = true;
+
+        let json = r#"{
+            "log_level": "Trace",
+            "log_file_path": "/var/log/nordvpnlite.log",
+            "adapter_type": "neptun",
+            "interface": {
+                "name": "nlx",
+                "config_provider": "manual"
+            },
+            "authentication_token": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+            "post_quantum": true
             }"#;
 
         assert_eq!(expected_config, serde_json::from_str(json).unwrap());

--- a/clis/nordvpnlite/src/daemon.rs
+++ b/clis/nordvpnlite/src/daemon.rs
@@ -275,10 +275,15 @@ impl TelioTaskCmd {
                             .unwrap_or(DEFAULT_WIREGUARD_PORT),
                     )),
                 };
-                match ctx.telio.connect_exit_node(&node) {
+                let (connect, kind): (fn(_, _) -> _, _) = if exit_node.post_quantum {
+                    (Device::connect_vpn_post_quantum, "post quantum ")
+                } else {
+                    (Device::connect_exit_node, "")
+                };
+                match connect(&ctx.telio, &node) {
                     Ok(_) => {
                         info!(
-                            "Connected to exit node: {} ({}) [{}]",
+                            "Connected to {kind}exit node: {} ({}) [{}]",
                             exit_node.endpoint.address,
                             exit_node.endpoint.public_key,
                             exit_node.endpoint.hostname.as_deref().unwrap_or_default()
@@ -329,6 +334,7 @@ async fn handle_exit_node_connection(config: &NordVpnLiteConfig, tx: mpsc::Sende
                 TelioTaskCmd::ConnectToExitNode(ExitNodeConfig {
                     endpoint: endpoint.to_owned(),
                     dns: config.dns.clone(),
+                    post_quantum: config.post_quantum,
                 })
             } else {
                 error!("Getting exit node endpoint failed: empty list");

--- a/nat-lab/tests/nordvpnlite.py
+++ b/nat-lab/tests/nordvpnlite.py
@@ -75,6 +75,7 @@ class NordVpnLiteConfig:
     interface: InterfaceConfig = field(default_factory=InterfaceConfig)
     override_default_wg_port: int = 1023
     dns: Optional[List[str]] = None
+    post_quantum: bool = False
 
     def to_dict(self):
         data = asdict(self)

--- a/nat-lab/tests/test_nordvpnlite.py
+++ b/nat-lab/tests/test_nordvpnlite.py
@@ -2,17 +2,21 @@ import asyncio
 import pytest
 from contextlib import AsyncExitStack
 from pathlib import Path
-from tests.config import PHOTO_ALBUM_IP, STUN_SERVER, WG_SERVER, WG_SERVER_2
+from tests.config import NLX_SERVER, PHOTO_ALBUM_IP, STUN_SERVER, WG_SERVER, WG_SERVER_2
 from tests.helpers import setup_connections
 from tests.nordvpnlite import (
     NordVpnLite,
     ConfigPresetName,
     CONFIG_PRESETS,
+    InterfaceConfig,
     NordVpnLiteConfig,
     VPNConfig,
+    VPNServer,
 )
+from tests.test_pq import inspect_preshared_key
 from tests.utils import stun
 from tests.utils.connection import ConnectionTag
+from tests.utils.connection_util import new_connection_by_tag
 from tests.utils.logger import log
 from tests.utils.ping import ping
 from tests.utils.process.process import ProcessExecError
@@ -187,3 +191,50 @@ async def test_nordvpnlite_config_created(
             ), "Default config was not created"
         finally:
             await nordvpnlite.remove_config(config_path)
+
+
+@pytest.mark.nlx
+@pytest.mark.parametrize(
+    "config_provider",
+    ["manual", "iproute"],
+)
+async def test_nordvpnlite_pq_vpn_connection(config_provider: str) -> None:
+    """Verify that nordvpnlite connects to a PQ-capable VPN server using
+    post-quantum handshake (mirrors the behaviour exercised by
+    ``test_pq.TestPqVpnConnection`` for the libtelio client)."""
+    config = NordVpnLiteConfig(
+        vpn=VPNConfig(
+            server=VPNServer(
+                address=str(NLX_SERVER["ipv4"]),
+                public_key=str(NLX_SERVER["public_key"]),
+            )
+        ),
+        interface=InterfaceConfig(config_provider=config_provider),
+        post_quantum=True,
+    )
+
+    async with AsyncExitStack() as exit_stack:
+        nordvpnlite = await NordVpnLite.new(exit_stack, config)
+        await nordvpnlite.request_credentials_from_core()
+
+        async with nordvpnlite.start():
+            log.debug("NordVPN Lite started, waiting for PQ VPN connected state...")
+            await nordvpnlite.wait_for_vpn_connected_state()
+
+            if config.interface.config_provider == "manual":
+                await exit_stack.enter_async_context(
+                    nordvpnlite.setup_interface(vpn_routes=True)
+                )
+
+            await ping(nordvpnlite.connection, PHOTO_ALBUM_IP)
+
+            ip = await stun.get(nordvpnlite.connection, STUN_SERVER)
+            assert (
+                ip == NLX_SERVER["ipv4"]
+            ), f"wrong public IP when connected to PQ VPN {ip}"
+
+            # Confirm the PQ handshake actually took place by inspecting the
+            # preshared-key slot on the NLX server side — a plain WireGuard
+            # connection would leave it unset.
+            async with new_connection_by_tag(ConnectionTag.VM_LINUX_NLX_1) as nlx_conn:
+                await inspect_preshared_key(nlx_conn)


### PR DESCRIPTION
### Problem
Nordvpnlite can only create non post-quantum safe vpn tunnels.

### Solution
Add new config option (disabled by default) that will control if the vpn tunnel is post-quantum secure.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
