### PR TITLE
nat-lab: bound fixture setup/teardown with a phase timeout

### DIFF
--- a/nat-lab/tests/conftest.py
+++ b/nat-lab/tests/conftest.py
@@ -280,7 +280,7 @@ class _PhaseTimeout:
             raise TimeoutError(f"{phase} exceeded {seconds}s for {nodeid}")
 
         old = signal.signal(signal.SIGALRM, _fire)
-        signal.setitimer(signal.ITIMER_REAL, seconds)
+        signal.setitimer(signal.ITIMER_REAL, seconds, seconds)
         return old
 
     @staticmethod

--- a/nat-lab/tests/conftest.py
+++ b/nat-lab/tests/conftest.py
@@ -5,6 +5,7 @@ import logging
 import os
 import Pyro5  # type: ignore
 import pytest
+import signal
 import threading
 from contextlib import AsyncExitStack
 from dataclasses import dataclass, field
@@ -266,6 +267,46 @@ def pytest_runtest_teardown(item, nextitem):  # pylint: disable=unused-argument
         _SESSION.current_test_log_file = None
 
     log.info("Post-test log collection completed for %s", item.reportinfo()[2])
+
+
+SETUP_PHASE_TIMEOUT_S = 300
+TEARDOWN_PHASE_TIMEOUT_S = 300
+
+
+class _PhaseTimeout:
+    @staticmethod
+    def _arm(seconds, phase, nodeid):
+        def _fire(signum, frame):  # pylint: disable=unused-argument
+            raise TimeoutError(f"{phase} exceeded {seconds}s for {nodeid}")
+
+        old = signal.signal(signal.SIGALRM, _fire)
+        signal.setitimer(signal.ITIMER_REAL, seconds)
+        return old
+
+    @staticmethod
+    def _disarm(old):
+        signal.setitimer(signal.ITIMER_REAL, 0)
+        signal.signal(signal.SIGALRM, old)
+
+    @pytest.hookimpl(hookwrapper=True)
+    def pytest_runtest_setup(self, item):
+        old = self._arm(SETUP_PHASE_TIMEOUT_S, "setup", item.nodeid)
+        try:
+            yield
+        finally:
+            self._disarm(old)
+
+    @pytest.hookimpl(hookwrapper=True)
+    def pytest_runtest_teardown(self, item, nextitem):  # pylint: disable=unused-argument
+        old = self._arm(TEARDOWN_PHASE_TIMEOUT_S, "teardown", item.nodeid)
+        try:
+            yield
+        finally:
+            self._disarm(old)
+
+
+def pytest_configure(config):
+    config.pluginmanager.register(_PhaseTimeout())
 
 
 # Session-long AsyncExitStack is created at session start and closed at session finish.

--- a/nat-lab/tests/conftest.py
+++ b/nat-lab/tests/conftest.py
@@ -297,7 +297,9 @@ class _PhaseTimeout:
             self._disarm(old)
 
     @pytest.hookimpl(hookwrapper=True)
-    def pytest_runtest_teardown(self, item, nextitem):  # pylint: disable=unused-argument
+    def pytest_runtest_teardown(
+        self, item, nextitem
+    ):  # pylint: disable=unused-argument
         old = self._arm(TEARDOWN_PHASE_TIMEOUT_S, "teardown", item.nodeid)
         try:
             yield


### PR DESCRIPTION
## Problem
nat-lab runs pytest with `--timeout=...` and `timeout_func_only=true`, so the per-test timeout guards **only the call phase**. A wedged SSH/RPC in fixture **setup** or **teardown** is unbounded — it hangs the shard until the 2h GitLab job ceiling.

Observed: `test_no_burst_after_monotonic_jump[VM_MAC-NEPTUN-CONE_CLIENT_2-]` printed its nodeid then produced no further output for ~1h33m until the job was killed (`execution took longer than 2h0m0s`). No `PASSED` line + func-only timeout not firing ⇒ hang was in the `env_mesh` **setup** phase (unbounded `ClientLog.wait_for` → `flush_logs` RPC to a wedged VM_MAC), which nothing bounds.

## Solution
Register a plugin that arms a `SIGALRM` phase timeout (300s) around **setup** and **teardown**. A stuck fixture now fails fast and names the phase+test (`setup exceeded 300s for <nodeid>`) instead of burning the whole 2h job. `SIGALRM` interrupts the blocked syscall via EINTR. Handler is saved/restored, so it coexists with pytest-timeout's call-phase alarm (verified: call-phase hang still reported by pytest-timeout, not this).

Existing `pytest_runtest_setup`/`teardown` hooks are untouched.

## Notes / limitations
- Bounds the symptom (no more 2h burn; culprit phase+test named). *Why* VM_MAC wedges after the cgroup-freeze is a separate investigation.
- 300s chosen from CI durations: slowest whole test observed ~212s (setup+call+teardown summed); a single phase is a fraction of that.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
