### PR TITLE
Bump neptun version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1252,11 +1252,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dispatch"
-version = "0.2.0"
-source = "git+https://github.com/NordSecurity/rust-dispatch.git?rev=13447cd7221a74ebcce1277ae0cfc9a421a28ec5#13447cd7221a74ebcce1277ae0cfc9a421a28ec5"
-
-[[package]]
 name = "dispatch2"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2751,27 +2746,27 @@ dependencies = [
 [[package]]
 name = "neptun"
 version = "2.2.3"
-source = "git+https://github.com/NordSecurity/neptun.git?tag=v3.0.0#2d739150cff117c781c1a6b31c0ffc742084d227"
+source = "git+https://github.com/NordSecurity/neptun.git?tag=v3.0.1#a45a31d28780695cb816d5e245a70bd520bd1293"
 dependencies = [
  "aead",
  "base64",
  "blake2",
  "chacha20poly1305",
  "crossbeam-channel",
- "dispatch",
+ "dispatch2",
  "hex",
  "hmac 0.12.1",
  "ip_network",
  "ip_network_table",
  "libc",
- "nix 0.29.0",
+ "nix 0.31.3",
  "num_cpus",
  "parking_lot",
  "rand_core 0.6.4",
  "ring",
  "socket2",
  "subtle",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tracing",
  "untrusted 0.9.0",
  "x25519-dalek",
@@ -2816,19 +2811,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
 dependencies = [
  "smallvec",
-]
-
-[[package]]
-name = "nix"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
-dependencies = [
- "bitflags",
- "cfg-if",
- "cfg_aliases",
- "libc",
- "memoffset",
 ]
 
 [[package]]
@@ -7027,18 +7009,18 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,14 +179,14 @@ windows = { version = "0.62.2", features = [
 ] }
 winreg = "0.56.0"
 
-neptun = { git = "https://github.com/NordSecurity/neptun.git", tag = "v3.0.0", features = [
+neptun = { git = "https://github.com/NordSecurity/neptun.git", tag = "v3.0.1", features = [
   "device",
 ] }
 x25519-dalek = { version = "2.0.1", features = [
   "reusable_secrets",
   "static_secrets",
 ] }
-zeroize = { version = "1.8.2", features = ["derive"] }
+zeroize = { version = "1.9.0", features = ["derive"] }
 hyper-util = "0.1.20"
 
 telio-crypto = { version = "0.1.0", path = "./crates/telio-crypto" }


### PR DESCRIPTION
### Problem
NepTUN has a few minor fixes, which would be nice to have in telio too and uses dispatch2 instead of dispatch, so we can get rid of the latter one

### Solution
Bump NepTUN dependency version

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
