### PR TITLE
nat-lab: fix SSH-read hang and teardown races behind the 2h CI wall-kill

### DIFF
--- a/nat-lab/tests/conftest.py
+++ b/nat-lab/tests/conftest.py
@@ -242,31 +242,28 @@ def pytest_runtest_teardown(item, nextitem):  # pylint: disable=unused-argument
     async def collect_all_logs():
         async with AsyncExitStack() as stack:
             for log_collector in LOG_COLLECTORS:
-                log.info(
-                    "[%s] Will run post-test log collection for %s",
-                    log_collector.node_name,
-                    log_collector.tag,
-                )
-                connection = await stack.enter_async_context(
-                    new_connection_raw(log_collector.tag)
-                )
-                await log_collector.cleanup(connection)
-                log.info(
-                    "[%s] Done running post-test log collection for %s",
-                    log_collector.node_name,
-                    log_collector.tag,
-                )
+                try:
+                    connection = await stack.enter_async_context(
+                        new_connection_raw(log_collector.tag)
+                    )
+                    await log_collector.cleanup(connection)
+                except Exception as e:  # pylint: disable=broad-exception-caught
+                    log.warning(
+                        "[%s] post-test log collection failed for %s: %s",
+                        log_collector.node_name,
+                        log_collector.tag,
+                        e,
+                    )
 
-    _SESSION.runner.run(collect_all_logs())
-
-    LOG_COLLECTORS.clear()
-
-    if _SESSION.current_test_log_file:
-        _SESSION.current_test_log_file.flush()
-        log.removeHandler(_SESSION.current_test_log_file)
-        _SESSION.current_test_log_file.close()
-
-    _SESSION.current_test_log_file = None
+    try:
+        _SESSION.runner.run(collect_all_logs())
+    finally:
+        LOG_COLLECTORS.clear()
+        if _SESSION.current_test_log_file:
+            _SESSION.current_test_log_file.flush()
+            log.removeHandler(_SESSION.current_test_log_file)
+            _SESSION.current_test_log_file.close()
+        _SESSION.current_test_log_file = None
 
     log.info("Post-test log collection completed for %s", item.reportinfo()[2])
 

--- a/nat-lab/tests/conftest.py
+++ b/nat-lab/tests/conftest.py
@@ -54,6 +54,8 @@ SETUP_CHECK_ARP_CACHE_RETRIES = 1
 SETUP_CHECK_DUPLICATE_IP_TIMEOUT_S = 60
 SETUP_CHECK_DUPLICATE_IP_RETRIES = 1
 
+SESSIONFINISH_CLEANUP_TIMEOUT_S = 600
+
 TASKS: List[asyncio.Task] = []
 END_TASKS: threading.Event = threading.Event()
 CURRENT_TEST_LOG_FILE = None
@@ -296,11 +298,25 @@ def pytest_sessionfinish(session, exitstatus):
     if _SESSION.runner is not None:
         try:
             if _SESSION.exit_stack is not None:
-                _SESSION.runner.run(_SESSION.exit_stack.aclose())
+                _SESSION.runner.run(
+                    asyncio.wait_for(
+                        _SESSION.exit_stack.aclose(),
+                        SESSIONFINISH_CLEANUP_TIMEOUT_S,
+                    )
+                )
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            log.warning("Session exit_stack aclose failed/timed out: %s", e)
         finally:
             _SESSION.runner.close()
 
-    asyncio.run(collect_logs(_SESSION.vm_marks))
+    try:
+        asyncio.run(
+            asyncio.wait_for(
+                collect_logs(_SESSION.vm_marks), SESSIONFINISH_CLEANUP_TIMEOUT_S
+            )
+        )
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        log.warning("Post-test log collection failed/timed out: %s", e)
 
 
 @pytest.fixture(autouse=True)

--- a/nat-lab/tests/conftest_helpers/log_collection.py
+++ b/nat-lab/tests/conftest_helpers/log_collection.py
@@ -18,8 +18,9 @@ def save_dmesg_from_host(suffix):
             capture_output=True,
             text=True,
             check=True,
+            timeout=30,
         ).stdout
-    except subprocess.CalledProcessError as e:
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
         setup_log.error("Error executing dmesg: %s", e)
         return
 
@@ -160,27 +161,31 @@ def collect_core_api_server_logs():
     container_name = "nat-lab-core-api-1"
     os.makedirs(LOG_DIR, exist_ok=True)
     out_path = os.path.join(LOG_DIR, "core_api.log")
-    with open(out_path, "w", encoding="utf-8") as f:
-        subprocess.run(
-            ["docker", "logs", container_name],
-            stdout=f,
-            stderr=subprocess.STDOUT,
-            text=True,
-            check=True,
-        )
+    try:
+        with open(out_path, "w", encoding="utf-8") as f:
+            subprocess.run(
+                ["docker", "logs", container_name],
+                stdout=f,
+                stderr=subprocess.STDOUT,
+                text=True,
+                check=True,
+                timeout=60,
+            )
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+        setup_log.warning("Error collecting core-api logs: %s", e)
 
 
 def copy_file_from_container(container_name, src_path, dst_path):
     docker_cp_command = f"docker cp {container_name}:{src_path} {dst_path}"
     try:
-        subprocess.run(docker_cp_command, shell=True, check=True)
+        subprocess.run(docker_cp_command, shell=True, check=True, timeout=60)
         setup_log.info(
             "Log file %s copied successfully from %s to %s",
             src_path,
             container_name,
             dst_path,
         )
-    except subprocess.CalledProcessError:
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
         setup_log.warning(
             "Error copying log file %s from %s to %s",
             src_path,

--- a/nat-lab/tests/test_no_burst_after_sleep.py
+++ b/nat-lab/tests/test_no_burst_after_sleep.py
@@ -275,11 +275,13 @@ async def test_no_burst_after_system_suspend(
     # Suspend the VM (halt vCPUs), hold it down, then resume. The paused/running
     # transition reported by the monitor is the proof the VM really suspended.
     await _qemu_monitor(container, "stop")
-    assert await _wait_for_run_state(
-        container, "paused"
-    ), f"{container} did not suspend (QEMU never reported 'paused')"
-    await asyncio.sleep(SUSPEND_DURATION_S)
-    await _qemu_monitor(container, "cont")
+    try:
+        assert await _wait_for_run_state(
+            container, "paused"
+        ), f"{container} did not suspend (QEMU never reported 'paused')"
+        await asyncio.sleep(SUSPEND_DURATION_S)
+    finally:
+        await _qemu_monitor(container, "cont")
     assert await _wait_for_run_state(
         container, "running"
     ), f"{container} did not resume after 'cont'"

--- a/nat-lab/tests/test_no_burst_after_sleep.py
+++ b/nat-lab/tests/test_no_burst_after_sleep.py
@@ -72,6 +72,28 @@ async def _read_guest_monotonic(connection: Connection) -> float:
     return float(process.get_stdout().strip())
 
 
+async def _reconnect_when_ready(
+    connection: SshConnection, deadline_s: float = 90.0, delay: float = 3.0
+) -> None:
+    # a just-unfrozen/resumed guest may accept a socket before it can run anything
+    attempts = max(1, int(deadline_s / delay))
+    last_error: Exception | None = None
+    for _ in range(attempts):
+        try:
+            await connection.reconnect()
+            await connection.create_process(
+                ["echo", "natlab_ready"], quiet=True
+            ).execute()
+            return
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            last_error = e
+            await asyncio.sleep(delay)
+    raise ConnectionError(
+        f"guest {connection.tag.name} did not become reachable within {deadline_s}s"
+        f" after freeze/suspend: {last_error}"
+    )
+
+
 # --- VM suspend, driven through the dockur QEMU monitor ----------------------
 # A VM client runs its guest OS in QEMU inside the dockur container. The QEMU
 # monitor lives inside that container (telnet on localhost) and is reachable with
@@ -177,8 +199,10 @@ async def test_no_burst_after_monotonic_jump(
     consolidations_before = (await client_alpha.log.get()).count(CONSOLIDATION_LOG)
 
     # VM SSH session can't survive the freeze: detach remote stdout (else EPIPE-crash) + rebuild SSH on wake.
-    is_ssh = isinstance(connection_alpha, SshConnection)
-    if is_ssh:
+    ssh_alpha = (
+        connection_alpha if isinstance(connection_alpha, SshConnection) else None
+    )
+    if ssh_alpha:
         await client_alpha.get_proxy().redirect_stdout_to_logfile()
 
     # Freeze the client: it does no work, but the monotonic clock keeps moving,
@@ -186,8 +210,8 @@ async def test_no_burst_after_monotonic_jump(
     async with paused_container(alpha_tag):
         await asyncio.sleep(SLEEP_DURATION_S)
 
-    if is_ssh:
-        await connection_alpha.reconnect()
+    if ssh_alpha:
+        await _reconnect_when_ready(ssh_alpha)
 
     mono_after = await _read_guest_monotonic(connection_alpha)
     slept = mono_after - mono_before
@@ -287,7 +311,7 @@ async def test_no_burst_after_system_suspend(
     ), f"{container} did not resume after 'cont'"
 
     assert isinstance(connection_alpha, SshConnection)
-    await connection_alpha.reconnect()
+    await _reconnect_when_ready(connection_alpha)
 
     # Let the guest settle and re-establish connectivity after the suspend.
     await asyncio.sleep(SETTLE_AFTER_WAKE_S)

--- a/nat-lab/tests/utils/connection/ssh_connection.py
+++ b/nat-lab/tests/utils/connection/ssh_connection.py
@@ -93,6 +93,10 @@ class SshConnection(Connection):
             password=password,
             known_hosts=None,
             agent_path=None,
+            connect_timeout=30,
+            login_timeout=30,
+            keepalive_interval=15,
+            keepalive_count_max=4,
         )
 
     async def reconnect(self) -> None:

--- a/nat-lab/tests/utils/process/docker_process.py
+++ b/nat-lab/tests/utils/process/docker_process.py
@@ -165,7 +165,13 @@ class DockerProcess(Process):
                     stderr=asyncio.subprocess.PIPE,
                 )
                 stdout, stderr = await proc.communicate()
-                if proc.returncode != 0:
+                if proc.returncode == 3:
+                    log.debug(
+                        "[%s] Cleanup: process already gone (natlab id %s)",
+                        self._container_name,
+                        self._kill_id,
+                    )
+                elif proc.returncode != 0:
                     log.warning(
                         "[%s] Cleanup failed: %s",
                         self._container_name,

--- a/nat-lab/tests/utils/tcpdump.py
+++ b/nat-lab/tests/utils/tcpdump.py
@@ -539,7 +539,10 @@ async def make_local_tcpdump():
         raise
     finally:
         if process:
-            process.kill()
+            try:
+                process.kill()
+            except ProcessLookupError:
+                pass
             await process.wait()
 
 


### PR DESCRIPTION
## Problem

Natlab shards could hang to GitLab's 2h wall-kill, and one failing test took down the rest of the shard. Root causes:

- **SSH read hang (the 2h killer):** `asyncssh.connect()` set no keepalive/timeouts. When a test left a VM half-alive (TCP up, guest frozen, no RST), any SSH read blocked forever — e.g. `pytest_sessionfinish`'s `collect_logs` SSHing a degraded Mac VM hung 86 min. `wait_for` cancellation alone can't break this (channel close does I/O on the dead transport).
- **Whole-shard cascade:** when a test left a VM unreachable (e.g. VM_MAC after a failed suspend, `Errno 113`), `pytest_runtest_teardown`'s log collection raised on the dead connection, so `LOG_COLLECTORS.clear()` never ran. The dead collector persisted and every following test's teardown re-tried it and errored (`previous item was not torn down properly`) — one failing test became `1 failed -> 27 errors`.
- **Freeze/suspend reconnect race:** a just-unfrozen/resumed guest can accept a socket before it can run anything, so a single `reconnect()` raced recovery and failed with `Errno 113` (e.g. `test_no_burst_after_monotonic_jump[VM_WINDOWS_1]`).
- **Teardown crash every run:** `make_local_tcpdump` called `kill()` on an already-exited local tcpdump → `ProcessLookupError` aborted the whole session `exit_stack` teardown.
- A failed suspend test could also leave the VM paused, cascading setup ERRORs.

## Solution

- **Root fix (hang):** asyncssh `keepalive_interval=15` / `keepalive_count_max=4` (+ connect/login timeouts) so a frozen peer is dropped and reads raise `ConnectionLost` in ~75s instead of hanging.
- **Cascade fix:** isolate each collector in `pytest_runtest_teardown` with try/except and move `LOG_COLLECTORS.clear()` + log-file teardown into a `finally`, so one dead VM can't fail every following test's teardown.
- **Freeze/suspend readiness gate (in-test):** after unfreeze/resume, poll until a real command (`echo`) runs over the session, bounded to 90s, raising a clear `ConnectionError` if the guest never recovers — confirms the guest is actually up, and fails loud on genuine non-recovery. `SshConnection` is unchanged.
- Guard `process.kill()` in `make_local_tcpdump` against `ProcessLookupError`; demote docker kill-by-natlab-id exit 3 (already gone) from warning to debug.
- Send QEMU `cont` from a `finally` so an interrupted suspend always resumes.
- Backstops for non-SSH stalls: bound `pytest_sessionfinish` cleanup with a 600s `asyncio.wait_for`, and add `timeout=` to the sync `docker logs`/`docker cp`/`dmesg` calls in log collection.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
