### PR TITLE
nat-lab: keep macOS libtelio remote alive across VM suspend (LLT-4961)

### DIFF
--- a/.unreleased/LLT-4961_mac_daemon_survive_suspend
+++ b/.unreleased/LLT-4961_mac_daemon_survive_suspend
@@ -1,0 +1,1 @@
+Fix nat-lab macOS VM suspend test: the libtelio remote process is now detached (setsid) so it survives the SSH session being torn down across a VM suspend, and SSH transport loss on a reconnected long-lived process no longer fails teardown.

--- a/nat-lab/tests/uniffi/libtelio_remote.py
+++ b/nat-lab/tests/uniffi/libtelio_remote.py
@@ -283,6 +283,15 @@ def main():
     container_ip = sys.argv[2]
     port = int(sys.argv[3])
 
+    # macOS sshd reaps the exec'd child when the SSH connection drops across a VM
+    # suspend, killing this RPC daemon (Windows OpenSSH keeps the orphan). Detach
+    # into our own session so the Pyro server survives the reconnect - LLT-4961.
+    if sys.platform == "darwin":
+        try:
+            os.setsid()
+        except OSError:
+            pass
+
     # Cleanup old log files if any exists
     try:
         os.remove(TCLI_LOG)

--- a/nat-lab/tests/utils/process/ssh_process.py
+++ b/nat-lab/tests/utils/process/ssh_process.py
@@ -156,6 +156,14 @@ class SshProcess(Process):
                         self._process.kill()
                         self._process.close()
                         await self._process.wait_closed()
+        except asyncssh.Error as e:
+            # run_async_context re-raises the launcher task's exception on exit; a
+            # transport loss (VM SSH session dies across a freeze/suspend) is
+            # expected and recovered via reconnect(), so don't fail teardown over
+            # it. A real command failure is ProcessExecError, which still propagates.
+            log.warning(
+                "[%s] SSH transport lost for %s: %s", self._vm_name, self._command, e
+            )
         finally:
             elapsed_ms = (time.monotonic() - start_time) * 1000
             log.info(


### PR DESCRIPTION
### Problem
`test_no_burst_after_system_suspend[VM_MAC]` fails: after the VM resumes, SSH recovers but the libtelio RPC daemon is dead (Pyro port refused), so the post-resume ping hangs into the test timeout. macOS sshd reaps the exec'd `libtelio_remote` child when the SSH connection drops across the suspend; Windows OpenSSH keeps the orphan, which is why only mac fails.

### Solution
- `libtelio_remote.py`: `os.setsid()` on darwin so the daemon detaches into its own session and survives the SSH teardown/reconnect.
- `ssh_process.py`: tolerate transport loss from the background launcher task at teardown (session is rebuilt via `reconnect()`), so a runner stall past the ~60s asyncssh keepalive window doesn't turn into a teardown error. Body exceptions and `ProcessExecError` still propagate.

Validated on the real Mac VM: `system_suspend` + `monotonic_jump` pass; daemon PID confirmed identical across the suspend even when the old socket is genuinely dead.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
