### PR TITLE
LLT-6756: Store authentication token separately from config

### DIFF
--- a/.unreleased/LLT-6756_store_auth_separately
+++ b/.unreleased/LLT-6756_store_auth_separately
@@ -1,0 +1,2 @@
+Updated `nordvpnlite` to store authentication token in a separate file.
+Added `login` and `logout` cli commands to store and clear the credentials.

--- a/clis/nordvpnlite/README.md
+++ b/clis/nordvpnlite/README.md
@@ -48,7 +48,11 @@ The config file should be provided in a JSON format
 
 Currently supported configuration variables:
 
-* `authentication_token` - Token from Nord VPN account to authenticate API calls
+* `auth_file_path` - Path to the file where the authentication token is stored,
+  defaults to `/etc/nordvpnlite/auth.json`. Use the `login`/`logout` commands
+  (see below) to manage its contents rather than editing it directly. The
+  `NORD_TOKEN` environment variable, when set to a valid token, takes precedence
+  over this file.
 * `vpn` - VPN config type. If omitted, 'recommended' type is chosen. Possible options:
   * `server` - manually specified endpoint:
     * `address` - The IP address of the server/endpoint to connect to
@@ -90,12 +94,20 @@ And following cli commands:
 * `nordvpnlite stop` - stop daemon execution
 * `nordvpnlite reload` - reload the configuration file and restart the daemon
 * `nordvpnlite countries` - list countries with available VPN servers
+* `nordvpnlite login <token>` (or `nordvpnlite login --token <token>`) - store the authentication token obtained
+  from [my.nordaccount.com](https://my.nordaccount.com) into the auth file
+  (`auth_file_path`). Overwrites any previously stored token.
+  * `--config-file <path>` - use an alternative configuration file
+  (defaults to `/etc/nordvpnlite/config.json`)
+* `nordvpnlite logout` - remove the stored authentication token (auth file).
+  * `--config-file <path>` - use an alternative configuration file
+  (defaults to `/etc/nordvpnlite/config.json`)
 
 ## OpenWRT
 
 After installing the `.ipk` package:
 
-* Edit the `/etc/nordvpnlite/config.json` file, and replace `authentication_token` with your authentication token obtained from [my.nordaccount.com](https://my.nordaccount.com)
+* Store your authentication token obtained from [my.nordaccount.com](https://my.nordaccount.com) by running `nordvpnlite login <token>` (or `nordvpnlite login --token <token>`) (it is saved to the `auth_file_path` configured in `/etc/nordvpnlite/config.json`, by default `/etc/nordvpnlite/auth.json`)
 * To start the `nordvpnlite` service run `/etc/init.d/nordvpnlite start`
 * After each edit of `/etc/nordvpnlite/config.json` reload the service with `/etc/init.d/nordvpnlite reload`
 * To stop the `nordvpnlite` service run `/etc/init.d/nordvpnlite stop`. Important: Simply running `nordvpnlite stop` will cause procd to respawn it

--- a/clis/nordvpnlite/example_nordvpnlite_config.json
+++ b/clis/nordvpnlite/example_nordvpnlite_config.json
@@ -1,5 +1,5 @@
 {
-  "authentication_token": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "auth_file_path": "/etc/nordvpnlite/auth.json",
   "vpn": {
     "country": "de"
   },

--- a/clis/nordvpnlite/example_nordvpnlite_config.json
+++ b/clis/nordvpnlite/example_nordvpnlite_config.json
@@ -1,5 +1,5 @@
 {
-  "auth_file_path": "/etc/nordvpnlite/auth.json",
+  "auth_file_path": "/tmp/example_auth_file.json",
   "vpn": {
     "country": "de"
   },

--- a/clis/nordvpnlite/openwrt/feed/net/nordvpnlite/files/config.json
+++ b/clis/nordvpnlite/openwrt/feed/net/nordvpnlite/files/config.json
@@ -1,5 +1,5 @@
 {
-  "authentication_token": "<REPLACE_WITH_YOUR_TOKEN>",
+  "auth_file_path": "/etc/nordvpnlite/auth.json",
   "vpn": "recommended",
   "log_level": "error",
   "log_file_path": "/var/log/nordvpnlite.log",

--- a/clis/nordvpnlite/openwrt/feed/net/nordvpnlite/files/luci/acl.d/luci-app-nordvpnlite.json
+++ b/clis/nordvpnlite/openwrt/feed/net/nordvpnlite/files/luci/acl.d/luci-app-nordvpnlite.json
@@ -3,12 +3,18 @@
 		"description": "Grant access to NordVPN Lite configuration",
 		"read": {
 			"ubus": {
-				"nordvpnlite": ["get_config"]
+				"nordvpnlite": [
+					"get_config"
+				]
 			}
 		},
 		"write": {
 			"ubus": {
-				"nordvpnlite": ["set_config"]
+				"nordvpnlite": [
+					"set_config",
+					"login",
+					"logout"
+				]
 			}
 		}
 	}

--- a/clis/nordvpnlite/openwrt/feed/net/nordvpnlite/files/luci/ucode/nordvpnlite.uc
+++ b/clis/nordvpnlite/openwrt/feed/net/nordvpnlite/files/luci/ucode/nordvpnlite.uc
@@ -1,6 +1,7 @@
 'use strict';
 
 const CONFIG_FILE = '/etc/nordvpnlite/config.json';
+const NORDVPNLITE_BIN = '/usr/bin/nordvpnlite';
 let fs = require('fs');
 let log = require('log');
 
@@ -31,6 +32,54 @@ return {
 					log.ERR("Failed to move temp file");
 					fs.unlink(tmp);
 					return { success: false, error: fs.error() };
+				}
+				return { success: true };
+			}
+		},
+
+		login: {
+			args: { token: '' },
+			call: function(req) {
+				const token = req.args.token;
+				if (type(token) != 'string' || length(token) == 0) {
+					return { success: false, error: 'Missing authentication token' };
+				}
+
+				// Store the token in the separate auth file via the login command.
+				// The token is passed on stdin to avoid exposing it in the process
+				// list (argv is world-readable via /proc).
+				const cmd = sprintf(
+					"%s login --config-file %s --token \"$(cat)\"",
+					NORDVPNLITE_BIN, CONFIG_FILE
+				);
+				let proc = fs.popen(cmd, 'w');
+				if (proc == null) {
+					log.ERR("Failed to spawn login command: %J", fs.error());
+					return { success: false, error: fs.error() };
+				}
+				proc.write(token);
+				const rc = proc.close();
+				if (rc != 0) {
+					log.ERR("login command failed with code %d", rc);
+					return { success: false, error: sprintf('login command failed (code %d)', rc) };
+				}
+				return { success: true };
+			}
+		},
+
+		logout: {
+			call: function() {
+				const cmd = sprintf("%s logout --config-file %s", NORDVPNLITE_BIN, CONFIG_FILE);
+				let proc = fs.popen(cmd, 'r');
+				if (proc == null) {
+					log.ERR("Failed to spawn logout command: %J", fs.error());
+					return { success: false, error: fs.error() };
+				}
+				proc.read('all');
+				const rc = proc.close();
+				if (rc != 0) {
+					log.ERR("logout command failed with code %d", rc);
+					return { success: false, error: sprintf('logout command failed (code %d)', rc) };
 				}
 				return { success: true };
 			}

--- a/clis/nordvpnlite/openwrt/feed/net/nordvpnlite/files/luci/view/nordvpnlite/settings.js
+++ b/clis/nordvpnlite/openwrt/feed/net/nordvpnlite/files/luci/view/nordvpnlite/settings.js
@@ -15,8 +15,19 @@ var callSetConfig = rpc.declare({
     params: ['config']
 });
 
+var callLogin = rpc.declare({
+    object: 'nordvpnlite',
+    method: 'login',
+    params: ['token']
+});
+
+var callLogout = rpc.declare({
+    object: 'nordvpnlite',
+    method: 'logout'
+});
+
 var defaultConfig = {
-    authentication_token: '<REPLACE_WITH_YOUR_TOKEN>',
+    auth_file_path: '/etc/nordvpnlite/auth.json',
     vpn: 'recommended',
     log_level: 'error',
     log_file_path: '/var/log/nordvpnlite.log',
@@ -40,8 +51,10 @@ return view.extend({
         this.config = config;
 
         var form_data = {
+            auth: {
+                authentication_token: ""
+            },
             config: {
-                authentication_token: this.config.authentication_token === "<REPLACE_WITH_YOUR_TOKEN>" ? "" : this.config.authentication_token,
                 vpn: this.config.vpn === "recommended" ? "" : this.config.vpn.country
             }
         };
@@ -49,11 +62,14 @@ return view.extend({
         var m = new form.JSONMap(form_data, _('NordVPN Lite'),
             _('Configure your NordVPN Lite connection settings.'));
 
-        var s = m.section(form.NamedSection, 'config');
+        var auth_section = m.section(form.NamedSection, 'auth', 'auth', _('Authentication'));
 
-        var o = this.authentication_token_option = s.option(form.Value, 'authentication_token', _('Authentication Token'));
+        var o = this.authentication_token_option = auth_section.option(form.Value, 'authentication_token', _('Authentication Token'));
         o.password = true;
         o.placeholder = _('Enter your Nord Account authentication token');
+        o.description = _('Leave empty to keep the currently stored token, or enter a new token to replace it.');
+
+        var s = m.section(form.NamedSection, 'config', 'config', _('Settings'));
 
         o = this.vpn_option = s.option(form.Value, 'vpn', _('Country Code'));
         o.placeholder = _('recommended');
@@ -71,10 +87,10 @@ return view.extend({
             return
         }
 
-        const token = String(this.authentication_token_option.formvalue('config') || '<REPLACE_WITH_YOUR_TOKEN>').trim();
+        const token = String(this.authentication_token_option.formvalue('auth') || '').trim();
         const vpn = String(this.vpn_option.formvalue('config') || '').trim();
 
-        this.config.authentication_token = token;
+        delete this.config.authentication_token;
 
         if (vpn === '') {
             this.config.vpn = 'recommended';
@@ -84,13 +100,32 @@ return view.extend({
 
         try {
             const res = await callSetConfig(this.config);
-            if (!res || res.success !== true)
+            if (!res || res.success !== true) {
                 ui.addNotification(_('Save failed'), E('p', _('Could not write config file.')));
-            else
-                ui.addNotification(_('Saved'), E('p', _('Configuration updated.')));
+                return;
+            }
         } catch (err) {
             ui.addNotification(_('Save failed'), E('p', err ? String(err) : _('Unknown error')));
+            return;
         }
+
+        // Store the token separately via the login command, which writes it to the auth file.
+        // An empty field keeps the previously stored token.
+        if (token !== '') {
+            try {
+                const authRes = await callLogin(token);
+                if (!authRes || authRes.success !== true) {
+                    ui.addNotification(_('Save failed'), E('p',
+                        (authRes && authRes.error) ? String(authRes.error) : _('Could not store authentication token.')));
+                    return;
+                }
+            } catch (err) {
+                ui.addNotification(_('Save failed'), E('p', err ? String(err) : _('Unknown error')));
+                return;
+            }
+        }
+
+        ui.addNotification(_('Saved'), E('p', _('Configuration updated.')));
     },
 
     handleSaveApply: null,

--- a/clis/nordvpnlite/src/auth.rs
+++ b/clis/nordvpnlite/src/auth.rs
@@ -1,0 +1,347 @@
+use std::{
+    fs::{self, OpenOptions},
+    io::{BufReader, Write},
+    os::unix::fs::{OpenOptionsExt, PermissionsExt},
+    path::Path,
+};
+
+use serde::{Deserialize, Serialize};
+
+use telio_core::{crypto::SecretKey, telio_utils::Hidden};
+
+use crate::{NordVpnLiteError, DEFAULT_FILE_PERMISSIONS};
+
+#[derive(PartialEq, Eq, Debug, Clone, Serialize, Deserialize)]
+#[serde(try_from = "Hidden<String>")]
+pub struct NordToken(Hidden<String>);
+
+impl NordToken {
+    pub fn new(token: &str) -> Result<Self, NordVpnLiteError> {
+        if Self::validate(token) {
+            Ok(NordToken(token.to_owned().into()))
+        } else {
+            Err(NordVpnLiteError::InvalidConfigToken {
+                msg: "Invalid authentication token format".to_owned(),
+            })
+        }
+    }
+
+    fn validate(token: &str) -> bool {
+        token.len() == 64 && token.chars().all(|c| c.is_ascii_hexdigit())
+    }
+}
+
+impl TryFrom<Hidden<String>> for NordToken {
+    type Error = NordVpnLiteError;
+
+    fn try_from(token: Hidden<String>) -> Result<Self, Self::Error> {
+        NordToken::new(&token.0)
+    }
+}
+
+impl std::fmt::Display for NordToken {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl AsRef<str> for NordToken {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for NordToken {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[derive(Deserialize)]
+pub struct NordlynxKeyResponse {
+    pub nordlynx_private_key: String,
+}
+
+impl NordlynxKeyResponse {
+    pub fn into_secret_key(self) -> Result<SecretKey, NordVpnLiteError> {
+        self.nordlynx_private_key.parse::<SecretKey>().map_err(|_| {
+            NordVpnLiteError::InvalidResponse("Failed to parse nordlynx private key".to_owned())
+        })
+    }
+}
+
+#[derive(PartialEq, Serialize, Deserialize, Debug, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct NordVpnLiteAuth {
+    authentication_token: NordToken,
+}
+
+impl NordVpnLiteAuth {
+    /// Create a new NordVpnLiteAuth with the given token
+    pub fn new(token: NordToken) -> Self {
+        NordVpnLiteAuth {
+            authentication_token: token,
+        }
+    }
+
+    /// Get the authentication token
+    pub fn get_token(&self) -> NordToken {
+        self.authentication_token.clone()
+    }
+
+    /// Deserialize the NordVpnLiteAuth from an existing file at the given path
+    pub fn from_existing_file<P: AsRef<Path>>(path: P) -> Result<Self, NordVpnLiteError> {
+        let path = path.as_ref();
+        println!("Reading auth from: {}", path.display());
+
+        match fs::File::open(path) {
+            Ok(file) => {
+                let auth: NordVpnLiteAuth = serde_json::from_reader(BufReader::new(file))?;
+                Ok(auth)
+            }
+            Err(err) => Err(err.into()),
+        }
+    }
+
+    /// Serialize the NordVpnLiteAuth and write it to a file at the given path
+    pub fn to_file<P: AsRef<Path>>(&self, path: P) -> Result<(), NordVpnLiteError> {
+        let path = path.as_ref();
+
+        // Create the file with restrictive permissions set at creation time.
+        match OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(DEFAULT_FILE_PERMISSIONS)
+            .open(path)
+        {
+            Ok(mut file) => {
+                // Ensure permissions are correct even if the file already existed
+                // (in which case `.mode()` on create is ignored by the OS).
+                let mut permissions = file.metadata()?.permissions();
+                permissions.set_mode(DEFAULT_FILE_PERMISSIONS);
+                fs::set_permissions(path, permissions)?;
+
+                let auth_json: Hidden<String> = serde_json::to_string_pretty(&self)?.into();
+                file.write_all(auth_json.as_bytes())?;
+                Ok(())
+            }
+            Err(err) => Err(err.into()),
+        }
+    }
+
+    /// Checks if NORD_TOKEN env var is set and contains a valid token
+    /// If so, returns a NordVpnLiteAuth, otherwise None
+    pub fn resolve_env_token() -> Option<Self> {
+        if let Ok(token) = std::env::var("NORD_TOKEN") {
+            println!("Overriding token from env");
+            match NordToken::new(&token) {
+                Ok(nord_token) => {
+                    return Some(NordVpnLiteAuth::new(nord_token));
+                }
+                Err(e) => {
+                    eprintln!("Token from env not valid: {}", e);
+                }
+            };
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::{EnvVarHelper, NORD_TOKEN_ENV, VALID_TOKEN};
+    use serial_test::serial;
+    use temp_file::TempFile;
+
+    #[test]
+    fn test_new_rejects_invalid_token() {
+        let too_short = "abcd1234";
+        assert_matches::assert_matches!(
+            NordToken::new(too_short),
+            Err(NordVpnLiteError::InvalidConfigToken { .. })
+        );
+
+        let non_hex = "g".repeat(64);
+        assert_matches::assert_matches!(
+            NordToken::new(&non_hex),
+            Err(NordVpnLiteError::InvalidConfigToken { .. })
+        );
+
+        let one_bad = "a".repeat(63) + "w";
+        assert_matches::assert_matches!(
+            NordToken::new(&one_bad),
+            Err(NordVpnLiteError::InvalidConfigToken { .. })
+        );
+
+        let too_short_63 = "a".repeat(63);
+        assert_matches::assert_matches!(
+            NordToken::new(&too_short_63),
+            Err(NordVpnLiteError::InvalidConfigToken { .. })
+        );
+
+        let too_long_65 = "a".repeat(65);
+        assert_matches::assert_matches!(
+            NordToken::new(&too_long_65),
+            Err(NordVpnLiteError::InvalidConfigToken { .. })
+        );
+    }
+
+    #[test]
+    fn test_new_accepts_valid_token() {
+        assert!(NordToken::new(VALID_TOKEN).is_ok());
+    }
+
+    #[test]
+    fn test_nord_token_display() {
+        let token = NordToken::new(VALID_TOKEN).unwrap();
+        assert_eq!(format!("{}", token), VALID_TOKEN);
+    }
+
+    #[test]
+    fn test_nord_token_deref() {
+        let token = NordToken::new(VALID_TOKEN).unwrap();
+        let as_str: &str = &token;
+        assert_eq!(as_str, VALID_TOKEN);
+    }
+
+    #[test]
+    fn test_nordlynx_into_secret_key_valid() {
+        let hex_key = VALID_TOKEN;
+        let expected: SecretKey = hex_key.parse().expect("hex key should parse");
+        let response = NordlynxKeyResponse {
+            nordlynx_private_key: hex_key.to_owned(),
+        };
+        let parsed = response
+            .into_secret_key()
+            .expect("valid nordlynx key should parse");
+        assert_eq!(parsed, expected);
+    }
+
+    #[test]
+    fn test_nordlynx_into_secret_key_invalid() {
+        let response = NordlynxKeyResponse {
+            nordlynx_private_key: "not-a-valid-key".to_owned(),
+        };
+        assert_matches::assert_matches!(
+            response.into_secret_key(),
+            Err(NordVpnLiteError::InvalidResponse(_))
+        );
+    }
+
+    #[test]
+    fn test_new_and_get_token() {
+        let token = NordToken::new(VALID_TOKEN).unwrap();
+        let auth = NordVpnLiteAuth::new(token.clone());
+        assert_eq!(auth.get_token(), token);
+    }
+
+    #[test]
+    fn test_to_and_from_file_roundtrip() {
+        let file = TempFile::new().expect("failed to create temp file");
+        let path = file.path().to_owned();
+
+        let token = NordToken::new(VALID_TOKEN).unwrap();
+        let auth = NordVpnLiteAuth::new(token.clone());
+        auth.to_file(&path).expect("failed to write auth file");
+
+        let mode = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, DEFAULT_FILE_PERMISSIONS);
+
+        let loaded =
+            NordVpnLiteAuth::from_existing_file(&path).expect("failed to read auth file back");
+        assert_eq!(loaded, auth);
+        assert_eq!(loaded.get_token().as_ref(), VALID_TOKEN);
+    }
+
+    #[test]
+    fn test_to_file_resets_permissions_on_existing_file() {
+        let file = TempFile::new().expect("failed to create temp file");
+        let path = file.path().to_owned();
+
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o666))
+            .expect("failed to set initial permissions");
+        assert_eq!(
+            fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+            0o666
+        );
+
+        let token = NordToken::new(VALID_TOKEN).unwrap();
+        let auth = NordVpnLiteAuth::new(token);
+        auth.to_file(&path).expect("failed to write auth file");
+
+        let mode = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, DEFAULT_FILE_PERMISSIONS);
+    }
+
+    #[test]
+    fn test_from_existing_file_rejects_unknown_fields() {
+        let json = format!(
+            r#"{{ "authentication_token": "{}", "unexpected_field": "value" }}"#,
+            VALID_TOKEN
+        );
+
+        let file = TempFile::new()
+            .expect("failed to create temp file")
+            .with_contents(json.as_bytes())
+            .expect("failed to write temp file");
+
+        assert!(NordVpnLiteAuth::from_existing_file(file.path()).is_err());
+    }
+
+    #[test]
+    fn test_to_file_fails_when_directory_missing() {
+        let token = NordToken::new(VALID_TOKEN).unwrap();
+        let auth = NordVpnLiteAuth::new(token);
+
+        let path = std::path::Path::new("/nonexistent_dir_for_test/auth.json");
+        assert_matches::assert_matches!(auth.to_file(path), Err(NordVpnLiteError::Io(_)));
+    }
+
+    #[test]
+    fn test_from_existing_file_fails_when_file_missing() {
+        let file = TempFile::new().expect("failed to create temp file");
+        let path = file.path().to_owned();
+        drop(file);
+
+        assert_matches::assert_matches!(
+            NordVpnLiteAuth::from_existing_file(&path),
+            Err(NordVpnLiteError::Io(ref e)) if e.kind() == std::io::ErrorKind::NotFound
+        );
+    }
+
+    #[test]
+    fn test_from_existing_file_rejects_invalid_token() {
+        let file = TempFile::new()
+            .expect("failed to create temp file")
+            .with_contents(br#"{ "authentication_token": "invalid-token" }"#)
+            .expect("failed to write temp file");
+
+        assert!(NordVpnLiteAuth::from_existing_file(file.path()).is_err());
+    }
+
+    #[test]
+    #[serial]
+    fn test_resolve_env_valid_token() {
+        let _env = EnvVarHelper::set(NORD_TOKEN_ENV, VALID_TOKEN);
+        let auth = NordVpnLiteAuth::resolve_env_token().expect("env token should resolve");
+        assert_eq!(auth.get_token().as_ref(), VALID_TOKEN);
+    }
+
+    #[test]
+    #[serial]
+    fn test_resolve_env_invalid_token() {
+        let _env = EnvVarHelper::set(NORD_TOKEN_ENV, "not-a-valid-token");
+        assert!(NordVpnLiteAuth::resolve_env_token().is_none());
+    }
+
+    #[test]
+    #[serial]
+    fn test_resolve_env_no_var() {
+        let _env = EnvVarHelper::unset(NORD_TOKEN_ENV);
+        assert!(NordVpnLiteAuth::resolve_env_token().is_none());
+    }
+}

--- a/clis/nordvpnlite/src/command_listener.rs
+++ b/clis/nordvpnlite/src/command_listener.rs
@@ -13,6 +13,7 @@ use crate::{
 };
 
 pub(crate) const TIMEOUT_SEC: u64 = 60;
+const DEFAULT_CONFIG_PATH: &str = "/etc/nordvpnlite/config.json";
 
 #[derive(Parser, Debug, PartialEq)]
 #[clap()]
@@ -51,7 +52,7 @@ pub(crate) struct DaemonOpts {
     #[clap(
         long = "config-file",
         short = 'c',
-        default_value = "/etc/nordvpnlite/config.json"
+        default_value = DEFAULT_CONFIG_PATH
     )]
     pub config_path: String,
 
@@ -72,6 +73,53 @@ pub(crate) struct DaemonOpts {
     pub stdout_path: String,
 }
 
+#[derive(Parser, Debug)]
+pub(crate) struct LoginOpts {
+    /// Configuration file to read authentication credentials path
+    #[clap(
+        long = "config-file",
+        short = 'c',
+        default_value = DEFAULT_CONFIG_PATH
+    )]
+    pub config_path: String,
+
+    /// Authentication token (long syntax)
+    #[clap(
+        long = "token",
+        value_name = "TOKEN",
+        conflicts_with = "token_positional"
+    )]
+    pub token: Option<String>,
+
+    /// Authentication token (short syntax)
+    #[clap(
+        value_name = "TOKEN",
+        required_unless_present = "token",
+        conflicts_with = "token"
+    )]
+    pub token_positional: Option<String>,
+}
+
+impl LoginOpts {
+    pub fn token(&self) -> &str {
+        self.token
+            .as_deref()
+            .or(self.token_positional.as_deref())
+            .unwrap_or_default()
+    }
+}
+
+#[derive(Parser, Debug)]
+pub(crate) struct LogoutOpts {
+    /// Configuration file to read authentication credentials path
+    #[clap(
+        long = "config-file",
+        short = 'c',
+        default_value = DEFAULT_CONFIG_PATH
+    )]
+    pub config_path: String,
+}
+
 /// NordVPN Lite is a lightweight, standalone VPN client built around
 /// the libtelio library. It is designed for embedded and edge environments,
 /// that are too resource constrained for the full NordVPN application.
@@ -85,6 +133,10 @@ pub enum Cmd {
     Client(ClientCmd),
     #[clap(about = "Show countries with available VPN servers")]
     Countries,
+    #[clap(about = "Store NordVPN authentication credentials")]
+    Login(LoginOpts),
+    #[clap(about = "Clear NordVPN authentication credentials")]
+    Logout(LogoutOpts),
 }
 
 /// Command response type used to communicate between `telio runner -> daemon -> client`
@@ -186,7 +238,7 @@ impl CommandListener {
                         NordVpnLiteError::CommandFailed(ClientCmd::QuitDaemon)
                     })?;
                 // Wait for a response from TelioTask
-                // this essentually blocks the client quit command until the daemon initiated
+                // this essentially blocks the client quit command until the daemon initiated
                 // cleanup
                 handle_response(response_rx, |_| Ok(CommandResponse::Ok)).await
             }
@@ -294,9 +346,9 @@ mod tests {
     const VALID_CONFIG_JSON: &str = r#"{
         "log_level": "Info",
         "log_file_path": "test.log",
+        "auth_file_path": "auth.json",
         "adapter_type": "linux-native",
-        "interface": { "name": "utun10", "config_provider": "manual" },
-        "authentication_token": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        "interface": { "name": "utun10", "config_provider": "manual" }
     }"#;
 
     // Create a random socket path for the test, since tests run in parallel they can deadlock
@@ -606,5 +658,38 @@ mod tests {
             had_pending,
             "pending_config must be set after a successful reload"
         );
+    }
+
+    #[test]
+    fn test_login_cmd_accepts_long_token_syntax() {
+        let cmd = Cmd::try_parse_from(["nordvpnlite", "login", "--token", "abcd"]).unwrap();
+
+        let Cmd::Login(opts) = cmd else {
+            panic!("expected login command")
+        };
+
+        assert_eq!(opts.token(), "abcd");
+    }
+
+    #[test]
+    fn test_login_cmd_accepts_short_token_syntax() {
+        let cmd = Cmd::try_parse_from(["nordvpnlite", "login", "abcd"]).unwrap();
+
+        let Cmd::Login(opts) = cmd else {
+            panic!("expected login command")
+        };
+
+        assert_eq!(opts.token(), "abcd");
+    }
+
+    #[test]
+    fn test_login_cmd_rejects_both_token_forms() {
+        let result = Cmd::try_parse_from(["nordvpnlite", "login", "--token", "abcd", "efgh"]);
+
+        assert!(result.is_err());
+
+        let result = Cmd::try_parse_from(["nordvpnlite", "login", "abcd", "--token", "efgh"]);
+
+        assert!(result.is_err());
     }
 }

--- a/clis/nordvpnlite/src/comms.rs
+++ b/clis/nordvpnlite/src/comms.rs
@@ -64,7 +64,7 @@ impl DaemonSocket {
             .reclaim_name(true);
 
         // Disable setting umask for tests.
-        // `umask()` C API call is operating on a process level, and therfore is not thread-safe.
+        // `umask()` C API call is operating on a process level, and therefore is not thread-safe.
         // As multiple cargo tests are executing in parallel this causes a panic.
         #[cfg(not(test))]
         // Mode for unix socket rw-------

--- a/clis/nordvpnlite/src/config.rs
+++ b/clis/nordvpnlite/src/config.rs
@@ -1,24 +1,23 @@
 use std::{
     fs,
     io::{BufReader, Write},
-    net::IpAddr,
-    net::Ipv4Addr,
-    os::unix::fs::PermissionsExt,
+    net::{IpAddr, Ipv4Addr},
+    os::unix::fs::{OpenOptionsExt as _, PermissionsExt},
     path::{Path, PathBuf},
     str::FromStr,
-    sync::Arc,
 };
 
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+
 use tracing::{level_filters::LevelFilter, Level};
 
-use telio_core::{
-    crypto::{PublicKey, SecretKey},
-    device::AdapterType,
-    telio_utils::Hidden,
-};
+use telio_core::{crypto::PublicKey, device::AdapterType};
 
-use crate::{interface::InterfaceConfig, NordVpnLiteError};
+use crate::{
+    auth::{NordToken, NordVpnLiteAuth},
+    interface::InterfaceConfig,
+    NordVpnLiteError, DEFAULT_FILE_PERMISSIONS,
+};
 
 #[derive(Clone, Debug)]
 pub struct RunningConfig {
@@ -59,6 +58,19 @@ impl RunningConfig {
 
         Ok(hasher.finish())
     }
+
+    pub fn migrate_config_format(&mut self, config_path: &str) -> Result<(), NordVpnLiteError> {
+        let result = self.parsed.migrate_config_format(config_path);
+        match result {
+            Ok(true) => {
+                // Update the hash after migration to reflect the new file content
+                self.hash = Self::hash_file(&self.path).unwrap_or(0);
+                Ok(())
+            }
+            Ok(false) => Ok(()),
+            Err(e) => Err(e),
+        }
+    }
 }
 
 // These IPs are documented but the documentation is not publicly available
@@ -69,91 +81,15 @@ fn dns_default() -> Vec<IpAddr> {
     ]
 }
 
-#[derive(PartialEq, Eq, Debug, Clone)]
-pub struct NordToken(Arc<Hidden<String>>);
-
-impl NordToken {
-    pub fn new(token: &str) -> Result<Self, NordVpnLiteError> {
-        if Self::validate(token) {
-            Ok(NordToken(Arc::new(token.to_owned().into())))
-        } else if token.to_lowercase().contains("token") {
-            Err(NordVpnLiteError::InvalidConfigToken {
-                msg: "Provide your authentication token from https://my.nordaccount.com".to_owned(),
-            })
-        } else {
-            Err(NordVpnLiteError::InvalidConfigToken {
-                msg: "Invalid authentication token format".to_owned(),
-            })
-        }
-    }
-
-    fn validate(token: &str) -> bool {
-        token.len() == 64 && token.chars().all(|c| c.is_ascii_hexdigit())
-    }
-
-    /// Token that will fail to deserialize, prompting the user to update it
-    pub fn new_invalid_template() -> Self {
-        NordToken(Arc::new(
-            "<PASTE_YOUR_AUTHENTICATION_TOKEN_HERE>".to_owned().into(),
-        ))
-    }
-
-    pub fn zeroize(&mut self) {
-        self.0 = Arc::new(Hidden::from(String::new()));
-    }
-}
-
-impl Default for NordToken {
-    fn default() -> Self {
-        NordToken(Arc::new(
-            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
-                .to_owned()
-                .into(),
-        ))
-    }
-}
-
-impl std::fmt::Display for NordToken {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl AsRef<str> for NordToken {
-    fn as_ref(&self) -> &str {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for NordToken {
-    type Target = str;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-#[derive(Deserialize)]
-pub struct NordlynxKeyResponse {
-    pub nordlynx_private_key: String,
-}
-
-impl NordlynxKeyResponse {
-    pub fn into_secret_key(self) -> Result<SecretKey, NordVpnLiteError> {
-        self.nordlynx_private_key.parse::<SecretKey>().map_err(|_| {
-            NordVpnLiteError::InvalidResponse("Failed to parse nordlynx private key".to_owned())
-        })
-    }
-}
-
 #[derive(PartialEq, Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct NordVpnLiteConfig {
-    #[serde(
-        deserialize_with = "deserialize_nord_token",
-        serialize_with = "serialize_nord_token"
-    )]
-    pub authentication_token: NordToken,
+    /// Authentication credentials file path
+    #[serde(default = "default_auth_file_path")]
+    pub auth_file_path: String,
+    /// Backward compatibility: accept old config format.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub authentication_token: Option<NordToken>,
 
     #[serde(default)]
     pub vpn: VpnConfig,
@@ -198,49 +134,85 @@ impl NordVpnLiteConfig {
 
         match fs::File::open(path) {
             Ok(file) => {
-                let mut config: NordVpnLiteConfig = serde_json::from_reader(file)?;
+                let mut config: NordVpnLiteConfig = serde_json::from_reader(BufReader::new(file))?;
                 config.log_file_path = Self::resolve_log_path(&config.log_file_path)?;
+                config.auth_file_path = Self::resolve_auth_path(&config.auth_file_path)?;
                 Ok(config)
             }
             // Create a default config if it does not exist
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-                eprintln!("File not found, creating default config");
-
-                // Create directories
-                if let Some(parent) = path.parent() {
-                    fs::create_dir_all(parent)?;
-                }
+                println!(
+                    "File not found, creating default config: {}",
+                    path.display()
+                );
 
                 // Write default config to file
-                let default_config = Self {
-                    authentication_token: NordToken::new_invalid_template(),
-                    ..Default::default()
-                };
+                let default_config = NordVpnLiteConfig::default();
+                default_config.to_file(path)?;
 
-                let mut file = fs::File::create(path)?;
-                let mut permissions = file.metadata()?.permissions();
-                permissions.set_mode(0o640);
-                fs::set_permissions(path, permissions)?;
-
-                let config_json = serde_json::to_string_pretty(&default_config)?;
-                file.write_all(config_json.as_bytes())?;
-
-                Err(NordVpnLiteError::InvalidConfigToken {
-                    msg: "Provide your authentication token from https://my.nordaccount.com"
-                        .to_owned(),
-                })
+                Ok(default_config)
             }
             Err(err) => Err(err.into()),
         }
     }
 
+    /// Construct a NordVpnLiteConfig by deserializing an existing file at the given path
+    pub fn from_existing_file<P: AsRef<Path>>(path: P) -> Result<Self, NordVpnLiteError> {
+        let path = path.as_ref();
+        println!("Reading config from: {}", path.display());
+
+        match fs::File::open(path) {
+            Ok(file) => {
+                let mut config: NordVpnLiteConfig = serde_json::from_reader(BufReader::new(file))?;
+                config.log_file_path = Self::resolve_log_path(&config.log_file_path)?;
+                config.auth_file_path = Self::resolve_auth_path(&config.auth_file_path)?;
+                Ok(config)
+            }
+            Err(err) => Err(err.into()),
+        }
+    }
+
+    fn to_file<P: AsRef<Path>>(&self, path: P) -> Result<(), NordVpnLiteError> {
+        let path = path.as_ref();
+
+        // Create directories
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+
+        // Create the file with restrictive permissions set at creation time.
+        let mut file = fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(DEFAULT_FILE_PERMISSIONS)
+            .open(path)?;
+
+        // Ensure permissions are correct even if the file already existed
+        let mut permissions = file.metadata()?.permissions();
+        permissions.set_mode(DEFAULT_FILE_PERMISSIONS);
+        fs::set_permissions(path, permissions)?;
+
+        let config_json = serde_json::to_string_pretty(&self)?;
+        file.write_all(config_json.as_bytes())?;
+        Ok(())
+    }
+
     fn resolve_log_path(log_file_path: &str) -> Result<String, NordVpnLiteError> {
-        let path = PathBuf::from(log_file_path);
+        Self::resolve_path("log_file_path", log_file_path)
+    }
+
+    fn resolve_auth_path(auth_file_path: &str) -> Result<String, NordVpnLiteError> {
+        Self::resolve_path("auth_file_path", auth_file_path)
+    }
+
+    fn resolve_path(key: &str, file_path: &str) -> Result<String, NordVpnLiteError> {
+        let path = PathBuf::from(file_path);
 
         let file_name = path
             .file_name()
             .ok_or_else(|| NordVpnLiteError::InvalidConfigOption {
-                key: "log_file_path".to_owned(),
+                key: key.to_owned(),
                 msg: "must specify a file name".to_owned(),
                 value: path.to_string_lossy().into_owned(),
             })?;
@@ -254,8 +226,8 @@ impl NordVpnLiteConfig {
             let path_canonical =
                 dir.canonicalize()
                     .map_err(|e| NordVpnLiteError::InvalidConfigOption {
-                        key: "log_file_path".to_owned(),
-                        msg: format!("could not resolve log directory: {e}"),
+                        key: key.to_owned(),
+                        msg: format!("could not resolve directory: {e}"),
                         value: path.to_string_lossy().into_owned(),
                     })?;
             path_canonical.join(file_name)
@@ -263,7 +235,7 @@ impl NordVpnLiteConfig {
             if let Some(parent) = path.parent() {
                 if !parent.is_dir() {
                     return Err(NordVpnLiteError::InvalidConfigOption {
-                        key: "log_file_path".to_owned(),
+                        key: key.to_owned(),
                         msg: "parent directory does not exist".to_owned(),
                         value: path.to_string_lossy().into_owned(),
                     });
@@ -281,21 +253,77 @@ impl NordVpnLiteConfig {
             || self.log_file_count != other.log_file_count
     }
 
-    /// Checks if NORD_TOKEN env var is set and contains a valid token.
-    pub fn resolve_env_token(&mut self) -> bool {
-        if let Ok(token) = std::env::var("NORD_TOKEN") {
-            println!("Overriding token from env");
-            match NordToken::new(&token) {
-                Ok(nordtoken) => {
-                    self.authentication_token = nordtoken;
-                    return true;
-                }
-                Err(e) => {
-                    eprintln!("Token from env not valid: {}", e);
-                }
-            };
+    /// Migrate the config format if it contains an authentication token.
+    /// This is a one-time action to move the token to a dedicated file (if not present)
+    /// and update the config file to remove the token.
+    pub fn migrate_config_format(&mut self, config_path: &str) -> Result<bool, NordVpnLiteError> {
+        if let Some(token) = self.authentication_token.take() {
+            // If the auth file already exists and contains a valid token, we don't overwrite it.
+            if NordVpnLiteAuth::from_existing_file(&self.auth_file_path).is_err() {
+                let auth = NordVpnLiteAuth::new(token);
+                auth.to_file(&self.auth_file_path)?;
+                println!(
+                    "Config migration - auth token moved to a dedicated file: {}",
+                    self.auth_file_path
+                );
+            }
+            self.to_file(config_path)?;
+            println!(
+                "Config migration - configuration file updated: {}",
+                config_path
+            );
+            return Ok(true);
         }
-        false
+        Ok(false)
+    }
+
+    /// Ensure a usable authentication token is configured.
+    ///
+    /// Checks if it is available in the environment or in the auth file.
+    /// Distinguishes the "not logged in yet" case from genuine failures
+    /// such as a corrupt file or insufficient permissions.
+    pub fn check_auth_token(&self) -> Result<(), NordVpnLiteError> {
+        if NordVpnLiteAuth::resolve_env_token().is_some() {
+            // Allow the authentication via the environment
+            return Ok(());
+        }
+        match NordVpnLiteAuth::from_existing_file(&self.auth_file_path) {
+            Ok(_) => Ok(()),
+            // Auth file absent: the user simply hasn't logged in yet.
+            Err(NordVpnLiteError::Io(ref e)) if e.kind() == std::io::ErrorKind::NotFound => {
+                Err(NordVpnLiteError::InvalidConfigToken {
+                    msg:
+                        "Please retrieve your authentication token from https://my.nordaccount.com \
+                         and use the following command to set it: `nordvpnlite login <your_token>` \
+                         (or `nordvpnlite login --token <your_token>`)."
+                            .to_owned(),
+                })
+            }
+            // File exists but could not be read/parsed/validated: surface the real cause.
+            Err(err) => Err(err),
+        }
+    }
+
+    /// Get the authentication token from the environment.
+    fn get_auth_env() -> Option<NordToken> {
+        let auth = NordVpnLiteAuth::resolve_env_token();
+        auth.map(|a| a.get_token())
+    }
+
+    /// Get the authentication token from the auth file.
+    fn get_auth_file(&self) -> Result<NordToken, NordVpnLiteError> {
+        let auth = NordVpnLiteAuth::from_existing_file(&self.auth_file_path)?;
+        Ok(auth.get_token())
+    }
+
+    /// Get the authentication token from either the environment or the auth file.
+    /// The environment variable takes precedence over the auth file.
+    pub fn get_auth_token(&self) -> Result<NordToken, NordVpnLiteError> {
+        if let Some(token) = Self::get_auth_env() {
+            Ok(token)
+        } else {
+            self.get_auth_file()
+        }
     }
 }
 
@@ -307,6 +335,8 @@ impl Default for NordVpnLiteConfig {
             } else {
                 Level::INFO
             }),
+            authentication_token: None,
+            auth_file_path: default_auth_file_path(),
             log_file_path: "/var/log/nordvpnlite.log".to_string(),
             log_file_count: default_log_file_count(),
             adapter_type: AdapterType::default(),
@@ -318,7 +348,6 @@ impl Default for NordVpnLiteConfig {
             vpn: Default::default(),
             dns: dns_default(),
             override_default_wg_port: None,
-            authentication_token: Default::default(),
             http_certificate_file_path: None,
             enable_firewall: false,
             post_quantum: false,
@@ -368,22 +397,18 @@ where
     serializer.serialize_str(&log_level.to_string())
 }
 
-fn deserialize_nord_token<'de, D: Deserializer<'de>>(
-    deserializer: D,
-) -> Result<NordToken, D::Error> {
-    let raw_string: Hidden<String> = de::Deserialize::deserialize(deserializer)?;
-    NordToken::new(&raw_string).map_err(de::Error::custom)
-}
-
-fn serialize_nord_token<S>(token: &NordToken, serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-{
-    serializer.serialize_str(token)
-}
-
 const fn default_log_file_count() -> usize {
     7
+}
+
+#[cfg(not(test))]
+fn default_auth_file_path() -> String {
+    "/etc/nordvpnlite/auth.json".to_string()
+}
+
+#[cfg(test)]
+fn default_auth_file_path() -> String {
+    "/tmp/nordvpnlite-auth.json".to_string()
 }
 
 #[derive(PartialEq, Eq, Deserialize, Serialize, Debug, Clone)]
@@ -409,35 +434,25 @@ pub enum VpnConfig {
 #[cfg(test)]
 mod tests {
     use crate::interface::InterfaceConfigurationProvider;
+    use crate::test_utils::{
+        build_json, temp_config, write_auth_file, EnvVarHelper, NORD_TOKEN_ENV, OTHER_VALID_TOKEN,
+        VALID_TOKEN,
+    };
 
     use super::*;
     use serial_test::serial;
     use temp_file::TempFile;
 
-    fn temp_config(content: &str) -> TempFile {
-        TempFile::new()
-            .expect("Failed to create temp config file")
-            .with_contents(content.as_bytes())
-            .expect("Failed to write config file")
+    fn config_json(log_path: &str, auth_path: &str) -> String {
+        build_json(log_path, auth_path, r#"{ "country": "lt" }"#)
     }
 
-    fn config_json_for_log(path: &str) -> String {
-        format!(
-            r#"{{
-                "log_level": "Info",
-                "log_file_path": "{}",
-                "adapter_type": "linux-native",
-                "interface": {{
-                    "name": "test",
-                    "config_provider": "manual"
-                }},
-                "vpn": {{
-                    "country": "lt"
-                }},
-                "authentication_token": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
-            }}"#,
-            path
-        )
+    /// Build a config whose auth file points at `auth_file_path`.
+    fn config_with_auth_path(auth_file_path: &str) -> NordVpnLiteConfig {
+        NordVpnLiteConfig {
+            auth_file_path: auth_file_path.to_owned(),
+            ..Default::default()
+        }
     }
 
     #[test]
@@ -454,8 +469,9 @@ mod tests {
             },
             vpn: Default::default(),
             dns: dns_default(),
+            authentication_token: None,
             override_default_wg_port: None,
-            authentication_token: Default::default(),
+            auth_file_path: "auth.json".to_owned(),
             http_certificate_file_path: None,
             enable_firewall: false,
             post_quantum: false,
@@ -464,13 +480,13 @@ mod tests {
             let json = r#"{
             "log_level": "Info",
             "log_file_path": "test.log",
+            "auth_file_path": "auth.json",
             "adapter_type": "linux-native",
             "interface": {
                 "name": "utun10",
                 "config_provider": "manual"
             },
             "vpn": "recommended",
-            "authentication_token": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
             "post_quantum": false
             }"#;
 
@@ -481,12 +497,12 @@ mod tests {
             let json = r#"{
                 "log_level": "Info",
                 "log_file_path": "test.log",
+                "auth_file_path": "auth.json",
                 "adapter_type": "linux-native",
                 "interface": {
                     "name": "utun10",
                     "config_provider": "manual"
-                },
-                "authentication_token": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+                }
             }"#;
 
             assert_eq!(expected, serde_json::from_str(json).unwrap());
@@ -507,13 +523,13 @@ mod tests {
         let json = r#"{
             "log_level": "Trace",
             "log_file_path": "/var/log/nordvpnlite.log",
+            "auth_file_path": "/tmp/nordvpnlite-auth.json",
             "adapter_type": "neptun",
             "interface": {
                 "name": "nlx",
                 "config_provider": "manual"
             },
-            "vpn": "recommended",
-            "authentication_token": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+            "vpn": "recommended"
             }"#;
 
         assert_eq!(expected_config, serde_json::from_str(json).unwrap());
@@ -521,19 +537,21 @@ mod tests {
 
     #[test]
     fn test_config_dns_custom() {
-        let mut expected_config = NordVpnLiteConfig::default();
-        expected_config.dns = vec![Ipv4Addr::new(1, 1, 1, 1).into()];
+        let expected_config = NordVpnLiteConfig {
+            dns: vec![Ipv4Addr::new(1, 1, 1, 1).into()],
+            ..Default::default()
+        };
 
         let json = r#"{
             "log_level": "Trace",
             "log_file_path": "/var/log/nordvpnlite.log",
+            "auth_file_path": "/tmp/nordvpnlite-auth.json",
             "adapter_type": "neptun",
             "interface": {
                 "name": "nlx",
                 "config_provider": "manual"
             },
-            "dns": ["1.1.1.1"],
-            "authentication_token": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+            "dns": ["1.1.1.1"]
             }"#;
 
         assert_eq!(expected_config, serde_json::from_str(json).unwrap());
@@ -541,22 +559,24 @@ mod tests {
 
     #[test]
     fn test_config_dns_custom_multiple() {
-        let mut expected_config = NordVpnLiteConfig::default();
-        expected_config.dns = vec![
-            Ipv4Addr::new(1, 1, 1, 1).into(),
-            Ipv4Addr::new(8, 8, 8, 8).into(),
-        ];
+        let expected_config = NordVpnLiteConfig {
+            dns: vec![
+                Ipv4Addr::new(1, 1, 1, 1).into(),
+                Ipv4Addr::new(8, 8, 8, 8).into(),
+            ],
+            ..Default::default()
+        };
 
         let json = r#"{
             "log_level": "Trace",
             "log_file_path": "/var/log/nordvpnlite.log",
+            "auth_file_path": "/tmp/nordvpnlite-auth.json",
             "adapter_type": "neptun",
             "interface": {
                 "name": "nlx",
                 "config_provider": "manual"
             },
-            "dns": ["1.1.1.1", "8.8.8.8"],
-            "authentication_token": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+            "dns": ["1.1.1.1", "8.8.8.8"]
             }"#;
 
         assert_eq!(expected_config, serde_json::from_str(json).unwrap());
@@ -569,12 +589,12 @@ mod tests {
         let json = r#"{
             "log_level": "Trace",
             "log_file_path": "/var/log/nordvpnlite.log",
+            "auth_file_path": "/tmp/nordvpnlite-auth.json",
             "adapter_type": "neptun",
             "interface": {
                 "name": "nlx",
                 "config_provider": "manual"
-            },
-            "authentication_token": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+            }
             }"#;
 
         assert_eq!(expected_config, serde_json::from_str(json).unwrap());
@@ -588,12 +608,12 @@ mod tests {
         let json = r#"{
             "log_level": "Trace",
             "log_file_path": "/var/log/nordvpnlite.log",
+            "auth_file_path": "/tmp/nordvpnlite-auth.json",
             "adapter_type": "neptun",
             "interface": {
                 "name": "nlx",
                 "config_provider": "manual"
             },
-            "authentication_token": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
             "post_quantum": true
             }"#;
 
@@ -616,6 +636,7 @@ mod tests {
         let json = r#"{
             "log_level": "Trace",
             "log_file_path": "/var/log/nordvpnlite.log",
+            "auth_file_path": "/tmp/nordvpnlite-auth.json",
             "adapter_type": "neptun",
             "interface": {
                 "name": "nlx",
@@ -626,8 +647,7 @@ mod tests {
                     "address": "127.0.0.1",
                     "public_key": "urq6urq6urq6urq6urq6urq6urq6urq6urq6urq6uro="
                 }
-            },
-            "authentication_token": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+            }
             }"#;
 
         assert_eq!(expected_config, serde_json::from_str(json).unwrap());
@@ -646,8 +666,7 @@ mod tests {
             "vpn": {
                 "country": "de",
                 "country": "pl"
-            },
-            "authentication_token": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+            }
             }"#;
         assert!(serde_json::from_str::<NordVpnLiteConfig>(json).is_err());
 
@@ -664,8 +683,7 @@ mod tests {
             },
             "vpn": {
                 "country": "pl"
-            },
-            "authentication_token": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+            }
             }"#;
 
         assert!(serde_json::from_str::<NordVpnLiteConfig>(json).is_err());
@@ -686,8 +704,7 @@ mod tests {
                     "address": "127.0.0.1",
                     "public_key": "urq6urq6urq6urq6urq6urq6urq6urq6urq6urq6uro="
                 }
-            },
-            "authentication_token": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+            }
             }"#;
 
         assert!(serde_json::from_str::<NordVpnLiteConfig>(json).is_err());
@@ -706,8 +723,7 @@ mod tests {
                     "address": "127.0.0.1",
                     "public_key": "urq6urq6urq6urq6urq6urq6urq6urq6urq6urq6uro="
                 }
-            },
-            "authentication_token": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+            }
             }"#;
 
         assert!(serde_json::from_str::<NordVpnLiteConfig>(json).is_err());
@@ -722,7 +738,6 @@ mod tests {
             },
             "vpn": "recommended",
             "dns": ["1.1.1.1.1"]
-            "authentication_token": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
             }"#;
 
         assert!(
@@ -734,7 +749,8 @@ mod tests {
     #[test]
     fn test_config_with_absolute_path() {
         let log_path = std::env::current_dir().unwrap().join("absolute.log");
-        let config_json = config_json_for_log(log_path.to_str().unwrap());
+        let auth_path = std::env::current_dir().unwrap().join("auth.json");
+        let config_json = config_json(log_path.to_str().unwrap(), auth_path.to_str().unwrap());
 
         let file = temp_config(&config_json);
         let config = NordVpnLiteConfig::from_file(file.path().to_str().unwrap()).unwrap();
@@ -748,7 +764,7 @@ mod tests {
 
     #[test]
     fn test_relative_log_path() {
-        let config_json = config_json_for_log("./relative.log");
+        let config_json = config_json("./relative.log", "./auth.json");
         let file = temp_config(&config_json);
         let config = NordVpnLiteConfig::from_file(file.path().to_str().unwrap()).unwrap();
 
@@ -758,62 +774,465 @@ mod tests {
 
     #[test]
     fn test_invalid_log_path_returns_error() {
-        let config_json = config_json_for_log("");
+        let config = config_json("", "./auth.json");
 
-        let file = temp_config(&config_json);
+        let file = temp_config(&config);
         let err = NordVpnLiteConfig::from_file(file.path().to_str().unwrap()).unwrap_err();
 
         assert!(
             matches!(err, NordVpnLiteError::InvalidConfigOption { ref key, .. } if key == "log_file_path"),
             "expected InvalidConfigOption for log_file_path, got: {err:?}"
         );
+
+        let config = config_json("./relative.log", "");
+
+        let file = temp_config(&config);
+        let err = NordVpnLiteConfig::from_file(file.path().to_str().unwrap()).unwrap_err();
+
+        assert!(
+            matches!(err, NordVpnLiteError::InvalidConfigOption { ref key, .. } if key == "auth_file_path"),
+            "expected InvalidConfigOption for auth_file_path, got: {err:?}"
+        );
     }
 
     #[test]
-    #[serial]
-    fn test_token_override_from_env() {
-        let config_json = config_json_for_log("test.log");
-        let file = temp_config(&config_json);
+    fn test_from_file_creates_default() {
+        use std::os::unix::fs::PermissionsExt;
 
-        let valid_token = "b".repeat(64);
-        std::env::set_var("NORD_TOKEN", &valid_token);
+        let file = TempFile::new().expect("Failed to create temp file");
+        let path = file.path().to_str().unwrap().to_owned();
+        drop(file);
 
-        let mut config = NordVpnLiteConfig::from_file(file.path().to_str().unwrap()).unwrap();
-        config.resolve_env_token();
-        assert_eq!(config.authentication_token.as_ref(), valid_token);
+        assert!(!std::path::Path::new(&path).exists());
 
-        std::env::remove_var("NORD_TOKEN");
+        let config = NordVpnLiteConfig::from_file(&path)
+            .expect("from_file should create and return a default config");
+
+        // default config should have been created
+        assert_eq!(config, NordVpnLiteConfig::default());
+
+        // verify config file was created with correct permissions
+        assert!(std::path::Path::new(&path).exists());
+        let mode = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, DEFAULT_FILE_PERMISSIONS);
+
+        // verify that the config can be read back from the file
+        let config = NordVpnLiteConfig::from_existing_file(&path)
+            .expect("written default config should be readable");
+        assert_eq!(config, NordVpnLiteConfig::default());
     }
 
     #[test]
-    #[serial]
-    fn test_invalid_env_token_ignored() {
-        let config_json = config_json_for_log("test.log");
-        let file = temp_config(&config_json);
+    fn test_from_file_propagates_errors() {
+        use std::os::unix::fs::PermissionsExt;
 
-        std::env::set_var("NORD_TOKEN", "short");
+        let file = TempFile::new().expect("Failed to create temp file");
+        let path = file.path().to_str().unwrap().to_owned();
 
-        let config = NordVpnLiteConfig::from_file(file.path().to_str().unwrap()).unwrap();
+        assert!(std::path::Path::new(&path).exists());
+        fs::write(&path, b"{}").unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o000)).unwrap();
+
+        // make sure test executed without root privileges
+        if fs::File::open(&path).is_err() {
+            let result = NordVpnLiteConfig::from_file(&path);
+            assert_matches::assert_matches!(
+                result,
+                Err(NordVpnLiteError::Io(ref e)) if e.kind() == std::io::ErrorKind::PermissionDenied
+            );
+        }
+    }
+
+    #[test]
+    fn test_get_auth_file_reads_token() {
+        let auth_file = TempFile::new().expect("Failed to create temp auth file");
+        let auth_path = auth_file.path().to_str().unwrap().to_owned();
+        write_auth_file(&auth_path, VALID_TOKEN);
+
+        let config = config_with_auth_path(&auth_path);
+        let token = config
+            .get_auth_file()
+            .expect("get_auth_file should read a valid token");
+        assert_eq!(token.as_ref(), VALID_TOKEN);
+    }
+
+    #[test]
+    fn test_get_auth_file_errors_when_missing() {
+        let auth_file = TempFile::new().expect("Failed to create temp auth file");
+        let auth_path = auth_file.path().to_str().unwrap().to_owned();
+        drop(auth_file);
+
+        let config = config_with_auth_path(&auth_path);
+        assert_matches::assert_matches!(
+            config.get_auth_file(),
+            Err(NordVpnLiteError::Io(ref e)) if e.kind() == std::io::ErrorKind::NotFound
+        );
+    }
+
+    #[test]
+    fn test_from_existing_file_errors_when_missing() {
+        let file = TempFile::new().expect("Failed to create temp config file");
+        let path = file.path().to_owned();
+        drop(file);
+
+        assert_matches::assert_matches!(
+            NordVpnLiteConfig::from_existing_file(&path),
+            Err(NordVpnLiteError::Io(ref e)) if e.kind() == std::io::ErrorKind::NotFound
+        );
+    }
+
+    #[test]
+    fn test_resolve_relative_path_missing_parent() {
+        let config = config_json("does_not_exist_dir/relative.log", "./auth.json");
+        let file = temp_config(&config);
+        let err = NordVpnLiteConfig::from_file(file.path().to_str().unwrap()).unwrap_err();
+
+        assert_matches::assert_matches!(
+            err,
+            NordVpnLiteError::InvalidConfigOption { ref key, .. } if key == "log_file_path"
+        );
+    }
+
+    #[test]
+    fn test_resolve_absolute_path_missing_parent() {
+        let config = config_json("/nonexistent_dir_for_test/absolute.log", "./auth.json");
+        let file = temp_config(&config);
+        let err = NordVpnLiteConfig::from_file(file.path().to_str().unwrap()).unwrap_err();
+
+        assert_matches::assert_matches!(
+            err,
+            NordVpnLiteError::InvalidConfigOption { ref key, ref msg, .. }
+                if key == "log_file_path" && msg == "parent directory does not exist"
+        );
+    }
+
+    #[test]
+    fn test_deserialize_invalid_adapter_type() {
+        let json = r#"{
+            "log_level": "Info",
+            "log_file_path": "test.log",
+            "auth_file_path": "auth.json",
+            "adapter_type": "not-a-real-adapter",
+            "interface": {
+                "name": "nlx",
+                "config_provider": "manual"
+            }
+            }"#;
+
+        assert!(serde_json::from_str::<NordVpnLiteConfig>(json).is_err());
+    }
+
+    #[test]
+    fn test_deserialize_invalid_log_level() {
+        let json = r#"{
+            "log_level": "not-a-real-level",
+            "log_file_path": "test.log",
+            "auth_file_path": "auth.json",
+            "adapter_type": "neptun",
+            "interface": {
+                "name": "nlx",
+                "config_provider": "manual"
+            }
+            }"#;
+
+        assert!(serde_json::from_str::<NordVpnLiteConfig>(json).is_err());
+    }
+
+    #[test]
+    fn test_serialize_adapter_type_all_variants() {
+        fn serialized(adapter: AdapterType) -> String {
+            let config = NordVpnLiteConfig {
+                adapter_type: adapter,
+                ..Default::default()
+            };
+            let value: serde_json::Value =
+                serde_json::to_value(&config).expect("config should serialize");
+            value["adapter_type"].as_str().unwrap().to_owned()
+        }
+
+        assert_eq!(serialized(AdapterType::NepTUN), "neptun");
+        assert_eq!(serialized(AdapterType::LinuxNativeWg), "linux-native");
+        assert_eq!(serialized(AdapterType::WindowsNativeWg), "wireguard-nt");
+    }
+
+    #[test]
+    fn test_serialize_log_level() {
+        fn serialized(level: LevelFilter) -> String {
+            let config = NordVpnLiteConfig {
+                log_level: level,
+                ..Default::default()
+            };
+            let value: serde_json::Value =
+                serde_json::to_value(&config).expect("config should serialize");
+            value["log_level"].as_str().unwrap().to_owned()
+        }
+
+        assert_eq!(serialized(LevelFilter::INFO), "info");
+        assert_eq!(serialized(LevelFilter::TRACE), "trace");
+        assert_eq!(serialized(LevelFilter::OFF), "off");
+    }
+
+    #[test]
+    fn test_config_serde_all_fields() {
+        let json = r#"{
+            "log_level": "Debug",
+            "log_file_path": "/var/log/nordvpnlite.log",
+            "log_file_count": 3,
+            "auth_file_path": "/etc/nordvpnlite/auth.json",
+            "adapter_type": "neptun",
+            "interface": {
+                "name": "nlx",
+                "config_provider": "iproute",
+                "max_route_priority": 100
+            },
+            "vpn": {
+                "server": {
+                    "address": "127.0.0.1",
+                    "public_key": "urq6urq6urq6urq6urq6urq6urq6urq6urq6urq6uro=",
+                    "hostname": "de123.nordvpn.com"
+                }
+            },
+            "dns": ["1.1.1.1", "8.8.8.8"],
+            "override_default_wg_port": 51820,
+            "http_certificate_file_path": "/etc/nordvpnlite/cert.pem",
+            "enable_firewall": true
+            }"#;
+
+        let config: NordVpnLiteConfig = serde_json::from_str(json).unwrap();
+
+        // Verify the parsed non-default values.
+        assert_eq!(config.log_level, LevelFilter::DEBUG);
+        assert_eq!(config.log_file_count, 3);
+        assert_eq!(config.adapter_type, AdapterType::NepTUN);
+        assert_eq!(config.interface.max_route_priority, Some(100));
         assert_eq!(
-            config.authentication_token.as_ref(),
-            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+            config.interface.config_provider,
+            InterfaceConfigurationProvider::Iproute
+        );
+        assert_eq!(config.override_default_wg_port, Some(51820));
+        assert_eq!(
+            config.http_certificate_file_path,
+            Some(PathBuf::from("/etc/nordvpnlite/cert.pem"))
+        );
+        assert!(config.enable_firewall);
+        assert_matches::assert_matches!(
+            config.vpn,
+            VpnConfig::Server(Endpoint { hostname: Some(ref h), .. }) if h == "de123.nordvpn.com"
         );
 
-        std::env::remove_var("NORD_TOKEN");
+        // Round-trip: serialize and deserialize again, expecting an identical value.
+        let serialized = serde_json::to_string(&config).expect("config should serialize");
+        let deserialized: NordVpnLiteConfig =
+            serde_json::from_str(&serialized).expect("serialized config should deserialize");
+        assert_eq!(config, deserialized);
+    }
+
+    #[test]
+    #[serial]
+    fn test_check_auth_token_valid_auth_file() {
+        let _env = EnvVarHelper::unset(NORD_TOKEN_ENV);
+        let auth_file = TempFile::new().expect("Failed to create temp auth file");
+        let auth_path = auth_file.path().to_str().unwrap().to_owned();
+
+        let token = NordToken::new(VALID_TOKEN).expect("token should be valid");
+        NordVpnLiteAuth::new(token)
+            .to_file(&auth_path)
+            .expect("Failed to write auth file");
+
+        let config = config_with_auth_path(&auth_path);
+        config
+            .check_auth_token()
+            .expect("check_auth_token should succeed for a valid token file");
+    }
+
+    #[test]
+    #[serial]
+    fn test_check_auth_token_returns_login_hint() {
+        let _env = EnvVarHelper::unset(NORD_TOKEN_ENV);
+        let auth_file = TempFile::new().expect("Failed to create temp auth file");
+        let auth_path = auth_file.path().to_str().unwrap().to_owned();
+        drop(auth_file);
+
+        let config = config_with_auth_path(&auth_path);
+        assert_matches::assert_matches!(
+            config.check_auth_token(),
+            Err(NordVpnLiteError::InvalidConfigToken { msg })
+                if msg == "Please retrieve your authentication token from https://my.nordaccount.com \
+                           and use the following command to set it: `nordvpnlite login <your_token>` \
+                           (or `nordvpnlite login --token <your_token>`)."
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_check_auth_token_propagates_permission_error() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let _env = EnvVarHelper::unset(NORD_TOKEN_ENV);
+        let dir = std::env::temp_dir().join("nordvpnlite_auth_perms");
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("auth.json");
+        let token = NordToken::new(VALID_TOKEN).expect("token should be valid");
+        NordVpnLiteAuth::new(token)
+            .to_file(&path)
+            .expect("Failed to write auth file");
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o000)).unwrap();
+
+        // Only assert when running without privileges that bypass permissions.
+        if fs::File::open(&path).is_err() {
+            let config = config_with_auth_path(path.to_str().unwrap());
+            assert_matches::assert_matches!(
+                config.check_auth_token(),
+                Err(NordVpnLiteError::Io(ref e)) if e.kind() == std::io::ErrorKind::PermissionDenied
+            );
+        }
+
+        let _ = fs::set_permissions(&path, fs::Permissions::from_mode(0o600));
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    #[serial]
+    fn test_check_auth_token_propagates_corrupt_file_error() {
+        let _env = EnvVarHelper::unset(NORD_TOKEN_ENV);
+        let auth_file = TempFile::new()
+            .expect("Failed to create temp auth file")
+            .with_contents(b"{ this is not valid json")
+            .expect("Failed to write auth file");
+        let auth_path = auth_file.path().to_str().unwrap().to_owned();
+
+        let config = config_with_auth_path(&auth_path);
+        assert_matches::assert_matches!(
+            config.check_auth_token(),
+            Err(NordVpnLiteError::ParsingError(_))
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_check_auth_token_env_token() {
+        let _env = EnvVarHelper::set(NORD_TOKEN_ENV, VALID_TOKEN);
+        let auth_file = TempFile::new().expect("Failed to create temp auth file");
+        let auth_path = auth_file.path().to_str().unwrap().to_owned();
+        drop(auth_file);
+
+        let config = config_with_auth_path(&auth_path);
+        let result = config.check_auth_token();
+
+        result.expect("should succeed when env token is set");
+    }
+
+    #[test]
+    #[serial]
+    fn test_get_auth_env_returns_token_when_set() {
+        let _env = EnvVarHelper::set(NORD_TOKEN_ENV, VALID_TOKEN);
+        let token = NordVpnLiteConfig::get_auth_env();
+        assert_eq!(
+            token.expect("env token should resolve").as_ref(),
+            VALID_TOKEN
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_get_auth_env_returns_none_when_unset() {
+        let _env = EnvVarHelper::unset(NORD_TOKEN_ENV);
+        assert!(NordVpnLiteConfig::get_auth_env().is_none());
+    }
+
+    #[test]
+    #[serial]
+    fn test_get_auth_token_prefers_env_over_file() {
+        let _env = EnvVarHelper::set(NORD_TOKEN_ENV, OTHER_VALID_TOKEN);
+
+        let auth_file = TempFile::new().expect("Failed to create temp auth file");
+        let auth_path = auth_file.path().to_str().unwrap().to_owned();
+        write_auth_file(&auth_path, VALID_TOKEN);
+
+        let config = config_with_auth_path(&auth_path);
+        let token = config.get_auth_token();
+
+        assert_eq!(
+            token.expect("env token should be used").as_ref(),
+            OTHER_VALID_TOKEN
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_get_auth_token_falls_back_to_file() {
+        let _env = EnvVarHelper::unset(NORD_TOKEN_ENV);
+
+        let auth_file = TempFile::new().expect("Failed to create temp auth file");
+        let auth_path = auth_file.path().to_str().unwrap().to_owned();
+        write_auth_file(&auth_path, VALID_TOKEN);
+
+        let config = config_with_auth_path(&auth_path);
+        let token = config
+            .get_auth_token()
+            .expect("should fall back to the file");
+
+        assert_eq!(token.as_ref(), VALID_TOKEN);
+    }
+
+    #[test]
+    fn test_migrate_config_format() {
+        let config_json = format!(
+            r#"{{
+            "log_level": "Info",
+            "log_file_path": "test.log",
+            "adapter_type": "linux-native",
+            "interface": {{
+                "name": "utun10",
+                "config_provider": "manual"
+            }},
+            "vpn": "recommended",
+            "post_quantum": false,
+            "authentication_token": "{}"
+        }}"#,
+            VALID_TOKEN
+        );
+
+        let config_file = temp_config(&config_json);
+        let config_path = config_file.path().to_str().unwrap().to_owned();
+
+        let mut config: NordVpnLiteConfig =
+            NordVpnLiteConfig::from_existing_file(&config_path).expect("config should load");
+
+        config
+            .migrate_config_format(&config_path)
+            .expect("migration should succeed");
+        assert!(
+            config.authentication_token.is_none(),
+            "in-memory config should clear inline token after migration"
+        );
+
+        let migrated_auth = NordVpnLiteAuth::from_existing_file(&config.auth_file_path)
+            .expect("auth file should be created during migration");
+        assert_eq!(migrated_auth.get_token().as_ref(), VALID_TOKEN);
+
+        let migrated_config = NordVpnLiteConfig::from_existing_file(&config_path)
+            .expect("migrated config file should be readable");
+        assert!(
+            migrated_config.authentication_token.is_none(),
+            "migrated config should not contain inline auth token"
+        );
     }
 
     #[test]
     fn running_config_valid_file_loads_parsed_config() {
+        let auth_path = std::env::current_dir().unwrap().join("auth.json");
         let log_path = std::env::current_dir().unwrap().join("test.log");
         let json = format!(
             r#"{{
                 "log_level": "Info",
                 "log_file_path": "{}",
+                "auth_file_path": "{}",
                 "adapter_type": "linux-native",
-                "interface": {{ "name": "utun10", "config_provider": "manual" }},
-                "authentication_token": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+                "interface": {{ "name": "utun10", "config_provider": "manual" }}
             }}"#,
-            log_path.display()
+            log_path.display(),
+            auth_path.display()
         );
         let file = temp_config(&json);
 
@@ -825,7 +1244,7 @@ mod tests {
 
     #[test]
     fn running_config_valid_file_canonicalizes_path() {
-        let json = config_json_for_log("test.log");
+        let json = config_json("test.log", "auth.json");
         let file = temp_config(&json);
 
         let rc = RunningConfig::from_file(file.path()).unwrap();
@@ -839,7 +1258,7 @@ mod tests {
 
     #[test]
     fn running_config_valid_file_produces_nonzero_hash() {
-        let json = config_json_for_log("test.log");
+        let json = config_json("test.log", "auth.json");
         let file = temp_config(&json);
 
         let rc = RunningConfig::from_file(file.path()).unwrap();
@@ -849,7 +1268,7 @@ mod tests {
 
     #[test]
     fn running_config_same_content_produces_same_hash() {
-        let json = config_json_for_log("test.log");
+        let json = config_json("test.log", "auth.json");
 
         let file_a = temp_config(&json);
         let file_b = temp_config(&json);
@@ -865,8 +1284,8 @@ mod tests {
 
     #[test]
     fn running_config_different_content_produces_different_hash() {
-        let json_a = config_json_for_log("a.log");
-        let json_b: String = config_json_for_log("b.log");
+        let json_a = config_json("a.log", "auth.json");
+        let json_b: String = config_json("b.log", "auth.json");
 
         let file_a = temp_config(&json_a);
         let file_b = temp_config(&json_b);
@@ -898,12 +1317,8 @@ mod tests {
         let dir = temp_dir::TempDir::new().expect("failed to create temp dir");
         let nonexistent = dir.path().join("does_not_exist.json");
 
-        let err = RunningConfig::from_file(&nonexistent)
-            .expect_err("RunningConfig::from_file should fail when config file is missing");
-
-        assert!(
-            matches!(err, NordVpnLiteError::InvalidConfigToken { .. }),
-            "expected InvalidConfigToken when config file is absent, got: {err:?}"
+        RunningConfig::from_file(&nonexistent).expect(
+            "RunningConfig::from_file should create a default config file if it does not exist",
         );
 
         assert!(

--- a/clis/nordvpnlite/src/core_api.rs
+++ b/clis/nordvpnlite/src/core_api.rs
@@ -17,7 +17,8 @@ use telio_core::telio_utils::exponential_backoff::{
     Backoff, Error as BackoffError, ExponentialBackoff, ExponentialBackoffBounds,
 };
 
-use crate::config::{Endpoint, NordToken, NordVpnLiteConfig, NordlynxKeyResponse, VpnConfig};
+use crate::auth::{NordToken, NordlynxKeyResponse};
+use crate::config::{Endpoint, NordVpnLiteConfig, VpnConfig};
 use crate::NordVpnLiteError;
 use crate::{nordvpnlite_logstd_error, nordvpnlite_logstd_warn};
 

--- a/clis/nordvpnlite/src/daemon.rs
+++ b/clis/nordvpnlite/src/daemon.rs
@@ -361,7 +361,7 @@ async fn handle_exit_node_connection(config: &NordVpnLiteConfig, tx: mpsc::Sende
 /// Outcome of a single daemon run
 enum LoopOutcome {
     Exit,
-    /// Carries new confguration
+    /// Carries new configuration
     Reload(Box<RunningConfig>),
 }
 
@@ -379,7 +379,6 @@ pub async fn daemon_event_loop(
                     config.parsed.logging_params_changed(&new_config.parsed);
 
                 config = *new_config;
-                config.parsed.resolve_env_token();
 
                 if logging_configuration_changed {
                     if let Err(e) = logging::reload_logging(
@@ -404,7 +403,7 @@ pub async fn daemon_event_loop(
     Ok(())
 }
 
-async fn run_daemon(mut config: RunningConfig) -> Result<LoopOutcome, NordVpnLiteError> {
+async fn run_daemon(config: RunningConfig) -> Result<LoopOutcome, NordVpnLiteError> {
     debug!("started with config: {:?}", config.parsed);
 
     let mut signals = Signals::new([SIGHUP, SIGTERM, SIGINT, SIGQUIT])?;
@@ -415,8 +414,15 @@ async fn run_daemon(mut config: RunningConfig) -> Result<LoopOutcome, NordVpnLit
     let mut cmd_listener = CommandListener::new(socket, telio_tx.clone(), config.clone());
 
     let nordlynx_private_key = {
+        let auth_token =
+            config
+                .parsed
+                .get_auth_token()
+                .map_err(|e| NordVpnLiteError::InvalidConfigToken {
+                    msg: format!("Failed to get authentication token: {e}"),
+                })?;
         let api_request_future = request_nordlynx_key(
-            &config.parsed.authentication_token,
+            &auth_token,
             config.parsed.http_certificate_file_path.as_deref(),
         );
         pin_mut!(api_request_future);
@@ -451,8 +457,6 @@ async fn run_daemon(mut config: RunningConfig) -> Result<LoopOutcome, NordVpnLit
             };
         }
     };
-
-    config.parsed.authentication_token.zeroize();
 
     let config_clone = config.parsed.clone();
     let (init_done_tx, init_done_rx) = oneshot::channel::<()>();

--- a/clis/nordvpnlite/src/logging.rs
+++ b/clis/nordvpnlite/src/logging.rs
@@ -111,16 +111,16 @@ pub fn reload_logging<P: AsRef<Path>>(
 
 #[macro_export]
 macro_rules! nordvpnlite_logstd_warn {
-    ($($arg:tt)*) => {
+    ($($arg:tt)*) => {{
         ::tracing::warn!($($arg)*);
-        eprintln!("WARNING: {}", format_args!($($arg)*));
-    };
+        ::std::eprintln!("WARNING: {}", ::std::format_args!($($arg)*));
+    }};
 }
 
 #[macro_export]
 macro_rules! nordvpnlite_logstd_error {
-    ($($arg:tt)*) => {
+    ($($arg:tt)*) => {{
         ::tracing::error!($($arg)*);
-        eprintln!("ERROR: {}", format_args!($($arg)*));
-    };
+        ::std::eprintln!("ERROR: {}", ::std::format_args!($($arg)*));
+    }};
 }

--- a/clis/nordvpnlite/src/main.rs
+++ b/clis/nordvpnlite/src/main.rs
@@ -2,9 +2,10 @@
 
 use clap::Parser;
 use daemonize::{Daemonize, Outcome};
-use std::fs::OpenOptions;
+use std::fs::{self, OpenOptions};
 use tokio::time::{timeout, Duration};
 
+mod auth;
 mod command_listener;
 mod comms;
 mod config;
@@ -14,15 +15,19 @@ mod interface;
 mod logging;
 
 use crate::{
-    command_listener::{ClientCmd, Cmd, CommandResponse, TIMEOUT_SEC},
+    auth::{NordToken, NordVpnLiteAuth},
+    command_listener::{ClientCmd, Cmd, CommandResponse, LoginOpts, LogoutOpts, TIMEOUT_SEC},
     comms::DaemonSocket,
-    config::RunningConfig,
+    config::{NordVpnLiteConfig, RunningConfig},
     core_api::get_countries_with_exp_backoff,
     daemon::NordVpnLiteError,
 };
 
 /// Umask allows only rw-rw-r--
 const DEFAULT_UMASK: u32 = 0o113;
+
+/// Default permissions for created files.
+const DEFAULT_FILE_PERMISSIONS: u32 = 0o640;
 
 fn main() -> Result<(), NordVpnLiteError> {
     let mut cmd = Cmd::parse();
@@ -36,7 +41,14 @@ fn main() -> Result<(), NordVpnLiteError> {
 
         // Parse config file
         let mut config = RunningConfig::from_file(&opts.config_path)?;
-        config.parsed.resolve_env_token();
+
+        // Migrate config format if it contains an authentication token
+        config.migrate_config_format(&opts.config_path)?;
+
+        // Make sure authentication token is configured
+        // Could be provided via environment variable or auth file
+        // Environment variables have precedence over the auth file
+        config.parsed.check_auth_token()?;
 
         println!("Saving logs to: {}", config.parsed.log_file_path);
         println!("Starting daemon");
@@ -144,8 +156,394 @@ async fn client_main(cmd: Cmd) -> Result<(), NordVpnLiteError> {
             }
             Ok(())
         }
+        // Handle login command
+        Cmd::Login(opts) => handle_login(opts),
+        // Handle logout command
+        Cmd::Logout(opts) => handle_logout(opts),
 
         // Unexpected command, Cmd::Start should be handled by main
         _ => Err(NordVpnLiteError::InvalidCommand(format!("{cmd:?}"))),
+    }
+}
+
+/// Store NordVPN authentication credentials in the auth file.
+///
+/// The token is validated before the config is read, then written to the
+/// auth file, overwriting any previously stored credentials.
+fn handle_login(opts: LoginOpts) -> Result<(), NordVpnLiteError> {
+    println!("Storing NordVPN authentication credentials");
+
+    let token = NordToken::new(opts.token())?;
+
+    let config = NordVpnLiteConfig::from_file(&opts.config_path)?;
+    let auth_token = NordVpnLiteAuth::new(token);
+    auth_token.to_file(&config.auth_file_path)?;
+
+    println!("Authentication credentials stored successfully.");
+
+    Ok(())
+}
+
+/// Clear NordVPN authentication credentials file.
+///
+/// Loads the config and removes the auth file specified in the config.
+fn handle_logout(opts: LogoutOpts) -> Result<(), NordVpnLiteError> {
+    println!("Clearing NordVPN authentication credentials");
+
+    let config = NordVpnLiteConfig::from_existing_file(&opts.config_path)?;
+    println!("Removing auth from: {}", config.auth_file_path);
+    match fs::remove_file(&config.auth_file_path) {
+        Ok(()) => {
+            println!("Authentication credentials cleared successfully.");
+            Ok(())
+        }
+        // If there are no stored credentials, treat it as a no-op.
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            println!("No authentication credentials to clear.");
+            Ok(())
+        }
+        Err(err) => Err(err.into()),
+    }
+}
+
+/// Shared helpers and fixtures for unit tests across the crate.
+#[cfg(test)]
+pub mod test_utils {
+    use std::env;
+    use std::ffi::OsString;
+
+    use temp_file::TempFile;
+
+    use crate::auth::{NordToken, NordVpnLiteAuth};
+
+    /// The environment variable used to pass authentication token.
+    pub const NORD_TOKEN_ENV: &str = "NORD_TOKEN";
+
+    /// A syntactically valid token: 64 lowercase hex characters.
+    pub const VALID_TOKEN: &str =
+        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+    /// A second valid token, distinct from [`VALID_TOKEN`], used to verify token updates.
+    pub const OTHER_VALID_TOKEN: &str =
+        "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210";
+
+    /// Create a temp file with the given content.
+    pub fn temp_config(content: &str) -> TempFile {
+        TempFile::new()
+            .expect("Failed to create temp config file")
+            .with_contents(content.as_bytes())
+            .expect("Failed to write config file")
+    }
+
+    /// Build a config JSON string with the given log path, auth path, and `vpn` section.
+    pub fn build_json(log_path: &str, auth_path: &str, vpn: &str) -> String {
+        format!(
+            r#"{{
+                "log_level": "Info",
+                "log_file_path": "{log_path}",
+                "auth_file_path": "{auth_path}",
+                "adapter_type": "linux-native",
+                "interface": {{
+                    "name": "test",
+                    "config_provider": "manual"
+                }},
+                "vpn": {vpn}
+            }}"#
+        )
+    }
+
+    /// Write a valid auth file containing the given token at `path`.
+    pub fn write_auth_file(path: &str, token: &str) {
+        let token = NordToken::new(token).expect("token should be valid");
+        NordVpnLiteAuth::new(token)
+            .to_file(path)
+            .expect("Failed to write auth file");
+    }
+
+    /// RAII helper that mutates a process environment variable
+    /// for the duration of a test and restores its original state on drop.
+    #[must_use = "the environment is restored when the guard is dropped; bind it to a variable"]
+    pub struct EnvVarHelper {
+        key: OsString,
+        previous: Option<OsString>,
+    }
+
+    impl EnvVarHelper {
+        /// Set `key` to `value`, remembering the previous value for restoration.
+        pub fn set(key: &str, value: &str) -> Self {
+            let guard = Self {
+                key: key.into(),
+                previous: env::var_os(key),
+            };
+            env::set_var(key, value);
+            guard
+        }
+
+        /// Ensure `key` is unset, remembering the previous value for restoration.
+        pub fn unset(key: &str) -> Self {
+            let guard = Self {
+                key: key.into(),
+                previous: env::var_os(key),
+            };
+            env::remove_var(key);
+            guard
+        }
+    }
+
+    impl Drop for EnvVarHelper {
+        fn drop(&mut self) {
+            match self.previous.take() {
+                Some(value) => env::set_var(&self.key, value),
+                None => env::remove_var(&self.key),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::{
+        build_json, temp_config, write_auth_file, EnvVarHelper, NORD_TOKEN_ENV, OTHER_VALID_TOKEN,
+        VALID_TOKEN,
+    };
+    use assert_matches::assert_matches;
+    use serial_test::serial;
+    use temp_file::TempFile;
+
+    /// Config JSON pointing its auth file at the given path.
+    fn config_json(auth_file_path: &str) -> String {
+        build_json("test.log", auth_file_path, "\"recommended\"")
+    }
+
+    /// Create a temp file to be used as the auth file and return its path.
+    /// The file is removed so initially it does not exist.
+    fn non_exist_auth_path() -> String {
+        let file = TempFile::new().expect("Failed to create temp auth file");
+        let path = file.path().to_str().unwrap().to_owned();
+        drop(file);
+        path
+    }
+
+    /// Create a temp file to be used as the config file and return its path.
+    /// The file is removed so initially it does not exist.
+    fn non_exist_config_path() -> String {
+        let file = temp_config(&config_json(&non_exist_auth_path()));
+        let path = file.path().to_str().unwrap().to_owned();
+        drop(file);
+        path
+    }
+
+    /// Read the config at the given path
+    fn read_config(path: &str) -> NordVpnLiteConfig {
+        NordVpnLiteConfig::from_existing_file(path).expect("Failed to read config back")
+    }
+
+    /// Assert that the config at the given path has no valid auth token.
+    macro_rules! assert_no_auth_token {
+        ($path:expr) => {
+            assert_matches!(
+                read_config($path).check_auth_token(),
+                Err(NordVpnLiteError::InvalidConfigToken { .. })
+            );
+        };
+    }
+
+    #[test]
+    fn test_logout_fails_with_no_config_file() {
+        let path = non_exist_config_path();
+
+        // no config file present initially
+        assert!(!std::path::Path::new(&path).exists());
+
+        let result = handle_logout(LogoutOpts {
+            config_path: path.clone(),
+        });
+
+        // should fail with a NotFound IO error
+        assert_matches!(
+            result,
+            Err(NordVpnLiteError::Io(ref e)) if e.kind() == std::io::ErrorKind::NotFound
+        );
+
+        // config file should not be created
+        assert!(!std::path::Path::new(&path).exists());
+    }
+
+    #[test]
+    #[serial]
+    fn test_login_creates_default_config_file() {
+        let _env = EnvVarHelper::unset(NORD_TOKEN_ENV);
+        let path = non_exist_config_path();
+
+        // no config file present initially
+        assert!(!std::path::Path::new(&path).exists());
+
+        handle_login(LoginOpts {
+            config_path: path.clone(),
+            token: Some(VALID_TOKEN.to_owned()),
+            token_positional: None,
+        })
+        .expect("login should succeed");
+
+        // config file should be created
+        assert!(std::path::Path::new(&path).exists());
+
+        // auth file created, token stored
+        let stored = read_config(&path)
+            .get_auth_token()
+            .expect("token should be stored after login");
+        assert_eq!(stored.as_ref(), VALID_TOKEN);
+    }
+
+    #[test]
+    #[serial]
+    fn test_login_creates_auth_file() {
+        let _env = EnvVarHelper::unset(NORD_TOKEN_ENV);
+        let auth_path = non_exist_auth_path();
+        let file = temp_config(&config_json(&auth_path));
+        let path = file.path().to_str().unwrap().to_owned();
+
+        // no auth file present initially
+        assert_no_auth_token!(&path);
+
+        handle_login(LoginOpts {
+            config_path: path.clone(),
+            token: Some(VALID_TOKEN.to_owned()),
+            token_positional: None,
+        })
+        .expect("login should succeed with a valid token");
+
+        // auth file created, token stored
+        let stored = read_config(&path)
+            .get_auth_token()
+            .expect("token should be stored after login");
+        assert_eq!(stored.as_ref(), VALID_TOKEN);
+    }
+
+    #[test]
+    #[serial]
+    fn test_login_updates_auth_file() {
+        let _env = EnvVarHelper::unset(NORD_TOKEN_ENV);
+        let auth_path = non_exist_auth_path();
+        write_auth_file(&auth_path, VALID_TOKEN);
+        let file = temp_config(&config_json(&auth_path));
+        let path = file.path().to_str().unwrap().to_owned();
+
+        // auth file present, initial token stored
+        let stored = read_config(&path)
+            .get_auth_token()
+            .expect("token should be stored after login");
+        assert_eq!(stored.as_ref(), VALID_TOKEN);
+
+        handle_login(LoginOpts {
+            config_path: path.clone(),
+            token: Some(OTHER_VALID_TOKEN.to_owned()),
+            token_positional: None,
+        })
+        .expect("login should succeed and overwrite the existing token");
+
+        // auth file present, new token stored
+        let stored = read_config(&path)
+            .get_auth_token()
+            .expect("new token should be stored after second login");
+        assert_eq!(stored.as_ref(), OTHER_VALID_TOKEN);
+    }
+
+    #[test]
+    #[serial]
+    fn test_login_rejects_invalid_token() {
+        let _env = EnvVarHelper::unset(NORD_TOKEN_ENV);
+        let auth_path = non_exist_auth_path();
+        let file = temp_config(&config_json(&auth_path));
+        let path = file.path().to_str().unwrap().to_owned();
+
+        // no auth file present initially
+        assert_no_auth_token!(&path);
+
+        let result = handle_login(LoginOpts {
+            config_path: path.clone(),
+            token: Some("not-a-valid-token".to_owned()),
+            token_positional: None,
+        });
+
+        // login should fail and the auth file should not be created
+        assert_matches!(result, Err(NordVpnLiteError::InvalidConfigToken { .. }));
+        assert_no_auth_token!(&path);
+    }
+
+    #[test]
+    #[serial]
+    fn test_logout_removes_auth_file() {
+        let _env = EnvVarHelper::unset(NORD_TOKEN_ENV);
+        let auth_path = non_exist_auth_path();
+        write_auth_file(&auth_path, VALID_TOKEN);
+        let file = temp_config(&config_json(&auth_path));
+        let path = file.path().to_str().unwrap().to_owned();
+
+        // auth file present, token stored
+        assert!(read_config(&path).check_auth_token().is_ok());
+
+        handle_logout(LogoutOpts {
+            config_path: path.clone(),
+        })
+        .expect("logout should succeed when auth file is present");
+
+        // auth file should be removed
+        assert_no_auth_token!(&path);
+    }
+
+    #[test]
+    #[serial]
+    fn test_login_then_logout_roundtrip() {
+        let _env = EnvVarHelper::unset(NORD_TOKEN_ENV);
+        let auth_path = non_exist_auth_path();
+        let file = temp_config(&config_json(&auth_path));
+        let path = file.path().to_str().unwrap().to_owned();
+
+        // no auth file present initially
+        assert_no_auth_token!(&path);
+
+        handle_login(LoginOpts {
+            config_path: path.clone(),
+            token: Some(VALID_TOKEN.to_owned()),
+            token_positional: None,
+        })
+        .expect("login should succeed");
+
+        // auth file created, token stored
+        let stored = read_config(&path)
+            .get_auth_token()
+            .expect("token should be stored after login");
+        assert_eq!(stored.as_ref(), VALID_TOKEN);
+
+        handle_logout(LogoutOpts {
+            config_path: path.clone(),
+        })
+        .expect("logout should succeed");
+
+        // auth file removed
+        assert_no_auth_token!(&path);
+
+        handle_login(LoginOpts {
+            config_path: path.clone(),
+            token: Some(OTHER_VALID_TOKEN.to_owned()),
+            token_positional: None,
+        })
+        .expect("login should succeed");
+
+        // auth file re-created, new token stored
+        let stored = read_config(&path)
+            .get_auth_token()
+            .expect("token should be stored after login");
+        assert_eq!(stored.as_ref(), OTHER_VALID_TOKEN);
+
+        handle_logout(LogoutOpts {
+            config_path: path.clone(),
+        })
+        .expect("logout should succeed");
+
+        // auth file removed
+        assert_no_auth_token!(&path);
     }
 }

--- a/nat-lab/tests/nordvpnlite.py
+++ b/nat-lab/tests/nordvpnlite.py
@@ -1,4 +1,5 @@
 import asyncio
+import copy
 import json
 import os
 import re
@@ -65,12 +66,12 @@ class InterfaceConfig:
 
 @dataclass
 class NordVpnLiteConfig:
-    authentication_token: str = CORE_API_CREDENTIALS["password"]
     vpn: Optional[VPNConfig] = None
     log_level: str = "debug"
     log_file_path: str = "/var/log/nordvpnlite_natlab.log"
     log_file_count: int = 0
     adapter_type: str = "neptun"
+    auth_file_path: str = "/run/auth.json"
     http_certificate_file_path: str = "/etc/ssl/server_certificate/test.pem"
     interface: InterfaceConfig = field(default_factory=InterfaceConfig)
     override_default_wg_port: int = 1023
@@ -151,45 +152,59 @@ class Paths:
     def lib_log(self) -> Path:
         return self.log_dir / "nordvpnlite_natlab.log"
 
+    @property
+    def auth_file(self) -> Path:
+        return self.run_dir / "auth.json"
+
 
 class Config:
     def __init__(
         self,
         config_data: NordVpnLiteConfig,
         config_path: Optional[Path] = None,
+        auth_path: Optional[Path] = None,
         config_name: ConfigPresetName = ConfigPresetName.DEFAULT,
         no_detach: bool = False,
         paths=Paths(),
     ):
         self.paths: Paths = paths
         self.config_path: Path = config_path or Path(f"/tmp/{config_name.value}")
+        self.auth_path: Path = auth_path or self.paths.auth_file
         self.config_name: ConfigPresetName = config_name
-        self.config_data: NordVpnLiteConfig = config_data
+        self.config_data: NordVpnLiteConfig = copy.deepcopy(config_data)
+        self.config_data.auth_file_path = str(self.auth_path)
         self.no_detach: bool = no_detach
 
     async def assert_match_daemon_start(
         self,
         stdout: str,
-    ) -> tuple[Path, Path]:
+    ) -> tuple[Path, Path, Path]:
         assert (
             "Starting daemon" in stdout
         ), f"Could not find 'Starting daemon' in: '{stdout}'"
 
-        config_match = re.search(r"Reading config from:\s*(.+.json)", stdout)
+        config_match = re.search(r"Reading config from:\s*(\S+\.json)", stdout)
         assert config_match, f"Could not find config path in: {stdout}"
-        stdout_config_path = Path(config_match.group(1).strip())
+        config_path = Path(config_match.group(1).strip())
         assert (
-            stdout_config_path == self.config_path
-        ), f"Config path does not match: '{stdout_config_path}' != '{self.config_path}'"
+            config_path == self.config_path
+        ), f"Config path does not match: '{config_path}' != '{self.config_path}'"
 
-        log_match = re.search(r"Saving logs to:\s*(.+\.log)", stdout)
+        auth_match = re.search(r"Reading auth from:\s*(\S+\.json)", stdout)
+        assert auth_match, f"Could not find auth path in: {stdout}"
+        auth_path = Path(auth_match.group(1).strip())
+        assert (
+            auth_path == self.auth_path
+        ), f"Auth path does not match: '{auth_path}' != '{self.auth_path}'"
+
+        log_match = re.search(r"Saving logs to:\s*(\S+\.log)", stdout)
         assert log_match, f"Could not find log path in: {stdout}"
         log_path = Path(log_match.group(1).strip())
         assert (
             log_path == self.paths.lib_log
         ), f"Log path does not match: '{log_path}' != '{self.paths.lib_log}'"
 
-        return stdout_config_path, log_path
+        return config_path, auth_path, log_path
 
 
 class NordVpnLite:
@@ -240,9 +255,11 @@ class NordVpnLite:
         content = json.dumps(self.config.config_data.to_dict(), indent=2)
         remote_path = str(self.config.config_path)
         safe_content = content.replace("EOF", "EO_F")
+        auth_dir = str(Path(self.config.config_data.auth_file_path).parent)
         cmd = [
             "sh",
             "-c",
+            f"mkdir -p {auth_dir}\n"
             f"cat <<'EOF' > {remote_path}\n{safe_content}\nEOF\n",
         ]
         await self.connection.create_process(cmd).execute()
@@ -271,7 +288,7 @@ class NordVpnLite:
         except ProcessExecError as exc:
             time_took = time.time() - start_time
             log.debug("Command: [%s] took %.3f seconds", cmd, time_took)
-            log.debug("Exception occured while executing nordvpnlite command: %s", exc)
+            log.debug("Exception occurred while executing nordvpnlite command: %s", exc)
             raise
 
     async def run_command(
@@ -290,6 +307,7 @@ class NordVpnLite:
         try:
             await self.remove_logs()
             await self.save_config()
+            await self.login()
 
             cmd = ["start"]
             if not self.config.no_detach:
@@ -344,6 +362,34 @@ class NordVpnLite:
             if "Error: DaemonIsNotRunning" in exc.stderr:
                 return False
             raise exc
+
+    async def login(self) -> bool:
+        log.info("NordVPN Lite login: storing credentials")
+        try:
+            cmd = ["login"]
+            cmd.append("--token")
+            cmd.append(CORE_API_CREDENTIALS["password"])
+            cmd.append("--config-file")
+            cmd.append(str(self.config.config_path))
+            stdout, _ = await self.execute_command(cmd)
+            return "Authentication credentials stored successfully" in stdout
+        except ProcessExecError as exc:
+            raise exc
+
+    async def logout(self) -> bool:
+        log.info("NordVPN Lite logout: clearing credentials")
+        try:
+            cmd = ["logout"]
+            cmd.append("--config-file")
+            cmd.append(str(self.config.config_path))
+            stdout, _ = await self.execute_command(cmd)
+            if "Authentication credentials cleared successfully" in stdout:
+                return True
+            if "No authentication credentials to clear" in stdout:
+                return True
+            return False
+        except ProcessExecError as exc:
+            raise IgnoreableError() from exc
 
     async def get_status(self) -> str:
         try:

--- a/nat-lab/tests/test_nordvpnlite.py
+++ b/nat-lab/tests/test_nordvpnlite.py
@@ -257,7 +257,7 @@ async def test_nordvpnlite_config_created(
             pytest.fail("Start should not succeed with default config")
         except ProcessExecError as exc:
             assert str(config_path) in exc.stdout, "Config path not mentioned in stdout"
-            assert "creating default config" in exc.stderr
+            assert "creating default config" in exc.stdout
             assert "InvalidConfigToken" in exc.stderr
             assert await nordvpnlite.config_exists(
                 config_path

--- a/nat-lab/tests/test_openwrt.py
+++ b/nat-lab/tests/test_openwrt.py
@@ -205,6 +205,7 @@ async def setup_openwrt_test_environment(
     country_config: ConfigPresetName,
     exit_stack: AsyncExitStack,
     config_path: Optional[Path] = None,
+    auth_path: Optional[Path] = None,
     client_tag: ConnectionTag = ConnectionTag.DOCKER_OPENWRT_CLIENT_1,
     gw_tag: ConnectionTag = ConnectionTag.VM_OPENWRT_GW_1,
 ) -> tuple[Connection, Connection, NordVpnLite]:
@@ -248,6 +249,7 @@ async def setup_openwrt_test_environment(
     config = Config(
         CONFIG_PRESETS[country_config],
         config_path,
+        auth_path,
         country_config,
         paths=paths,
     )
@@ -660,6 +662,7 @@ async def test_openwrt_router_restart(
                     ConfigPresetName.VPN_OPENWRT_UCI_PL,
                     exit_stack,
                     config_path=Path("/etc/nordvpnlite/config.json"),
+                    auth_path=Path("/etc/nordvpnlite/auth.json"),
                     client_tag=client_tag,
                     gw_tag=gw_tag,
                 )

--- a/nat-lab/tests/ui/test_openwrt_ui.py
+++ b/nat-lab/tests/ui/test_openwrt_ui.py
@@ -29,10 +29,8 @@ async def test_nordvpnlite_settings_required_fields(
     """
     Steps:
     1. Log into LuCI and open the NordVPN Lite settings page.
-    2. Assert the Authentication Token field is visible.
-    3. Assert the Country Code field is visible.
+    2. Assert the Country Code field is visible.
     """
-    await expect(nordvpnlite_settings.token).to_be_visible()
     await expect(nordvpnlite_settings.vpn).to_be_visible()
 
 

--- a/nat-lab/tests/utils/luci/nordvpnlite_page.py
+++ b/nat-lab/tests/utils/luci/nordvpnlite_page.py
@@ -8,7 +8,7 @@ class NordVpnLiteSettingsPage(LuciPage):
 
     def __init__(self, page: Page, base_url: str):
         super().__init__(page, base_url)
-        self.token = cbi_input(page, "config", "authentication_token")
+        self.token = cbi_input(page, "auth", "authentication_token")
         self.vpn = cbi_input(page, "config", "vpn")
         self.save_button = cbi_button_save(page)
 


### PR DESCRIPTION
### Problem
The authentication token is stored as part of the `nordvpnlite` configuration.
The user must know where this file is located and edit it before launching the daemon.
Daemon can't start with the default config until it will be manually updated.

### Solution
Authentication token removed from the general config and stored in a separate file.
Added `login` and `logout` commands to store credentials similar to NordVPN Linux application. 
Keep support for passing the token via environment variables.
Produced default config file require no manual updates.
Previous config supported and will be automatically migrated during at first daemon `start`.

This solution provides the groundwork for the following improvements to store secrets in a secure location - SR-WR2-104.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
