### PR TITLE
Fix firewall consolidation

### DIFF
--- a/crates/telio-firewall/src/firewall.rs
+++ b/crates/telio-firewall/src/firewall.rs
@@ -65,8 +65,16 @@ const ICMPV6_BLOCKED_TYPES: [u8; 4] = [
 pub const FILE_SEND_PORT: u16 = 49111;
 
 /// Type for chain configuration function
-pub(crate) type ConfigureChainFn =
-    Box<dyn Fn(&FirewallConfig, &FirewallState, &[StdIpAddr]) -> FfiChainGuard + Send + Sync>;
+pub(crate) type ConfigureChainFn = Box<
+    dyn Fn(
+            &FirewallConfig,
+            &FirewallDynamicState,
+            &FirewallConfiguredState,
+            &[StdIpAddr],
+        ) -> FfiChainGuard
+        + Send
+        + Sync,
+>;
 
 #[allow(dead_code)]
 pub(crate) trait Icmp: Sized {
@@ -85,10 +93,10 @@ impl Icmp for Icmpv6Type {
 #[cfg_attr(any(test, feature = "mockall"), mockall::automock)]
 pub trait Firewall: Sync + Send {
     /// Applies a new firewall state and updates the chain if it differs from current state
-    fn apply_state(&self, state: FirewallState);
+    fn apply_dynamic_state(&self, state: FirewallDynamicState);
 
     /// Returns a clone of the current firewall state
-    fn get_state(&self) -> FirewallState;
+    fn get_dynamic_state(&self) -> FirewallDynamicState;
 
     /// For new connections it opens a pinhole for incoming connection
     /// If connection is already cached, it resets its timer and extends its lifetime
@@ -152,9 +160,9 @@ pub struct Whitelist {
     pub vpn_peer: Option<PublicKey>,
 }
 
-/// Runtime state for firewall rules that can be updated dynamically.
+/// Dynamic state for firewall rules that is updated dynamically by wg_controller's consolidation.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct FirewallState {
+pub struct FirewallDynamicState {
     /// Whitelist configuration
     pub whitelist: Whitelist,
     /// Local node ip addresses
@@ -164,6 +172,11 @@ pub struct FirewallState {
     /// these addresses, protecting the VPN tunnel from accidental leaks.
     /// When empty, this protection is disabled.
     pub tunnel_ips: Vec<StdIpAddr>,
+}
+
+/// Configured state that is configured via tp_lite API calls.
+#[derive(Clone, Debug, Default)]
+pub struct FirewallConfiguredState {
     /// List of DNS server IPs for which only plaintext DNS should be allowed
     pub force_plaintext_dns_for_servers: Option<Vec<StdIpAddr>>,
     /// Domain patterns whitelisted from TP-Lite DNS
@@ -193,11 +206,13 @@ pub struct StatefulFirewall {
     firewall: *mut LibfwFirewall,
     /// Firewall configuration set at initialization
     config: FirewallConfig,
-    /// Current firewall state
-    state: RwLock<FirewallState>,
+    /// Dynamic state
+    dynamic_state: RwLock<FirewallDynamicState>,
     /// IP addresses currently assigned to the host's local network interfaces,
     /// as last reported by the network monitor.
     interface_ips: RwLock<Vec<StdIpAddr>>,
+    /// Configured state
+    configured_state: RwLock<FirewallConfiguredState>,
     /// Chain configuration function
     configure_chain_fn: ConfigureChainFn,
     /// Callback for TP-Lite stats
@@ -275,14 +290,13 @@ impl StatefulFirewall {
             feature,
         };
 
-        let state = FirewallState::default();
-
         let result = Self {
             firewall_lib,
             firewall,
             config,
-            state: RwLock::new(state.clone()),
+            dynamic_state: RwLock::new(FirewallDynamicState::default()),
             interface_ips: RwLock::new(Vec::new()),
+            configured_state: RwLock::new(FirewallConfiguredState::default()),
             configure_chain_fn,
             tp_lite_stats_cb: CallbackManager::new(),
         };
@@ -326,12 +340,16 @@ impl StatefulFirewall {
 
     fn refresh_chain(&self) {
         let interface_ips = self.interface_ips.read().clone();
-        self.refresh_chain_with_interface_ips(&interface_ips);
-    }
+        let dynamic_state = self.dynamic_state.read().clone();
+        let configured_state = self.configured_state.read().clone();
 
-    fn refresh_chain_with_interface_ips(&self, interface_ips: &[StdIpAddr]) {
-        let state = self.state.read().clone();
-        let ffi_chain = (self.configure_chain_fn)(&self.config, &state, interface_ips);
+        let ffi_chain = (self.configure_chain_fn)(
+            &self.config,
+            &dynamic_state,
+            &configured_state,
+            &interface_ips,
+        );
+
         unsafe {
             self.firewall_lib.libfw_configure_chain_v2(
                 self.firewall,
@@ -373,9 +391,10 @@ impl StatefulFirewall {
             std::mem::swap(&mut old_cb, &mut cb);
         }
 
-        let mut state = self.get_state();
-        state.force_plaintext_dns_for_servers = force_plaintext_dns_for_servers;
-        self.apply_state(state);
+        self.configured_state
+            .write()
+            .force_plaintext_dns_for_servers = force_plaintext_dns_for_servers;
+        self.refresh_chain();
 
         let res = unsafe {
             self.firewall_lib.libfw_enable_tp_lite_stats_collection(
@@ -396,9 +415,10 @@ impl StatefulFirewall {
 
     /// Disable collection of TP-Lite stats
     pub fn disable_tp_lite_stats_collection(&self) {
-        let mut state = self.get_state();
-        state.force_plaintext_dns_for_servers = None;
-        self.apply_state(state);
+        self.configured_state
+            .write()
+            .force_plaintext_dns_for_servers = None;
+        self.refresh_chain();
 
         unsafe {
             self.firewall_lib
@@ -410,10 +430,9 @@ impl StatefulFirewall {
     /// and the (blocking, standard) DNS server redirect pairs. Both are applied
     /// together, reconfiguring the firewall to DNAT-redirect matching queries.
     pub fn set_tp_lite_domain_whitelist(&self, domains: Vec<String>, redirects: Vec<DnsRedirect>) {
-        let mut state = self.get_state();
-        state.tp_lite_whitelisted_domains = domains;
-        state.tp_lite_dns_redirects = redirects;
-        self.apply_state(state);
+        self.configured_state.write().tp_lite_whitelisted_domains = domains;
+        self.configured_state.write().tp_lite_dns_redirects = redirects;
+        self.refresh_chain();
     }
 }
 
@@ -509,12 +528,13 @@ fn get_local_area_networks_filters(
 /// so tests can inspect the Rule vec directly.
 pub(crate) fn build_chain_rules(
     config: &FirewallConfig,
-    state: &FirewallState,
+    dynamic_state: &FirewallDynamicState,
+    configured_state: &FirewallConfiguredState,
     local_ifs_addrs: &[StdIpAddr],
 ) -> Vec<Rule> {
     let mut rules = vec![];
 
-    if let Some(dns_server_ips) = &state.force_plaintext_dns_for_servers {
+    if let Some(dns_server_ips) = &configured_state.force_plaintext_dns_for_servers {
         dns_server_ips.iter().for_each(|ip| {
             rules.push(Rule {
                 filters: vec![
@@ -559,8 +579,8 @@ pub(crate) fn build_chain_rules(
 
     // DNS whitelisting: redirect outbound DNS queries for whitelisted domains
     // away from the "blocking" DNS server to the "standard" one via DNAT.
-    if !state.tp_lite_whitelisted_domains.is_empty() {
-        for redirect in &state.tp_lite_dns_redirects {
+    if !configured_state.tp_lite_whitelisted_domains.is_empty() {
+        for redirect in &configured_state.tp_lite_dns_redirects {
             let blocking_net = IpNet::from(StdIpAddr::V4(*redirect.blocking.ip()));
             rules.push(Rule {
                 filters: vec![
@@ -581,7 +601,7 @@ pub(crate) fn build_chain_rules(
                     },
                     Filter {
                         filter_data: FilterData::DnsQueryDomain(
-                            state.tp_lite_whitelisted_domains.clone(),
+                            configured_state.tp_lite_whitelisted_domains.clone(),
                         ),
                         inverted: false,
                     },
@@ -594,12 +614,12 @@ pub(crate) fn build_chain_rules(
     // Reject outbound packets with a wrong source IP (not a tunnel IP).
     // Has to be placed before the blanket outbound-accept rule below
     // so it takes effect.
-    if !state.tunnel_ips.is_empty() {
+    if !dynamic_state.tunnel_ips.is_empty() {
         let mut filters = vec![Filter {
             filter_data: FilterData::Direction(Direction::Outbound),
             inverted: false,
         }];
-        for tunnel_ip in &state.tunnel_ips {
+        for tunnel_ip in &dynamic_state.tunnel_ips {
             filters.push(filter_src_ip_all_ports(IpNet::from(*tunnel_ip), true));
         }
         let reject_rule = Rule {
@@ -619,7 +639,7 @@ pub(crate) fn build_chain_rules(
     });
 
     // Add VPN rule
-    if let Some(vpn_pk) = state.whitelist.vpn_peer {
+    if let Some(vpn_pk) = dynamic_state.whitelist.vpn_peer {
         rules.push(Rule {
             filters: vec![Filter {
                 filter_data: FilterData::AssociatedData(Some(vpn_pk.to_vec())),
@@ -635,7 +655,7 @@ pub(crate) fn build_chain_rules(
     );
 
     #[allow(clippy::indexing_slicing)]
-    for peer in state.whitelist.peer_whitelists[Permissions::LocalAreaConnections].iter() {
+    for peer in dynamic_state.whitelist.peer_whitelists[Permissions::LocalAreaConnections].iter() {
         for local_net in local_network_filters.iter() {
             let mut filters = vec![Filter {
                 filter_data: FilterData::AssociatedData(Some(peer.to_vec())),
@@ -658,10 +678,11 @@ pub(crate) fn build_chain_rules(
     }
 
     // Rules for incoming connections
-    for ip in &state.ip_addresses {
+    for ip in &dynamic_state.ip_addresses {
         // Accept packets for whitelisted peers
         #[allow(clippy::indexing_slicing)]
-        for peer in state.whitelist.peer_whitelists[Permissions::IncomingConnections].iter() {
+        for peer in dynamic_state.whitelist.peer_whitelists[Permissions::IncomingConnections].iter()
+        {
             rules.push(Rule {
                 filters: vec![
                     Filter {
@@ -685,7 +706,7 @@ pub(crate) fn build_chain_rules(
 
         // Accept packets for whitelisted ports
         for proto in [NextLevelProtocol::Tcp, NextLevelProtocol::Udp] {
-            for (peer, &port) in &state.whitelist.port_whitelist {
+            for (peer, &port) in &dynamic_state.whitelist.port_whitelist {
                 rules.push(Rule {
                     filters: vec![
                         Filter {
@@ -717,7 +738,7 @@ pub(crate) fn build_chain_rules(
     }
 
     #[allow(clippy::indexing_slicing)]
-    for peer in state.whitelist.peer_whitelists[Permissions::RoutingConnections].iter() {
+    for peer in dynamic_state.whitelist.peer_whitelists[Permissions::RoutingConnections].iter() {
         rules.push(Rule {
             filters: vec![Filter {
                 filter_data: FilterData::AssociatedData(Some(peer.to_vec())),
@@ -733,10 +754,11 @@ pub(crate) fn build_chain_rules(
 /// Configures the firewall chain based on the provided configuration.
 pub(crate) fn configure_chain(
     config: &FirewallConfig,
-    state: &FirewallState,
+    dynamic_state: &FirewallDynamicState,
+    configured_state: &FirewallConfiguredState,
     local_ifs_addrs: &[StdIpAddr],
 ) -> FfiChainGuard {
-    build_chain_rules(config, state, local_ifs_addrs)
+    build_chain_rules(config, dynamic_state, configured_state, local_ifs_addrs)
         .as_slice()
         .into()
 }
@@ -774,17 +796,17 @@ extern "C" fn log_callback(level: LibfwLogLevel, log_line: *const std::ffi::c_ch
 }
 
 impl Firewall for StatefulFirewall {
-    fn apply_state(&self, new_state: FirewallState) {
-        if *self.state.read() == new_state {
+    fn apply_dynamic_state(&self, new_state: FirewallDynamicState) {
+        if *self.dynamic_state.read() == new_state {
             return;
         }
-        *self.state.write() = new_state;
+        *self.dynamic_state.write() = new_state;
 
         self.refresh_chain();
     }
 
-    fn get_state(&self) -> FirewallState {
-        self.state.read().clone()
+    fn get_dynamic_state(&self) -> FirewallDynamicState {
+        self.dynamic_state.read().clone()
     }
 
     fn process_outbound_packet(
@@ -860,8 +882,9 @@ mod tests {
             let mut result = Self {
                 firewall: 0x1 as *mut crate::libfirewall::LibfwFirewall,
                 firewall_lib: crate::libfirewall::MockLibfirewall::default(),
-                state: RwLock::new(FirewallState::default()),
+                dynamic_state: RwLock::new(FirewallDynamicState::default()),
                 interface_ips: RwLock::new(Vec::new()),
+                configured_state: RwLock::new(FirewallConfiguredState::default()),
                 config: FirewallConfig {
                     allow_ipv6: use_ipv6,
                     feature,
@@ -891,11 +914,13 @@ mod tests {
     fn test_notify_triggers_refresh_with_callback_addrs() {
         let captured_addrs = Arc::new(ParkingLotMutex::new(Vec::<Vec<StdIpAddr>>::new()));
         let addrs_clone = captured_addrs.clone();
-        let spy_fn =
-            move |_config: &FirewallConfig, _state: &FirewallState, addrs: &[StdIpAddr]| {
-                addrs_clone.lock().push(addrs.to_vec());
-                (Vec::<Rule>::new().as_slice()).into()
-            };
+        let spy_fn = move |_: &FirewallConfig,
+                           _: &FirewallDynamicState,
+                           _: &FirewallConfiguredState,
+                           addrs: &[StdIpAddr]| {
+            addrs_clone.lock().push(addrs.to_vec());
+            (Vec::<Rule>::new().as_slice()).into()
+        };
 
         let mut firewall =
             StatefulFirewall::new_mock(true, FeatureFirewall::default(), Box::new(spy_fn));
@@ -946,11 +971,12 @@ mod tests {
             allow_ipv6: false,
             feature: FeatureFirewall::default(),
         };
-        let state = FirewallState {
-            tunnel_ips: vec![],
-            ..Default::default()
-        };
-        let rules = build_chain_rules(&config, &state, &[]);
+        let rules = build_chain_rules(
+            &config,
+            &FirewallDynamicState::default(),
+            &FirewallConfiguredState::default(),
+            &[],
+        );
         assert!(
             rules.iter().all(|r| r.action != RuleAction::Reject),
             "no Reject rule should be emitted when tunnel_ips is empty"
@@ -964,11 +990,11 @@ mod tests {
             feature: FeatureFirewall::default(),
         };
         let tunnel_ip = StdIpAddr::V4(Ipv4Addr::new(10, 5, 0, 2));
-        let state = FirewallState {
+        let state = FirewallDynamicState {
             tunnel_ips: vec![tunnel_ip],
             ..Default::default()
         };
-        let rules = build_chain_rules(&config, &state, &[]);
+        let rules = build_chain_rules(&config, &state, &FirewallConfiguredState::default(), &[]);
         let rule = reject_rule_for_outbound_src(&rules, tunnel_ip).expect(
             "expected a Reject rule with Direction::Outbound and inverted SrcNetwork(tunnel_ip)",
         );
@@ -990,11 +1016,11 @@ mod tests {
         let v6 = StdIpAddr::V6(std::net::Ipv6Addr::new(
             0xfd74, 0x656c, 0x696f, 0, 0, 0, 0, 2,
         ));
-        let state = FirewallState {
+        let state = FirewallDynamicState {
             tunnel_ips: vec![v4, v6],
             ..Default::default()
         };
-        let rules = build_chain_rules(&config, &state, &[]);
+        let rules = build_chain_rules(&config, &state, &FirewallConfiguredState::default(), &[]);
         // A single Reject rule must carry one inverted SrcNetwork filter per IP.
         let rule = rules
             .iter()
@@ -1033,7 +1059,7 @@ mod tests {
             feature: FeatureFirewall::default(),
         };
         let tunnel_ip = StdIpAddr::V4(Ipv4Addr::new(10, 5, 0, 2));
-        let state = FirewallState {
+        let state = FirewallDynamicState {
             tunnel_ips: vec![tunnel_ip],
             whitelist: Whitelist {
                 vpn_peer: Some(vpn_pk),
@@ -1041,7 +1067,7 @@ mod tests {
             },
             ..Default::default()
         };
-        let rules = build_chain_rules(&config, &state, &[]);
+        let rules = build_chain_rules(&config, &state, &FirewallConfiguredState::default(), &[]);
 
         let reject_pos = rules.iter().position(|r| {
             r.action == RuleAction::Reject
@@ -1080,11 +1106,13 @@ mod tests {
     fn test_notify_addrs_are_used_by_subsequent_refreshes() {
         let captured_addrs = Arc::new(ParkingLotMutex::new(Vec::<Vec<StdIpAddr>>::new()));
         let addrs_clone = captured_addrs.clone();
-        let spy_fn =
-            move |_config: &FirewallConfig, _state: &FirewallState, addrs: &[StdIpAddr]| {
-                addrs_clone.lock().push(addrs.to_vec());
-                (Vec::<Rule>::new().as_slice()).into()
-            };
+        let spy_fn = move |_: &FirewallConfig,
+                           _: &FirewallDynamicState,
+                           _: &FirewallConfiguredState,
+                           addrs: &[StdIpAddr]| {
+            addrs_clone.lock().push(addrs.to_vec());
+            (Vec::<Rule>::new().as_slice()).into()
+        };
 
         let mut firewall =
             StatefulFirewall::new_mock(true, FeatureFirewall::default(), Box::new(spy_fn));
@@ -1103,7 +1131,7 @@ mod tests {
 
         let notify_addrs = vec![StdIpAddr::V4(Ipv4Addr::new(192, 168, 77, 7))];
         firewall.notify(&notify_addrs);
-        firewall.apply_state(FirewallState {
+        firewall.apply_dynamic_state(FirewallDynamicState {
             ip_addresses: vec![StdIpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))],
             ..Default::default()
         });

--- a/crates/telio-firewall/tests/firewall_integration_tests.rs
+++ b/crates/telio-firewall/tests/firewall_integration_tests.rs
@@ -15,7 +15,7 @@ use std::{
 };
 use telio_crypto::SecretKey;
 use telio_firewall::firewall::{
-    Firewall, FirewallState, Permissions, StatefulFirewall, FILE_SEND_PORT,
+    Firewall, FirewallDynamicState, Permissions, StatefulFirewall, FILE_SEND_PORT,
 };
 use telio_model::{
     features::{FeatureFirewall, FirewallBlacklistTuple, IpProtocol},
@@ -632,7 +632,7 @@ fn ipv6_blocked() {
     ];
     for TestInput { src1, src2, src3, src4, src5, dst1, dst2, make_udp , is_ipv4} in test_inputs {
         let fw = StatefulFirewall::new(false, FeatureFirewall::default(),).expect("Failed to load libfirewall");
-        fw.apply_state(FirewallState {
+        fw.apply_dynamic_state(FirewallDynamicState {
             ip_addresses: vec![(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))), IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1))],
             ..Default::default()
         });
@@ -697,7 +697,7 @@ fn outgoing_blacklist() {
             outgoing_blacklist: blacklist.clone(),
             ..Default::default()
         },).expect("Failed to load libfirewall");
-        fw.apply_state(FirewallState {
+        fw.apply_dynamic_state(FirewallDynamicState {
             ip_addresses: vec![
                 IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
                 IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)),
@@ -760,9 +760,9 @@ fn firewall_whitelist() {
         let mut feature = FeatureFirewall::default();
         feature.neptun_reset_conns = true;
         let fw = StatefulFirewall::new(true, feature).expect("Failed to load libfirewall");
-        let mut state = fw.get_state();
+        let mut state = fw.get_dynamic_state();
         state.ip_addresses = vec![(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))), IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1))];
-        fw.apply_state(state.clone());
+        fw.apply_dynamic_state(state.clone());
         let peer1 = make_random_peer();
         let peer2 = make_random_peer();
 
@@ -772,8 +772,8 @@ fn firewall_whitelist() {
         assert_eq!(fw.process_inbound_packet(&peer2.0, &mut make_udp(src2, dst1,)), false);
 
         state.whitelist.port_whitelist.insert(peer2, 1111);
-        fw.apply_state(state.clone());
-        assert_eq!(fw.get_state().whitelist.port_whitelist.len(), 1);
+        fw.apply_dynamic_state(state.clone());
+        assert_eq!(fw.get_dynamic_state().whitelist.port_whitelist.len(), 1);
 
         assert_eq!(fw.process_inbound_packet(&peer1.0, &mut make_udp(src1, dst1,)), false);
         assert_eq!(fw.process_inbound_packet(&peer2.0, &mut make_udp(src2, dst1,)), true);
@@ -785,7 +785,7 @@ fn firewall_whitelist() {
         assert_eq!(fw.process_inbound_packet(&peer2.0, &mut make_tcp(src5, dst1, TcpFlags::SYN)), true);
 
         state.whitelist.peer_whitelists[Permissions::IncomingConnections].insert(peer2);
-        fw.apply_state(state.clone());
+        fw.apply_dynamic_state(state.clone());
         let src = src1.parse::<StdSocketAddr>().unwrap().ip().to_string();
         let dst = dst1.parse::<StdSocketAddr>().unwrap().ip().to_string();
         assert_eq!(fw.process_inbound_packet(&peer1.0, &mut make_icmp(&src, &dst, IcmpTypes::EchoRequest.into())), false);
@@ -824,9 +824,9 @@ fn firewall_vpn_peer() {
         for TestInput { src1, src2, dst1, make_udp, make_tcp } in &test_inputs {
             let feature = FeatureFirewall::default();
             let fw = StatefulFirewall::new(true, feature).expect("Failed to load libfirewall");
-            let mut state = fw.get_state();
+            let mut state = fw.get_dynamic_state();
             state.ip_addresses = vec![(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))), IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1))];
-            fw.apply_state(state.clone());
+            fw.apply_dynamic_state(state.clone());
 
             let peer1 = make_random_peer();
             let peer2 = make_random_peer();
@@ -837,7 +837,7 @@ fn firewall_vpn_peer() {
             assert_eq!(fw.process_inbound_packet(&peer2.0, &mut make_tcp(src2, dst1, synack)), false);
 
             state.whitelist.vpn_peer = Some(peer1);
-            fw.apply_state(state.clone());
+            fw.apply_dynamic_state(state.clone());
             assert_eq!(fw.process_inbound_packet(&peer1.0, &mut make_udp(src1, dst1,)), true);
             assert_eq!(fw.process_inbound_packet(&peer2.0, &mut make_udp(src2, dst1,)), false);
 
@@ -845,7 +845,7 @@ fn firewall_vpn_peer() {
             assert_eq!(fw.process_outbound_packet_sink(&peer1.0, &mut make_tcp(dst1, src1, synack)), true);
 
             state.whitelist.vpn_peer = None;
-            fw.apply_state(state.clone());
+            fw.apply_dynamic_state(state.clone());
             assert_eq!(fw.process_inbound_packet(&peer1.0, &mut make_udp(src1, dst1,)), false);
             assert_eq!(fw.process_inbound_packet(&peer2.0, &mut make_udp(src2, dst1,)), false);
             // Peer-initiated established TCP: no longer accepted once the vpn-peer rule is gone
@@ -873,12 +873,12 @@ fn firewall_whitelist_change_icmp() {
         let feature = FeatureFirewall::default();
         // Set number of conntrack entries to 0 to test only the whitelist
         let fw = StatefulFirewall::new(true, feature).expect("Failed to load libfirewall");
-        fw.apply_state(FirewallState {
+        fw.apply_dynamic_state(FirewallDynamicState {
             ip_addresses: vec![(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))), IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1))],
             ..Default::default()
         });
 
-        let mut state = fw.get_state();
+        let mut state = fw.get_dynamic_state();
         let peer = make_random_peer();
         assert_eq!(fw.process_inbound_packet(&peer.0, &mut make_icmp(them, us, IcmpTypes::EchoReply.into())), false);
 
@@ -890,7 +890,7 @@ fn firewall_whitelist_change_icmp() {
         }
 
         state.whitelist.peer_whitelists[Permissions::IncomingConnections].insert(peer);
-        fw.apply_state(state.clone());
+        fw.apply_dynamic_state(state.clone());
         assert_eq!(fw.process_inbound_packet(&peer.0, &mut make_icmp(them, us, IcmpTypes::EchoRequest.into())), true);
         assert_eq!(fw.process_inbound_packet(&peer.0, &mut make_icmp(them, us, IcmpTypes::EchoReply.into())), true);
         if *is_v4 {
@@ -930,12 +930,12 @@ fn firewall_orig_src_ip_peer_initiated_blocked_after_removal() {
 
     for TestInput { us, them, make_icmp_echo } in &test_inputs {
         let fw = StatefulFirewall::new(true, FeatureFirewall::default()).expect("Failed to load libfirewall");
-        fw.apply_state(FirewallState {
+        fw.apply_dynamic_state(FirewallDynamicState {
             ip_addresses: vec![IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1))],
             ..Default::default()
         });
 
-        let mut state = fw.get_state();
+        let mut state = fw.get_dynamic_state();
         let peer = make_random_peer();
 
         // Not whitelisted yet: the peer's pings are dropped.
@@ -943,7 +943,7 @@ fn firewall_orig_src_ip_peer_initiated_blocked_after_removal() {
 
         // Allow the peer to open incoming connections.
         state.whitelist.peer_whitelists[Permissions::IncomingConnections].insert(peer);
-        fw.apply_state(state.clone());
+        fw.apply_dynamic_state(state.clone());
 
         // The peer pings the host -> accepted by the incoming-peer rule. This opens
         // a conntrack entry whose original direction source is the peer's IP.
@@ -955,7 +955,7 @@ fn firewall_orig_src_ip_peer_initiated_blocked_after_removal() {
 
         // Remove the peer from the incoming whitelist.
         state.whitelist.peer_whitelists[Permissions::IncomingConnections].remove(&peer);
-        fw.apply_state(state.clone());
+        fw.apply_dynamic_state(state.clone());
 
         // Pings must now fail: not from an allowed peer anymore, and the connection
         // was initiated by the peer (orig src != our IP) so OrigSrcIp doesn't help -
@@ -990,7 +990,7 @@ fn firewall_orig_src_ip_host_initiated_allowed_without_whitelist() {
 
     for TestInput { us, them, make_icmp_echo } in &test_inputs {
         let fw = StatefulFirewall::new(true, FeatureFirewall::default()).expect("Failed to load libfirewall");
-        fw.apply_state(FirewallState {
+        fw.apply_dynamic_state(FirewallDynamicState {
             ip_addresses: vec![IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1))],
             ..Default::default()
         });
@@ -1031,7 +1031,7 @@ fn firewall_orig_src_ip_icmp_error_for_host_initiated_connection_allowed() {
 
     for TestInput { us, us_unsent, them, make_udp, make_icmp_error } in &test_inputs {
         let fw = StatefulFirewall::new(true, FeatureFirewall::default()).expect("Failed to load libfirewall");
-        fw.apply_state(FirewallState {
+        fw.apply_dynamic_state(FirewallDynamicState {
             ip_addresses: vec![IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1))],
             ..Default::default()
         });
@@ -1058,23 +1058,23 @@ fn firewall_whitelist_change_udp_allow() {
 
     for TestInput { us, them, make_udp } in test_inputs {
         let fw = StatefulFirewall::new(true, FeatureFirewall::default(),).expect("Failed to load libfirewall");
-        fw.apply_state(FirewallState {
+        fw.apply_dynamic_state(FirewallDynamicState {
             ip_addresses: vec![(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))), IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1))],
             ..Default::default()
         });
-        let mut state = fw.get_state();
+        let mut state = fw.get_dynamic_state();
 
         let them_peer = make_random_peer();
 
         assert_eq!(fw.process_inbound_packet(&them_peer.0, &mut make_udp(them, us)), false);
         state.whitelist.port_whitelist.insert(them_peer, 8888);
-        fw.apply_state(state.clone()); // NOTE: this doesn't change anything about this test
+        fw.apply_dynamic_state(state.clone()); // NOTE: this doesn't change anything about this test
         assert_eq!(fw.process_outbound_packet_sink(&them_peer.0, &mut make_udp(us, them)), true);
         // Peer-initiated (the peer's packet above was seen first), so OrigSrcIp doesn't accept it
         assert_eq!(fw.process_inbound_packet(&them_peer.0, &mut make_udp(them, us)), false);
         assert_eq!(fw.process_inbound_packet(&them_peer.0, &mut make_udp(them, us)), false);
         state.whitelist.port_whitelist.remove(&them_peer);
-        fw.apply_state(state.clone()); // NOTE: also has no impact on this test
+        fw.apply_dynamic_state(state.clone()); // NOTE: also has no impact on this test
         assert_eq!(fw.process_inbound_packet(&them_peer.0, &mut make_udp(them, us)), false);
     }
 }
@@ -1090,22 +1090,22 @@ fn firewall_whitelist_change_udp_block() {
 
     for TestInput { us, them, make_udp } in test_inputs {
         let fw = StatefulFirewall::new(true, FeatureFirewall::default(),).expect("Failed to load libfirewall");
-        fw.apply_state(FirewallState {
+        fw.apply_dynamic_state(FirewallDynamicState {
             ip_addresses: vec![(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))), IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1))],
             ..Default::default()
         });
-        let mut state = fw.get_state();
+        let mut state = fw.get_dynamic_state();
         let them_peer = make_random_peer();
 
         state.whitelist.port_whitelist.insert(them_peer, 1111);
-        fw.apply_state(state.clone());
+        fw.apply_dynamic_state(state.clone());
         assert_eq!(fw.process_inbound_packet(&them_peer.0, &mut make_udp(them, us)), true);
         assert_eq!(fw.process_outbound_packet_sink(&them_peer.0, &mut make_udp(us, them)), true);
 
         // The already started connection should still work
         assert_eq!(fw.process_inbound_packet(&them_peer.0, &mut make_udp(them, us)), true);
         state.whitelist.port_whitelist.remove(&them_peer);
-        fw.apply_state(state.clone());
+        fw.apply_dynamic_state(state.clone());
         // Peer-initiated: dropped after the port whitelist is removed (OrigSrcIp doesn't match)
         assert_eq!(fw.process_inbound_packet(&them_peer.0, &mut make_udp(them, us)), false);
     }
@@ -1121,14 +1121,14 @@ fn firewall_whitelist_change_tcp_allow() {
     ];
     for TestInput { us, them, make_tcp } in test_inputs {
         let fw = StatefulFirewall::new(true, FeatureFirewall::default(),).expect("Failed to load libfirewall");
-        let mut state = fw.get_state();
+        let mut state = fw.get_dynamic_state();
         state.ip_addresses = vec![(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))), IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1))];
-        fw.apply_state(state.clone());
+        fw.apply_dynamic_state(state.clone());
 
         let them_peer = make_random_peer();
 
         state.whitelist.port_whitelist.insert(them_peer, 8888);
-        fw.apply_state(state.clone()); // NOTE: this doesn't change anything about the test
+        fw.apply_dynamic_state(state.clone()); // NOTE: this doesn't change anything about the test
         assert_eq!(fw.process_inbound_packet(&them_peer.0, &mut make_tcp(them, us, TcpFlags::SYN | TcpFlags::ACK)), false);
         assert_eq!(fw.process_outbound_packet_sink(&them_peer.0, &mut make_tcp(us, them, TcpFlags::SYN)), true);
         assert_eq!(fw.process_inbound_packet(&them_peer.0, &mut make_tcp(them, us, TcpFlags::SYN | TcpFlags::ACK)), true);
@@ -1137,7 +1137,7 @@ fn firewall_whitelist_change_tcp_allow() {
         // Should PASS because we started the session
         assert_eq!(fw.process_inbound_packet(&them_peer.0, &mut make_tcp(them, us, TcpFlags::ACK)), true);
         state.whitelist.port_whitelist.remove(&them_peer);
-        fw.apply_state(state.clone());
+        fw.apply_dynamic_state(state.clone());
         assert_eq!(fw.process_inbound_packet(&them_peer.0, &mut make_tcp(them, us, TcpFlags::ACK)), true);
     }
 
@@ -1153,15 +1153,15 @@ fn firewall_whitelist_change_tcp_block() {
     ];
     for TestInput { us, them, make_tcp } in test_inputs {
         let fw = StatefulFirewall::new(true, FeatureFirewall::default(),).expect("Failed to load libfirewall");
-        let mut state = fw.get_state();
+        let mut state = fw.get_dynamic_state();
         state.ip_addresses = vec![(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))), IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1))];
-        fw.apply_state(state.clone());
+        fw.apply_dynamic_state(state.clone());
 
         let them_peer = make_random_peer();
 
         assert_eq!(fw.process_inbound_packet(&them_peer.0, &mut make_tcp(them, us, TcpFlags::SYN)), false);
         state.whitelist.port_whitelist.insert(them_peer, 1111);
-        fw.apply_state(state.clone());
+        fw.apply_dynamic_state(state.clone());
         assert_eq!(fw.process_inbound_packet(&them_peer.0, &mut make_tcp(them, us, TcpFlags::SYN)), true);
         assert_eq!(fw.process_outbound_packet_sink(&them_peer.0, &mut make_tcp(us, them, TcpFlags::SYN | TcpFlags::ACK)), true);
 
@@ -1169,7 +1169,7 @@ fn firewall_whitelist_change_tcp_block() {
         // Firewall allows already established connections while the peer is whitelisted
         assert_eq!(fw.process_inbound_packet(&them_peer.0, &mut make_tcp(them, us, TcpFlags::ACK)), true);
         state.whitelist.port_whitelist.remove(&them_peer);
-        fw.apply_state(state.clone());
+        fw.apply_dynamic_state(state.clone());
         // Peer-initiated: dropped after the port whitelist is removed (OrigSrcIp doesn't match)
         assert_eq!(fw.process_inbound_packet(&them_peer.0, &mut make_tcp(them, us, TcpFlags::ACK)), false);
     }
@@ -1207,11 +1207,11 @@ fn firewall_whitelist_peer() {
         for TestInput { src1, src2, dst, make_udp, make_tcp, make_icmp } in &test_inputs {
             let feature = FeatureFirewall::default();
             let fw = StatefulFirewall::new(true, feature).expect("Failed to load libfirewall");
-            fw.apply_state(FirewallState {
+            fw.apply_dynamic_state(FirewallDynamicState {
                 ip_addresses: vec![(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))), IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1))],
                 ..Default::default()
             });
-            let mut state = fw.get_state();
+            let mut state = fw.get_dynamic_state();
             assert!(state.whitelist.peer_whitelists[Permissions::IncomingConnections].is_empty());
 
             let src2_ip = src2.parse::<StdSocketAddr>().unwrap().ip().to_string();
@@ -1222,16 +1222,16 @@ fn firewall_whitelist_peer() {
             assert_eq!(fw.process_inbound_packet(&make_peer(), &mut make_tcp(src2, dst, TcpFlags::PSH)), false);
 
             state.whitelist.peer_whitelists[Permissions::IncomingConnections].insert((&make_peer()).into());
-            fw.apply_state(state.clone());
-            assert_eq!(fw.get_state().whitelist.peer_whitelists[Permissions::IncomingConnections].len(), 1);
+            fw.apply_dynamic_state(state.clone());
+            assert_eq!(fw.get_dynamic_state().whitelist.peer_whitelists[Permissions::IncomingConnections].len(), 1);
 
             assert_eq!(fw.process_inbound_packet(&make_peer(), &mut make_udp(src1, dst,)), true);
             assert_eq!(fw.process_inbound_packet(&make_peer(), &mut make_icmp(&src2_ip, &dst_ip, IcmpTypes::EchoRequest.into())), true);
             assert_eq!(fw.process_inbound_packet(&make_peer(), &mut make_tcp(src2, dst, TcpFlags::PSH)), true);
 
             state.whitelist.peer_whitelists[Permissions::IncomingConnections].remove(&(&make_peer()).into());
-            fw.apply_state(state.clone());
-            assert_eq!(fw.get_state().whitelist.peer_whitelists[Permissions::IncomingConnections].len(), 0);
+            fw.apply_dynamic_state(state.clone());
+            assert_eq!(fw.get_dynamic_state().whitelist.peer_whitelists[Permissions::IncomingConnections].len(), 0);
 
             assert_eq!(fw.process_inbound_packet(&make_peer(), &mut make_udp(src1, dst,)), false);
             assert_eq!(fw.process_inbound_packet(&make_peer(), &mut make_icmp(&src2_ip, &dst_ip, IcmpTypes::EchoRequest.into())), false);
@@ -1280,12 +1280,12 @@ fn firewall_test_permissions() {
         let mut feature = FeatureFirewall::default();
         feature.neptun_reset_conns = true;
         let fw = StatefulFirewall::new(true, feature).expect("Failed to load libfirewall");
-        let mut state = fw.get_state();
+        let mut state = fw.get_dynamic_state();
         state.ip_addresses = vec![
             IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
             IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)),
         ];
-        fw.apply_state(state.clone());
+        fw.apply_dynamic_state(state.clone());
         assert!(state.whitelist.peer_whitelists[Permissions::IncomingConnections].is_empty());
         assert!(state.whitelist.peer_whitelists[Permissions::RoutingConnections].is_empty());
         assert!(state.whitelist.peer_whitelists[Permissions::LocalAreaConnections].is_empty());
@@ -1299,7 +1299,7 @@ fn firewall_test_permissions() {
         // Allow incoming connection
         state.whitelist.peer_whitelists[Permissions::IncomingConnections]
             .insert((&make_peer()).into());
-        fw.apply_state(state.clone());
+        fw.apply_dynamic_state(state.clone());
         assert_eq!(
             state.whitelist.peer_whitelists[Permissions::IncomingConnections].len(),
             1
@@ -1325,7 +1325,7 @@ fn firewall_test_permissions() {
         // Allow local area connections
         state.whitelist.peer_whitelists[Permissions::LocalAreaConnections]
             .insert((&make_peer()).into());
-        fw.apply_state(state.clone());
+        fw.apply_dynamic_state(state.clone());
         assert_eq!(
             state.whitelist.peer_whitelists[Permissions::LocalAreaConnections].len(),
             1
@@ -1345,7 +1345,7 @@ fn firewall_test_permissions() {
         // Allow routing permissiongs but no local area connection
         state.whitelist.peer_whitelists[Permissions::LocalAreaConnections]
             .remove(&(&make_peer()).into());
-        fw.apply_state(state.clone());
+        fw.apply_dynamic_state(state.clone());
         assert_eq!(
             state.whitelist.peer_whitelists[Permissions::LocalAreaConnections].len(),
             0
@@ -1353,7 +1353,7 @@ fn firewall_test_permissions() {
 
         state.whitelist.peer_whitelists[Permissions::RoutingConnections]
             .insert((&make_peer()).into());
-        fw.apply_state(state.clone());
+        fw.apply_dynamic_state(state.clone());
         assert_eq!(
             state.whitelist.peer_whitelists[Permissions::RoutingConnections].len(),
             1
@@ -1373,7 +1373,7 @@ fn firewall_test_permissions() {
         // Allow only routing
         state.whitelist.peer_whitelists[Permissions::IncomingConnections]
             .remove(&(&make_peer()).into());
-        fw.apply_state(state.clone());
+        fw.apply_dynamic_state(state.clone());
         assert_eq!(
             state.whitelist.peer_whitelists[Permissions::IncomingConnections].len(),
             0
@@ -1393,7 +1393,7 @@ fn firewall_test_permissions() {
 
         state.whitelist.peer_whitelists[Permissions::RoutingConnections]
             .remove(&(&make_peer()).into());
-        fw.apply_state(state.clone());
+        fw.apply_dynamic_state(state.clone());
         assert_eq!(
             state.whitelist.peer_whitelists[Permissions::RoutingConnections].len(),
             0
@@ -1449,21 +1449,21 @@ fn firewall_whitelist_port() {
     ];
     for test_input @ TestInput { src: _, dst: _, make_udp, make_tcp, make_icmp } in test_inputs {
         let fw = StatefulFirewall::new(true, FeatureFirewall::default(),).expect("Failed to load libfirewall");
-        fw.apply_state(FirewallState {
+        fw.apply_dynamic_state(FirewallDynamicState {
             ip_addresses: vec![(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))), IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1))],
             ..Default::default()
         });
-        let mut state = fw.get_state();
-        assert!(fw.get_state().whitelist.peer_whitelists[Permissions::IncomingConnections].is_empty());
-        assert!(fw.get_state().whitelist.port_whitelist.is_empty());
+        let mut state = fw.get_dynamic_state();
+        assert!(fw.get_dynamic_state().whitelist.peer_whitelists[Permissions::IncomingConnections].is_empty());
+        assert!(fw.get_dynamic_state().whitelist.port_whitelist.is_empty());
 
         assert_eq!(fw.process_inbound_packet(&make_peer(), &mut make_udp(&test_input.src_socket(11111), &test_input.dst_socket(FILE_SEND_PORT))), false);
         assert_eq!(fw.process_inbound_packet(&make_peer(), &mut make_icmp(&test_input.src, &test_input.dst, IcmpTypes::EchoRequest.into())), false);
         assert_eq!(fw.process_inbound_packet(&make_peer(), &mut make_tcp(&test_input.src_socket(11111), &test_input.dst_socket(FILE_SEND_PORT), TcpFlags::PSH)), false);
 
         state.whitelist.port_whitelist.insert(PublicKey(make_peer()), FILE_SEND_PORT);
-        fw.apply_state(state.clone());
-        assert_eq!(fw.get_state().whitelist.port_whitelist.len(), 1);
+        fw.apply_dynamic_state(state.clone());
+        assert_eq!(fw.get_dynamic_state().whitelist.port_whitelist.len(), 1);
 
         assert_eq!(fw.process_inbound_packet(&make_peer(), &mut make_icmp(&test_input.src, &test_input.dst, IcmpTypes::EchoRequest.into())), false);
 
@@ -1474,8 +1474,8 @@ fn firewall_whitelist_port() {
         assert_eq!(fw.process_inbound_packet(&make_peer(), &mut make_tcp(&test_input.src_socket(11111), &test_input.dst_socket(12345), TcpFlags::PSH)), false);
 
         state.whitelist.port_whitelist.remove(&PublicKey(make_peer()));
-        fw.apply_state(state.clone());
-        assert_eq!(fw.get_state().whitelist.port_whitelist.len(), 0);
+        fw.apply_dynamic_state(state.clone());
+        assert_eq!(fw.get_dynamic_state().whitelist.port_whitelist.len(), 0);
 
         assert_eq!(fw.process_inbound_packet(&make_peer(), &mut make_udp(&test_input.src_socket(11111), &test_input.dst_socket(FILE_SEND_PORT))), false);
         assert_eq!(fw.process_inbound_packet(&make_peer(), &mut make_icmp(&test_input.src, &test_input.dst, IcmpTypes::EchoRequest.into())), false);
@@ -1520,12 +1520,12 @@ mod tp_lite_stats {
     fn tp_lite_stats_enabled() {
         let fw = StatefulFirewall::new(true, FeatureFirewall::default())
             .expect("Failed to load libfirewall");
-        let mut state = fw.get_state();
+        let mut state = fw.get_dynamic_state();
         state.ip_addresses = vec![
             IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
             IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)),
         ];
-        fw.apply_state(state.clone());
+        fw.apply_dynamic_state(state.clone());
         let config = TpLiteStatsOptions {
             dns_server_ips: vec![IpAddr::from([10, 5, 0, 53])],
             callback_interval_s: Some(1),
@@ -1585,12 +1585,12 @@ mod tp_lite_stats {
 
         let fw = StatefulFirewall::new(true, FeatureFirewall::default())
             .expect("Failed to load libfirewall");
-        let mut state = fw.get_state();
+        let mut state = fw.get_dynamic_state();
         state.ip_addresses = vec![
             IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
             IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)),
         ];
-        fw.apply_state(state.clone());
+        fw.apply_dynamic_state(state.clone());
 
         let stats = Arc::new(Mutex::new(Stats::default()));
         let callback = Callback {
@@ -1810,9 +1810,9 @@ mod dns_whitelisting {
         let client: SocketAddrV4 = "127.0.0.1:12345".parse().unwrap();
         let peer = make_peer();
 
-        let mut state = fw.get_state();
+        let mut state = fw.get_dynamic_state();
         state.ip_addresses = vec![IpAddr::V4(*client.ip())];
-        fw.apply_state(state);
+        fw.apply_dynamic_state(state);
 
         let mut query = make_dns_request_to(client, blocking, 42, "example.com");
         assert!(fw.process_outbound_packet(&peer, &mut query, &mut io::sink()));
@@ -1843,7 +1843,7 @@ fn outbound_wrong_tunnel_src_ip_rejected() {
 
     let fw = StatefulFirewall::new(false, FeatureFirewall::default())
         .expect("Failed to load libfirewall");
-    fw.apply_state(FirewallState {
+    fw.apply_dynamic_state(FirewallDynamicState {
         tunnel_ips: vec![IpAddr::V4(tunnel_ip.parse().unwrap())],
         ..Default::default()
     });
@@ -1873,7 +1873,7 @@ fn outbound_wrong_src_ip_allowed_when_tunnel_ips_unset() {
     let fw = StatefulFirewall::new(false, FeatureFirewall::default())
         .expect("Failed to load libfirewall");
     // Empty tunnel_ips disables the protection: outbound is unrestricted.
-    fw.apply_state(FirewallState::default());
+    fw.apply_dynamic_state(FirewallDynamicState::default());
 
     assert!(
         fw.process_outbound_packet_sink(&make_peer(), &mut make_udp("10.5.0.9:1111", dst)),
@@ -1890,7 +1890,7 @@ fn outbound_wrong_tunnel_src_ip_rejected_dual_stack() {
 
     let fw = StatefulFirewall::new(true, FeatureFirewall::default())
         .expect("Failed to load libfirewall");
-    fw.apply_state(FirewallState {
+    fw.apply_dynamic_state(FirewallDynamicState {
         tunnel_ips: vec![
             IpAddr::V4(tunnel_v4.parse().unwrap()),
             IpAddr::V6(tunnel_v6.parse().unwrap()),

--- a/nat-lab/tests/test_tp_lite_stats.py
+++ b/nat-lab/tests/test_tp_lite_stats.py
@@ -271,6 +271,11 @@ class TestTpLiteStats:
             _tp_lite_config(force_plaintext_dns=True)
         )
 
+        # LLT-7452: This sleep is added as a regression test in order to validate that
+        # the configuration set by enable_stats_collection is not cleared by the
+        # firewall consilidation. Consolidation runs every 5 seconds.
+        await asyncio.sleep(10)
+
         for port in NON_PLAINTEXT_DNS_PORTS:
             with pytest.raises(ProcessExecError):
                 await query_dns_port(connection, port, ALLOWED_DOMAIN, TP_LITE_DNS_IP)
@@ -667,6 +672,11 @@ class TestDnsWhitelisting:
                 )
             ],
         )
+
+        # LLT-7452: This sleep is added as a regression test in order to validate that
+        # the configuration set by set_domain_whitelist is not cleared by the
+        # firewall consilidation. Consolidation runs every 5 seconds.
+        await asyncio.sleep(10)
 
         # blocked-malware.com is NXDOMAIN at the TP-Lite (blocking) server, but it
         # is now whitelisted, so the firewall DNATs the query to the standard DNS

--- a/src/device/wg_controller.rs
+++ b/src/device/wg_controller.rs
@@ -14,7 +14,7 @@ use tokio::sync::Mutex;
 use telio_crypto::PublicKey;
 use telio_dns::DnsResolver;
 #[cfg(feature = "enable_firewall")]
-use telio_firewall::firewall::{Firewall, FirewallState, Permissions, FILE_SEND_PORT};
+use telio_firewall::firewall::{Firewall, FirewallDynamicState, Permissions, FILE_SEND_PORT};
 use telio_model::{
     constants::{VPN_EXTERNAL_IPV4, VPN_INTERNAL_IPV4, VPN_INTERNAL_IPV6},
     features::Features,
@@ -609,7 +609,8 @@ async fn consolidate_firewall<F: Firewall>(
     starcast_vpeer_pubkey: Option<PublicKey>,
     dns_pubkey: Option<PublicKey>,
 ) -> Result {
-    let mut state = FirewallState::default();
+    let mut state = FirewallDynamicState::default();
+
     let peers: Vec<_> = iter_peers(requested_state).collect();
 
     state.whitelist.port_whitelist = peers
@@ -666,7 +667,7 @@ async fn consolidate_firewall<F: Firewall>(
         Vec::new()
     };
 
-    firewall.apply_state(state);
+    firewall.apply_dynamic_state(state);
 
     Ok(())
 }
@@ -1482,9 +1483,9 @@ mod tests {
         ]);
 
         firewall
-            .expect_apply_state()
+            .expect_apply_dynamic_state()
             .once()
-            .with(eq(FirewallState {
+            .with(eq(FirewallDynamicState {
                 whitelist: Whitelist {
                     peer_whitelists: enum_map! {
                         Permissions::IncomingConnections => FwHashSet::from_iter([pub_key_1, pub_key_2, pub_key_starcast_vpeer].iter().cloned()),
@@ -1528,9 +1529,9 @@ mod tests {
         ]);
 
         firewall
-            .expect_apply_state()
+            .expect_apply_dynamic_state()
             .once()
-            .with(eq(FirewallState {
+            .with(eq(FirewallDynamicState {
                 whitelist: Whitelist {
                     peer_whitelists: enum_map! {
                         Permissions::IncomingConnections => FwHashSet::from_iter([pub_key_1, pub_key_2, pub_key_starcast_vpeer].iter().cloned()),
@@ -1573,9 +1574,9 @@ mod tests {
         });
 
         firewall
-            .expect_apply_state()
+            .expect_apply_dynamic_state()
             .once()
-            .with(eq(FirewallState {
+            .with(eq(FirewallDynamicState {
                 whitelist: Whitelist {
                     peer_whitelists: enum_map! {
                         Permissions::IncomingConnections => FwHashSet::from_iter([pub_key_starcast_vpeer].iter().cloned()),
@@ -1586,7 +1587,6 @@ mod tests {
                     vpn_peer: Some(pub_key_2),
                 },
                 ip_addresses: vec![IpAddr::V4(Ipv4Addr::LOCALHOST), IpAddr::V6(Ipv6Addr::LOCALHOST)],
-                force_plaintext_dns_for_servers: None,
                 ..Default::default()
             }))
             .return_const(());
@@ -1618,7 +1618,7 @@ mod tests {
         requested_state.tunnel_ips = vec![IpAddr::V4(Ipv4Addr::new(10, 5, 0, 2))];
 
         firewall
-            .expect_apply_state()
+            .expect_apply_dynamic_state()
             .once()
             .withf(|state| state.tunnel_ips == vec![IpAddr::V4(Ipv4Addr::new(10, 5, 0, 2))])
             .return_const(());
@@ -1645,7 +1645,7 @@ mod tests {
         requested_state.tunnel_ips = vec![IpAddr::V4(Ipv4Addr::new(10, 5, 0, 2))];
 
         firewall
-            .expect_apply_state()
+            .expect_apply_dynamic_state()
             .once()
             .withf(|state| state.tunnel_ips.is_empty())
             .return_const(());
@@ -1677,21 +1677,21 @@ mod tests {
         let mut seq = mockall::Sequence::new();
         // 1) Exit node up: tunnel IP protection applied.
         firewall
-            .expect_apply_state()
+            .expect_apply_dynamic_state()
             .once()
             .in_sequence(&mut seq)
             .withf(|state| state.tunnel_ips == vec![IpAddr::V4(Ipv4Addr::new(10, 5, 0, 2))])
             .return_const(());
         // 2) Exit node down: protection cleared from the firewall state.
         firewall
-            .expect_apply_state()
+            .expect_apply_dynamic_state()
             .once()
             .in_sequence(&mut seq)
             .withf(|state| state.tunnel_ips.is_empty())
             .return_const(());
         // 3) Exit node back up: tunnel IP reapplied without the app re-supplying it.
         firewall
-            .expect_apply_state()
+            .expect_apply_dynamic_state()
             .once()
             .in_sequence(&mut seq)
             .withf(|state| state.tunnel_ips == vec![IpAddr::V4(Ipv4Addr::new(10, 5, 0, 2))])
@@ -1757,9 +1757,9 @@ mod tests {
         });
 
         firewall
-            .expect_apply_state()
+            .expect_apply_dynamic_state()
             .once()
-            .with(eq(FirewallState {
+            .with(eq(FirewallDynamicState {
                 whitelist: Whitelist {
                     peer_whitelists: enum_map! {
                         Permissions::IncomingConnections => FwHashSet::from_iter([pub_key_starcast_vpeer].iter().cloned()),
@@ -1770,7 +1770,6 @@ mod tests {
                     vpn_peer: None,
                 },
                 ip_addresses: vec![IpAddr::V4(Ipv4Addr::LOCALHOST), IpAddr::V6(Ipv6Addr::LOCALHOST)],
-                force_plaintext_dns_for_servers: None,
                 ..Default::default()
             }))
             .return_const(());
@@ -1803,9 +1802,9 @@ mod tests {
         });
 
         firewall
-            .expect_apply_state()
+            .expect_apply_dynamic_state()
             .once()
-            .with(eq(FirewallState {
+            .with(eq(FirewallDynamicState {
                 whitelist: Whitelist {
                     peer_whitelists: enum_map! {
                         Permissions::IncomingConnections => FwHashSet::from_iter([pub_key_starcast_vpeer].iter().cloned()),
@@ -1816,7 +1815,6 @@ mod tests {
                     vpn_peer: None,
                 },
                 ip_addresses: vec![IpAddr::V4(Ipv4Addr::LOCALHOST), IpAddr::V6(Ipv6Addr::LOCALHOST)],
-                force_plaintext_dns_for_servers: None,
                 ..Default::default()
             }))
             .return_const(());
@@ -1844,7 +1842,7 @@ mod tests {
             (pub_key_2, vec![], false, true, false, false),
         ]);
 
-        let expected_state = FirewallState {
+        let expected_state = FirewallDynamicState {
             whitelist: Whitelist {
                 peer_whitelists: enum_map! {
                     Permissions::IncomingConnections => FwHashSet::from_iter([pub_key_1, pub_key_starcast_vpeer].iter().cloned()),
@@ -1863,7 +1861,7 @@ mod tests {
 
         // Calling consolidate_firewall multiple times with same state should produce same config
         firewall
-            .expect_apply_state()
+            .expect_apply_dynamic_state()
             .times(3)
             .with(eq(expected_state))
             .returning(|_| ());


### PR DESCRIPTION
Make consolidate_firewall preserve firewall state set by enable/set_tp_lite_* calls.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
