### PR TITLE
Fix nat-lab setup_checks and log_collection hangs

### DIFF
--- a/nat-lab/tests/conftest_helpers/log_collection.py
+++ b/nat-lab/tests/conftest_helpers/log_collection.py
@@ -1,6 +1,6 @@
+import asyncio
 import os
 import shutil
-import subprocess
 from tests.config import LAN_ADDR_MAP
 from tests.utils.connection import ConnectionTag
 from tests.utils.connection.ssh_connection import SshConnection
@@ -11,18 +11,20 @@ from tests.utils.process import ProcessExecError
 LOG_DIR = "logs"
 
 
-def save_dmesg_from_host(suffix):
-    try:
-        result = subprocess.run(
-            ["sudo", "dmesg", "-d", "-T"],
-            capture_output=True,
-            text=True,
-            check=True,
-            timeout=30,
-        ).stdout
-    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
-        setup_log.error("Error executing dmesg: %s", e)
+async def save_dmesg_from_host(suffix):
+    proc = await asyncio.create_subprocess_exec(
+        "sudo",
+        "dmesg",
+        "-d",
+        "-T",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stdout, stderr = await proc.communicate()
+    if proc.returncode != 0:
+        setup_log.error("Error executing dmesg: %s", stderr.decode(errors="replace"))
         return
+    result = stdout.decode(errors="replace")
 
     if result:
         with open(
@@ -108,7 +110,7 @@ async def collect_kernel_logs(
 ):
     os.makedirs(LOG_DIR, exist_ok=True)
 
-    save_dmesg_from_host(suffix)
+    await save_dmesg_from_host(suffix)
     save_audit_log_from_host(suffix)
     if "nlx" in session_vm_marks:
         await save_dmesg_from_remote_vm(ConnectionTag.VM_LINUX_NLX_1, suffix)
@@ -127,71 +129,84 @@ async def collect_kernel_logs(
 async def collect_logs(
     session_vm_marks: set[str],
 ):
-    collect_nordderper_logs()
-    collect_dns_server_logs()
-    collect_core_api_server_logs()
+    await collect_nordderper_logs()
+    await collect_dns_server_logs()
+    await collect_core_api_server_logs()
     await collect_kernel_logs("after_tests", session_vm_marks)
     await collect_mac_diagnostic_reports(session_vm_marks)
     await save_nordlynx_logs(session_vm_marks)
 
 
-def collect_nordderper_logs():
+async def collect_nordderper_logs():
     num_containers = 3
 
     for i in range(1, num_containers + 1):
         container_name = f"nat-lab-derp-{i:02d}-1"
         destination_path = f"{LOG_DIR}/derp_{i:02d}_relay.log"
 
-        copy_file_from_container(
+        await copy_file_from_container(
             container_name, "/etc/nordderper/relay.log", destination_path
         )
 
 
-def collect_dns_server_logs():
+async def collect_dns_server_logs():
     num_containers = 2
 
     for i in range(1, num_containers + 1):
         container_name = f"nat-lab-dns-server-{i}-1"
         destination_path = f"{LOG_DIR}/dns_server_{i}.log"
 
-        copy_file_from_container(container_name, "/dns-server.log", destination_path)
+        await copy_file_from_container(
+            container_name, "/dns-server.log", destination_path
+        )
 
 
-def collect_core_api_server_logs():
+async def collect_core_api_server_logs():
     container_name = "nat-lab-core-api-1"
     os.makedirs(LOG_DIR, exist_ok=True)
     out_path = os.path.join(LOG_DIR, "core_api.log")
-    try:
-        with open(out_path, "w", encoding="utf-8") as f:
-            subprocess.run(
-                ["docker", "logs", container_name],
-                stdout=f,
-                stderr=subprocess.STDOUT,
-                text=True,
-                check=True,
-                timeout=60,
-            )
-    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
-        setup_log.warning("Error collecting core-api logs: %s", e)
-
-
-def copy_file_from_container(container_name, src_path, dst_path):
-    docker_cp_command = f"docker cp {container_name}:{src_path} {dst_path}"
-    try:
-        subprocess.run(docker_cp_command, shell=True, check=True, timeout=60)
-        setup_log.info(
-            "Log file %s copied successfully from %s to %s",
-            src_path,
-            container_name,
-            dst_path,
-        )
-    except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
+    proc = await asyncio.create_subprocess_exec(
+        "docker",
+        "logs",
+        container_name,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+    )
+    stdout, _ = await proc.communicate()
+    if proc.returncode != 0:
         setup_log.warning(
-            "Error copying log file %s from %s to %s",
+            "Error collecting core-api logs: %s", stdout.decode(errors="replace")
+        )
+        return
+    with open(out_path, "w", encoding="utf-8") as f:
+        f.write(stdout.decode(errors="replace"))
+
+
+async def copy_file_from_container(container_name, src_path, dst_path):
+    proc = await asyncio.create_subprocess_exec(
+        "docker",
+        "cp",
+        f"{container_name}:{src_path}",
+        dst_path,
+        stdout=asyncio.subprocess.DEVNULL,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    _, stderr = await proc.communicate()
+    if proc.returncode != 0:
+        setup_log.warning(
+            "Error copying log file %s from %s to %s: %s",
             src_path,
             container_name,
             dst_path,
+            stderr.decode(errors="replace"),
         )
+        return
+    setup_log.info(
+        "Log file %s copied successfully from %s to %s",
+        src_path,
+        container_name,
+        dst_path,
+    )
 
 
 async def collect_mac_diagnostic_reports(

--- a/nat-lab/tests/conftest_helpers/setup_checks.py
+++ b/nat-lab/tests/conftest_helpers/setup_checks.py
@@ -1,7 +1,6 @@
 import asyncio
 import json
 import re
-import subprocess
 import tests.config
 from collections import defaultdict
 from contextlib import AsyncExitStack
@@ -36,6 +35,8 @@ SETUP_CHECK_MAC_COLLISION_TIMEOUT_S = 300
 SETUP_CHECK_MAC_COLLISION_RETRIES = 1
 SETUP_CHECK_ARP_CACHE_TIMEOUT_S = 300
 SETUP_CHECK_ARP_CACHE_RETRIES = 1
+SETUP_CHECK_ARP_PER_IP_DEADLINE_S = 60
+ARP_POLL_INTERVAL_S = 1.0
 SETUP_CHECK_DUPLICATE_IP_TIMEOUT_S = 60
 SETUP_CHECK_DUPLICATE_IP_RETRIES = 1
 
@@ -92,33 +93,36 @@ async def setup_check_interderp():
                 await derp_test.save_logs()
 
 
-def _gather_container_ips(cid: str) -> tuple[str, list[str]]:
-    try:
-        name = subprocess.check_output(
-            ["docker", "inspect", "--format={{.Name}}", cid],
-            text=True,
-        ).strip()
-        name = re.sub(r"^/+", "", name)
-    except subprocess.CalledProcessError:
+async def _gather_container_ips(cid: str) -> tuple[str, list[str]]:
+    proc = await asyncio.create_subprocess_exec(
+        "docker",
+        "inspect",
+        "--format={{.Name}}",
+        cid,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.DEVNULL,
+    )
+    stdout, _ = await proc.communicate()
+    if proc.returncode == 0:
+        name = re.sub(r"^/+", "", stdout.decode().strip())
+    else:
         name = cid
 
     # Extract IPv4 addresses inside the container without relying on grep -P.
     # Use: ip -4 -o addr show -> "... IFACE ... A.B.C.D/XX ..."
     # Then project the CIDR column and strip mask.
-    try:
-        ips_out = subprocess.check_output(
-            [
-                "docker",
-                "exec",
-                cid,
-                "sh",
-                "-c",
-                "ip -4 -o addr show | awk '{print $4}' | cut -d/ -f1",
-            ],
-            text=True,
-        )
-    except subprocess.CalledProcessError:
-        ips_out = ""
+    proc = await asyncio.create_subprocess_exec(
+        "docker",
+        "exec",
+        cid,
+        "sh",
+        "-c",
+        "ip -4 -o addr show | awk '{print $4}' | cut -d/ -f1",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.DEVNULL,
+    )
+    stdout, _ = await proc.communicate()
+    ips_out = stdout.decode() if proc.returncode == 0 else ""
 
     ips = [
         ip.strip() for ip in ips_out.split() if ip.strip() and not ip.startswith("127.")
@@ -134,9 +138,17 @@ async def setup_check_duplicate_ip_addresses():
     """
     setup_log.info("Running duplicate IP addresses check..")
     try:
-        containers_out = subprocess.check_output(
-            ["docker", "ps", "-q"], text=True
-        ).strip()
+        proc = await asyncio.create_subprocess_exec(
+            "docker",
+            "ps",
+            "-q",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        stdout, _ = await proc.communicate()
+        if proc.returncode != 0:
+            raise RuntimeError(f"return code {proc.returncode}")
+        containers_out = stdout.decode().strip()
     except Exception as e:  # pylint: disable=broad-exception-caught
         setup_log.error(
             f"cannot execute 'docker ps -q': {e}; skipping duplicate IP check"
@@ -153,7 +165,7 @@ async def setup_check_duplicate_ip_addresses():
     duplicates: dict[str, set[str]] = defaultdict(set)
 
     for cid in containers:
-        name, ips = _gather_container_ips(cid)
+        name, ips = await _gather_container_ips(cid)
 
         # Print container name and IPs (for debugging parity with the original script)
         setup_log.debug("========== %s (%s) ==========", name, cid)
@@ -253,71 +265,84 @@ async def setup_check_arp_cache(session_vm_marks: set[str]):
 
     setup_log.info("Running ARP cache check..")
 
-    def warm_arp(ip: str) -> None:
-        subprocess.call(
-            ["ping", "-c", "1", "-W", "1", ip],
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
+    async def warm_arp(ip: str) -> None:
+        proc = await asyncio.create_subprocess_exec(
+            "ping",
+            "-c",
+            "1",
+            "-W",
+            "1",
+            ip,
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
         )
+        await proc.wait()
 
-    def read_arp_entries() -> list[dict]:
-        return json.loads(
-            subprocess.check_output(
-                ["ip", "-j", "neigh", "show"],
-                text=True,
-            ).strip()
+    async def read_arp_entries() -> list[dict]:
+        proc = await asyncio.create_subprocess_exec(
+            "ip",
+            "-j",
+            "neigh",
+            "show",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
         )
+        stdout, _ = await proc.communicate()
+        if proc.returncode != 0:
+            raise RuntimeError(
+                f"'ip -j neigh show' failed with return code {proc.returncode}"
+            )
+        return json.loads(stdout)
 
-    subprocess.call(
-        ["sudo", "ip", "-s", "-s", "neigh", "flush", "all"],
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
+    flush_proc = await asyncio.create_subprocess_exec(
+        "sudo",
+        "ip",
+        "-s",
+        "-s",
+        "neigh",
+        "flush",
+        "all",
+        stdout=asyncio.subprocess.DEVNULL,
+        stderr=asyncio.subprocess.DEVNULL,
     )
+    await flush_proc.wait()
 
     acceptable_states = {"REACHABLE", "STALE", "DELAY", "PROBE", "PERMANENT"}
-    failures: list[str] = []
 
-    def check_arp_for_ip(tag, ip: str) -> str | None:
-        success = False
+    async def check_arp_for_ip(tag, ip: str) -> str | None:
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + SETUP_CHECK_ARP_PER_IP_DEADLINE_S
         last_arp_entries: list[dict] = []
         while True:
-            if success:
-                break
-            warm_arp(ip)
-            last_arp_entries = read_arp_entries()
+            await warm_arp(ip)
+            last_arp_entries = await read_arp_entries()
             for e in last_arp_entries:
-                dst_ip = e.get("dst")
-                lladdr = e.get("lladdr")
+                if e.get("dst") != ip:
+                    continue
+                if e.get("lladdr") is None:
+                    continue
                 state = e.get("state")
-                if dst_ip is None or dst_ip != ip:
-                    continue
-                if lladdr is None:
-                    continue
                 if state is None or state[0] not in acceptable_states:
                     continue
-                success = True
+                return None
+            if loop.time() >= deadline:
                 break
-        if not success:
-            state = next(
-                (
-                    e.get("state", "missing")
-                    for e in last_arp_entries
-                    if e.get("dst") == ip
-                ),
-                "missing",
-            )
-            return f"{tag.name}:{ip} state={state}"
-        return None
+            await asyncio.sleep(ARP_POLL_INTERVAL_S)
+        state = next(
+            (e.get("state", "missing") for e in last_arp_entries if e.get("dst") == ip),
+            "missing",
+        )
+        return f"{tag.name}:{ip} state={state}"
 
-    for tag in get_required_vm_containers_from_marks(session_vm_marks):
-        if tag in OPENWRT_VM_TAGS:
-            continue
-        for ip in LAN_ADDR_MAP[tag].values():
-            if ip == "":
-                continue
-            failure = check_arp_for_ip(tag, ip)
-            if failure is not None:
-                failures.append(failure)
+    checks = [
+        (tag, ip)
+        for tag in get_required_vm_containers_from_marks(session_vm_marks)
+        if tag not in OPENWRT_VM_TAGS
+        for ip in LAN_ADDR_MAP[tag].values()
+        if ip != ""
+    ]
+    results = await asyncio.gather(*(check_arp_for_ip(tag, ip) for tag, ip in checks))
+    failures = [f for f in results if f is not None]
 
     if failures:
         raise RuntimeError("ARP cache not ready for VMs: " + ", ".join(failures))
@@ -402,14 +427,12 @@ async def perform_setup_checks(
                     setup_nlx_vpn_server,
                 ]:
                     await asyncio.wait_for(
-                        asyncio.shield(target(session_is_container_running)), timeout
+                        target(session_is_container_running), timeout
                     )
                 elif target is setup_check_arp_cache:
-                    await asyncio.wait_for(
-                        asyncio.shield(target(session_vm_marks)), timeout
-                    )
+                    await asyncio.wait_for(target(session_vm_marks), timeout)
                 else:
-                    await asyncio.wait_for(asyncio.shield(target()), timeout)
+                    await asyncio.wait_for(target(), timeout)
                 break
             except asyncio.TimeoutError:
                 setup_log.warning("%s() timeout, retrying...", target)


### PR DESCRIPTION
### Problem
*--setup_checks and log_collection uses blocking subprocess calls, freezing the event loop until the job-level timeout--*

### Solution
*--Convert to asyncio subprocess so their wait_for guards work--*


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
