### PR TITLE
LLT-6287: Reset WG-NT listen port on dynamic down

### DIFF
--- a/.unreleased/LLT-6287
+++ b/.unreleased/LLT-6287
@@ -1,0 +1,1 @@
+Fix WG-NT re-binding the previously used listen port after a dynamic down transition, which could clash with a port taken by another process in the meantime.

--- a/crates/telio-wg/src/adapter/windows_native_wg.rs
+++ b/crates/telio-wg/src/adapter/windows_native_wg.rs
@@ -584,6 +584,15 @@ impl Adapter for WindowsNativeWg {
                 // If all of the peers has been removed -> bring the adapter down
                 if self.enable_dynamic_wg_nt_control && peer_cnt.map(|p| p == 0).unwrap_or(false) {
                     self.ensure_adapter_state(AdapterState::Down).await?;
+                    // The driver retains the previously bound port across Down and would
+                    // re-bind it on the next Up; reset it so a fresh ephemeral port is chosen
+                    let reset_port = xplatform::set::Device {
+                        listen_port: Some(0),
+                        ..Default::default()
+                    };
+                    if let Err(err) = self.adapter.set_config_uapi(&reset_port) {
+                        telio_log_warn!("Failed to reset listen port after adapter down: {err}");
+                    }
                 }
 
                 resp

--- a/nat-lab/tests/conftest_helpers/log_collection.py
+++ b/nat-lab/tests/conftest_helpers/log_collection.py
@@ -109,7 +109,8 @@ async def collect_kernel_logs(
 
     save_dmesg_from_host(suffix)
     save_audit_log_from_host(suffix)
-    await save_dmesg_from_remote_vm(ConnectionTag.VM_LINUX_NLX_1, suffix)
+    if "nlx" in session_vm_marks:
+        await save_dmesg_from_remote_vm(ConnectionTag.VM_LINUX_NLX_1, suffix)
 
     if "mac" in session_vm_marks:
         try:

--- a/nat-lab/tests/test_adapter.py
+++ b/nat-lab/tests/test_adapter.py
@@ -1,5 +1,6 @@
 import asyncio
 import pytest
+import re
 from enum import Enum
 from tests import config
 from tests.helpers import SetupParameters, Environment
@@ -17,6 +18,7 @@ from tests.utils.connection_util import (
     ConnectionManager,
 )
 from tests.utils.process import ProcessExecError
+from tests.utils.python import get_python_binary
 from typing import Awaitable, Callable, List
 
 
@@ -251,6 +253,77 @@ class TestAdapterStateForVpnAndDns:
 
         state = await get_interface_state(client_conn, client_alpha)
         assert state == expected_idle_state
+
+    @pytest.mark.parametrize(
+        "alpha_setup_params",
+        [
+            pytest.param(
+                SetupParameters(
+                    connection_tag=ConnectionTag.VM_WINDOWS_1,
+                    adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
+                    connection_tracker_config=generate_connection_tracker_config(
+                        connection_tag=ConnectionTag.VM_WINDOWS_1,
+                        vpn_1_limits=(1, 2),
+                    ),
+                    is_meshnet=False,
+                    features=default_features(enable_dynamic_wg_nt_control=True),
+                ),
+                marks=[pytest.mark.windows],
+            ),
+        ],
+    )
+    async def test_wg_nt_down_releases_listen_port(
+        self,
+        alpha_setup_params: SetupParameters,  # pylint: disable=unused-argument
+        env: Environment,
+    ) -> None:
+        """
+        LLT-6287: after a dynamic adapter Down the driver must not re-bind the
+        stale listen port, so reconnecting works even if another process took it.
+        """
+        client_conn, *_ = [conn.connection for conn in env.connections]
+        client_alpha, *_ = env.clients
+
+        server_ip = str(config.WG_SERVER["ipv4"])
+        server_port = int(config.WG_SERVER["port"])
+        server_public_key = str(config.WG_SERVER["public_key"])
+
+        await client_alpha.vpn.connect(server_ip, server_port, server_public_key)
+
+        state = await get_interface_state(client_conn, client_alpha)
+        assert state == AdapterState.UP
+
+        ports = re.findall(r"listen_port: Some\((\d+)\)", await client_alpha.log.get())
+        assert ports, "listen_port not found in libtelio log"
+        listen_port = int(ports[-1])
+        assert listen_port != 0
+
+        await client_alpha.vpn.disconnect(server_public_key)
+
+        state = await get_interface_state(client_conn, client_alpha)
+        assert state == AdapterState.DOWN
+
+        # TODO: LLT-5689 - rewrite with the NetCat wrapper once it supports Windows
+        occupy_port_cmd = [
+            get_python_binary(client_conn),
+            "-c",
+            "import socket, time; "
+            "s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM); "
+            f"s.bind(('0.0.0.0', {listen_port})); "
+            "print('BOUND', flush=True); "
+            "time.sleep(600)",
+        ]
+        async with client_conn.create_process(occupy_port_cmd).run() as process:
+            await process.wait_stdin_ready()
+            while "BOUND" not in process.get_stdout():
+                await asyncio.sleep(0.1)
+
+            await client_alpha.vpn.connect(
+                server_ip, server_port, server_public_key, timeout=40
+            )
+
+            state = await get_interface_state(client_conn, client_alpha)
+            assert state == AdapterState.UP
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Problem

With dynamic WG-NT control enabled, bringing the adapter down after the last peer is removed leaves the previously bound listen port cached inside the wireguard-nt driver. On the next up transition the driver re-binds that exact port; if another process took it in the meantime, the adapter never comes up - the driver logs `Could not bind socket ... (0xc0000043)` and libtelio retries `Failed to set adapter state to Up (os error 32)` until it gives up, so reconnecting to VPN fails.

### Solution

After the dynamic down transition send a `listen_port=0` UAPI set to the driver, so the next up binds a fresh ephemeral port instead of the stale one.

Covered by a new nat-lab test which occupies the previous listen port on the Windows VM and asserts that a subsequent connect still brings the adapter up. Verified red/green on a local nat-lab: the test fails without the fix (`0xc0000043` in the client log) and passes with it. The branch also gates NLX dmesg collection on the `nlx` session mark, since local runs with `--skip-nlx` and `NATLAB_SAVE_LOGS` crashed the whole pytest session before any test ran.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
