### PR TITLE
nat-lab: make VM SSH survive freeze/suspend + gate readiness on :22

### DIFF
--- a/nat-lab/bin/fullcone-gw-vm
+++ b/nat-lab/bin/fullcone-gw-vm
@@ -2,27 +2,7 @@
 
 set -euxo pipefail
 
-# Wait up to 60 seconds for SSH service to be running on the Linux VM
-timeout_secs=60
-interval_secs=2
-end=$((SECONDS + timeout_secs))
-last_rc=1
-
-while [ $SECONDS -lt $end ]; do
-    if output=$(python3 /run/qga.py --sh 'if command -v systemctl >/dev/null 2>&1; then if systemctl is-active --quiet sshd || systemctl is-active --quiet ssh; then echo "SSH service is active"; exit 0; else echo "SSH service not active"; exit 2; fi; else if pgrep -x sshd >/dev/null 2>&1; then echo "sshd process running"; exit 0; else echo "sshd process not running"; exit 2; fi; fi'); then
-        echo "$output"
-        break
-    else
-        last_rc=$?
-        echo "$output"
-        echo "SSH service not ready yet (rc=$last_rc). Retrying in ${interval_secs}s..."
-        sleep "$interval_secs"
-    fi
-done
-
-if [ $SECONDS -ge $end ]; then
-    echo "Timed out waiting for SSH service to become active within ${timeout_secs}s"
-    exit "$last_rc"
-fi
+# Signal readiness only once the guest is truly reachable over SSH.
+"$(dirname "$0")/wait_for_guest_ssh.sh" linux
 
 python3 /run/qga.py --timeout 180 /mnt/shared/nat-lab/bin/fullcone-gw

--- a/nat-lab/bin/mac-client
+++ b/nat-lab/bin/mac-client
@@ -4,29 +4,8 @@ set -euxo pipefail
 
 /libtelio/nat-lab/bin/configure_route.sh primary mac
 
-# Wait up to 60 seconds for Remote Login (SSH) to be enabled
-timeout_secs=60
-interval_secs=2
-end=$((SECONDS + timeout_secs))
-last_rc=1
-
-while [ $SECONDS -lt $end ]; do
-    if output=$(python3 /run/qga.py --sh 'if ! command -v systemsetup >/dev/null 2>&1; then echo "systemsetup not found"; exit 3; fi; if /usr/sbin/systemsetup -getremotelogin 2>/dev/null | grep -q "On"; then echo "Remote Login (SSH) is On"; exit 0; else echo "Remote Login (SSH) is Off"; exit 2; fi'); then
-        echo "$output"
-        break
-    else
-        last_rc=$?
-        # Print whatever the remote reported
-        echo "$output"
-        echo "Remote Login (SSH) not enabled yet (rc=$last_rc). Retrying in ${interval_secs}s..."
-        sleep "$interval_secs"
-    fi
-done
-
-if [ $SECONDS -ge $end ]; then
-    echo "Timed out waiting for Remote Login (SSH) to be enabled within ${timeout_secs}s"
-    exit "$last_rc"
-fi
+# Signal readiness only once the guest is truly reachable over SSH.
+"$(dirname "$0")/wait_for_guest_ssh.sh" mac
 
 commands=(
     'osascript -e "tell application \"System Preferences\" to quit"'

--- a/nat-lab/bin/nlx-vm
+++ b/nat-lab/bin/nlx-vm
@@ -2,27 +2,7 @@
 
 set -euxo pipefail
 
-# Wait up to 60 seconds for SSH service to be running on the Linux VM
-timeout_secs=60
-interval_secs=2
-end=$((SECONDS + timeout_secs))
-last_rc=1
-
-while [ $SECONDS -lt $end ]; do
-    if output=$(python3 /run/qga.py --sh 'if command -v systemctl >/dev/null 2>&1; then if systemctl is-active --quiet sshd || systemctl is-active --quiet ssh; then echo "SSH service is active"; exit 0; else echo "SSH service not active"; exit 2; fi; else if pgrep -x sshd >/dev/null 2>&1; then echo "sshd process running"; exit 0; else echo "sshd process not running"; exit 2; fi; fi'); then
-        echo "$output"
-        break
-    else
-        last_rc=$?
-        echo "$output"
-        echo "SSH service not ready yet (rc=$last_rc). Retrying in ${interval_secs}s..."
-        sleep "$interval_secs"
-    fi
-done
-
-if [ $SECONDS -ge $end ]; then
-    echo "Timed out waiting for SSH service to become active within ${timeout_secs}s"
-    exit "$last_rc"
-fi
+# Signal readiness only once the guest is truly reachable over SSH.
+"$(dirname "$0")/wait_for_guest_ssh.sh" linux
 
 python3 /run/qga.py --timeout 180 /mnt/shared/nat-lab/bin/nordlynx

--- a/nat-lab/bin/wait_for_guest_ssh.sh
+++ b/nat-lab/bin/wait_for_guest_ssh.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+#
+# Wait until a nat-lab guest VM is reachable over SSH, then exit 0. If it never
+# becomes reachable within the timeout, exit non-zero.
+#
+# Why this exists
+# ---------------
+# A guest's sshd reports "running" (Windows) / "On" (macOS) / "active" (Linux)
+# slightly BEFORE its listener is actually bound to the port. During that window
+# the container looks healthy but the test runner's SSH to the guest LAN IP is
+# refused -- which used to abort the whole pytest session with an INTERNALERROR.
+#
+# So every VM entrypoint calls this before signalling readiness. dockur only
+# writes /ready (the healthcheck marker) when the entrypoint exits 0, so timing
+# out here keeps the VM "unhealthy" at bring-up instead of failing a test later.
+#
+# All three per-OS checks live here, in one place, so the entrypoints stay a
+# single line: `wait_for_guest_ssh.sh <windows|mac|linux> [timeout_secs]`.
+
+set -euo pipefail
+
+os="${1:?usage: wait_for_guest_ssh.sh <windows|mac|linux> [timeout_secs]}"
+timeout_secs="${2:-120}"
+interval_secs=2
+
+case "$os" in
+    windows | mac | linux) ;;
+    *) echo "unknown OS '$os' (expected windows|mac|linux)" >&2; exit 64 ;;
+esac
+
+# --- readiness probes --------------------------------------------------------
+#
+# Each probe runs INSIDE the guest via the QEMU guest agent (qga.py). It must
+# exit 0 ONLY when SSH is truly reachable: first a cheap service-state check,
+# then a real TCP connect to 127.0.0.1:22 (the check that actually caught the
+# race). Distinct non-zero codes make boot logs easy to read:
+#   2 = sshd service not up      3 = probe tool missing
+#   4 = service up but :22 not accepting yet
+
+probe_windows() {
+    # PowerShell is always present on the Windows guest; Test-NetConnection does
+    # the TCP connect. -InformationLevel Quiet returns a bare $true/$false.
+    python3 /run/qga.py powershell -Command '
+        $svc = Get-Service -Name "sshd" -ErrorAction SilentlyContinue
+        if ($null -eq $svc)          { Write-Output "sshd service not found";       exit 3 }
+        if ($svc.Status -ne "Running") { Write-Output ("sshd status: " + $svc.Status); exit 2 }
+        if (-not (Test-NetConnection -ComputerName 127.0.0.1 -Port 22 -InformationLevel Quiet -WarningAction SilentlyContinue)) {
+            Write-Output "sshd not accepting on :22 yet"; exit 4
+        }
+        Write-Output "sshd running and accepting on :22"; exit 0
+    '
+}
+
+probe_mac() {
+    # systemsetup reports the Remote Login (SSH) toggle; nc does the TCP connect
+    # (-G is the connect timeout on macOS nc, which is always present).
+    python3 /run/qga.py --sh '
+        command -v systemsetup >/dev/null 2>&1 || { echo "systemsetup not found"; exit 3; }
+        /usr/sbin/systemsetup -getremotelogin 2>/dev/null | grep -q "On" || { echo "Remote Login (SSH) is Off"; exit 2; }
+        nc -z -G 2 127.0.0.1 22 >/dev/null 2>&1 || { echo "SSH not accepting on :22 yet"; exit 4; }
+        echo "Remote Login (SSH) on and accepting on :22"; exit 0
+    '
+}
+
+probe_linux() {
+    # systemctl (or pgrep fallback) for the service; nc for the TCP connect
+    # (-w is the connect timeout on Linux nc). nc is not guaranteed on every
+    # Linux guest, so the connect check is skipped when nc is absent rather than
+    # deadlocking -- the service check remains the floor.
+    python3 /run/qga.py --sh '
+        if command -v systemctl >/dev/null 2>&1; then
+            systemctl is-active --quiet sshd || systemctl is-active --quiet ssh || { echo "SSH service not active"; exit 2; }
+        else
+            pgrep -x sshd >/dev/null 2>&1 || { echo "sshd process not running"; exit 2; }
+        fi
+        if command -v nc >/dev/null 2>&1 && ! nc -z -w2 127.0.0.1 22; then
+            echo "SSH not accepting on :22 yet"; exit 4
+        fi
+        echo "SSH active and accepting on :22"; exit 0
+    '
+}
+
+probe_once() {
+    case "$os" in
+        windows) probe_windows ;;
+        mac)     probe_mac ;;
+        linux)   probe_linux ;;
+    esac
+}
+
+# --- retry loop --------------------------------------------------------------
+#
+# Poll until the probe succeeds or the deadline passes. A failing probe is
+# normal during boot, so we capture its exit code, log it, and retry; only a
+# real timeout is fatal (and carries the last probe's code out to the caller).
+
+end=$((SECONDS + timeout_secs))
+last_rc=1
+
+while [ "$SECONDS" -lt "$end" ]; do
+    if output=$(probe_once); then
+        echo "$output"
+        exit 0
+    else
+        last_rc=$?
+        echo "$output"
+        echo "[$os] SSH not ready yet (rc=$last_rc); retrying in ${interval_secs}s..."
+        sleep "$interval_secs"
+    fi
+done
+
+echo "[$os] timed out waiting for guest SSH on :22 after ${timeout_secs}s"
+exit "$last_rc"

--- a/nat-lab/bin/windows-client
+++ b/nat-lab/bin/windows-client
@@ -10,24 +10,5 @@ python3 /run/qga.py powershell -Command 'Set-MpPreference -DisableRealtimeMonito
 #Disable Windows Updates Services that can be restored after reboot
 python3 /run/qga.py powershell -Command 'cd C:\workspace\update-disabler; & "./disable updates.bat"'
 
-# Wait up to 60 seconds for OpenSSH SSH Server (sshd) to be running
-timeout_secs=60
-interval_secs=2
-end=$((SECONDS + timeout_secs))
-last_rc=1
-
-while [ $SECONDS -lt $end ]; do
-    if output=$(python3 /run/qga.py powershell -Command '$svc = Get-Service -Name "sshd" -ErrorAction SilentlyContinue; if ($null -eq $svc) { Write-Output "OpenSSH SSH Server (sshd) service not found"; exit 3 } elseif ($svc.Status -eq "Running") { Write-Output "OpenSSH SSH Server is running"; exit 0 } else { Write-Output ("OpenSSH SSH Server status: " + $svc.Status); exit 2 }'); then
-        echo "$output"
-        exit 0
-    else
-        last_rc=$?
-        # Print whatever the remote reported
-        echo "$output"
-        echo "OpenSSH SSH Server not running yet (rc=$last_rc). Retrying in ${interval_secs}s..."
-        sleep "$interval_secs"
-    fi
-done
-
-echo "Timed out waiting for OpenSSH SSH Server to start within ${timeout_secs}s"
-exit "$last_rc"
+# Signal readiness only once the guest is truly reachable over SSH.
+"$(dirname "$0")/wait_for_guest_ssh.sh" windows

--- a/nat-lab/tests/test_no_burst_after_sleep.py
+++ b/nat-lab/tests/test_no_burst_after_sleep.py
@@ -35,6 +35,7 @@ from tests.utils.connection.docker_connection import (
     backing_container_id,
     paused_container,
 )
+from tests.utils.connection.ssh_connection import SshConnection
 from tests.utils.python import get_python_binary
 
 # Each tick of libtelio's 5s WireGuard-consolidation poll (src/device.rs) emits
@@ -175,10 +176,18 @@ async def test_no_burst_after_monotonic_jump(
     mono_before = await _read_guest_monotonic(connection_alpha)
     consolidations_before = (await client_alpha.log.get()).count(CONSOLIDATION_LOG)
 
+    # VM SSH session can't survive the freeze: detach remote stdout (else EPIPE-crash) + rebuild SSH on wake.
+    is_ssh = isinstance(connection_alpha, SshConnection)
+    if is_ssh:
+        await client_alpha.get_proxy().redirect_stdout_to_logfile()
+
     # Freeze the client: it does no work, but the monotonic clock keeps moving,
     # so on unpause the poll interval has many overdue ticks.
     async with paused_container(alpha_tag):
         await asyncio.sleep(SLEEP_DURATION_S)
+
+    if is_ssh:
+        await connection_alpha.reconnect()
 
     mono_after = await _read_guest_monotonic(connection_alpha)
     slept = mono_after - mono_before
@@ -254,10 +263,14 @@ async def test_no_burst_after_system_suspend(
     guest-suspend-ram command - so the hypervisor-level suspend is used instead.)
     """
     client_alpha = env_mesh.clients[0]
-    container = backing_container_id(client_alpha.get_connection().tag)
+    connection_alpha = client_alpha.get_connection()
+    container = backing_container_id(connection_alpha.tag)
 
     await ping_between_all_nodes(env_mesh)
     consolidations_before = (await client_alpha.log.get()).count(CONSOLIDATION_LOG)
+
+    # VM SSH session can't survive the suspend: detach remote stdout (else EPIPE-crash) + rebuild SSH on resume.
+    await client_alpha.get_proxy().redirect_stdout_to_logfile()
 
     # Suspend the VM (halt vCPUs), hold it down, then resume. The paused/running
     # transition reported by the monitor is the proof the VM really suspended.
@@ -270,6 +283,9 @@ async def test_no_burst_after_system_suspend(
     assert await _wait_for_run_state(
         container, "running"
     ), f"{container} did not resume after 'cont'"
+
+    assert isinstance(connection_alpha, SshConnection)
+    await connection_alpha.reconnect()
 
     # Let the guest settle and re-establish connectivity after the suspend.
     await asyncio.sleep(SETTLE_AFTER_WAKE_S)

--- a/nat-lab/tests/uniffi/libtelio_proxy.py
+++ b/nat-lab/tests/uniffi/libtelio_proxy.py
@@ -202,6 +202,10 @@ class LibtelioProxy:
         self._handle_remote_error(lambda r: r.flush_logs())
 
     @move_to_async_thread
+    def redirect_stdout_to_logfile(self) -> None:
+        self._handle_remote_error(lambda r: r.redirect_stdout_to_logfile())
+
+    @move_to_async_thread
     def enable_tp_lite_stats_collection(self, config: libtelio.TpLiteStatsOptions):
         self._handle_remote_error(lambda r: r.enable_tp_lite_stats_collection(config))
 

--- a/nat-lab/tests/uniffi/libtelio_remote.py
+++ b/nat-lab/tests/uniffi/libtelio_remote.py
@@ -125,6 +125,7 @@ class TpLiteStatsCallbackImpl(libtelio.TpLiteStatsCallback):
 class LibtelioWrapper:
     def __init__(self, daemon, logfile):
         self._daemon = daemon
+        self._logfile = logfile
 
         self._libtelio = None
         self._event_cb = TelioEventCbImpl()
@@ -137,6 +138,13 @@ class LibtelioWrapper:
         if self._libtelio is not None:
             self._libtelio.shutdown()
         self._daemon.shutdown()
+
+    @serialize_error
+    def redirect_stdout_to_logfile(self):
+        # Point stdout at tcli.log so telio-task stdout can't EPIPE-crash the remote when SSH
+        # dies mid-freeze — same as the Android startup guard in main() below, but on demand.
+        sys.stdout.flush()
+        os.dup2(self._logfile.fileno(), sys.stdout.fileno())
 
     @serialize_error
     def create(self, features: libtelio.Features):

--- a/nat-lab/tests/utils/connection/ssh_connection.py
+++ b/nat-lab/tests/utils/connection/ssh_connection.py
@@ -17,11 +17,14 @@ from uuid import uuid4
 class SshConnection(Connection):
     _connection: asyncssh.SSHClientConnection
     _connection_id: str
+    _ip: str
+    _reconnected: bool
 
     def __init__(
         self,
         connection: asyncssh.SSHClientConnection,
         tag: ConnectionTag,
+        ip: str = "",
     ):
         if tag in [ConnectionTag.VM_WINDOWS_1, ConnectionTag.VM_WINDOWS_2]:
             target_os = TargetOS.Windows
@@ -44,6 +47,8 @@ class SshConnection(Connection):
         super().__init__(target_os, tag)
         self._connection = connection
         self._connection_id = str(uuid4())
+        self._ip = ip or connection._host  # pylint: disable=protected-access
+        self._reconnected = False
 
     async def __aenter__(self):
         log.info(
@@ -60,6 +65,54 @@ class SshConnection(Connection):
             self.tag.name,
             self._connection_id,
         )
+        # Close the rebuilt session here; new_connection's asyncssh ctx only owns the original.
+        if self._reconnected:
+            self._connection.close()
+            await self._connection.wait_closed()
+
+    @staticmethod
+    def _credentials(tag: ConnectionTag) -> tuple[str, str | None]:
+        if tag is ConnectionTag.VM_MAC:
+            return "root", "jobs"
+        if tag in [ConnectionTag.VM_WINDOWS_1, ConnectionTag.VM_WINDOWS_2]:
+            return "bill", "gates"
+        if tag in [
+            ConnectionTag.VM_OPENWRT_GW_1,
+            ConnectionTag.VM_OPENWRT_GW_2,
+            ConnectionTag.VM_OPENWRT_GW_3,
+        ]:
+            return "root", None
+        return "root", "root"
+
+    @staticmethod
+    async def _connect(ip: str, tag: ConnectionTag) -> asyncssh.SSHClientConnection:
+        username, password = SshConnection._credentials(tag)
+        return await asyncssh.connect(
+            ip,
+            username=username,
+            password=password,
+            known_hosts=None,
+            agent_path=None,
+        )
+
+    async def reconnect(self) -> None:
+        # The per-client asyncssh session dies when the guest is frozen/suspended for tens of seconds; rebuild in place.
+        try:
+            self._connection.close()
+            await self._connection.wait_closed()
+        except Exception as e:  # pylint: disable=broad-except
+            log.warning(
+                "[%s] error closing dead SSH session before reconnect: %s",
+                self.tag.name,
+                e,
+            )
+        self._connection = await self._connect(self._ip, self.tag)
+        self._reconnected = True
+        log.info(
+            "[%s] SSH connection reopened after reconnect() (conn_id=%s)",
+            self.tag.name,
+            self._connection_id,
+        )
 
     @classmethod
     @asynccontextmanager
@@ -69,30 +122,9 @@ class SshConnection(Connection):
         tag: ConnectionTag,
         copy_binaries: bool = False,
     ) -> AsyncIterator["SshConnection"]:
-        username = "root"
-        password: str | None = "root"
-        if tag is ConnectionTag.VM_MAC:
-            username = "root"
-            password = "jobs"
-        elif tag in [ConnectionTag.VM_WINDOWS_1, ConnectionTag.VM_WINDOWS_2]:
-            username = "bill"
-            password = "gates"
-        elif tag in [
-            ConnectionTag.VM_OPENWRT_GW_1,
-            ConnectionTag.VM_OPENWRT_GW_2,
-            ConnectionTag.VM_OPENWRT_GW_3,
-        ]:
-            password = None
-
         try:
-            async with asyncssh.connect(
-                ip,
-                username=username,
-                password=password,
-                known_hosts=None,
-                agent_path=None,
-            ) as ssh_connection:
-                async with cls(ssh_connection, tag) as connection:
+            async with await cls._connect(ip, tag) as ssh_connection:
+                async with cls(ssh_connection, tag, ip) as connection:
                     if copy_binaries:
                         await connection.copy_binaries()
 


### PR DESCRIPTION
## Problem

Nightly nat-lab flake on the VM_MAC no-burst tests — harness limitation, not libtelio:

- `test_no_burst_after_monotonic_jump[VM_MAC]` died with `ChannelOpenError` — the single per-client SSH session can't survive the 60s cgroup freeze.
- `test_no_burst_after_system_suspend[VM_MAC]` wedged the full 2h.

Separately, VMs signalled container-ready before their guest sshd was actually accepting on `:22`, so the runner's SSH was refused and pytest aborted with `INTERNALERROR` (0 tests run).

## Solution

- **Remote survives the pause**: new `redirect_stdout_to_logfile()` (Pyro) points the remote's fd 1 at `tcli.log` before the freeze, so telio-task's stdout can't EPIPE-crash the remote — the same guard the Android path already applies.
- **Reconnect**: `SshConnection.reconnect()` rebuilds the dead session on wake. The Pyro proxy already reconnects per-call and logs are read from the `tcli.log` file, so the *same* remote process + log persist across the pause and the burst counts stay meaningful (not vacuous).
- **Readiness gate**: `bin/{mac,windows}-client` now require `:22` to actually accept (`Test-NetConnection` / `nc`), not just service status; wait raised 60→120s. dockur gates `/ready` on the entrypoint exit code, so a VM whose SSH isn't up stays unhealthy at bring-up instead of failing pytest later.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
