### PR TITLE
Add diagnostics on VM SSH connection failure in setup checks

### DIFF
--- a/nat-lab/tests/conftest_helpers/setup_checks.py
+++ b/nat-lab/tests/conftest_helpers/setup_checks.py
@@ -9,7 +9,10 @@ from itertools import combinations
 from tests.config import LAN_ADDR_MAP
 from tests.interderp_cli import InterDerpClient
 from tests.utils.connection import ConnectionTag, TargetOS
-from tests.utils.connection.docker_connection import DockerConnection
+from tests.utils.connection.docker_connection import (
+    DockerConnection,
+    DOCKER_VM_SERVICE_IDS,
+)
 from tests.utils.connection_util import (
     new_connection_raw,
     is_running,
@@ -183,6 +186,41 @@ async def setup_check_duplicate_ip_addresses():
         raise RuntimeError(f"Found duplicate container IPv4 addresses: {details}")
 
 
+async def _run_cmd(cmd: list[str]) -> str:
+    proc = await asyncio.create_subprocess_exec(
+        *cmd,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stdout, stderr = await proc.communicate()
+    out = (stdout or b"").decode(errors="replace")
+    err = (stderr or b"").decode(errors="replace")
+    return out + err
+
+
+async def _dump_vm_connection_failure_diagnostics(conn_tag: ConnectionTag) -> None:
+    """Dump container logs and host network state when a VM SSH connection fails.
+
+    Helps identify whether the failure is inside the guest (sshd not ready)
+    or on the host network path (routing/ARP not yet established).
+    """
+    if conn_tag not in DOCKER_VM_SERVICE_IDS:
+        return
+
+    container = f"nat-lab-{DOCKER_VM_SERVICE_IDS[conn_tag]}-1"
+    logs = await _run_cmd(["docker", "logs", "--tail", "100", container])
+    setup_log.warning("Last 100 lines of %s container logs:\n%s", container, logs)
+
+    primary_ip = LAN_ADDR_MAP[conn_tag]["primary"]
+    for cmd, label in [
+        (["ping", "-c", "1", "-W", "2", primary_ip], "ping"),
+        (["ip", "neigh", "show", primary_ip], "arp"),
+        (["ip", "route", "get", primary_ip], "route"),
+    ]:
+        out = await _run_cmd(cmd)
+        setup_log.warning("Host diag [%s] for %s:\n%s", label, primary_ip, out)
+
+
 async def setup_check_duplicate_mac_addresses(
     session_is_container_running: dict[ConnectionTag, bool],
 ):
@@ -212,6 +250,7 @@ async def setup_check_duplicate_mac_addresses(
                 setup_log.warning(
                     "Failed to check MAC address for %s: %s", conn_tag.name, e
                 )
+                await _dump_vm_connection_failure_diagnostics(conn_tag)
                 raise e
 
             if conn.target_os in (TargetOS.Linux, TargetOS.Android):


### PR DESCRIPTION
### Problem
- When SSH connection to a Windows VM fails there is - no information about why the connection was refused or what state the VM was in

### Solution
- On SSH connection failure, dump the last 100 lines of the VM's container logs and host-side network diagnostics (ping, ip neigh, ip route) to the setup log before re-raising the exception

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
