### PR TITLE
LLT-6304 Check meshnet status, before doing dynamic wg nt control

### DIFF
--- a/.unreleased/LLT-6304_check_meshnet_in_dynamic_wgnt_control
+++ b/.unreleased/LLT-6304_check_meshnet_in_dynamic_wgnt_control
@@ -1,0 +1,1 @@
+Check, whether the meshnet is enabled, before making control decision in wg-nt dynamic mode.

--- a/crates/telio-core/src/device.rs
+++ b/crates/telio-core/src/device.rs
@@ -340,6 +340,9 @@ pub struct Entities {
     // Wireguard interface
     wireguard_interface: Arc<DynamicWg>,
 
+    // Shared meshnet status for WireGuard callbacks
+    meshnet_on: Arc<Mutex<bool>>,
+
     // Internal DNS server
     dns: Arc<Mutex<DNS>>,
 
@@ -1229,7 +1232,14 @@ impl Runtime {
         #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
         set_tunnel_interface(&socket_pool, config.tun.as_ref(), config.name.as_ref());
 
+        let meshnet_on = Arc::new(Mutex::new(false));
+
         let requested_device_config = RequestedDeviceConfig::from(&config);
+
+        let enable_dynamic_wg_nt_control = features
+            .wireguard
+            .enable_dynamic_wg_nt_control
+            .then(|| meshnet_on_checker(meshnet_on.clone()));
 
         // tests runtime use wg::MockedAdapter
         cfg_if! {
@@ -1253,7 +1263,7 @@ impl Runtime {
                         firewall_process_inbound_callback,
                         firewall_process_outbound_callback,
                         firewall_reset_connections,
-                        enable_dynamic_wg_nt_control: features.wireguard.enable_dynamic_wg_nt_control,
+                        enable_dynamic_wg_nt_control,
                         skt_buffer_size : Runtime::sanitize_neptun_config(features.wireguard.skt_buffer_size, config.adapter.clone()),
                         inter_thread_channel_size : Runtime::sanitize_neptun_config(features.wireguard.inter_thread_channel_size, config.adapter.clone()),
                         max_inter_thread_batched_pkts : Runtime::sanitize_neptun_config(features.wireguard.max_inter_thread_batched_pkts, config.adapter.clone()),
@@ -1278,7 +1288,7 @@ impl Runtime {
                             firewall_process_inbound_callback,
                             firewall_process_outbound_callback,
                             firewall_reset_connections,
-                            enable_dynamic_wg_nt_control: features.wireguard.enable_dynamic_wg_nt_control,
+                            enable_dynamic_wg_nt_control,
                             skt_buffer_size: features.wireguard.skt_buffer_size,
                             inter_thread_channel_size: features.wireguard.inter_thread_channel_size,
                             max_inter_thread_batched_pkts: features.wireguard.max_inter_thread_batched_pkts,
@@ -1355,6 +1365,8 @@ impl Runtime {
             ..Default::default()
         };
 
+        *meshnet_on.lock().await = requested_state.meshnet_config.is_some();
+
         let dns = Arc::new(Mutex::new(DNS {
             resolver: None,
             #[cfg(unix)]
@@ -1396,6 +1408,7 @@ impl Runtime {
             requested_state,
             entities: Entities {
                 wireguard_interface: wireguard_interface.clone(),
+                meshnet_on,
                 dns,
                 #[cfg(feature = "enable_firewall")]
                 firewall,
@@ -1947,6 +1960,7 @@ impl Runtime {
 
         self.requested_state.old_meshnet_config = self.requested_state.meshnet_config.clone();
         self.requested_state.meshnet_config = config.clone();
+        *self.entities.meshnet_on.lock().await = self.requested_state.meshnet_config.is_some();
 
         let wg_itf = self.entities.wireguard_interface.get_interface().await?;
         let secret_key = if let Some(secret_key) = wg_itf.private_key {
@@ -1961,6 +1975,7 @@ impl Runtime {
             .iter()
             .map(|p| p.base.public_key)
             .collect();
+        let peers_cnt = peers.len();
 
         // Update for proxy and derp config
         if let Some(config) = config {
@@ -2138,6 +2153,22 @@ impl Runtime {
             if tx.send(Box::new(event)).is_err() {
                 telio_log_warn!("Failed to send MeshConfigUpdateEvent to nurse component");
             }
+        }
+
+        // Check, if we have to toggle the wg-nt adapter
+        if let Err(err) = self
+            .entities
+            .wireguard_interface
+            .ensure_expected_adapter_state(
+                peers_cnt,
+                self.features
+                    .wireguard
+                    .enable_dynamic_wg_nt_control
+                    .then(|| meshnet_on_checker(self.entities.meshnet_on.clone())),
+            )
+            .await
+        {
+            telio_log_debug!("Failed to ensure adapter state: {}", err);
         }
 
         Ok(())
@@ -2871,6 +2902,10 @@ fn fd_to_if_index(tun_fd: i32) -> Option<u64> {
             None
         }
     }
+}
+
+fn meshnet_on_checker(meshnet_on: Arc<Mutex<bool>>) -> Arc<dyn Fn() -> bool + Send + Sync> {
+    Arc::new(move || meshnet_on.try_lock().map(|value| *value).unwrap_or(false))
 }
 
 fn node_from_exit_node(exit_node: &ExitNode) -> Node {

--- a/crates/telio-wg/src/adapter.rs
+++ b/crates/telio-wg/src/adapter.rs
@@ -41,6 +41,9 @@ pub type FirewallOutboundCb =
 /// Function pointer for reseting all the connections
 pub type FirewallResetConnsCb = Option<Arc<dyn Fn(&PublicKey, &mut dyn io::Write) + Send + Sync>>;
 
+/// Function pointer for checking, whether the meshnet is enabled
+pub type IsMeshnetEnabledCb = Option<Arc<dyn Fn() -> bool + Send + Sync>>;
+
 /// Tunnel file descriptor
 #[cfg(not(target_os = "windows"))]
 #[cfg_attr(docsrs, doc(cfg(not(windows))))]
@@ -93,6 +96,15 @@ pub trait Adapter: Send + Sync {
     ///
     /// Only the custom adapters can be cloned this way.
     fn clone_box(&self) -> Option<Box<dyn Adapter>>;
+
+    /// Ensure that adapter is UP or DOWN
+    async fn ensure_expected_adapter_state(
+        &self,
+        _peers_cnt: usize,
+        _is_meshnet_on: IsMeshnetEnabledCb,
+    ) -> Result<(), Error> {
+        Ok(())
+    }
 }
 
 /// Enumeration of `Error` types for `Adapter` struct

--- a/crates/telio-wg/src/adapter/windows_native_wg.rs
+++ b/crates/telio-wg/src/adapter/windows_native_wg.rs
@@ -1,4 +1,4 @@
-use super::{Adapter, Error as AdapterError, Tun as NativeTun};
+use super::{Adapter, Error as AdapterError, IsMeshnetEnabledCb, Tun as NativeTun};
 use crate::{
     uapi::{Cmd, Cmd::Get, Cmd::Set, Interface, Peer, Response},
     windows::{service, tunnel::interfacewatcher::InterfaceWatcher},
@@ -53,8 +53,8 @@ pub struct WindowsNativeWg {
     cleaned_up: Arc<Mutex<bool>>,
     watcher: Arc<Mutex<InterfaceWatcher>>,
 
-    /// Configurable up/down behavior of WireGuard-NT adapter. See RFC LLT-0089 for details
-    enable_dynamic_wg_nt_control: bool,
+    /// Optional callback for dynamic WireGuard-NT behavior.
+    enable_dynamic_wg_nt_control: IsMeshnetEnabledCb,
 }
 
 /// Error type implementation for wg-nt
@@ -77,7 +77,7 @@ impl WindowsNativeWg {
         adapter: &Arc<wireguard_nt::Adapter>,
         luid: u64,
         watcher: &Arc<Mutex<InterfaceWatcher>>,
-        enable_dynamic_wg_nt_control: bool,
+        enable_dynamic_wg_nt_control: IsMeshnetEnabledCb,
     ) -> Self {
         Self {
             adapter: adapter.clone(),
@@ -110,14 +110,14 @@ impl WindowsNativeWg {
     fn create(
         name: &str,
         path: &str,
-        enable_dynamic_wg_nt_control: bool,
+        enable_dynamic_wg_nt_control: IsMeshnetEnabledCb,
     ) -> std::result::Result<Self, AdapterError> {
         // try to load dll
         match unsafe { wireguard_nt::load_from_path(path) } {
             Ok(wg_dll) => {
                 // Someone to watch over me while I sleep
                 let watcher = Arc::new(Mutex::new(InterfaceWatcher::new(
-                    enable_dynamic_wg_nt_control,
+                    enable_dynamic_wg_nt_control.clone(),
                 )));
                 if let Ok(mut watcher) = watcher.lock() {
                     if let Err(monitoring_err) = watcher.start_monitoring() {
@@ -326,7 +326,7 @@ impl WindowsNativeWg {
     ///
     pub async fn start(
         name: &str,
-        enable_dynamic_wg_nt_control: bool,
+        enable_dynamic_wg_nt_control: IsMeshnetEnabledCb,
     ) -> std::result::Result<Self, AdapterError> {
         const SWD_WIREGUARD: &str = r"SYSTEM\CurrentControlSet\Enum\SWD\WireGuard";
         telio_log_debug!("Print registry before adapter creation!");
@@ -338,7 +338,7 @@ impl WindowsNativeWg {
         Self::cleanup_orphaned_devices().await;
 
         let dll_path = "wireguard.dll";
-        let tmp_wg_dev = Self::create(name, dll_path, enable_dynamic_wg_nt_control);
+        let tmp_wg_dev = Self::create(name, dll_path, enable_dynamic_wg_nt_control.clone());
 
         telio_log_debug!("Print registry after adapter creation!");
         Self::print_registry_key_contents(HKEY_LOCAL_MACHINE, service::GUID_DEVINTERFACE_NET_STR);
@@ -348,7 +348,7 @@ impl WindowsNativeWg {
         telio_log_info!(
             "Adapter '{}' using created successfully. enable_dynamic_wg_nt_control: {}",
             name,
-            enable_dynamic_wg_nt_control
+            enable_dynamic_wg_nt_control.is_some()
         );
         if !service::wait_for_service("WireGuard", service::DEFAULT_SERVICE_WAIT_TIMEOUT) {
             return Err(AdapterError::WindowsNativeWg(Error::Fail(
@@ -377,7 +377,7 @@ impl WindowsNativeWg {
             )));
         }
 
-        if !wg_dev.enable_dynamic_wg_nt_control {
+        if wg_dev.enable_dynamic_wg_nt_control.is_none() {
             wg_dev.ensure_adapter_state(AdapterState::Up).await?;
         }
 
@@ -452,7 +452,7 @@ impl WindowsNativeWg {
                 "Attempting to bring interface {:?}, currently it is: {:?}, enable_dynamic_wg_nt_control: {:?}",
                 want_adapter_state,
                 have_adapter_state,
-                self.enable_dynamic_wg_nt_control
+                self.enable_dynamic_wg_nt_control.is_some()
             );
 
             // The wireguard-nt-rust-wrapper here indicates success using
@@ -554,10 +554,12 @@ impl Adapter for WindowsNativeWg {
         match cmd {
             Get => Ok(self.get_config_uapi()),
             Set(set_cfg) => {
-                // If we have any peers added -> bring the adapter up
-                if self.enable_dynamic_wg_nt_control && !set_cfg.peers.is_empty() {
-                    self.ensure_adapter_state(AdapterState::Up).await?;
-                }
+                // If we have any peers added OR have meshnet enabled -> bring the adapter up
+                self.ensure_expected_adapter_state(
+                    set_cfg.peers.len(),
+                    self.enable_dynamic_wg_nt_control.clone(),
+                )
+                .await?;
 
                 let (resp, peer_cnt) = match self.adapter.set_config_uapi(set_cfg) {
                     Ok(()) => {
@@ -581,19 +583,12 @@ impl Adapter for WindowsNativeWg {
                     ),
                 };
 
-                // If all of the peers has been removed -> bring the adapter down
-                if self.enable_dynamic_wg_nt_control && peer_cnt.map(|p| p == 0).unwrap_or(false) {
-                    self.ensure_adapter_state(AdapterState::Down).await?;
-                    // The driver retains the previously bound port across Down and would
-                    // re-bind it on the next Up; reset it so a fresh ephemeral port is chosen
-                    let reset_port = xplatform::set::Device {
-                        listen_port: Some(0),
-                        ..Default::default()
-                    };
-                    if let Err(err) = self.adapter.set_config_uapi(&reset_port) {
-                        telio_log_warn!("Failed to reset listen port after adapter down: {err}");
-                    }
-                }
+                // If all of the peers has been removed and meshnet is disabled -> bring the adapter down
+                self.ensure_expected_adapter_state(
+                    peer_cnt.unwrap_or(0),
+                    self.enable_dynamic_wg_nt_control.clone(),
+                )
+                .await?;
 
                 resp
             }
@@ -623,6 +618,36 @@ impl Adapter for WindowsNativeWg {
 
     fn clone_box(&self) -> Option<Box<dyn Adapter>> {
         None
+    }
+
+    async fn ensure_expected_adapter_state(
+        &self,
+        peers_cnt: usize,
+        is_meshnet_on: IsMeshnetEnabledCb,
+    ) -> std::result::Result<(), AdapterError> {
+        let meshnet_on = is_meshnet_on
+            .as_ref()
+            .is_some_and(|is_meshnet_on_cb| is_meshnet_on_cb());
+        let has_peers = peers_cnt > 0;
+
+        // We have dynamic control on, so let's take some control decision
+        if is_meshnet_on.is_some() {
+            if !meshnet_on && !has_peers {
+                self.ensure_adapter_state(AdapterState::Down).await?;
+
+                let reset_port = xplatform::set::Device {
+                    listen_port: Some(0),
+                    ..Default::default()
+                };
+                if let Err(err) = self.adapter.set_config_uapi(&reset_port) {
+                    telio_log_warn!("Failed to reset listen port after adapter down: {err}");
+                }
+            } else {
+                self.ensure_adapter_state(AdapterState::Up).await?;
+            }
+        }
+
+        Ok(())
     }
 }
 

--- a/crates/telio-wg/src/wg.rs
+++ b/crates/telio-wg/src/wg.rs
@@ -32,7 +32,7 @@ use telio_task::{
 };
 
 use crate::{
-    adapter::{self, Adapter, AdapterType, Error, FirewallResetConnsCb, Tun},
+    adapter::{self, Adapter, AdapterType, Error, FirewallResetConnsCb, IsMeshnetEnabledCb, Tun},
     link_detection::{self, LinkDetection, LinkDetectionUpdateResult},
     uapi::{self, AnalyticsEvent, Cmd, Event, Interface, Peer, PeerState, Response, UpdateReason},
     FirewallInboundCb, FirewallOutboundCb,
@@ -77,6 +77,14 @@ pub trait WireGuard: Send + Sync + 'static {
     async fn reset_existing_connections(&self, exit_pubkey: PublicKey) -> Result<(), Error>;
     /// Set the ip stack for the adapter
     async fn set_ip_stack(&self, ip_stack: Option<IpStack>) -> Result<(), Error>;
+    /// Ensure that adapter is UP or DOWN
+    async fn ensure_expected_adapter_state(
+        &self,
+        _peers_cnt: usize,
+        _is_meshnet_on: IsMeshnetEnabledCb,
+    ) -> Result<(), Error> {
+        Ok(())
+    }
 }
 
 /// WireGuard implementation allowing dynamic selection of implementation.
@@ -101,8 +109,10 @@ pub struct Config {
     /// Callback of firewall to create connection reset packets
     /// for all active connections
     pub firewall_reset_connections: FirewallResetConnsCb,
-    /// Configurable up/down behavior of WireGuard-NT adapter. See RFC LLT-0089 for details
-    pub enable_dynamic_wg_nt_control: bool,
+    /// Optional callback controlling dynamic WireGuard-NT behavior.
+    /// When present, the callback is consulted by the Windows native adapter
+    /// to determine whether meshnet is currently enabled.
+    pub enable_dynamic_wg_nt_control: IsMeshnetEnabledCb,
     /// Configurable socket buffer size, if None doesn't modify default OS set values
     pub skt_buffer_size: Option<u32>,
     /// Configurable socket buffer size, if None doesn't modify default OS set values
@@ -224,7 +234,7 @@ impl DynamicWg {
     ///             firewall_process_outbound_callback:
     ///                 Some(Arc::new(firewall_filter_outbound_packets)),
     ///             firewall_reset_connections: None,
-    ///             enable_dynamic_wg_nt_control: false,
+    ///             enable_dynamic_wg_nt_control: None,
     ///             skt_buffer_size: None,
     ///             inter_thread_channel_size: None,
     ///             max_inter_thread_batched_pkts: None,
@@ -463,6 +473,22 @@ impl WireGuard for DynamicWg {
         })
         .await?)
     }
+
+    /// Ensure that adapter is UP or DOWN
+    async fn ensure_expected_adapter_state(
+        &self,
+        peers_cnt: usize,
+        is_meshnet_on: IsMeshnetEnabledCb,
+    ) -> Result<(), Error> {
+        Ok(task_exec!(&self.task, async move |s| {
+            let _ = s
+                .adapter
+                .ensure_expected_adapter_state(peers_cnt, is_meshnet_on)
+                .await;
+            Ok(())
+        })
+        .await?)
+    }
 }
 
 impl Config {
@@ -483,7 +509,7 @@ impl Config {
             firewall_process_inbound_callback: self.firewall_process_inbound_callback.clone(),
             firewall_process_outbound_callback: self.firewall_process_outbound_callback.clone(),
             firewall_reset_connections: self.firewall_reset_connections.clone(),
-            enable_dynamic_wg_nt_control: self.enable_dynamic_wg_nt_control,
+            enable_dynamic_wg_nt_control: self.enable_dynamic_wg_nt_control.clone(),
             skt_buffer_size: self.skt_buffer_size,
             inter_thread_channel_size: self.inter_thread_channel_size,
             max_inter_thread_batched_pkts: self.max_inter_thread_batched_pkts,
@@ -1091,7 +1117,7 @@ pub mod tests {
                 firewall_process_inbound_callback: Default::default(),
                 firewall_process_outbound_callback: Default::default(),
                 firewall_reset_connections: None,
-                enable_dynamic_wg_nt_control: false,
+                enable_dynamic_wg_nt_control: None,
                 skt_buffer_size: None,
                 inter_thread_channel_size: None,
                 max_inter_thread_batched_pkts: None,
@@ -1155,7 +1181,11 @@ pub mod tests {
         pub wg: Arc<DynamicWg>,
     }
 
-    pub async fn setup(#[cfg(all(not(test), feature = "test-adapter"))] cfg: Config) -> Env {
+    pub async fn setup(
+        #[cfg(all(not(test), feature = "test-adapter"))]
+        #[allow(unused_variables)]
+        cfg: Config,
+    ) -> Env {
         let events_ch = Chan::default();
         let analytics_ch = Some(McChan::default().tx);
         let adapter = Arc::new(Mutex::new(MockAdapter::new()));

--- a/crates/telio-wg/src/windows/tunnel/interfacewatcher.rs
+++ b/crates/telio-wg/src/windows/tunnel/interfacewatcher.rs
@@ -13,7 +13,7 @@
 
 use super::addressconfig;
 use super::mtumonitor::MtuMonitor;
-use crate::windows::cleanup::*;
+use crate::{adapter::IsMeshnetEnabledCb, windows::cleanup::*};
 use std::sync::{Arc, Mutex, MutexGuard};
 use std::{mem, option, ptr};
 use telio_utils::{
@@ -32,7 +32,7 @@ pub struct InterfaceWatcher {
     iface_cb_handle: Arc<Mutex<usize>>, // iface_cb_handle: HANDLE,
 
     watched_adapter: Arc<Mutex<AdapterConfiguration>>,
-    enable_dynamic_wg_nt_control: bool,
+    enable_dynamic_wg_nt_control: IsMeshnetEnabledCb,
 }
 
 struct AdapterConfiguration {
@@ -85,7 +85,7 @@ impl AdapterConfiguration {
 }
 
 impl InterfaceWatcher {
-    pub fn new(enable_dynamic_wg_nt_control: bool) -> Self {
+    pub fn new(enable_dynamic_wg_nt_control: IsMeshnetEnabledCb) -> Self {
         telio_log_trace!("InterfaceWatcher::new");
         Self {
             iface_cb_handle: Arc::new(Mutex::new(0)), // iface_cb_handle: NULL,
@@ -320,8 +320,16 @@ impl InterfaceWatcher {
                         .last_known_config
                         .as_ref()
                         .is_some_and(|c| !c.config.peers.is_empty());
-                    if self.enable_dynamic_wg_nt_control && !has_peers {
-                        telio_log_info!("Skipping adatper.up() due to empty peer list");
+                    let meshnet_enabled = self
+                        .enable_dynamic_wg_nt_control
+                        .as_ref()
+                        .is_some_and(|is_meshnet_on_cb| is_meshnet_on_cb());
+                    if self.enable_dynamic_wg_nt_control.is_some()
+                        && (!has_peers && !meshnet_enabled)
+                    {
+                        telio_log_info!(
+                            "Skipping adapter.up() due to empty peer list and meshnet disabled"
+                        );
                     } else if adapter.up().is_err() {
                         telio_log_error!("Adapter could not be set to online state");
                     }

--- a/nat-lab/tests/test_adapter.py
+++ b/nat-lab/tests/test_adapter.py
@@ -335,7 +335,7 @@ class TestAdapterStateForVpnAndDns:
                 adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     connection_tag=ConnectionTag.VM_WINDOWS_1,
-                    derp_1_limits=(1, 1),
+                    derp_1_limits=(3, 3),
                 ),
                 features=default_features(enable_dynamic_wg_nt_control=True),
             ),
@@ -347,7 +347,7 @@ class TestAdapterStateForVpnAndDns:
                 adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
                 connection_tracker_config=generate_connection_tracker_config(
                     connection_tag=ConnectionTag.VM_WINDOWS_1,
-                    derp_1_limits=(1, 1),
+                    derp_1_limits=(3, 3),
                 ),
                 features=default_features(enable_dynamic_wg_nt_control=False),
             ),
@@ -370,20 +370,34 @@ async def test_adapter_state_for_meshnet(
         else AdapterState.UP
     )
 
-    state = await get_interface_state(client_conn, client_alpha)
-    assert state == expected_idle_state
-
-    # Add node to meshnet
-    api.default_config_two_nodes()
-    first_node_id = next(iter(api.nodes))
-    await client_alpha.set_meshnet_config(
-        api.get_meshnet_config(first_node_id, derp_servers=[config.DERP_PRIMARY])
-    )
-
+    # If meshnet is enabled without any peers, adapter should still be Up
     state = await get_interface_state(client_conn, client_alpha)
     assert state == AdapterState.UP
 
     await client_alpha.set_mesh_off()
+    state = await get_interface_state(client_conn, client_alpha)
+    assert state == expected_idle_state
 
+    # Add node to meshnet, adapter should go UP
+    api.default_config_two_nodes()
+    first_node_id = next(iter(api.nodes))
+    mesh_config = api.get_meshnet_config(
+        first_node_id, derp_servers=[config.DERP_PRIMARY]
+    )
+    await client_alpha.set_meshnet_config(mesh_config)
+    state = await get_interface_state(client_conn, client_alpha)
+    assert state == AdapterState.UP
+
+    await client_alpha.set_mesh_off()
+    state = await get_interface_state(client_conn, client_alpha)
+    assert state == expected_idle_state
+
+    # Mesh with config, but without peers, adapter should be UP
+    mesh_config.peers = None
+    await client_alpha.set_meshnet_config(mesh_config)
+    state = await get_interface_state(client_conn, client_alpha)
+    assert state == AdapterState.UP
+
+    await client_alpha.set_mesh_off()
     state = await get_interface_state(client_conn, client_alpha)
     assert state == expected_idle_state


### PR DESCRIPTION
### Problem
When `enable_dynamic_wg_nt_control=true` then `WireguardNT` adapter is brought up or down by `libtelio` depending on the peer count. As a result services like `NordDrop` may fail to bind to meshnet's IP address if meshnet is enabled, but there are no peers since the adapter would not be up.

### Solution
Provide a callback interface to adapter, to check and take into account meshnet status, while deciding whether to enable or disable the adapter. Meshnet's status is considered `enabled`, when mesh config is set some value (even without any peers in it).

```
|Mesh status | Peer count > 0    | Adapter status
|    1       |       1           |      Up
|    0       |       1           |      Up
|    1       |       0           |      Up
|    0       |       0           |      Down
```

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
