### PR TITLE
LLT-4837: Fix data race in wg-nt MTU monitor callbacks

### DIFF
--- a/.unreleased/LLT-4837
+++ b/.unreleased/LLT-4837
@@ -1,0 +1,1 @@
+Fix a data race between the route change and interface change callbacks in the WG-NT MTU monitor, which could concurrently mutate the cached MTU state.

--- a/crates/telio-wg/src/windows/tunnel/interfacewatcher.rs
+++ b/crates/telio-wg/src/windows/tunnel/interfacewatcher.rs
@@ -27,12 +27,18 @@ use winapi::shared::{
 };
 
 pub struct InterfaceWatcher {
-    // Quickhack: Adapter is Sync+Send, so it cannot hold any substructures with raw ptr / HANDLE
-    iface_cb_handle: Arc<Mutex<usize>>, // iface_cb_handle: HANDLE,
+    // OS change-notification handle; see the `unsafe impl Send` below.
+    iface_cb_handle: HANDLE,
 
     watched_adapter: Arc<Mutex<AdapterConfiguration>>,
     enable_dynamic_wg_nt_control: IsMeshnetEnabledCb,
 }
+
+// SAFETY: `iface_cb_handle` is an opaque OS change-notification handle. It is
+// never dereferenced, only handed back to CancelMibChangeNotify2, which may be
+// called from any thread. The watcher is therefore safe to move between
+// threads.
+unsafe impl Send for InterfaceWatcher {}
 
 struct AdapterConfiguration {
     luid: u64,
@@ -87,7 +93,7 @@ impl InterfaceWatcher {
     pub fn new(enable_dynamic_wg_nt_control: IsMeshnetEnabledCb) -> Self {
         telio_log_trace!("InterfaceWatcher::new");
         Self {
-            iface_cb_handle: Arc::new(Mutex::new(0)), // iface_cb_handle: NULL,
+            iface_cb_handle: NULL,
 
             watched_adapter: Arc::new(Mutex::new(AdapterConfiguration::new())),
             enable_dynamic_wg_nt_control,
@@ -106,47 +112,38 @@ impl InterfaceWatcher {
 
         telio_log_trace!("+++ InterfaceWatcher::start_monitoring");
 
-        if let Ok(mut iface_cb_handle) = self.iface_cb_handle.clone().lock() {
-            let mut cb_handle: HANDLE = NULL;
-            let result = unsafe {
-                winapi::shared::netioapi::NotifyIpInterfaceChange(
-                    AF_UNSPEC as _,
-                    Some(Self::interface_change_callback),
-                    self as *mut Self as _,
-                    false as _,
-                    &mut cb_handle,
-                )
-            };
-            telio_log_trace!("--- InterfaceWatcher::start_monitoring {}", result);
-            if NO_ERROR != result {
-                Err(result)
-            } else {
-                *iface_cb_handle = cb_handle as _;
-                Ok(())
-            }
+        let mut cb_handle: HANDLE = NULL;
+        let result = unsafe {
+            winapi::shared::netioapi::NotifyIpInterfaceChange(
+                AF_UNSPEC as _,
+                Some(Self::interface_change_callback),
+                self as *mut Self as _,
+                false as _,
+                &mut cb_handle,
+            )
+        };
+        telio_log_trace!("--- InterfaceWatcher::start_monitoring {}", result);
+        if NO_ERROR != result {
+            Err(result)
         } else {
-            telio_log_error!("error obtaining lock");
-            Err(ERROR_INVALID_PARAMETER)
+            self.iface_cb_handle = cb_handle;
+            Ok(())
         }
     }
 
-    pub fn stop(&self) {
+    pub fn stop(&mut self) {
         telio_log_trace!("+++ InterfaceWatcher::stop");
 
-        if let Ok(mut iface_cb_handle) = self.iface_cb_handle.clone().lock() {
-            unsafe {
-                if 0 != *iface_cb_handle {
-                    CancelMibChangeNotify2(*iface_cb_handle as HANDLE);
-                    *iface_cb_handle = 0;
-                }
+        unsafe {
+            if !self.iface_cb_handle.is_null() {
+                CancelMibChangeNotify2(self.iface_cb_handle);
+                self.iface_cb_handle = NULL;
             }
-        } else {
-            telio_log_error!("error obtaining lock");
         }
 
         if let Ok(watched_adapter) = self.watched_adapter.clone().lock() {
             for mtu_monitor in watched_adapter.mtu_monitor.as_slice() {
-                if let Ok(mtumon) = mtu_monitor.clone().lock() {
+                if let Ok(mut mtumon) = mtu_monitor.clone().lock() {
                     mtumon.stop();
                 }
             }

--- a/crates/telio-wg/src/windows/tunnel/interfacewatcher.rs
+++ b/crates/telio-wg/src/windows/tunnel/interfacewatcher.rs
@@ -14,8 +14,7 @@
 use super::addressconfig;
 use super::mtumonitor::MtuMonitor;
 use crate::{adapter::IsMeshnetEnabledCb, windows::cleanup::*};
-use std::sync::{Arc, Mutex, MutexGuard};
-use std::{mem, option, ptr};
+use std::sync::{Arc, Mutex};
 use telio_utils::{
     telio_log_debug, telio_log_error, telio_log_info, telio_log_trace, telio_log_warn, Hidden,
 };

--- a/crates/telio-wg/src/windows/tunnel/mtumonitor.rs
+++ b/crates/telio-wg/src/windows/tunnel/mtumonitor.rs
@@ -7,7 +7,6 @@
 
 use super::winipcfg::luid::InterfaceLuid;
 use std::ptr;
-use std::sync::{Arc, Mutex};
 use telio_utils::{
     telio_log_debug, telio_log_error, telio_log_info, telio_log_trace, telio_log_warn,
 };
@@ -26,10 +25,16 @@ pub struct MtuMonitor {
 
     last_mtu: u32,
 
-    // Quickhack: Adapter is Sync+Send, so it cannot hold any substructures with raw ptr / HANDLE
-    route_cb_handle: Arc<Mutex<usize>>, // route_cb_handle: HANDLE,
-    iface_cb_handle: Arc<Mutex<usize>>, // iface_cb_handle: HANDLE,
+    // OS change-notification handles; see the `unsafe impl Send` below.
+    route_cb_handle: HANDLE,
+    iface_cb_handle: HANDLE,
 }
+
+// SAFETY: `route_cb_handle` and `iface_cb_handle` are opaque OS
+// change-notification handles. They are never dereferenced, only handed back
+// to CancelMibChangeNotify2, which may be called from any thread. The monitor
+// is therefore safe to move between threads.
+unsafe impl Send for MtuMonitor {}
 
 impl MtuMonitor {
     pub fn new(own_luid: u64, family: ADDRESS_FAMILY) -> Self {
@@ -45,77 +50,60 @@ impl MtuMonitor {
             min_mtu,
             last_mtu: 0,
 
-            route_cb_handle: Arc::new(Mutex::new(0)),
-            iface_cb_handle: Arc::new(Mutex::new(0)),
+            route_cb_handle: NULL,
+            iface_cb_handle: NULL,
         }
     }
 
     pub fn start_monitoring(&mut self) -> Result<(), NETIO_STATUS> {
         self.do_it()?;
 
-        if let Ok(mut route_cb_handle) = self.route_cb_handle.clone().lock() {
-            let mut cb_handle: HANDLE = NULL;
-            let result = unsafe {
-                winapi::shared::netioapi::NotifyRouteChange2(
-                    self.family,
-                    Some(Self::route_change_callback),
-                    self as *mut Self as _,
-                    false as _,
-                    &mut cb_handle,
-                )
-            };
-            if NO_ERROR != result {
-                return Err(result);
-            }
-            *route_cb_handle = cb_handle as _;
+        let mut cb_handle: HANDLE = NULL;
+        let result = unsafe {
+            winapi::shared::netioapi::NotifyRouteChange2(
+                self.family,
+                Some(Self::route_change_callback),
+                self as *mut Self as _,
+                false as _,
+                &mut cb_handle,
+            )
+        };
+        if NO_ERROR != result {
+            return Err(result);
         }
+        self.route_cb_handle = cb_handle;
 
-        if let Ok(mut iface_cb_handle) = self.iface_cb_handle.clone().lock() {
-            let mut cb_handle: HANDLE = NULL;
-            let result = unsafe {
-                winapi::shared::netioapi::NotifyIpInterfaceChange(
-                    self.family,
-                    Some(Self::interface_change_callback),
-                    self as *mut Self as _,
-                    false as _,
-                    &mut cb_handle,
-                )
-            };
-            if NO_ERROR != result {
-                return Err(result);
-            }
-            *iface_cb_handle = cb_handle as _;
-        } else {
-            telio_log_error!("error obtaining lock");
-            return Err(ERROR_INVALID_PARAMETER);
+        let mut cb_handle: HANDLE = NULL;
+        let result = unsafe {
+            winapi::shared::netioapi::NotifyIpInterfaceChange(
+                self.family,
+                Some(Self::interface_change_callback),
+                self as *mut Self as _,
+                false as _,
+                &mut cb_handle,
+            )
+        };
+        if NO_ERROR != result {
+            return Err(result);
         }
+        self.iface_cb_handle = cb_handle;
 
         Ok(())
     }
 
-    pub fn stop(&self) {
+    pub fn stop(&mut self) {
         telio_log_trace!("+++ MtuMonitor::stop");
 
-        if let Ok(mut route_cb_handle) = self.route_cb_handle.clone().lock() {
-            unsafe {
-                if 0 != *route_cb_handle {
-                    CancelMibChangeNotify2(*route_cb_handle as HANDLE);
-                    *route_cb_handle = 0;
-                }
+        unsafe {
+            if !self.route_cb_handle.is_null() {
+                CancelMibChangeNotify2(self.route_cb_handle);
+                self.route_cb_handle = NULL;
             }
-        } else {
-            telio_log_error!("error obtaining lock");
-        }
 
-        if let Ok(mut iface_cb_handle) = self.iface_cb_handle.clone().lock() {
-            unsafe {
-                if 0 != *iface_cb_handle {
-                    CancelMibChangeNotify2(*iface_cb_handle as HANDLE);
-                    *iface_cb_handle = 0;
-                }
+            if !self.iface_cb_handle.is_null() {
+                CancelMibChangeNotify2(self.iface_cb_handle);
+                self.iface_cb_handle = NULL;
             }
-        } else {
-            telio_log_error!("error obtaining lock");
         }
 
         telio_log_trace!("--- MtuMonitor::stop");

--- a/crates/telio-wg/src/windows/tunnel/mtumonitor.rs
+++ b/crates/telio-wg/src/windows/tunnel/mtumonitor.rs
@@ -6,8 +6,8 @@
 //
 
 use super::winipcfg::luid::InterfaceLuid;
+use std::ptr;
 use std::sync::{Arc, Mutex};
-use std::{mem, ptr};
 use telio_utils::{
     telio_log_debug, telio_log_error, telio_log_info, telio_log_trace, telio_log_warn,
 };
@@ -24,8 +24,6 @@ pub struct MtuMonitor {
     family: ADDRESS_FAMILY,
     min_mtu: u32,
 
-    last_luid: u64,
-    last_index: i32,
     last_mtu: u32,
 
     // Quickhack: Adapter is Sync+Send, so it cannot hold any substructures with raw ptr / HANDLE
@@ -45,8 +43,6 @@ impl MtuMonitor {
             own_luid,
             family,
             min_mtu,
-            last_luid: 0,
-            last_index: -1,
             last_mtu: 0,
 
             route_cb_handle: Arc::new(Mutex::new(0)),
@@ -196,17 +192,17 @@ impl MtuMonitor {
         telio_log_trace!("+++ MtuMonitor::do_it");
 
         telio_log_trace!("+++ MtuMonitor::do_it: find_default_luid");
-        self.find_default_luid()?;
+        let default_luid = self.find_default_luid()?;
         telio_log_trace!("--- MtuMonitor::do_it: find_default_luid");
 
         let mut mtu: u32 = 0;
 
-        if 0 != self.last_luid {
-            let last_luid = InterfaceLuid::new(self.last_luid);
+        if 0 != default_luid {
+            let default_luid = InterfaceLuid::new(default_luid);
             telio_log_trace!("+++ MtuMonitor::do_it: get_interface");
-            let last_iface = last_luid.get_interface()?;
-            if last_iface.Mtu > 0 {
-                mtu = last_iface.Mtu;
+            let default_iface = default_luid.get_interface()?;
+            if default_iface.Mtu > 0 {
+                mtu = default_iface.Mtu;
             }
         }
 
@@ -232,7 +228,7 @@ impl MtuMonitor {
         Ok(())
     }
 
-    fn find_default_luid(&mut self) -> Result<(), NETIO_STATUS> {
+    fn find_default_luid(&self) -> Result<u64, NETIO_STATUS> {
         let mut p_table: PMIB_IPFORWARD_TABLE2 = ptr::null_mut();
         let result = unsafe { GetIpForwardTable2(self.family, &mut p_table) };
         if NO_ERROR != result {
@@ -243,7 +239,6 @@ impl MtuMonitor {
             return Err(result);
         }
         let mut lowest_metric: u32 = u32::MAX;
-        let mut index: u32 = 0;
         let mut luid: u64 = 0;
 
         assert!(!p_table.is_null());
@@ -276,7 +271,6 @@ impl MtuMonitor {
                     let current_metric = unsafe { (*current_entry).Metric + iface.Metric };
                     if current_metric < lowest_metric {
                         lowest_metric = current_metric;
-                        index = unsafe { (*current_entry).InterfaceIndex };
                         luid = unsafe { (*current_entry).InterfaceLuid.Value };
                     }
                 }
@@ -288,10 +282,7 @@ impl MtuMonitor {
 
         unsafe { FreeMibTable(p_table as _) };
 
-        self.last_luid = luid;
-        self.last_index = index as i32;
-
-        Ok(())
+        Ok(luid)
     }
 }
 

--- a/crates/telio-wg/src/windows/tunnel/mtumonitor.rs
+++ b/crates/telio-wg/src/windows/tunnel/mtumonitor.rs
@@ -7,6 +7,7 @@
 
 use super::winipcfg::luid::InterfaceLuid;
 use std::ptr;
+use std::sync::Mutex;
 use telio_utils::{
     telio_log_debug, telio_log_error, telio_log_info, telio_log_trace, telio_log_warn,
 };
@@ -23,7 +24,9 @@ pub struct MtuMonitor {
     family: ADDRESS_FAMILY,
     min_mtu: u32,
 
-    last_mtu: u32,
+    // Serialises route_change_callback and interface_change_callback, which are
+    // registered on separate handles and so can run concurrently on different threads.
+    last_mtu: Mutex<u32>,
 
     // OS change-notification handles; see the `unsafe impl Send` below.
     route_cb_handle: HANDLE,
@@ -48,7 +51,7 @@ impl MtuMonitor {
             own_luid,
             family,
             min_mtu,
-            last_mtu: 0,
+            last_mtu: Mutex::new(0),
 
             route_cb_handle: NULL,
             iface_cb_handle: NULL,
@@ -176,8 +179,16 @@ impl MtuMonitor {
         );
     }
 
-    fn do_it(&mut self) -> Result<(), NETIO_STATUS> {
+    fn do_it(&self) -> Result<(), NETIO_STATUS> {
         telio_log_trace!("+++ MtuMonitor::do_it");
+
+        let mut last_mtu = match self.last_mtu.lock() {
+            Ok(last_mtu) => last_mtu,
+            Err(_) => {
+                telio_log_error!("error obtaining lock");
+                return Err(ERROR_INVALID_PARAMETER);
+            }
+        };
 
         telio_log_trace!("+++ MtuMonitor::do_it: find_default_luid");
         let default_luid = self.find_default_luid()?;
@@ -194,7 +205,7 @@ impl MtuMonitor {
             }
         }
 
-        if mtu > 0 && self.last_mtu != mtu {
+        if mtu > 0 && *last_mtu != mtu {
             let own_luid = InterfaceLuid::new(self.own_luid);
             telio_log_trace!("+++ MtuMonitor::do_it: get_ip_interface");
             let mut own_iface = own_luid.get_ip_interface(self.family)?;
@@ -208,7 +219,7 @@ impl MtuMonitor {
             if NO_ERROR != result {
                 return Err(result);
             }
-            self.last_mtu = mtu;
+            *last_mtu = mtu;
         }
 
         telio_log_trace!("--- MtuMonitor::do_it");


### PR DESCRIPTION
### Problem
The route change and interface change callbacks are registered on separate
handles, so they can run concurrently on different threads. Both mutated the
monitor's cached MTU state without any synchronisation between them.

This finishes the root-cause work deferred by the temporary deadlock fix
in #307.

### Solution
Guard that state with a single mutex taken only by the callbacks, so
CancelMibChangeNotify2 in stop() can never wait on a callback that waits on
us. Also drop the per-handle mutexes in MtuMonitor and InterfaceWatcher,
since the callbacks no longer lock them.

The first commit is preparatory cleanup (removes write-only state) so the
fix commit stays minimal.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests