### PR TITLE
Fix firewall consolidation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4369,15 +4369,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scc"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
-dependencies = [
- "sdd",
-]
-
-[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4411,12 +4402,6 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
-
-[[package]]
-name = "sdd"
-version = "3.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "security-framework"
@@ -4530,24 +4515,23 @@ dependencies = [
 
 [[package]]
 name = "serial_test"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
 dependencies = [
  "futures-executor",
  "futures-util",
  "log",
  "once_cell",
  "parking_lot",
- "scc",
  "serial_test_derive",
 ]
 
 [[package]]
 name = "serial_test_derive"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/telio-firewall/src/firewall.rs
+++ b/crates/telio-firewall/src/firewall.rs
@@ -64,8 +64,16 @@ const ICMPV6_BLOCKED_TYPES: [u8; 4] = [
 pub const FILE_SEND_PORT: u16 = 49111;
 
 /// Type for chain configuration function
-pub(crate) type ConfigureChainFn =
-    Box<dyn Fn(&FirewallConfig, &FirewallState, &[StdIpAddr]) -> FfiChainGuard + Send + Sync>;
+pub(crate) type ConfigureChainFn = Box<
+    dyn Fn(
+            &FirewallConfig,
+            &FirewallDynamicState,
+            &FirewallConfiguredState,
+            &[StdIpAddr],
+        ) -> FfiChainGuard
+        + Send
+        + Sync,
+>;
 
 #[allow(dead_code)]
 pub(crate) trait Icmp: Sized {
@@ -84,10 +92,10 @@ impl Icmp for Icmpv6Type {
 #[cfg_attr(any(test, feature = "mockall"), mockall::automock)]
 pub trait Firewall: Sync + Send {
     /// Applies a new firewall state and updates the chain if it differs from current state
-    fn apply_state(&self, state: FirewallState);
+    fn apply_dynamic_state(&self, state: FirewallDynamicState);
 
     /// Returns a clone of the current firewall state
-    fn get_state(&self) -> FirewallState;
+    fn get_dynamic_state(&self) -> FirewallDynamicState;
 
     /// For new connections it opens a pinhole for incoming connection
     /// If connection is already cached, it resets its timer and extends its lifetime
@@ -151,13 +159,18 @@ pub struct Whitelist {
     pub vpn_peer: Option<PublicKey>,
 }
 
-/// Runtime state for firewall rules that can be updated dynamically.
+/// Dynamic state for firewall rules that is updated dynamically by wg_controller's consolidation.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct FirewallState {
+pub struct FirewallDynamicState {
     /// Whitelist configuration
     pub whitelist: Whitelist,
     /// Local node ip addresses
     pub ip_addresses: Vec<StdIpAddr>,
+}
+
+/// Configured state that is configured via tp_lite API calls.
+#[derive(Clone, Debug, Default)]
+pub struct FirewallConfiguredState {
     /// List of DNS server IPs for which only plaintext DNS should be allowed
     pub force_plaintext_dns_for_servers: Option<Vec<StdIpAddr>>,
 }
@@ -180,10 +193,12 @@ pub struct StatefulFirewall {
     firewall: *mut LibfwFirewall,
     /// Firewall configuration set at initialization
     config: FirewallConfig,
-    /// Current firewall state
-    state: RwLock<FirewallState>,
+    /// Dynamic state
+    dynamic_state: RwLock<FirewallDynamicState>,
     /// Last known host interface IPs reported by network monitor.
     interface_ips: RwLock<Vec<StdIpAddr>>,
+    /// Configured state
+    configured_state: RwLock<FirewallConfiguredState>,
     /// Chain configuration function
     configure_chain_fn: ConfigureChainFn,
     /// Callback for TP-Lite stats
@@ -261,14 +276,13 @@ impl StatefulFirewall {
             feature,
         };
 
-        let state = FirewallState::default();
-
         let result = Self {
             firewall_lib,
             firewall,
             config,
-            state: RwLock::new(state.clone()),
+            dynamic_state: RwLock::new(FirewallDynamicState::default()),
             interface_ips: RwLock::new(Vec::new()),
+            configured_state: RwLock::new(FirewallConfiguredState::default()),
             configure_chain_fn,
             tp_lite_stats_cb: CallbackManager::new(),
         };
@@ -312,12 +326,16 @@ impl StatefulFirewall {
 
     fn refresh_chain(&self) {
         let interface_ips = self.interface_ips.read().clone();
-        self.refresh_chain_with_interface_ips(&interface_ips);
-    }
+        let dynamic_state = self.dynamic_state.read().clone();
+        let configured_state = self.configured_state.read().clone();
 
-    fn refresh_chain_with_interface_ips(&self, interface_ips: &[StdIpAddr]) {
-        let state = self.state.read().clone();
-        let ffi_chain = (self.configure_chain_fn)(&self.config, &state, interface_ips);
+        let ffi_chain = (self.configure_chain_fn)(
+            &self.config,
+            &dynamic_state,
+            &configured_state,
+            &interface_ips,
+        );
+
         unsafe {
             self.firewall_lib
                 .libfw_configure_chain(self.firewall, (&ffi_chain.ffi_chain) as *const LibfwChain);
@@ -357,9 +375,10 @@ impl StatefulFirewall {
             std::mem::swap(&mut old_cb, &mut cb);
         }
 
-        let mut state = self.get_state();
-        state.force_plaintext_dns_for_servers = force_plaintext_dns_for_servers;
-        self.apply_state(state);
+        self.configured_state
+            .write()
+            .force_plaintext_dns_for_servers = force_plaintext_dns_for_servers;
+        self.refresh_chain();
 
         let res = unsafe {
             self.firewall_lib.libfw_enable_tp_lite_stats_collection(
@@ -380,9 +399,10 @@ impl StatefulFirewall {
 
     /// Disable collection of TP-Lite stats
     pub fn disable_tp_lite_stats_collection(&self) {
-        let mut state = self.get_state();
-        state.force_plaintext_dns_for_servers = None;
-        self.apply_state(state);
+        self.configured_state
+            .write()
+            .force_plaintext_dns_for_servers = None;
+        self.refresh_chain();
 
         unsafe {
             self.firewall_lib
@@ -472,12 +492,13 @@ fn get_local_area_networks_filters(
 /// Configures the firewall chain based on the provided configuration.
 pub(crate) fn configure_chain(
     config: &FirewallConfig,
-    state: &FirewallState,
+    dynamic_state: &FirewallDynamicState,
+    configured_state: &FirewallConfiguredState,
     local_ifs_addrs: &[StdIpAddr],
 ) -> FfiChainGuard {
     let mut rules = vec![];
 
-    if let Some(dns_server_ips) = &state.force_plaintext_dns_for_servers {
+    if let Some(dns_server_ips) = &configured_state.force_plaintext_dns_for_servers {
         dns_server_ips.iter().for_each(|ip| {
             rules.push(Rule {
                 filters: vec![
@@ -529,7 +550,7 @@ pub(crate) fn configure_chain(
     });
 
     // Add VPN rule
-    if let Some(vpn_pk) = state.whitelist.vpn_peer {
+    if let Some(vpn_pk) = dynamic_state.whitelist.vpn_peer {
         rules.push(Rule {
             filters: vec![Filter {
                 filter_data: FilterData::AssociatedData(Some(vpn_pk.to_vec())),
@@ -545,7 +566,7 @@ pub(crate) fn configure_chain(
     );
 
     #[allow(clippy::indexing_slicing)]
-    for peer in state.whitelist.peer_whitelists[Permissions::LocalAreaConnections].iter() {
+    for peer in dynamic_state.whitelist.peer_whitelists[Permissions::LocalAreaConnections].iter() {
         for local_net in local_network_filters.iter() {
             let mut filters = vec![Filter {
                 filter_data: FilterData::AssociatedData(Some(peer.to_vec())),
@@ -568,10 +589,11 @@ pub(crate) fn configure_chain(
     }
 
     // Rules for incoming connections
-    for ip in &state.ip_addresses {
+    for ip in &dynamic_state.ip_addresses {
         // Accept packets for whitelisted peers
         #[allow(clippy::indexing_slicing)]
-        for peer in state.whitelist.peer_whitelists[Permissions::IncomingConnections].iter() {
+        for peer in dynamic_state.whitelist.peer_whitelists[Permissions::IncomingConnections].iter()
+        {
             rules.push(Rule {
                 filters: vec![
                     Filter {
@@ -595,7 +617,7 @@ pub(crate) fn configure_chain(
 
         // Accept packets for whitelisted ports
         for proto in [NextLevelProtocol::Tcp, NextLevelProtocol::Udp] {
-            for (peer, &port) in &state.whitelist.port_whitelist {
+            for (peer, &port) in &dynamic_state.whitelist.port_whitelist {
                 rules.push(Rule {
                     filters: vec![
                         Filter {
@@ -627,7 +649,7 @@ pub(crate) fn configure_chain(
     }
 
     #[allow(clippy::indexing_slicing)]
-    for peer in state.whitelist.peer_whitelists[Permissions::RoutingConnections].iter() {
+    for peer in dynamic_state.whitelist.peer_whitelists[Permissions::RoutingConnections].iter() {
         rules.push(Rule {
             filters: vec![Filter {
                 filter_data: FilterData::AssociatedData(Some(peer.to_vec())),
@@ -673,17 +695,17 @@ extern "C" fn log_callback(level: LibfwLogLevel, log_line: *const std::ffi::c_ch
 }
 
 impl Firewall for StatefulFirewall {
-    fn apply_state(&self, new_state: FirewallState) {
-        if *self.state.read() == new_state {
+    fn apply_dynamic_state(&self, new_state: FirewallDynamicState) {
+        if *self.dynamic_state.read() == new_state {
             return;
         }
-        *self.state.write() = new_state;
+        *self.dynamic_state.write() = new_state;
 
         self.refresh_chain();
     }
 
-    fn get_state(&self) -> FirewallState {
-        self.state.read().clone()
+    fn get_dynamic_state(&self) -> FirewallDynamicState {
+        self.dynamic_state.read().clone()
     }
 
     fn process_outbound_packet(
@@ -759,8 +781,9 @@ mod tests {
             let mut result = Self {
                 firewall: 0x1 as *mut crate::libfirewall::LibfwFirewall,
                 firewall_lib: crate::libfirewall::MockLibfirewall::default(),
-                state: RwLock::new(FirewallState::default()),
+                dynamic_state: RwLock::new(FirewallDynamicState::default()),
                 interface_ips: RwLock::new(Vec::new()),
+                configured_state: RwLock::new(FirewallConfiguredState::default()),
                 config: FirewallConfig {
                     allow_ipv6: use_ipv6,
                     feature,
@@ -790,11 +813,13 @@ mod tests {
     fn test_notify_triggers_refresh_with_callback_addrs() {
         let captured_addrs = Arc::new(ParkingLotMutex::new(Vec::<Vec<StdIpAddr>>::new()));
         let addrs_clone = captured_addrs.clone();
-        let spy_fn =
-            move |_config: &FirewallConfig, _state: &FirewallState, addrs: &[StdIpAddr]| {
-                addrs_clone.lock().push(addrs.to_vec());
-                (Vec::<Rule>::new().as_slice()).into()
-            };
+        let spy_fn = move |_: &FirewallConfig,
+                           _: &FirewallDynamicState,
+                           _: &FirewallConfiguredState,
+                           addrs: &[StdIpAddr]| {
+            addrs_clone.lock().push(addrs.to_vec());
+            (Vec::<Rule>::new().as_slice()).into()
+        };
 
         let mut firewall =
             StatefulFirewall::new_mock(true, FeatureFirewall::default(), Box::new(spy_fn));
@@ -831,11 +856,13 @@ mod tests {
     fn test_notify_addrs_are_used_by_subsequent_refreshes() {
         let captured_addrs = Arc::new(ParkingLotMutex::new(Vec::<Vec<StdIpAddr>>::new()));
         let addrs_clone = captured_addrs.clone();
-        let spy_fn =
-            move |_config: &FirewallConfig, _state: &FirewallState, addrs: &[StdIpAddr]| {
-                addrs_clone.lock().push(addrs.to_vec());
-                (Vec::<Rule>::new().as_slice()).into()
-            };
+        let spy_fn = move |_: &FirewallConfig,
+                           _: &FirewallDynamicState,
+                           _: &FirewallConfiguredState,
+                           addrs: &[StdIpAddr]| {
+            addrs_clone.lock().push(addrs.to_vec());
+            (Vec::<Rule>::new().as_slice()).into()
+        };
 
         let mut firewall =
             StatefulFirewall::new_mock(true, FeatureFirewall::default(), Box::new(spy_fn));
@@ -854,7 +881,7 @@ mod tests {
 
         let notify_addrs = vec![StdIpAddr::V4(Ipv4Addr::new(192, 168, 77, 7))];
         firewall.notify(&notify_addrs);
-        firewall.apply_state(FirewallState {
+        firewall.apply_dynamic_state(FirewallDynamicState {
             ip_addresses: vec![StdIpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))],
             ..Default::default()
         });

--- a/crates/telio-firewall/tests/firewall_integration_tests.rs
+++ b/crates/telio-firewall/tests/firewall_integration_tests.rs
@@ -15,7 +15,7 @@ use std::{
 };
 use telio_crypto::SecretKey;
 use telio_firewall::firewall::{
-    Firewall, FirewallState, Permissions, StatefulFirewall, FILE_SEND_PORT,
+    Firewall, FirewallDynamicState, Permissions, StatefulFirewall, FILE_SEND_PORT,
 };
 use telio_model::{
     features::{FeatureFirewall, FirewallBlacklistTuple, IpProtocol},
@@ -484,7 +484,7 @@ fn ipv6_blocked() {
     ];
     for TestInput { src1, src2, src3, src4, src5, dst1, dst2, make_udp , is_ipv4} in test_inputs {
         let fw = StatefulFirewall::new(false, FeatureFirewall::default(),).expect("Failed to load libfirewall");
-        fw.apply_state(FirewallState {
+        fw.apply_dynamic_state(FirewallDynamicState {
             ip_addresses: vec![(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))), IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1))],
             ..Default::default()
         });
@@ -552,7 +552,7 @@ fn outgoing_blacklist() {
             outgoing_blacklist: blacklist.clone(),
             ..Default::default()
         },).expect("Failed to load libfirewall");
-        fw.apply_state(FirewallState {
+        fw.apply_dynamic_state(FirewallDynamicState {
             ip_addresses: vec![
                 IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
                 IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)),
@@ -615,9 +615,9 @@ fn firewall_whitelist() {
         let mut feature = FeatureFirewall::default();
         feature.neptun_reset_conns = true;
         let fw = StatefulFirewall::new(true, feature).expect("Failed to load libfirewall");
-        let mut state = fw.get_state();
+        let mut state = fw.get_dynamic_state();
         state.ip_addresses = vec![(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))), IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1))];
-        fw.apply_state(state.clone());
+        fw.apply_dynamic_state(state.clone());
         let peer1 = make_random_peer();
         let peer2 = make_random_peer();
 
@@ -627,8 +627,8 @@ fn firewall_whitelist() {
         assert_eq!(fw.process_inbound_packet(&peer2.0, &mut make_udp(src2, dst1,)), false);
 
         state.whitelist.port_whitelist.insert(peer2, 1111);
-        fw.apply_state(state.clone());
-        assert_eq!(fw.get_state().whitelist.port_whitelist.len(), 1);
+        fw.apply_dynamic_state(state.clone());
+        assert_eq!(fw.get_dynamic_state().whitelist.port_whitelist.len(), 1);
 
         assert_eq!(fw.process_inbound_packet(&peer1.0, &mut make_udp(src1, dst1,)), false);
         assert_eq!(fw.process_inbound_packet(&peer2.0, &mut make_udp(src2, dst1,)), true);
@@ -640,7 +640,7 @@ fn firewall_whitelist() {
         assert_eq!(fw.process_inbound_packet(&peer2.0, &mut make_tcp(src5, dst1, TcpFlags::SYN)), true);
 
         state.whitelist.peer_whitelists[Permissions::IncomingConnections].insert(peer2);
-        fw.apply_state(state.clone());
+        fw.apply_dynamic_state(state.clone());
         let src = src1.parse::<StdSocketAddr>().unwrap().ip().to_string();
         let dst = dst1.parse::<StdSocketAddr>().unwrap().ip().to_string();
         assert_eq!(fw.process_inbound_packet(&peer1.0, &mut make_icmp(&src, &dst, IcmpTypes::EchoRequest.into())), false);
@@ -679,9 +679,9 @@ fn firewall_vpn_peer() {
         for TestInput { src1, src2, dst1, make_udp, make_tcp } in &test_inputs {
             let feature = FeatureFirewall::default();
             let fw = StatefulFirewall::new(true, feature).expect("Failed to load libfirewall");
-            let mut state = fw.get_state();
+            let mut state = fw.get_dynamic_state();
             state.ip_addresses = vec![(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))), IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1))];
-            fw.apply_state(state.clone());
+            fw.apply_dynamic_state(state.clone());
 
             let peer1 = make_random_peer();
             let peer2 = make_random_peer();
@@ -692,7 +692,7 @@ fn firewall_vpn_peer() {
             assert_eq!(fw.process_inbound_packet(&peer2.0, &mut make_tcp(src2, dst1, synack)), false);
 
             state.whitelist.vpn_peer = Some(peer1);
-            fw.apply_state(state.clone());
+            fw.apply_dynamic_state(state.clone());
             assert_eq!(fw.process_inbound_packet(&peer1.0, &mut make_udp(src1, dst1,)), true);
             assert_eq!(fw.process_inbound_packet(&peer2.0, &mut make_udp(src2, dst1,)), false);
 
@@ -700,7 +700,7 @@ fn firewall_vpn_peer() {
             assert_eq!(fw.process_outbound_packet_sink(&peer1.0, &make_tcp(dst1, src1, synack)), true);
 
             state.whitelist.vpn_peer = None;
-            fw.apply_state(state.clone());
+            fw.apply_dynamic_state(state.clone());
             assert_eq!(fw.process_inbound_packet(&peer1.0, &mut make_udp(src1, dst1,)), false);
             assert_eq!(fw.process_inbound_packet(&peer2.0, &mut make_udp(src2, dst1,)), false);
             // Peer-initiated established TCP: no longer accepted once the vpn-peer rule is gone
@@ -728,12 +728,12 @@ fn firewall_whitelist_change_icmp() {
         let feature = FeatureFirewall::default();
         // Set number of conntrack entries to 0 to test only the whitelist
         let fw = StatefulFirewall::new(true, feature).expect("Failed to load libfirewall");
-        fw.apply_state(FirewallState {
+        fw.apply_dynamic_state(FirewallDynamicState {
             ip_addresses: vec![(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))), IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1))],
             ..Default::default()
         });
 
-        let mut state = fw.get_state();
+        let mut state = fw.get_dynamic_state();
         let peer = make_random_peer();
         assert_eq!(fw.process_inbound_packet(&peer.0, &mut make_icmp(them, us, IcmpTypes::EchoReply.into())), false);
 
@@ -745,7 +745,7 @@ fn firewall_whitelist_change_icmp() {
         }
 
         state.whitelist.peer_whitelists[Permissions::IncomingConnections].insert(peer);
-        fw.apply_state(state.clone());
+        fw.apply_dynamic_state(state.clone());
         assert_eq!(fw.process_inbound_packet(&peer.0, &mut make_icmp(them, us, IcmpTypes::EchoRequest.into())), true);
         assert_eq!(fw.process_inbound_packet(&peer.0, &mut make_icmp(them, us, IcmpTypes::EchoReply.into())), true);
         if *is_v4 {
@@ -785,12 +785,12 @@ fn firewall_orig_src_ip_peer_initiated_blocked_after_removal() {
 
     for TestInput { us, them, make_icmp_echo } in &test_inputs {
         let fw = StatefulFirewall::new(true, FeatureFirewall::default()).expect("Failed to load libfirewall");
-        fw.apply_state(FirewallState {
+        fw.apply_dynamic_state(FirewallDynamicState {
             ip_addresses: vec![IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1))],
             ..Default::default()
         });
 
-        let mut state = fw.get_state();
+        let mut state = fw.get_dynamic_state();
         let peer = make_random_peer();
 
         // Not whitelisted yet: the peer's pings are dropped.
@@ -798,7 +798,7 @@ fn firewall_orig_src_ip_peer_initiated_blocked_after_removal() {
 
         // Allow the peer to open incoming connections.
         state.whitelist.peer_whitelists[Permissions::IncomingConnections].insert(peer);
-        fw.apply_state(state.clone());
+        fw.apply_dynamic_state(state.clone());
 
         // The peer pings the host -> accepted by the incoming-peer rule. This opens
         // a conntrack entry whose original direction source is the peer's IP.
@@ -810,7 +810,7 @@ fn firewall_orig_src_ip_peer_initiated_blocked_after_removal() {
 
         // Remove the peer from the incoming whitelist.
         state.whitelist.peer_whitelists[Permissions::IncomingConnections].remove(&peer);
-        fw.apply_state(state.clone());
+        fw.apply_dynamic_state(state.clone());
 
         // Pings must now fail: not from an allowed peer anymore, and the connection
         // was initiated by the peer (orig src != our IP) so OrigSrcIp doesn't help -
@@ -845,7 +845,7 @@ fn firewall_orig_src_ip_host_initiated_allowed_without_whitelist() {
 
     for TestInput { us, them, make_icmp_echo } in &test_inputs {
         let fw = StatefulFirewall::new(true, FeatureFirewall::default()).expect("Failed to load libfirewall");
-        fw.apply_state(FirewallState {
+        fw.apply_dynamic_state(FirewallDynamicState {
             ip_addresses: vec![IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1))],
             ..Default::default()
         });
@@ -886,7 +886,7 @@ fn firewall_orig_src_ip_icmp_error_for_host_initiated_connection_allowed() {
 
     for TestInput { us, us_unsent, them, make_udp, make_icmp_error } in &test_inputs {
         let fw = StatefulFirewall::new(true, FeatureFirewall::default()).expect("Failed to load libfirewall");
-        fw.apply_state(FirewallState {
+        fw.apply_dynamic_state(FirewallDynamicState {
             ip_addresses: vec![IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1))],
             ..Default::default()
         });
@@ -913,23 +913,23 @@ fn firewall_whitelist_change_udp_allow() {
 
     for TestInput { us, them, make_udp } in test_inputs {
         let fw = StatefulFirewall::new(true, FeatureFirewall::default(),).expect("Failed to load libfirewall");
-        fw.apply_state(FirewallState {
+        fw.apply_dynamic_state(FirewallDynamicState {
             ip_addresses: vec![(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))), IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1))],
             ..Default::default()
         });
-        let mut state = fw.get_state();
+        let mut state = fw.get_dynamic_state();
 
         let them_peer = make_random_peer();
 
         assert_eq!(fw.process_inbound_packet(&them_peer.0, &mut make_udp(them, us)), false);
         state.whitelist.port_whitelist.insert(them_peer, 8888);
-        fw.apply_state(state.clone()); // NOTE: this doesn't change anything about this test
+        fw.apply_dynamic_state(state.clone()); // NOTE: this doesn't change anything about this test
         assert_eq!(fw.process_outbound_packet_sink(&them_peer.0, &make_udp(us, them)), true);
         // Peer-initiated (the peer's packet above was seen first), so OrigSrcIp doesn't accept it
         assert_eq!(fw.process_inbound_packet(&them_peer.0, &mut make_udp(them, us)), false);
         assert_eq!(fw.process_inbound_packet(&them_peer.0, &mut make_udp(them, us)), false);
         state.whitelist.port_whitelist.remove(&them_peer);
-        fw.apply_state(state.clone()); // NOTE: also has no impact on this test
+        fw.apply_dynamic_state(state.clone()); // NOTE: also has no impact on this test
         assert_eq!(fw.process_inbound_packet(&them_peer.0, &mut make_udp(them, us)), false);
     }
 }
@@ -945,22 +945,22 @@ fn firewall_whitelist_change_udp_block() {
 
     for TestInput { us, them, make_udp } in test_inputs {
         let fw = StatefulFirewall::new(true, FeatureFirewall::default(),).expect("Failed to load libfirewall");
-        fw.apply_state(FirewallState {
+        fw.apply_dynamic_state(FirewallDynamicState {
             ip_addresses: vec![(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))), IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1))],
             ..Default::default()
         });
-        let mut state = fw.get_state();
+        let mut state = fw.get_dynamic_state();
         let them_peer = make_random_peer();
 
         state.whitelist.port_whitelist.insert(them_peer, 1111);
-        fw.apply_state(state.clone());
+        fw.apply_dynamic_state(state.clone());
         assert_eq!(fw.process_inbound_packet(&them_peer.0, &mut make_udp(them, us)), true);
         assert_eq!(fw.process_outbound_packet_sink(&them_peer.0, &make_udp(us, them)), true);
 
         // The already started connection should still work
         assert_eq!(fw.process_inbound_packet(&them_peer.0, &mut make_udp(them, us)), true);
         state.whitelist.port_whitelist.remove(&them_peer);
-        fw.apply_state(state.clone());
+        fw.apply_dynamic_state(state.clone());
         // Peer-initiated: dropped after the port whitelist is removed (OrigSrcIp doesn't match)
         assert_eq!(fw.process_inbound_packet(&them_peer.0, &mut make_udp(them, us)), false);
     }
@@ -976,14 +976,14 @@ fn firewall_whitelist_change_tcp_allow() {
     ];
     for TestInput { us, them, make_tcp } in test_inputs {
         let fw = StatefulFirewall::new(true, FeatureFirewall::default(),).expect("Failed to load libfirewall");
-        let mut state = fw.get_state();
+        let mut state = fw.get_dynamic_state();
         state.ip_addresses = vec![(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))), IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1))];
-        fw.apply_state(state.clone());
+        fw.apply_dynamic_state(state.clone());
 
         let them_peer = make_random_peer();
 
         state.whitelist.port_whitelist.insert(them_peer, 8888);
-        fw.apply_state(state.clone()); // NOTE: this doesn't change anything about the test
+        fw.apply_dynamic_state(state.clone()); // NOTE: this doesn't change anything about the test
         assert_eq!(fw.process_inbound_packet(&them_peer.0, &mut make_tcp(them, us, TcpFlags::SYN | TcpFlags::ACK)), false);
         assert_eq!(fw.process_outbound_packet_sink(&them_peer.0, &make_tcp(us, them, TcpFlags::SYN)), true);
         assert_eq!(fw.process_inbound_packet(&them_peer.0, &mut make_tcp(them, us, TcpFlags::SYN | TcpFlags::ACK)), true);
@@ -992,7 +992,7 @@ fn firewall_whitelist_change_tcp_allow() {
         // Should PASS because we started the session
         assert_eq!(fw.process_inbound_packet(&them_peer.0, &mut make_tcp(them, us, TcpFlags::ACK)), true);
         state.whitelist.port_whitelist.remove(&them_peer);
-        fw.apply_state(state.clone());
+        fw.apply_dynamic_state(state.clone());
         assert_eq!(fw.process_inbound_packet(&them_peer.0, &mut make_tcp(them, us, TcpFlags::ACK)), true);
     }
 
@@ -1008,15 +1008,15 @@ fn firewall_whitelist_change_tcp_block() {
     ];
     for TestInput { us, them, make_tcp } in test_inputs {
         let fw = StatefulFirewall::new(true, FeatureFirewall::default(),).expect("Failed to load libfirewall");
-        let mut state = fw.get_state();
+        let mut state = fw.get_dynamic_state();
         state.ip_addresses = vec![(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))), IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1))];
-        fw.apply_state(state.clone());
+        fw.apply_dynamic_state(state.clone());
 
         let them_peer = make_random_peer();
 
         assert_eq!(fw.process_inbound_packet(&them_peer.0, &mut make_tcp(them, us, TcpFlags::SYN)), false);
         state.whitelist.port_whitelist.insert(them_peer, 1111);
-        fw.apply_state(state.clone());
+        fw.apply_dynamic_state(state.clone());
         assert_eq!(fw.process_inbound_packet(&them_peer.0, &mut make_tcp(them, us, TcpFlags::SYN)), true);
         assert_eq!(fw.process_outbound_packet_sink(&them_peer.0, &make_tcp(us, them, TcpFlags::SYN | TcpFlags::ACK)), true);
 
@@ -1024,7 +1024,7 @@ fn firewall_whitelist_change_tcp_block() {
         // Firewall allows already established connections while the peer is whitelisted
         assert_eq!(fw.process_inbound_packet(&them_peer.0, &mut make_tcp(them, us, TcpFlags::ACK)), true);
         state.whitelist.port_whitelist.remove(&them_peer);
-        fw.apply_state(state.clone());
+        fw.apply_dynamic_state(state.clone());
         // Peer-initiated: dropped after the port whitelist is removed (OrigSrcIp doesn't match)
         assert_eq!(fw.process_inbound_packet(&them_peer.0, &mut make_tcp(them, us, TcpFlags::ACK)), false);
     }
@@ -1062,11 +1062,11 @@ fn firewall_whitelist_peer() {
         for TestInput { src1, src2, dst, make_udp, make_tcp, make_icmp } in &test_inputs {
             let feature = FeatureFirewall::default();
             let fw = StatefulFirewall::new(true, feature).expect("Failed to load libfirewall");
-            fw.apply_state(FirewallState {
+            fw.apply_dynamic_state(FirewallDynamicState {
                 ip_addresses: vec![(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))), IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1))],
                 ..Default::default()
             });
-            let mut state = fw.get_state();
+            let mut state = fw.get_dynamic_state();
             assert!(state.whitelist.peer_whitelists[Permissions::IncomingConnections].is_empty());
 
             let src2_ip = src2.parse::<StdSocketAddr>().unwrap().ip().to_string();
@@ -1077,16 +1077,16 @@ fn firewall_whitelist_peer() {
             assert_eq!(fw.process_inbound_packet(&make_peer(), &mut make_tcp(src2, dst, TcpFlags::PSH)), false);
 
             state.whitelist.peer_whitelists[Permissions::IncomingConnections].insert((&make_peer()).into());
-            fw.apply_state(state.clone());
-            assert_eq!(fw.get_state().whitelist.peer_whitelists[Permissions::IncomingConnections].len(), 1);
+            fw.apply_dynamic_state(state.clone());
+            assert_eq!(fw.get_dynamic_state().whitelist.peer_whitelists[Permissions::IncomingConnections].len(), 1);
 
             assert_eq!(fw.process_inbound_packet(&make_peer(), &mut make_udp(src1, dst,)), true);
             assert_eq!(fw.process_inbound_packet(&make_peer(), &mut make_icmp(&src2_ip, &dst_ip, IcmpTypes::EchoRequest.into())), true);
             assert_eq!(fw.process_inbound_packet(&make_peer(), &mut make_tcp(src2, dst, TcpFlags::PSH)), true);
 
             state.whitelist.peer_whitelists[Permissions::IncomingConnections].remove(&(&make_peer()).into());
-            fw.apply_state(state.clone());
-            assert_eq!(fw.get_state().whitelist.peer_whitelists[Permissions::IncomingConnections].len(), 0);
+            fw.apply_dynamic_state(state.clone());
+            assert_eq!(fw.get_dynamic_state().whitelist.peer_whitelists[Permissions::IncomingConnections].len(), 0);
 
             assert_eq!(fw.process_inbound_packet(&make_peer(), &mut make_udp(src1, dst,)), false);
             assert_eq!(fw.process_inbound_packet(&make_peer(), &mut make_icmp(&src2_ip, &dst_ip, IcmpTypes::EchoRequest.into())), false);
@@ -1135,12 +1135,12 @@ fn firewall_test_permissions() {
         let mut feature = FeatureFirewall::default();
         feature.neptun_reset_conns = true;
         let fw = StatefulFirewall::new(true, feature).expect("Failed to load libfirewall");
-        let mut state = fw.get_state();
+        let mut state = fw.get_dynamic_state();
         state.ip_addresses = vec![
             IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
             IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)),
         ];
-        fw.apply_state(state.clone());
+        fw.apply_dynamic_state(state.clone());
         assert!(state.whitelist.peer_whitelists[Permissions::IncomingConnections].is_empty());
         assert!(state.whitelist.peer_whitelists[Permissions::RoutingConnections].is_empty());
         assert!(state.whitelist.peer_whitelists[Permissions::LocalAreaConnections].is_empty());
@@ -1154,7 +1154,7 @@ fn firewall_test_permissions() {
         // Allow incoming connection
         state.whitelist.peer_whitelists[Permissions::IncomingConnections]
             .insert((&make_peer()).into());
-        fw.apply_state(state.clone());
+        fw.apply_dynamic_state(state.clone());
         assert_eq!(
             state.whitelist.peer_whitelists[Permissions::IncomingConnections].len(),
             1
@@ -1180,7 +1180,7 @@ fn firewall_test_permissions() {
         // Allow local area connections
         state.whitelist.peer_whitelists[Permissions::LocalAreaConnections]
             .insert((&make_peer()).into());
-        fw.apply_state(state.clone());
+        fw.apply_dynamic_state(state.clone());
         assert_eq!(
             state.whitelist.peer_whitelists[Permissions::LocalAreaConnections].len(),
             1
@@ -1200,7 +1200,7 @@ fn firewall_test_permissions() {
         // Allow routing permissiongs but no local area connection
         state.whitelist.peer_whitelists[Permissions::LocalAreaConnections]
             .remove(&(&make_peer()).into());
-        fw.apply_state(state.clone());
+        fw.apply_dynamic_state(state.clone());
         assert_eq!(
             state.whitelist.peer_whitelists[Permissions::LocalAreaConnections].len(),
             0
@@ -1208,7 +1208,7 @@ fn firewall_test_permissions() {
 
         state.whitelist.peer_whitelists[Permissions::RoutingConnections]
             .insert((&make_peer()).into());
-        fw.apply_state(state.clone());
+        fw.apply_dynamic_state(state.clone());
         assert_eq!(
             state.whitelist.peer_whitelists[Permissions::RoutingConnections].len(),
             1
@@ -1228,7 +1228,7 @@ fn firewall_test_permissions() {
         // Allow only routing
         state.whitelist.peer_whitelists[Permissions::IncomingConnections]
             .remove(&(&make_peer()).into());
-        fw.apply_state(state.clone());
+        fw.apply_dynamic_state(state.clone());
         assert_eq!(
             state.whitelist.peer_whitelists[Permissions::IncomingConnections].len(),
             0
@@ -1248,7 +1248,7 @@ fn firewall_test_permissions() {
 
         state.whitelist.peer_whitelists[Permissions::RoutingConnections]
             .remove(&(&make_peer()).into());
-        fw.apply_state(state.clone());
+        fw.apply_dynamic_state(state.clone());
         assert_eq!(
             state.whitelist.peer_whitelists[Permissions::RoutingConnections].len(),
             0
@@ -1304,21 +1304,21 @@ fn firewall_whitelist_port() {
     ];
     for test_input @ TestInput { src: _, dst: _, make_udp, make_tcp, make_icmp } in test_inputs {
         let fw = StatefulFirewall::new(true, FeatureFirewall::default(),).expect("Failed to load libfirewall");
-        fw.apply_state(FirewallState {
+        fw.apply_dynamic_state(FirewallDynamicState {
             ip_addresses: vec![(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))), IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1))],
             ..Default::default()
         });
-        let mut state = fw.get_state();
-        assert!(fw.get_state().whitelist.peer_whitelists[Permissions::IncomingConnections].is_empty());
-        assert!(fw.get_state().whitelist.port_whitelist.is_empty());
+        let mut state = fw.get_dynamic_state();
+        assert!(fw.get_dynamic_state().whitelist.peer_whitelists[Permissions::IncomingConnections].is_empty());
+        assert!(fw.get_dynamic_state().whitelist.port_whitelist.is_empty());
 
         assert_eq!(fw.process_inbound_packet(&make_peer(), &mut make_udp(&test_input.src_socket(11111), &test_input.dst_socket(FILE_SEND_PORT))), false);
         assert_eq!(fw.process_inbound_packet(&make_peer(), &mut make_icmp(&test_input.src, &test_input.dst, IcmpTypes::EchoRequest.into())), false);
         assert_eq!(fw.process_inbound_packet(&make_peer(), &mut make_tcp(&test_input.src_socket(11111), &test_input.dst_socket(FILE_SEND_PORT), TcpFlags::PSH)), false);
 
         state.whitelist.port_whitelist.insert(PublicKey(make_peer()), FILE_SEND_PORT);
-        fw.apply_state(state.clone());
-        assert_eq!(fw.get_state().whitelist.port_whitelist.len(), 1);
+        fw.apply_dynamic_state(state.clone());
+        assert_eq!(fw.get_dynamic_state().whitelist.port_whitelist.len(), 1);
 
         assert_eq!(fw.process_inbound_packet(&make_peer(), &mut make_icmp(&test_input.src, &test_input.dst, IcmpTypes::EchoRequest.into())), false);
 
@@ -1329,8 +1329,8 @@ fn firewall_whitelist_port() {
         assert_eq!(fw.process_inbound_packet(&make_peer(), &mut make_tcp(&test_input.src_socket(11111), &test_input.dst_socket(12345), TcpFlags::PSH)), false);
 
         state.whitelist.port_whitelist.remove(&PublicKey(make_peer()));
-        fw.apply_state(state.clone());
-        assert_eq!(fw.get_state().whitelist.port_whitelist.len(), 0);
+        fw.apply_dynamic_state(state.clone());
+        assert_eq!(fw.get_dynamic_state().whitelist.port_whitelist.len(), 0);
 
         assert_eq!(fw.process_inbound_packet(&make_peer(), &mut make_udp(&test_input.src_socket(11111), &test_input.dst_socket(FILE_SEND_PORT))), false);
         assert_eq!(fw.process_inbound_packet(&make_peer(), &mut make_icmp(&test_input.src, &test_input.dst, IcmpTypes::EchoRequest.into())), false);
@@ -1494,12 +1494,12 @@ mod tp_lite_stats {
     fn tp_lite_stats_enabled() {
         let fw = StatefulFirewall::new(true, FeatureFirewall::default())
             .expect("Failed to load libfirewall");
-        let mut state = fw.get_state();
+        let mut state = fw.get_dynamic_state();
         state.ip_addresses = vec![
             IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
             IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)),
         ];
-        fw.apply_state(state.clone());
+        fw.apply_dynamic_state(state.clone());
         let config = TpLiteStatsOptions {
             dns_server_ips: vec![IpAddr::from([10, 5, 0, 53])],
             callback_interval_s: Some(1),
@@ -1557,12 +1557,12 @@ mod tp_lite_stats {
 
         let fw = StatefulFirewall::new(true, FeatureFirewall::default())
             .expect("Failed to load libfirewall");
-        let mut state = fw.get_state();
+        let mut state = fw.get_dynamic_state();
         state.ip_addresses = vec![
             IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
             IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)),
         ];
-        fw.apply_state(state.clone());
+        fw.apply_dynamic_state(state.clone());
 
         let stats = Arc::new(Mutex::new(Stats::default()));
         let callback = Callback {

--- a/src/device/wg_controller.rs
+++ b/src/device/wg_controller.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use telio_crypto::PublicKey;
 use telio_dns::DnsResolver;
 #[cfg(feature = "enable_firewall")]
-use telio_firewall::firewall::{Firewall, FirewallState, Permissions, FILE_SEND_PORT};
+use telio_firewall::firewall::{Firewall, FirewallDynamicState, Permissions, FILE_SEND_PORT};
 use telio_model::constants::{VPN_EXTERNAL_IPV4, VPN_INTERNAL_IPV4, VPN_INTERNAL_IPV6};
 use telio_model::features::Features;
 use telio_model::mesh::{LinkState, NodeState};
@@ -601,7 +601,7 @@ async fn consolidate_firewall<F: Firewall>(
     starcast_vpeer_pubkey: Option<PublicKey>,
     dns_pubkey: Option<PublicKey>,
 ) -> Result {
-    let mut state = FirewallState::default();
+    let mut state = FirewallDynamicState::default();
 
     state.whitelist.port_whitelist = iter_peers(requested_state)
         .filter(|p| p.allow_peer_send_files)
@@ -645,7 +645,7 @@ async fn consolidate_firewall<F: Firewall>(
             .ok_or(Error::IpNotSet)?;
     }
 
-    firewall.apply_state(state);
+    firewall.apply_dynamic_state(state);
 
     Ok(())
 }
@@ -1461,9 +1461,9 @@ mod tests {
         ]);
 
         firewall
-            .expect_apply_state()
+            .expect_apply_dynamic_state()
             .once()
-            .with(eq(FirewallState {
+            .with(eq(FirewallDynamicState {
                 whitelist: Whitelist {
                     peer_whitelists: enum_map! {
                         Permissions::IncomingConnections => FwHashSet::from_iter([pub_key_1, pub_key_2, pub_key_starcast_vpeer].iter().cloned()),
@@ -1507,9 +1507,9 @@ mod tests {
         ]);
 
         firewall
-            .expect_apply_state()
+            .expect_apply_dynamic_state()
             .once()
-            .with(eq(FirewallState {
+            .with(eq(FirewallDynamicState {
                 whitelist: Whitelist {
                     peer_whitelists: enum_map! {
                         Permissions::IncomingConnections => FwHashSet::from_iter([pub_key_1, pub_key_2, pub_key_starcast_vpeer].iter().cloned()),
@@ -1552,9 +1552,9 @@ mod tests {
         });
 
         firewall
-            .expect_apply_state()
+            .expect_apply_dynamic_state()
             .once()
-            .with(eq(FirewallState {
+            .with(eq(FirewallDynamicState {
                 whitelist: Whitelist {
                     peer_whitelists: enum_map! {
                         Permissions::IncomingConnections => FwHashSet::from_iter([pub_key_starcast_vpeer].iter().cloned()),
@@ -1565,7 +1565,6 @@ mod tests {
                     vpn_peer: Some(pub_key_2),
                 },
                 ip_addresses: vec![IpAddr::V4(Ipv4Addr::LOCALHOST), IpAddr::V6(Ipv6Addr::LOCALHOST)],
-                force_plaintext_dns_for_servers: None,
                 ..Default::default()
             }))
             .return_const(());
@@ -1597,9 +1596,9 @@ mod tests {
         });
 
         firewall
-            .expect_apply_state()
+            .expect_apply_dynamic_state()
             .once()
-            .with(eq(FirewallState {
+            .with(eq(FirewallDynamicState {
                 whitelist: Whitelist {
                     peer_whitelists: enum_map! {
                         Permissions::IncomingConnections => FwHashSet::from_iter([pub_key_starcast_vpeer].iter().cloned()),
@@ -1610,7 +1609,6 @@ mod tests {
                     vpn_peer: None,
                 },
                 ip_addresses: vec![IpAddr::V4(Ipv4Addr::LOCALHOST), IpAddr::V6(Ipv6Addr::LOCALHOST)],
-                force_plaintext_dns_for_servers: None,
                 ..Default::default()
             }))
             .return_const(());
@@ -1643,9 +1641,9 @@ mod tests {
         });
 
         firewall
-            .expect_apply_state()
+            .expect_apply_dynamic_state()
             .once()
-            .with(eq(FirewallState {
+            .with(eq(FirewallDynamicState {
                 whitelist: Whitelist {
                     peer_whitelists: enum_map! {
                         Permissions::IncomingConnections => FwHashSet::from_iter([pub_key_starcast_vpeer].iter().cloned()),
@@ -1656,7 +1654,6 @@ mod tests {
                     vpn_peer: None,
                 },
                 ip_addresses: vec![IpAddr::V4(Ipv4Addr::LOCALHOST), IpAddr::V6(Ipv6Addr::LOCALHOST)],
-                force_plaintext_dns_for_servers: None,
                 ..Default::default()
             }))
             .return_const(());
@@ -1684,7 +1681,7 @@ mod tests {
             (pub_key_2, vec![], false, true, false, false),
         ]);
 
-        let expected_state = FirewallState {
+        let expected_state = FirewallDynamicState {
             whitelist: Whitelist {
                 peer_whitelists: enum_map! {
                     Permissions::IncomingConnections => FwHashSet::from_iter([pub_key_1, pub_key_starcast_vpeer].iter().cloned()),
@@ -1703,7 +1700,7 @@ mod tests {
 
         // Calling consolidate_firewall multiple times with same state should produce same config
         firewall
-            .expect_apply_state()
+            .expect_apply_dynamic_state()
             .times(3)
             .with(eq(expected_state))
             .returning(|_| ());


### PR DESCRIPTION
Make consolidate_firewall preserve firewall state set by
enable/set_tp_lite_* calls.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
