### PR TITLE
LLT-7470: Increase nordvpnlite client command timeout to 60 seconds

### DIFF
--- a/.unreleased/LLT-7470
+++ b/.unreleased/LLT-7470
@@ -1,0 +1,1 @@
+Increase nordvpnlite client command timeout to 60 seconds

--- a/clis/nordvpnlite/src/command_listener.rs
+++ b/clis/nordvpnlite/src/command_listener.rs
@@ -12,7 +12,7 @@ use crate::{
     daemon::{NordVpnLiteError, TelioStatusReport},
 };
 
-pub(crate) const TIMEOUT_SEC: u64 = 30;
+pub(crate) const TIMEOUT_SEC: u64 = 60;
 
 #[derive(Parser, Debug, PartialEq)]
 #[clap()]


### PR DESCRIPTION
## What

Bumps the nordvpnlite CLI client IPC response timeout `TIMEOUT_SEC` from 30s to 60s.

## Why

Natlab tests intermittently fail because the CLI client trips its 30s IPC response timeout while the daemon is slow to reply during startup / heavy load. This timeout has already been extended several times (1 → 2 → 10 → 20 → 30). Doubling the client-side safety net to 60s reduces flakiness while keeping a guard against a genuinely stuck daemon (removing it entirely would let the CLI hang forever on a deadlocked daemon).

Jira: LLT-7470

## Notes

A separate, self-contained follow-up hardens the IPC protocol itself (newline-framed responses so the client no longer depends on the socket closing) under LLT-7476 / branch `LLT-7476-ipc-response-framing`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
