### PR TITLE
Remove stale ifconfig comment in nordvpnlite

### DIFF
--- a/clis/nordvpnlite/src/interface.rs
+++ b/clis/nordvpnlite/src/interface.rs
@@ -136,8 +136,6 @@ impl ConfigureInterface for Manual {
     fn set_ip(&mut self, _ip_address: &IpAddr) -> Result<(), NordVpnLiteError> {
         Ok(()) // No-op implementation
     }
-    /// For manual configuration, we still use ifconfig to query the interface
-    /// This is a fallback for when the interface is configured manually
     fn get_ip(&self) -> Option<IpAddr> {
         None
     }


### PR DESCRIPTION
### Problem
The ifconfig provider was removed in 4d634b394 ("Remove ifconfig provider"), but Manual::get_ip kept a doc comment claiming it still uses ifconfig to query the interface.

### Solution
Removed it.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
