### PR TITLE
Publish changelog.md to github pages

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,7 +1,12 @@
-name: Rust Docs to Github Pages
-run-name: ${{ github.actor }} is building and deploying rustdoc to GitHub Pages from ${{ github.ref }}
+name: Docs and Changelog to Github Pages
+run-name: ${{ github.actor }} is building and deploying rustdoc and changelog to GitHub Pages from ${{ github.ref }}
 # Because documentation versioning and build promotion are not implemente yet, leaving this to be triggered manually only for now.
-on: [workflow_dispatch]
+# `repository_dispatch` (type `changelog-updated`) lets the release pipeline redeploy the
+# page after it pushes a new changelog entry to the `gh-pages` branch.
+on:
+  workflow_dispatch:
+  repository_dispatch:
+    types: [changelog-updated]
 
 permissions:
   contents: read
@@ -19,8 +24,20 @@ jobs:
     - name: Checkout
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
+    # The changelog is not kept on `main`; its source of truth is the `gh-pages` branch
+    - name: Checkout changelog source
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      with:
+        ref: gh-pages
+        path: changelog-src
+
     - name: Configure GitHub Pages
       uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # 5.0.0
+
+    - name: Install Protoc
+      uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build Rust Docs
       uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.6
@@ -32,6 +49,21 @@ jobs:
     # --no-deps is required to prevent rustdoc from adding third party dependencies to our documentation, but that also brakes links to
     # local pages so that's fixed by adding --workspace.
     - run: cargo +nightly-2025-08-07 doc --no-deps --workspace --document-private-items
+
+    - name: Set up Python
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+      with:
+        python-version: '3.12'
+
+    # Render the changelog into the docs tree at /changelog/ so it is served next to the
+    # rustdoc pages, and link it from the generated docs index page (--docs-index).
+    - name: Render changelog page
+      run: |
+        python3 -m pip install markdown==3.10.2
+        python3 ci/render_changelog.py \
+          --in changelog-src/changelog.md \
+          --out target/doc/changelog/index.html \
+          --docs-index target/doc/index.html
 
     # Using @v1 of actions/upload-pages-artifact, because the later versions are buggy: https://github.com/actions/deploy-pages/issues/179
     - name: Upload Github pages artifact

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,8 @@ The naming convention for files in `.unreleased` is as follows:
 
 When a release is made, the script `ci/generate_changelog.py` is executed which will take all files in `.unreleased` and generate a changelog. Only files that are non-empty are included, and each of those files gets a changelog entry like: `<file name>: <file contents>`. Afterwards the script deletes all files in `.unreleased` to prepare for the next release.
 
+The compiled changelog for all released versions is published to GitHub Pages at `/changelog/`, next to the rustdoc API docs. Its source of truth is the `changelog.md` file on the [`gh-pages`](https://github.com/NordSecurity/libtelio/tree/gh-pages) branch (not `main`), which the `.github/workflows/gh-pages.yml` workflow renders to HTML and deploys. Keeping it off `main` lets the release pipeline update it without opening a PR against `main`. Do not edit `changelog.md` by hand — add your entry to `.unreleased` as described above.
+
 Not all PRs need an addition to the changelog. The changelog is our way of communicating to the apps about changes since the last version, so only changes that are of interest or concern to the apps need to actually have something show up in the changelog. However, to remind you that you may have to add something to the changelog, the CI pipeline requires that you add a file to `.unreleased` in every PR. It is up to both the implementer(s) and the reviewers of a PR to make sure that the file in `.unreleased` has the "right" content for the PR, whether that be leaving it empty because the apps don't care or leaving an accurate description of what has changed.
 
 Some (non-exhaustive) examples of what should end up in the changelog:

--- a/ci/render_changelog.py
+++ b/ci/render_changelog.py
@@ -1,0 +1,154 @@
+"""Render the changelog markdown into a static HTML page for GitHub Pages.
+
+Converts `changelog.md` (the format produced by `generate_changelog.py`) into an
+HTML page that reuses the same styling assets as the rustdoc pages.
+
+Usage:
+    python3 ci/render_changelog.py \
+        --in changelog.md \
+        --out target/doc/changelog/index.html \
+        --docs-index target/doc/index.html
+
+The `markdown` package is required (install with `pip install markdown`).
+"""
+
+import argparse
+import os
+import re
+
+import markdown
+
+# Path back to the rustdoc index, relative to the changelog page
+DOCS_HOME_HREF = "../index.html"
+
+TITLE = "libtelio changelog"
+
+# Placeholder series header for versions without a series name (e.g. "### ****").
+# It carries no information so it is dropped.
+EMPTY_SERIES_RE = re.compile(r"^###\s+\*+\s*$", re.MULTILINE)
+
+# Link to the changelog injected into the rustdoc docs index page (see --docs-index).
+DOCS_INDEX_LINK = (
+    '<p style="margin:1rem 0;font-family:sans-serif"><a href="changelog/" '
+    'style="font-size:1.15rem;font-weight:600;text-decoration:underline">'
+    "View the changelog &rarr;</a></p>"
+)
+MAIN_CONTENT_RE = re.compile(r'(<section id="main-content"[^>]*>)')
+BODY_RE = re.compile(r"(<body[^>]*>)")
+
+PAGE_TEMPLATE = """\
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{title}</title>
+{header}
+<style>
+  body {{ margin: 0; background: #fff; color: #1a1a1a;
+         font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; }}
+  .changelog {{ max-width: 900px; margin: 0 auto; padding: 2rem 1.5rem 4rem; }}
+  .changelog nav {{ margin-bottom: 2rem; font-size: .9rem; }}
+  .changelog h1 {{ font-size: 2rem; margin: 0 0 1.5rem; }}
+  /* Version headers and their series-name subheaders (both rendered as <h3>). */
+  .changelog h3 {{ font-size: 1.35rem; margin: 2rem 0 .25rem; }}
+  .changelog h3 + h3 {{ font-size: 1rem; font-weight: 400; color: #666;
+                        margin: 0 0 .5rem; }}
+  .changelog hr {{ border: 0; border-top: 1px solid #e2e2e2; margin: .5rem 0 1rem; }}
+  .changelog ul {{ line-height: 1.55; }}
+  .changelog code {{ background: #f4f4f4; padding: .1em .35em; border-radius: 4px;
+                     font-size: .9em; }}
+  @media (prefers-color-scheme: dark) {{
+    body {{ background: #0f1419; color: #e6e6e6; }}
+    .changelog h3 + h3 {{ color: #9aa4ae; }}
+    .changelog hr {{ border-top-color: #2a2f36; }}
+    .changelog code {{ background: #1c232b; }}
+    a {{ color: #6cb6ff; }}
+  }}
+</style>
+</head>
+<body>
+<main class="changelog">
+<nav><a href="{docs_home}">&larr; Back to docs</a></nav>
+<h1>{title}</h1>
+{body}
+</main>
+{footer}
+</body>
+</html>
+"""
+
+
+def read_optional(path):
+    if path and os.path.isfile(path):
+        with open(path, "r", encoding="utf-8") as f:
+            return f.read()
+    return ""
+
+
+def render(md_text: str, header: str, footer: str) -> str:
+    md_text = EMPTY_SERIES_RE.sub("", md_text)
+    body_html = markdown.markdown(md_text, extensions=["extra", "sane_lists"])
+    return PAGE_TEMPLATE.format(
+        title=TITLE,
+        header=header,
+        footer=footer,
+        body=body_html,
+        docs_home=DOCS_HOME_HREF,
+    )
+
+
+def inject_docs_link(index_path: str) -> None:
+    """Insert a link to the changelog into the rustdoc index page, in place."""
+    with open(index_path, "r", encoding="utf-8") as f:
+        html = f.read()
+    html, n = MAIN_CONTENT_RE.subn(r"\1" + DOCS_INDEX_LINK, html, count=1)
+    if n == 0:
+        html, n = BODY_RE.subn(r"\1" + DOCS_INDEX_LINK, html, count=1)
+    if n == 0:
+        raise SystemExit(f"No changelog-link injection point found in {index_path}")
+    with open(index_path, "w", encoding="utf-8") as f:
+        f.write(html)
+    print(f"Linked changelog from {index_path}")
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--in", dest="in_file", default="changelog.md")
+    ap.add_argument("--out", dest="out_file", default="target/doc/changelog/index.html")
+    ap.add_argument(
+        "--header",
+        default="rustdoc/header.html",
+        help="HTML injected into <head> (shared rustdoc styling assets).",
+    )
+    ap.add_argument(
+        "--footer",
+        default="rustdoc/footer.html",
+        help="HTML injected at end of <body> (shared rustdoc scripts).",
+    )
+    ap.add_argument(
+        "--docs-index",
+        help="If set, inject a link to the changelog into this rustdoc index.html.",
+    )
+    args = ap.parse_args()
+
+    with open(args.in_file, "r", encoding="utf-8") as f:
+        md_text = f.read()
+
+    html = render(
+        md_text,
+        read_optional(args.header),
+        read_optional(args.footer),
+    )
+
+    os.makedirs(os.path.dirname(os.path.abspath(args.out_file)), exist_ok=True)
+    with open(args.out_file, "w", encoding="utf-8") as f:
+        f.write(html)
+    print(f"Wrote {args.out_file}")
+
+    if args.docs_index:
+        inject_docs_link(args.docs_index)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Problem
*--We want to host `changelog.md` on GitHub pages to make release process more automatable. The goal is to have changelog generation and update as part of `generate-release` job without opening a PR on `main` branch--*

### Solution
*--The `changelog.md` moves to the `gh-pages` branch so the release pipeline can update it without a PR to `main`.  Render the changelog.md to HTML and serve it at /changelog/ next to the rustdoc API docs. --*

There'll be a second stage of release automation with:
- Change `generate-release` job to update changelog.md on `gh-pages` branch and trigger GitHub action to update Github Pages
- Cleans up `.unreleased` folder and bumps cargo version creating PR

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
