### PR TITLE
Add cert printing on failed derp handshake

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5137,7 +5137,6 @@ dependencies = [
  "crypto_box",
  "env_logger",
  "futures",
- "hex",
  "http-body-util",
  "httparse",
  "hyper",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5104,6 +5104,7 @@ dependencies = [
  "tower",
  "tracing",
  "uuid",
+ "x509-parser",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5103,6 +5103,7 @@ dependencies = [
  "tower",
  "tracing",
  "uuid",
+ "x509-parser",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1402,11 +1402,10 @@ checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5136,7 +5136,6 @@ dependencies = [
  "crypto_box",
  "env_logger",
  "futures",
- "hex",
  "http-body-util",
  "httparse",
  "hyper",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -188,6 +188,7 @@ x25519-dalek = { version = "2.0.1", features = [
 ] }
 zeroize = { version = "1.9.0", features = ["derive"] }
 hyper-util = "0.1.20"
+x509-parser = { version = "0.18.1", default-features = false }
 
 telio-crypto = { version = "0.1.0", path = "./crates/telio-crypto" }
 telio-dns = { version = "0.1.0", path = "./crates/telio-dns" }

--- a/crates/telio-proto/Cargo.toml
+++ b/crates/telio-proto/Cargo.toml
@@ -49,6 +49,7 @@ thiserror.workspace = true
 tokio = { workspace = true, features = ["full"] }
 tracing.workspace = true
 uuid = { workspace = true, features = ["v4"], optional = true }
+x509-parser.workspace = true
 
 telio-crypto.workspace = true
 telio-model.workspace = true

--- a/crates/telio-proto/src/ens/ens_impl.rs
+++ b/crates/telio-proto/src/ens/ens_impl.rs
@@ -492,6 +492,7 @@ pub(crate) mod tests {
         time::{Duration, Instant},
     };
 
+    use assert_matches::assert_matches;
     use async_channel::{self, unbounded, Receiver, Sender};
     use llt_proto::ens::{
         ens_server::{self, EnsServer},

--- a/crates/telio-proto/src/ens/ens_impl.rs
+++ b/crates/telio-proto/src/ens/ens_impl.rs
@@ -9,10 +9,7 @@ use blake3::{derive_key, keyed_hash};
 use http::Uri;
 use hyper_util::rt::TokioIo;
 
-use rustls::{
-    client::danger::ServerCertVerifier, crypto::CryptoProvider, pki_types::CertificateDer,
-    ClientConfig, RootCertStore,
-};
+use rustls::{crypto::CryptoProvider, ClientConfig};
 use telio_crypto::{SecretKey, SharedSecret};
 use telio_model::PublicKey;
 use telio_sockets::SocketPool;
@@ -387,7 +384,7 @@ async fn create_external_channel(
         .await?)
 }
 
-fn make_crypto_provider(allow_only_mlkem: bool) -> Arc<CryptoProvider> {
+pub(crate) fn make_crypto_provider(allow_only_mlkem: bool) -> Arc<CryptoProvider> {
     let mut provider = tokio_rustls::rustls::crypto::aws_lc_rs::default_provider();
 
     if allow_only_mlkem {
@@ -396,89 +393,6 @@ fn make_crypto_provider(allow_only_mlkem: bool) -> Arc<CryptoProvider> {
     }
 
     Arc::new(provider)
-}
-
-fn make_trusted_root_cert_verifier(
-    crypto_provider: Arc<CryptoProvider>,
-    root_certificate: &[u8],
-) -> std::io::Result<Arc<impl ServerCertVerifier>> {
-    use rustls::{
-        client::{danger::HandshakeSignatureValid, WebPkiServerVerifier},
-        pki_types::{ServerName, UnixTime},
-        DigitallySignedStruct, SignatureScheme,
-    };
-
-    #[derive(Debug)]
-    struct CertFingerprintLogger(Arc<WebPkiServerVerifier>);
-
-    impl ServerCertVerifier for CertFingerprintLogger {
-        fn verify_server_cert(
-            &self,
-            end_entity: &CertificateDer<'_>,
-            intermediates: &[CertificateDer<'_>],
-            server_name: &ServerName<'_>,
-            ocsp_response: &[u8],
-            now: UnixTime,
-        ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
-            use sha2::{Digest, Sha256};
-            let hash: [u8; 32] = Sha256::digest(end_entity).into();
-            telio_log_info!(
-                "Remote gRPC server ({server_name:?}) sha256 fingerprint: {}",
-                hex::encode(hash)
-            );
-
-            let verification = self.0.verify_server_cert(
-                end_entity,
-                intermediates,
-                server_name,
-                ocsp_response,
-                now,
-            );
-
-            telio_log_info!("Remote gRPC TLS certificate verification result: {verification:?}");
-
-            verification
-        }
-
-        fn verify_tls12_signature(
-            &self,
-            message: &[u8],
-            cert: &CertificateDer<'_>,
-            dss: &DigitallySignedStruct,
-        ) -> Result<HandshakeSignatureValid, rustls::Error> {
-            self.0.verify_tls12_signature(message, cert, dss)
-        }
-
-        fn verify_tls13_signature(
-            &self,
-            message: &[u8],
-            cert: &CertificateDer<'_>,
-            dss: &DigitallySignedStruct,
-        ) -> Result<HandshakeSignatureValid, rustls::Error> {
-            self.0.verify_tls13_signature(message, cert, dss)
-        }
-
-        fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
-            self.0.supported_verify_schemes()
-        }
-    }
-
-    let mut roots = RootCertStore::empty();
-    let (added, ignored) =
-        roots.add_parsable_certificates([CertificateDer::from_slice(root_certificate)]);
-    if ignored > 0 {
-        telio_log_warn!("Added {added} certs to trusted store, ignored: {ignored}");
-        return Err(std::io::Error::other(
-            "Failed to add root cert to the root certificate store",
-        ));
-    } else {
-        telio_log_debug!("Added {added} certs to trusted store, ignored: {ignored}");
-    }
-
-    let verifier = WebPkiServerVerifier::builder_with_provider(Arc::new(roots), crypto_provider)
-        .build()
-        .map_err(std::io::Error::other)?;
-    Ok(Arc::new(CertFingerprintLogger(verifier)))
 }
 
 fn make_tls_connector(
@@ -491,7 +405,7 @@ fn make_tls_connector(
         .with_safe_default_protocol_versions()
         .map_err(std::io::Error::other)?
         .dangerous()
-        .with_custom_certificate_verifier(make_trusted_root_cert_verifier(
+        .with_custom_certificate_verifier(crate::tls::make_trusted_root_cert_verifier(
             provider,
             root_certificate,
         )?)
@@ -518,7 +432,7 @@ pub fn install_default_crypto_provider() {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use std::{
         collections::HashSet,
         net::Ipv4Addr,
@@ -526,7 +440,6 @@ mod tests {
         time::Duration,
     };
 
-    use assert_matches::assert_matches;
     use async_channel::{self, unbounded, Receiver, Sender};
     use llt_proto::ens::{
         ens_server::{self, EnsServer},
@@ -548,7 +461,7 @@ mod tests {
 
     use super::*;
 
-    const SUBJECT_ALT_NAMES: LazyLock<Vec<String>> =
+    pub(crate) const SUBJECT_ALT_NAMES: LazyLock<Vec<String>> =
         LazyLock::new(|| vec!["localhost".to_string(), "127.0.0.1".to_string()]);
 
     #[derive(Debug)]
@@ -576,14 +489,14 @@ mod tests {
 
     // Root CA and a leaf cert issued by it
     #[derive(Debug)]
-    struct TlsConfig {
-        ca_cert: Certificate,
-        leaf_cert: Certificate,
+    pub(crate) struct TlsConfig {
+        pub(crate) ca_cert: Certificate,
+        pub(crate) leaf_cert: Certificate,
         leaf_key_pem: String,
     }
 
     impl TlsConfig {
-        fn new() -> Self {
+        pub(crate) fn new() -> Self {
             let mut ca_params = CertificateParams::default();
             ca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
 
@@ -1016,120 +929,5 @@ mod tests {
             )
             .unwrap(),
         ))
-    }
-
-    #[test]
-    fn test_cert_verification_rejects_invalid_request() {
-        use rustls::{
-            client::danger::ServerCertVerifier,
-            internal::msgs::codec::{Codec, Reader},
-            DigitallySignedStruct, SignatureScheme,
-        };
-
-        let tls = TlsConfig::new();
-        let verifier =
-            make_trusted_root_cert_verifier(make_crypto_provider(true), &tls.ca_cert.der())
-                .unwrap();
-        let leaf_cert = tls.leaf_cert.der();
-
-        // DigitallySignedStruct with incorrect signature bytes
-        // Wire format: 2 bytes scheme (big-endian u16) + 2 bytes length + signature bytes
-        let scheme_u16: u16 = SignatureScheme::ECDSA_NISTP256_SHA256.into();
-        let garbage_signature = vec![0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x01, 0x02, 0x03];
-        let mut wire_bytes = Vec::new();
-        wire_bytes.extend_from_slice(&scheme_u16.to_be_bytes());
-        wire_bytes.extend_from_slice(&(garbage_signature.len() as u16).to_be_bytes());
-        wire_bytes.extend_from_slice(&garbage_signature);
-
-        let mut reader = Reader::init(&wire_bytes);
-        let dss = DigitallySignedStruct::read(&mut reader).expect("Failed to parse DSS");
-        assert_eq!(dss.scheme, SignatureScheme::ECDSA_NISTP256_SHA256);
-
-        let message = b"this is a TLS handshake message that was NOT signed by the cert's key";
-
-        let tls12_result = verifier.verify_tls12_signature(message, &leaf_cert, &dss);
-        assert_matches!(
-            tls12_result,
-            Err(rustls::Error::InvalidCertificate(
-                rustls::CertificateError::BadSignature
-            ))
-        );
-
-        let tls13_result = verifier.verify_tls13_signature(message, &leaf_cert, &dss);
-        assert_matches!(
-            tls13_result,
-            Err(rustls::Error::InvalidCertificate(
-                rustls::CertificateError::BadSignature
-            ))
-        );
-    }
-
-    #[test]
-    fn test_cert_verification_accepts_correct_request() {
-        use rustls::{
-            client::danger::ServerCertVerified,
-            pki_types::{ServerName, UnixTime},
-        };
-
-        let tls = TlsConfig::new();
-        let verifier =
-            make_trusted_root_cert_verifier(make_crypto_provider(true), &tls.ca_cert.der())
-                .unwrap();
-
-        assert_matches!(
-            verifier.verify_server_cert(
-                tls.leaf_cert.der(),
-                &[tls.ca_cert.der().clone()],
-                &ServerName::DnsName("localhost".try_into().unwrap()),
-                &[],
-                UnixTime::now(),
-            ),
-            Ok(ServerCertVerified { .. })
-        );
-    }
-
-    #[test]
-    fn test_cert_verification_rejects_incorrect_request() {
-        use rustls::pki_types::{ServerName, UnixTime};
-
-        let tls = TlsConfig::new();
-        let verifier =
-            make_trusted_root_cert_verifier(make_crypto_provider(true), &tls.ca_cert.der())
-                .unwrap();
-
-        assert_matches!(
-            verifier.verify_server_cert(
-                tls.leaf_cert.der(),
-                &[tls.ca_cert.der().clone()],
-                &ServerName::DnsName("some-other-name".try_into().unwrap()),
-                &[],
-                UnixTime::now(),
-            ),
-            Err(rustls::Error::InvalidCertificate(
-                rustls::CertificateError::NotValidForNameContext {
-                    expected,
-                    presented
-                }
-            ))
-            if
-                expected == ServerName::DnsName("some-other-name".try_into().unwrap()) &&
-                presented == vec![ "DnsName(\"localhost\")", "IpAddress(127.0.0.1)" ]
-        );
-
-        let random_leaf_cert =
-            rcgen::generate_simple_self_signed(SUBJECT_ALT_NAMES.clone()).unwrap();
-
-        assert_matches!(
-            verifier.verify_server_cert(
-                random_leaf_cert.cert.der(),
-                &[tls.ca_cert.der().clone()],
-                &ServerName::DnsName("localhost".try_into().unwrap()),
-                &[],
-                UnixTime::now(),
-            ),
-            Err(rustls::Error::InvalidCertificate(
-                rustls::CertificateError::UnknownIssuer
-            ))
-        );
     }
 }

--- a/crates/telio-proto/src/ens/ens_impl.rs
+++ b/crates/telio-proto/src/ens/ens_impl.rs
@@ -10,10 +10,7 @@ use blake3::{derive_key, keyed_hash};
 use http::Uri;
 use hyper_util::rt::TokioIo;
 
-use rustls::{
-    client::danger::ServerCertVerifier, crypto::CryptoProvider, pki_types::CertificateDer,
-    ClientConfig, RootCertStore,
-};
+use rustls::{crypto::CryptoProvider, ClientConfig};
 use telio_crypto::{SecretKey, SharedSecret};
 use telio_model::PublicKey;
 use telio_sockets::SocketPool;
@@ -432,7 +429,7 @@ async fn create_external_channel(
         .await?)
 }
 
-fn make_crypto_provider(allow_only_mlkem: bool) -> Arc<CryptoProvider> {
+pub(crate) fn make_crypto_provider(allow_only_mlkem: bool) -> Arc<CryptoProvider> {
     let mut provider = tokio_rustls::rustls::crypto::aws_lc_rs::default_provider();
 
     if allow_only_mlkem {
@@ -441,89 +438,6 @@ fn make_crypto_provider(allow_only_mlkem: bool) -> Arc<CryptoProvider> {
     }
 
     Arc::new(provider)
-}
-
-fn make_trusted_root_cert_verifier(
-    crypto_provider: Arc<CryptoProvider>,
-    root_certificate: &[u8],
-) -> std::io::Result<Arc<impl ServerCertVerifier>> {
-    use rustls::{
-        client::{danger::HandshakeSignatureValid, WebPkiServerVerifier},
-        pki_types::{ServerName, UnixTime},
-        DigitallySignedStruct, SignatureScheme,
-    };
-
-    #[derive(Debug)]
-    struct CertFingerprintLogger(Arc<WebPkiServerVerifier>);
-
-    impl ServerCertVerifier for CertFingerprintLogger {
-        fn verify_server_cert(
-            &self,
-            end_entity: &CertificateDer<'_>,
-            intermediates: &[CertificateDer<'_>],
-            server_name: &ServerName<'_>,
-            ocsp_response: &[u8],
-            now: UnixTime,
-        ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
-            use sha2::{Digest, Sha256};
-            let hash: [u8; 32] = Sha256::digest(end_entity).into();
-            telio_log_info!(
-                "Remote gRPC server ({server_name:?}) sha256 fingerprint: {}",
-                hex::encode(hash)
-            );
-
-            let verification = self.0.verify_server_cert(
-                end_entity,
-                intermediates,
-                server_name,
-                ocsp_response,
-                now,
-            );
-
-            telio_log_info!("Remote gRPC TLS certificate verification result: {verification:?}");
-
-            verification
-        }
-
-        fn verify_tls12_signature(
-            &self,
-            message: &[u8],
-            cert: &CertificateDer<'_>,
-            dss: &DigitallySignedStruct,
-        ) -> Result<HandshakeSignatureValid, rustls::Error> {
-            self.0.verify_tls12_signature(message, cert, dss)
-        }
-
-        fn verify_tls13_signature(
-            &self,
-            message: &[u8],
-            cert: &CertificateDer<'_>,
-            dss: &DigitallySignedStruct,
-        ) -> Result<HandshakeSignatureValid, rustls::Error> {
-            self.0.verify_tls13_signature(message, cert, dss)
-        }
-
-        fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
-            self.0.supported_verify_schemes()
-        }
-    }
-
-    let mut roots = RootCertStore::empty();
-    let (added, ignored) =
-        roots.add_parsable_certificates([CertificateDer::from_slice(root_certificate)]);
-    if ignored > 0 {
-        telio_log_warn!("Added {added} certs to trusted store, ignored: {ignored}");
-        return Err(std::io::Error::other(
-            "Failed to add root cert to the root certificate store",
-        ));
-    } else {
-        telio_log_debug!("Added {added} certs to trusted store, ignored: {ignored}");
-    }
-
-    let verifier = WebPkiServerVerifier::builder_with_provider(Arc::new(roots), crypto_provider)
-        .build()
-        .map_err(std::io::Error::other)?;
-    Ok(Arc::new(CertFingerprintLogger(verifier)))
 }
 
 fn make_tls_connector(
@@ -536,7 +450,7 @@ fn make_tls_connector(
         .with_safe_default_protocol_versions()
         .map_err(std::io::Error::other)?
         .dangerous()
-        .with_custom_certificate_verifier(make_trusted_root_cert_verifier(
+        .with_custom_certificate_verifier(crate::tls::make_trusted_root_cert_verifier(
             provider,
             root_certificate,
         )?)
@@ -567,7 +481,7 @@ fn make_user_agent() -> String {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use std::{
         collections::HashSet,
         net::Ipv4Addr,
@@ -578,7 +492,6 @@ mod tests {
         time::{Duration, Instant},
     };
 
-    use assert_matches::assert_matches;
     use async_channel::{self, unbounded, Receiver, Sender};
     use llt_proto::ens::{
         ens_server::{self, EnsServer},
@@ -604,7 +517,7 @@ mod tests {
 
     use super::*;
 
-    const SUBJECT_ALT_NAMES: LazyLock<Vec<String>> =
+    pub(crate) const SUBJECT_ALT_NAMES: LazyLock<Vec<String>> =
         LazyLock::new(|| vec!["localhost".to_string(), "127.0.0.1".to_string()]);
 
     #[derive(Debug)]
@@ -632,14 +545,14 @@ mod tests {
 
     // Root CA and a leaf cert issued by it
     #[derive(Debug)]
-    struct TlsConfig {
-        ca_cert: Certificate,
-        leaf_cert: Certificate,
+    pub(crate) struct TlsConfig {
+        pub(crate) ca_cert: Certificate,
+        pub(crate) leaf_cert: Certificate,
         leaf_key_pem: String,
     }
 
     impl TlsConfig {
-        fn new() -> Self {
+        pub(crate) fn new() -> Self {
             let mut ca_params = CertificateParams::default();
             ca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
 
@@ -1349,120 +1262,5 @@ mod tests {
             )
             .unwrap(),
         ))
-    }
-
-    #[test]
-    fn test_cert_verification_rejects_invalid_request() {
-        use rustls::{
-            client::danger::ServerCertVerifier,
-            internal::msgs::codec::{Codec, Reader},
-            DigitallySignedStruct, SignatureScheme,
-        };
-
-        let tls = TlsConfig::new();
-        let verifier =
-            make_trusted_root_cert_verifier(make_crypto_provider(true), &tls.ca_cert.der())
-                .unwrap();
-        let leaf_cert = tls.leaf_cert.der();
-
-        // DigitallySignedStruct with incorrect signature bytes
-        // Wire format: 2 bytes scheme (big-endian u16) + 2 bytes length + signature bytes
-        let scheme_u16: u16 = SignatureScheme::ECDSA_NISTP256_SHA256.into();
-        let garbage_signature = vec![0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x01, 0x02, 0x03];
-        let mut wire_bytes = Vec::new();
-        wire_bytes.extend_from_slice(&scheme_u16.to_be_bytes());
-        wire_bytes.extend_from_slice(&(garbage_signature.len() as u16).to_be_bytes());
-        wire_bytes.extend_from_slice(&garbage_signature);
-
-        let mut reader = Reader::init(&wire_bytes);
-        let dss = DigitallySignedStruct::read(&mut reader).expect("Failed to parse DSS");
-        assert_eq!(dss.scheme, SignatureScheme::ECDSA_NISTP256_SHA256);
-
-        let message = b"this is a TLS handshake message that was NOT signed by the cert's key";
-
-        let tls12_result = verifier.verify_tls12_signature(message, &leaf_cert, &dss);
-        assert_matches!(
-            tls12_result,
-            Err(rustls::Error::InvalidCertificate(
-                rustls::CertificateError::BadSignature
-            ))
-        );
-
-        let tls13_result = verifier.verify_tls13_signature(message, &leaf_cert, &dss);
-        assert_matches!(
-            tls13_result,
-            Err(rustls::Error::InvalidCertificate(
-                rustls::CertificateError::BadSignature
-            ))
-        );
-    }
-
-    #[test]
-    fn test_cert_verification_accepts_correct_request() {
-        use rustls::{
-            client::danger::ServerCertVerified,
-            pki_types::{ServerName, UnixTime},
-        };
-
-        let tls = TlsConfig::new();
-        let verifier =
-            make_trusted_root_cert_verifier(make_crypto_provider(true), &tls.ca_cert.der())
-                .unwrap();
-
-        assert_matches!(
-            verifier.verify_server_cert(
-                tls.leaf_cert.der(),
-                &[tls.ca_cert.der().clone()],
-                &ServerName::DnsName("localhost".try_into().unwrap()),
-                &[],
-                UnixTime::now(),
-            ),
-            Ok(ServerCertVerified { .. })
-        );
-    }
-
-    #[test]
-    fn test_cert_verification_rejects_incorrect_request() {
-        use rustls::pki_types::{ServerName, UnixTime};
-
-        let tls = TlsConfig::new();
-        let verifier =
-            make_trusted_root_cert_verifier(make_crypto_provider(true), &tls.ca_cert.der())
-                .unwrap();
-
-        assert_matches!(
-            verifier.verify_server_cert(
-                tls.leaf_cert.der(),
-                &[tls.ca_cert.der().clone()],
-                &ServerName::DnsName("some-other-name".try_into().unwrap()),
-                &[],
-                UnixTime::now(),
-            ),
-            Err(rustls::Error::InvalidCertificate(
-                rustls::CertificateError::NotValidForNameContext {
-                    expected,
-                    presented
-                }
-            ))
-            if
-                expected == ServerName::DnsName("some-other-name".try_into().unwrap()) &&
-                presented == vec![ "DnsName(\"localhost\")", "IpAddress(127.0.0.1)" ]
-        );
-
-        let random_leaf_cert =
-            rcgen::generate_simple_self_signed(SUBJECT_ALT_NAMES.clone()).unwrap();
-
-        assert_matches!(
-            verifier.verify_server_cert(
-                random_leaf_cert.cert.der(),
-                &[tls.ca_cert.der().clone()],
-                &ServerName::DnsName("localhost".try_into().unwrap()),
-                &[],
-                UnixTime::now(),
-            ),
-            Err(rustls::Error::InvalidCertificate(
-                rustls::CertificateError::UnknownIssuer
-            ))
-        );
     }
 }

--- a/crates/telio-proto/src/ens/mod.rs
+++ b/crates/telio-proto/src/ens/mod.rs
@@ -4,7 +4,7 @@
 //! (when `enable_ens` feature is on) or a stub implementation (when disabled).
 
 #[cfg(feature = "enable_ens")]
-mod ens_impl;
+pub(crate) mod ens_impl;
 #[cfg(feature = "enable_ens")]
 pub(crate) use ens_impl::grpc;
 #[cfg(feature = "enable_ens")]

--- a/crates/telio-proto/src/ens/mod.rs
+++ b/crates/telio-proto/src/ens/mod.rs
@@ -16,7 +16,7 @@ pub struct KeepaliveConfig {
 }
 
 #[cfg(feature = "enable_ens")]
-mod ens_impl;
+pub(crate) mod ens_impl;
 #[cfg(feature = "enable_ens")]
 pub(crate) use ens_impl::grpc;
 #[cfg(feature = "enable_ens")]

--- a/crates/telio-proto/src/lib.rs
+++ b/crates/telio-proto/src/lib.rs
@@ -16,6 +16,9 @@ mod packet;
 
 mod ens;
 
+#[cfg(feature = "enable_ens")]
+mod tls;
+
 pub use ens::{
     grpc::{ConnectionError, Error as GrpcError},
     install_default_crypto_provider, Error, ErrorNotificationService,

--- a/crates/telio-proto/src/lib.rs
+++ b/crates/telio-proto/src/lib.rs
@@ -16,13 +16,14 @@ mod packet;
 
 mod ens;
 
-#[cfg(feature = "enable_ens")]
 mod tls;
 
 pub use ens::{
     grpc::{ConnectionError, Error as GrpcError},
     install_default_crypto_provider, Error, ErrorNotificationService,
 };
+
+pub use tls::CertLoggingVerifier;
 
 pub use codec::{Codec, Error as CodecError, Result as CodecResult};
 pub use packet::*;

--- a/crates/telio-proto/src/lib.rs
+++ b/crates/telio-proto/src/lib.rs
@@ -16,6 +16,9 @@ mod packet;
 
 mod ens;
 
+#[cfg(feature = "enable_ens")]
+mod tls;
+
 pub use ens::{
     grpc::{ConnectionError, Error as GrpcError},
     install_default_crypto_provider, Error, ErrorNotificationService, KeepaliveConfig,

--- a/crates/telio-proto/src/lib.rs
+++ b/crates/telio-proto/src/lib.rs
@@ -16,13 +16,14 @@ mod packet;
 
 mod ens;
 
-#[cfg(feature = "enable_ens")]
 mod tls;
 
 pub use ens::{
     grpc::{ConnectionError, Error as GrpcError},
     install_default_crypto_provider, Error, ErrorNotificationService, KeepaliveConfig,
 };
+
+pub use tls::CertLoggingVerifier;
 
 pub use codec::{Codec, Error as CodecError, Result as CodecResult};
 pub use packet::*;

--- a/crates/telio-proto/src/tls.rs
+++ b/crates/telio-proto/src/tls.rs
@@ -118,9 +118,12 @@ fn format_failed_cert(
     err: &rustls::Error,
 ) -> String {
     let fingerprint = fingerprint(end_entity);
+    // `err` is deliberately printed with `Debug`: it keeps the rustls variant name (e.g.
+    // `InvalidCertificate(UnknownIssuer)`) in the log, which support tooling and
+    // `nat-lab/tests/test_ens.py` grep for. `Display` would drop it.
     match x509_parser::parse_x509_certificate(end_entity.as_ref()) {
         Ok((_, cert)) => format!(
-            "{} TLS cert verification failed for {:?}: {}. Presented cert: issuer=[{}], subject=[{}], validity=[{} .. {}], sha256={}, intermediates={}",
+            "{} TLS cert verification failed for {:?}: {:?}. Presented cert: issuer=[{}], subject=[{}], validity=[{} .. {}], sha256={}, intermediates={}",
             context,
             server_name,
             err,
@@ -132,7 +135,7 @@ fn format_failed_cert(
             intermediates.len()
         ),
         Err(parse_err) => format!(
-            "{} TLS cert verification failed for {:?}: {}. Presented cert unparsable ({}), sha256={}, intermediates={}",
+            "{} TLS cert verification failed for {:?}: {:?}. Presented cert unparsable ({}), sha256={}, intermediates={}",
             context,
             server_name,
             err,
@@ -296,7 +299,9 @@ mod tests {
         for needle in [
             "DERP TLS cert verification failed",
             SERVER_NAME,
-            "UnknownIssuer",
+            // `Debug`-formatted variant name; test_ens_will_not_emit_errors_from_incorrect_tls_session
+            // in nat-lab greps the client log for exactly this substring
+            "InvalidCertificate(UnknownIssuer)",
             "issuer=[CN=Evil Proxy CA]",
             "subject=[CN=Evil Proxy CA]",
             &format!("sha256={}", fingerprint(evil_cert.der())),

--- a/crates/telio-proto/src/tls.rs
+++ b/crates/telio-proto/src/tls.rs
@@ -3,20 +3,40 @@
 use std::sync::Arc;
 
 use rustls::{
-    client::{
-        danger::{HandshakeSignatureValid, ServerCertVerifier},
-        WebPkiServerVerifier,
-    },
-    crypto::CryptoProvider,
+    client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier},
     pki_types::{CertificateDer, ServerName, UnixTime},
-    DigitallySignedStruct, RootCertStore, SignatureScheme,
+    DigitallySignedStruct, SignatureScheme,
 };
-use telio_utils::{telio_log_debug, telio_log_info, telio_log_warn};
+use sha2::{Digest, Sha256};
+use telio_utils::{telio_log_info, telio_log_warn};
 
+/// Decorator around a certificate verifier which logs details of the presented server
+/// certificate. Verification itself is fully delegated to the inner verifier.
 #[derive(Debug)]
-pub(crate) struct CertFingerprintLogger(Arc<WebPkiServerVerifier>);
+pub struct CertLoggingVerifier {
+    inner: Arc<dyn ServerCertVerifier>,
+    context: &'static str,
+    log_success: bool,
+}
 
-impl ServerCertVerifier for CertFingerprintLogger {
+impl CertLoggingVerifier {
+    /// Wraps `inner`, prefixing the logged messages with `context` to tell the connection kind
+    /// apart. With `log_success` on, the fingerprint and the outcome of every accepted
+    /// certificate are logged too, not only the details of the rejected ones.
+    pub fn new(
+        inner: Arc<dyn ServerCertVerifier>,
+        context: &'static str,
+        log_success: bool,
+    ) -> Self {
+        Self {
+            inner,
+            context,
+            log_success,
+        }
+    }
+}
+
+impl ServerCertVerifier for CertLoggingVerifier {
     fn verify_server_cert(
         &self,
         end_entity: &CertificateDer<'_>,
@@ -24,21 +44,39 @@ impl ServerCertVerifier for CertFingerprintLogger {
         server_name: &ServerName<'_>,
         ocsp_response: &[u8],
         now: UnixTime,
-    ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
-        use sha2::{Digest, Sha256};
-        let hash: [u8; 32] = Sha256::digest(end_entity).into();
-        telio_log_info!(
-            "Remote gRPC server ({server_name:?}) sha256 fingerprint: {}",
-            hex::encode(hash)
+    ) -> Result<ServerCertVerified, rustls::Error> {
+        if self.log_success {
+            telio_log_info!(
+                "{} TLS cert sha256={} presented for {server_name:?}",
+                self.context,
+                fingerprint(end_entity)
+            );
+        }
+
+        let result = self.inner.verify_server_cert(
+            end_entity,
+            intermediates,
+            server_name,
+            ocsp_response,
+            now,
         );
 
-        let verification =
-            self.0
-                .verify_server_cert(end_entity, intermediates, server_name, ocsp_response, now);
+        match &result {
+            Ok(_) => {
+                if self.log_success {
+                    telio_log_info!(
+                        "{} TLS cert verification succeeded for {server_name:?}",
+                        self.context
+                    );
+                }
+            }
+            Err(err) => telio_log_warn!(
+                "{}",
+                format_failed_cert(self.context, end_entity, intermediates, server_name, err)
+            ),
+        }
 
-        telio_log_info!("Remote gRPC TLS certificate verification result: {verification:?}");
-
-        verification
+        result
     }
 
     fn verify_tls12_signature(
@@ -47,7 +85,7 @@ impl ServerCertVerifier for CertFingerprintLogger {
         cert: &CertificateDer<'_>,
         dss: &DigitallySignedStruct,
     ) -> Result<HandshakeSignatureValid, rustls::Error> {
-        self.0.verify_tls12_signature(message, cert, dss)
+        self.inner.verify_tls12_signature(message, cert, dss)
     }
 
     fn verify_tls13_signature(
@@ -56,19 +94,64 @@ impl ServerCertVerifier for CertFingerprintLogger {
         cert: &CertificateDer<'_>,
         dss: &DigitallySignedStruct,
     ) -> Result<HandshakeSignatureValid, rustls::Error> {
-        self.0.verify_tls13_signature(message, cert, dss)
+        self.inner.verify_tls13_signature(message, cert, dss)
     }
 
     fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
-        self.0.supported_verify_schemes()
+        self.inner.supported_verify_schemes()
+    }
+
+    fn requires_raw_public_keys(&self) -> bool {
+        self.inner.requires_raw_public_keys()
     }
 }
 
+fn fingerprint(cert: &CertificateDer<'_>) -> String {
+    hex::encode(Sha256::digest(cert.as_ref()))
+}
+
+fn format_failed_cert(
+    context: &str,
+    end_entity: &CertificateDer<'_>,
+    intermediates: &[CertificateDer<'_>],
+    server_name: &ServerName<'_>,
+    err: &rustls::Error,
+) -> String {
+    let fingerprint = fingerprint(end_entity);
+    match x509_parser::parse_x509_certificate(end_entity.as_ref()) {
+        Ok((_, cert)) => format!(
+            "{} TLS cert verification failed for {:?}: {}. Presented cert: issuer=[{}], subject=[{}], validity=[{} .. {}], sha256={}, intermediates={}",
+            context,
+            server_name,
+            err,
+            cert.issuer(),
+            cert.subject(),
+            cert.validity().not_before,
+            cert.validity().not_after,
+            fingerprint,
+            intermediates.len()
+        ),
+        Err(parse_err) => format!(
+            "{} TLS cert verification failed for {:?}: {}. Presented cert unparsable ({}), sha256={}, intermediates={}",
+            context,
+            server_name,
+            err,
+            parse_err,
+            fingerprint,
+            intermediates.len()
+        ),
+    }
+}
+
+#[cfg(feature = "enable_ens")]
 pub(crate) fn make_trusted_root_cert_verifier(
-    crypto_provider: Arc<CryptoProvider>,
+    crypto_provider: Arc<rustls::crypto::CryptoProvider>,
     root_certificate: &[u8],
 ) -> std::io::Result<Arc<impl ServerCertVerifier>> {
-    let mut roots = RootCertStore::empty();
+    use rustls::client::WebPkiServerVerifier;
+    use telio_utils::telio_log_debug;
+
+    let mut roots = rustls::RootCertStore::empty();
     let (added, ignored) =
         roots.add_parsable_certificates([CertificateDer::from_slice(root_certificate)]);
     if ignored > 0 {
@@ -83,132 +166,280 @@ pub(crate) fn make_trusted_root_cert_verifier(
     let verifier = WebPkiServerVerifier::builder_with_provider(Arc::new(roots), crypto_provider)
         .build()
         .map_err(std::io::Error::other)?;
-    Ok(Arc::new(CertFingerprintLogger(verifier)))
+    Ok(Arc::new(CertLoggingVerifier::new(
+        verifier, "ENS gRPC", true,
+    )))
 }
 
 #[cfg(test)]
 mod tests {
-    use assert_matches::assert_matches;
-
-    use crate::ens::ens_impl::{
-        make_crypto_provider,
-        tests::{TlsConfig, SUBJECT_ALT_NAMES},
+    use rcgen::{
+        BasicConstraints, Certificate, CertificateParams, DistinguishedName, DnType, IsCa, Issuer,
+        KeyPair,
+    };
+    use rustls::{
+        client::WebPkiServerVerifier, crypto::CryptoProvider, CertificateError, RootCertStore,
     };
 
     use super::*;
 
-    #[test]
-    fn test_cert_verification_rejects_invalid_request() {
-        use rustls::{
-            client::danger::ServerCertVerifier,
-            internal::msgs::codec::{Codec, Reader},
-            DigitallySignedStruct, SignatureScheme,
-        };
+    const SERVER_NAME: &str = "derp.example.com";
 
-        let tls = TlsConfig::new();
-        let verifier =
-            make_trusted_root_cert_verifier(make_crypto_provider(true), &tls.ca_cert.der())
+    // Explicit provider: with both `ring` and `aws-lc-rs` rustls features enabled
+    // (workspace-wide test builds), the ambient default is ambiguous and panics
+    fn test_crypto_provider() -> Arc<CryptoProvider> {
+        Arc::new(rustls::crypto::ring::default_provider())
+    }
+
+    fn self_signed_ca(common_name: &str) -> (Certificate, Issuer<'static, KeyPair>) {
+        let mut params = CertificateParams::default();
+        params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+        let mut dn = DistinguishedName::new();
+        dn.push(DnType::CommonName, common_name);
+        params.distinguished_name = dn;
+
+        let key = KeyPair::generate().unwrap();
+        let cert = params.self_signed(&key).unwrap();
+        (cert, Issuer::new(params, key))
+    }
+
+    fn leaf_signed_by(issuer: &Issuer<'static, KeyPair>) -> Certificate {
+        let params = CertificateParams::new(vec![SERVER_NAME.to_string()]).unwrap();
+        let key = KeyPair::generate().unwrap();
+        params.signed_by(&key, issuer).unwrap()
+    }
+
+    fn self_signed_leaf(common_name: &str) -> Certificate {
+        let mut params = CertificateParams::new(vec![SERVER_NAME.to_string()]).unwrap();
+        let mut dn = DistinguishedName::new();
+        dn.push(DnType::CommonName, common_name);
+        params.distinguished_name = dn;
+
+        let key = KeyPair::generate().unwrap();
+        params.self_signed(&key).unwrap()
+    }
+
+    // A verifier trusting only `root`, wrapped in the logging decorator
+    fn verifier_trusting(root: &Certificate, log_success: bool) -> CertLoggingVerifier {
+        let mut roots = RootCertStore::empty();
+        roots.add(root.der().clone()).unwrap();
+        let inner =
+            WebPkiServerVerifier::builder_with_provider(Arc::new(roots), test_crypto_provider())
+                .build()
                 .unwrap();
-        let leaf_cert = tls.leaf_cert.der();
+        CertLoggingVerifier::new(inner, "DERP", log_success)
+    }
 
-        // DigitallySignedStruct with incorrect signature bytes
-        // Wire format: 2 bytes scheme (big-endian u16) + 2 bytes length + signature bytes
-        let scheme_u16: u16 = SignatureScheme::ECDSA_NISTP256_SHA256.into();
-        let garbage_signature = vec![0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x01, 0x02, 0x03];
-        let mut wire_bytes = Vec::new();
-        wire_bytes.extend_from_slice(&scheme_u16.to_be_bytes());
-        wire_bytes.extend_from_slice(&(garbage_signature.len() as u16).to_be_bytes());
-        wire_bytes.extend_from_slice(&garbage_signature);
+    // Simulates a MITM proxy presenting a certificate from an unknown CA: the decorator must
+    // return the inner verifier's UnknownIssuer error unchanged
+    #[test]
+    fn rejects_unknown_issuer() {
+        let (trusted_ca, _) = self_signed_ca("Test Root CA");
+        let evil_cert = self_signed_leaf("Evil Proxy CA");
 
-        let mut reader = Reader::init(&wire_bytes);
-        let dss = DigitallySignedStruct::read(&mut reader).expect("Failed to parse DSS");
-        assert_eq!(dss.scheme, SignatureScheme::ECDSA_NISTP256_SHA256);
+        let verifier = verifier_trusting(&trusted_ca, false);
+        let server_name = ServerName::try_from(SERVER_NAME).unwrap();
 
-        let message = b"this is a TLS handshake message that was NOT signed by the cert's key";
+        let result =
+            verifier.verify_server_cert(evil_cert.der(), &[], &server_name, &[], UnixTime::now());
 
-        let tls12_result = verifier.verify_tls12_signature(message, &leaf_cert, &dss);
-        assert_matches!(
-            tls12_result,
-            Err(rustls::Error::InvalidCertificate(
-                rustls::CertificateError::BadSignature
-            ))
-        );
-
-        let tls13_result = verifier.verify_tls13_signature(message, &leaf_cert, &dss);
-        assert_matches!(
-            tls13_result,
-            Err(rustls::Error::InvalidCertificate(
-                rustls::CertificateError::BadSignature
-            ))
+        assert!(
+            matches!(
+                result,
+                Err(rustls::Error::InvalidCertificate(
+                    CertificateError::UnknownIssuer
+                ))
+            ),
+            "expected UnknownIssuer for a self-signed cert, got: {result:?}"
         );
     }
 
+    // Happy path: a chain anchored in the trust store passes through the decorator unchanged,
+    // whether or not successful verifications are logged
     #[test]
-    fn test_cert_verification_accepts_correct_request() {
-        use rustls::{
-            client::danger::ServerCertVerified,
-            pki_types::{ServerName, UnixTime},
-        };
+    fn accepts_trusted_chain() {
+        let (ca_cert, issuer) = self_signed_ca("Test Root CA");
+        let leaf_cert = leaf_signed_by(&issuer);
+        let server_name = ServerName::try_from(SERVER_NAME).unwrap();
 
-        let tls = TlsConfig::new();
-        let verifier =
-            make_trusted_root_cert_verifier(make_crypto_provider(true), &tls.ca_cert.der())
-                .unwrap();
+        for log_success in [false, true] {
+            let verifier = verifier_trusting(&ca_cert, log_success);
 
-        assert_matches!(
-            verifier.verify_server_cert(
-                tls.leaf_cert.der(),
-                &[tls.ca_cert.der().clone()],
-                &ServerName::DnsName("localhost".try_into().unwrap()),
+            let result = verifier.verify_server_cert(
+                leaf_cert.der(),
+                &[],
+                &server_name,
                 &[],
                 UnixTime::now(),
-            ),
-            Ok(ServerCertVerified { .. })
-        );
+            );
+
+            assert!(
+                result.is_ok(),
+                "expected trusted chain to verify with log_success={log_success}, got: {result:?}"
+            );
+        }
     }
 
     #[test]
-    fn test_cert_verification_rejects_incorrect_request() {
-        use rustls::pki_types::{ServerName, UnixTime};
+    fn format_failed_cert_describes_the_presented_cert() {
+        let evil_cert = self_signed_leaf("Evil Proxy CA");
+        let server_name = ServerName::try_from(SERVER_NAME).unwrap();
 
-        let tls = TlsConfig::new();
-        let verifier =
-            make_trusted_root_cert_verifier(make_crypto_provider(true), &tls.ca_cert.der())
-                .unwrap();
-
-        assert_matches!(
-            verifier.verify_server_cert(
-                tls.leaf_cert.der(),
-                &[tls.ca_cert.der().clone()],
-                &ServerName::DnsName("some-other-name".try_into().unwrap()),
-                &[],
-                UnixTime::now(),
-            ),
-            Err(rustls::Error::InvalidCertificate(
-                rustls::CertificateError::NotValidForNameContext {
-                    expected,
-                    presented
-                }
-            ))
-            if
-                expected == ServerName::DnsName("some-other-name".try_into().unwrap()) &&
-                presented == vec![ "DnsName(\"localhost\")", "IpAddress(127.0.0.1)" ]
+        let msg = format_failed_cert(
+            "DERP",
+            evil_cert.der(),
+            &[],
+            &server_name,
+            &rustls::Error::InvalidCertificate(CertificateError::UnknownIssuer),
         );
 
-        let random_leaf_cert =
-            rcgen::generate_simple_self_signed(SUBJECT_ALT_NAMES.clone()).unwrap();
+        for needle in [
+            "DERP TLS cert verification failed",
+            SERVER_NAME,
+            "UnknownIssuer",
+            "issuer=[CN=Evil Proxy CA]",
+            "subject=[CN=Evil Proxy CA]",
+            &format!("sha256={}", fingerprint(evil_cert.der())),
+            "intermediates=0",
+        ] {
+            assert!(
+                msg.contains(needle),
+                "expected log message to contain {needle:?}, got: {msg:?}"
+            );
+        }
+    }
 
-        assert_matches!(
-            verifier.verify_server_cert(
-                random_leaf_cert.cert.der(),
-                &[tls.ca_cert.der().clone()],
-                &ServerName::DnsName("localhost".try_into().unwrap()),
-                &[],
-                UnixTime::now(),
-            ),
-            Err(rustls::Error::InvalidCertificate(
-                rustls::CertificateError::UnknownIssuer
-            ))
+    #[test]
+    fn format_failed_cert_handles_unparsable_certificate() {
+        let garbage = CertificateDer::from(vec![0u8; 16]);
+        let server_name = ServerName::try_from(SERVER_NAME).unwrap();
+        // Must not panic on a certificate that is not valid X.509
+        let msg = format_failed_cert(
+            "DERP",
+            &garbage,
+            &[],
+            &server_name,
+            &rustls::Error::DecryptError,
         );
+        assert!(
+            msg.contains("unparsable"),
+            "expected log message to mention the cert is unparsable, got: {msg:?}"
+        );
+    }
+
+    #[cfg(feature = "enable_ens")]
+    mod ens {
+        use assert_matches::assert_matches;
+
+        use crate::ens::ens_impl::{
+            make_crypto_provider,
+            tests::{TlsConfig, SUBJECT_ALT_NAMES},
+        };
+
+        use super::*;
+
+        #[test]
+        fn test_cert_verification_rejects_invalid_request() {
+            use rustls::internal::msgs::codec::{Codec, Reader};
+
+            let tls = TlsConfig::new();
+            let verifier =
+                make_trusted_root_cert_verifier(make_crypto_provider(true), &tls.ca_cert.der())
+                    .unwrap();
+            let leaf_cert = tls.leaf_cert.der();
+
+            // DigitallySignedStruct with incorrect signature bytes
+            // Wire format: 2 bytes scheme (big-endian u16) + 2 bytes length + signature bytes
+            let scheme_u16: u16 = SignatureScheme::ECDSA_NISTP256_SHA256.into();
+            let garbage_signature = vec![0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x01, 0x02, 0x03];
+            let mut wire_bytes = Vec::new();
+            wire_bytes.extend_from_slice(&scheme_u16.to_be_bytes());
+            wire_bytes.extend_from_slice(&(garbage_signature.len() as u16).to_be_bytes());
+            wire_bytes.extend_from_slice(&garbage_signature);
+
+            let mut reader = Reader::init(&wire_bytes);
+            let dss = DigitallySignedStruct::read(&mut reader).expect("Failed to parse DSS");
+            assert_eq!(dss.scheme, SignatureScheme::ECDSA_NISTP256_SHA256);
+
+            let message = b"this is a TLS handshake message that was NOT signed by the cert's key";
+
+            let tls12_result = verifier.verify_tls12_signature(message, &leaf_cert, &dss);
+            assert_matches!(
+                tls12_result,
+                Err(rustls::Error::InvalidCertificate(
+                    rustls::CertificateError::BadSignature
+                ))
+            );
+
+            let tls13_result = verifier.verify_tls13_signature(message, &leaf_cert, &dss);
+            assert_matches!(
+                tls13_result,
+                Err(rustls::Error::InvalidCertificate(
+                    rustls::CertificateError::BadSignature
+                ))
+            );
+        }
+
+        #[test]
+        fn test_cert_verification_accepts_correct_request() {
+            let tls = TlsConfig::new();
+            let verifier =
+                make_trusted_root_cert_verifier(make_crypto_provider(true), &tls.ca_cert.der())
+                    .unwrap();
+
+            assert_matches!(
+                verifier.verify_server_cert(
+                    tls.leaf_cert.der(),
+                    &[tls.ca_cert.der().clone()],
+                    &ServerName::DnsName("localhost".try_into().unwrap()),
+                    &[],
+                    UnixTime::now(),
+                ),
+                Ok(ServerCertVerified { .. })
+            );
+        }
+
+        #[test]
+        fn test_cert_verification_rejects_incorrect_request() {
+            let tls = TlsConfig::new();
+            let verifier =
+                make_trusted_root_cert_verifier(make_crypto_provider(true), &tls.ca_cert.der())
+                    .unwrap();
+
+            assert_matches!(
+                verifier.verify_server_cert(
+                    tls.leaf_cert.der(),
+                    &[tls.ca_cert.der().clone()],
+                    &ServerName::DnsName("some-other-name".try_into().unwrap()),
+                    &[],
+                    UnixTime::now(),
+                ),
+                Err(rustls::Error::InvalidCertificate(
+                    rustls::CertificateError::NotValidForNameContext {
+                        expected,
+                        presented
+                    }
+                ))
+                if
+                    expected == ServerName::DnsName("some-other-name".try_into().unwrap()) &&
+                    presented == vec![ "DnsName(\"localhost\")", "IpAddress(127.0.0.1)" ]
+            );
+
+            let random_leaf_cert =
+                rcgen::generate_simple_self_signed(SUBJECT_ALT_NAMES.clone()).unwrap();
+
+            assert_matches!(
+                verifier.verify_server_cert(
+                    random_leaf_cert.cert.der(),
+                    &[tls.ca_cert.der().clone()],
+                    &ServerName::DnsName("localhost".try_into().unwrap()),
+                    &[],
+                    UnixTime::now(),
+                ),
+                Err(rustls::Error::InvalidCertificate(
+                    rustls::CertificateError::UnknownIssuer
+                ))
+            );
+        }
     }
 }

--- a/crates/telio-proto/src/tls.rs
+++ b/crates/telio-proto/src/tls.rs
@@ -1,0 +1,214 @@
+//! TLS certificate verification helpers.
+
+use std::sync::Arc;
+
+use rustls::{
+    client::{
+        danger::{HandshakeSignatureValid, ServerCertVerifier},
+        WebPkiServerVerifier,
+    },
+    crypto::CryptoProvider,
+    pki_types::{CertificateDer, ServerName, UnixTime},
+    DigitallySignedStruct, RootCertStore, SignatureScheme,
+};
+use telio_utils::{telio_log_debug, telio_log_info, telio_log_warn};
+
+#[derive(Debug)]
+pub(crate) struct CertFingerprintLogger(Arc<WebPkiServerVerifier>);
+
+impl ServerCertVerifier for CertFingerprintLogger {
+    fn verify_server_cert(
+        &self,
+        end_entity: &CertificateDer<'_>,
+        intermediates: &[CertificateDer<'_>],
+        server_name: &ServerName<'_>,
+        ocsp_response: &[u8],
+        now: UnixTime,
+    ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+        use sha2::{Digest, Sha256};
+        let hash: [u8; 32] = Sha256::digest(end_entity).into();
+        telio_log_info!(
+            "Remote gRPC server ({server_name:?}) sha256 fingerprint: {}",
+            hex::encode(hash)
+        );
+
+        let verification =
+            self.0
+                .verify_server_cert(end_entity, intermediates, server_name, ocsp_response, now);
+
+        telio_log_info!("Remote gRPC TLS certificate verification result: {verification:?}");
+
+        verification
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        self.0.verify_tls12_signature(message, cert, dss)
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        self.0.verify_tls13_signature(message, cert, dss)
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        self.0.supported_verify_schemes()
+    }
+}
+
+pub(crate) fn make_trusted_root_cert_verifier(
+    crypto_provider: Arc<CryptoProvider>,
+    root_certificate: &[u8],
+) -> std::io::Result<Arc<impl ServerCertVerifier>> {
+    let mut roots = RootCertStore::empty();
+    let (added, ignored) =
+        roots.add_parsable_certificates([CertificateDer::from_slice(root_certificate)]);
+    if ignored > 0 {
+        telio_log_warn!("Added {added} certs to trusted store, ignored: {ignored}");
+        return Err(std::io::Error::other(
+            "Failed to add root cert to the root certificate store",
+        ));
+    } else {
+        telio_log_debug!("Added {added} certs to trusted store, ignored: {ignored}");
+    }
+
+    let verifier = WebPkiServerVerifier::builder_with_provider(Arc::new(roots), crypto_provider)
+        .build()
+        .map_err(std::io::Error::other)?;
+    Ok(Arc::new(CertFingerprintLogger(verifier)))
+}
+
+#[cfg(test)]
+mod tests {
+    use assert_matches::assert_matches;
+
+    use crate::ens::ens_impl::{
+        make_crypto_provider,
+        tests::{TlsConfig, SUBJECT_ALT_NAMES},
+    };
+
+    use super::*;
+
+    #[test]
+    fn test_cert_verification_rejects_invalid_request() {
+        use rustls::{
+            client::danger::ServerCertVerifier,
+            internal::msgs::codec::{Codec, Reader},
+            DigitallySignedStruct, SignatureScheme,
+        };
+
+        let tls = TlsConfig::new();
+        let verifier =
+            make_trusted_root_cert_verifier(make_crypto_provider(true), &tls.ca_cert.der())
+                .unwrap();
+        let leaf_cert = tls.leaf_cert.der();
+
+        // DigitallySignedStruct with incorrect signature bytes
+        // Wire format: 2 bytes scheme (big-endian u16) + 2 bytes length + signature bytes
+        let scheme_u16: u16 = SignatureScheme::ECDSA_NISTP256_SHA256.into();
+        let garbage_signature = vec![0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x01, 0x02, 0x03];
+        let mut wire_bytes = Vec::new();
+        wire_bytes.extend_from_slice(&scheme_u16.to_be_bytes());
+        wire_bytes.extend_from_slice(&(garbage_signature.len() as u16).to_be_bytes());
+        wire_bytes.extend_from_slice(&garbage_signature);
+
+        let mut reader = Reader::init(&wire_bytes);
+        let dss = DigitallySignedStruct::read(&mut reader).expect("Failed to parse DSS");
+        assert_eq!(dss.scheme, SignatureScheme::ECDSA_NISTP256_SHA256);
+
+        let message = b"this is a TLS handshake message that was NOT signed by the cert's key";
+
+        let tls12_result = verifier.verify_tls12_signature(message, &leaf_cert, &dss);
+        assert_matches!(
+            tls12_result,
+            Err(rustls::Error::InvalidCertificate(
+                rustls::CertificateError::BadSignature
+            ))
+        );
+
+        let tls13_result = verifier.verify_tls13_signature(message, &leaf_cert, &dss);
+        assert_matches!(
+            tls13_result,
+            Err(rustls::Error::InvalidCertificate(
+                rustls::CertificateError::BadSignature
+            ))
+        );
+    }
+
+    #[test]
+    fn test_cert_verification_accepts_correct_request() {
+        use rustls::{
+            client::danger::ServerCertVerified,
+            pki_types::{ServerName, UnixTime},
+        };
+
+        let tls = TlsConfig::new();
+        let verifier =
+            make_trusted_root_cert_verifier(make_crypto_provider(true), &tls.ca_cert.der())
+                .unwrap();
+
+        assert_matches!(
+            verifier.verify_server_cert(
+                tls.leaf_cert.der(),
+                &[tls.ca_cert.der().clone()],
+                &ServerName::DnsName("localhost".try_into().unwrap()),
+                &[],
+                UnixTime::now(),
+            ),
+            Ok(ServerCertVerified { .. })
+        );
+    }
+
+    #[test]
+    fn test_cert_verification_rejects_incorrect_request() {
+        use rustls::pki_types::{ServerName, UnixTime};
+
+        let tls = TlsConfig::new();
+        let verifier =
+            make_trusted_root_cert_verifier(make_crypto_provider(true), &tls.ca_cert.der())
+                .unwrap();
+
+        assert_matches!(
+            verifier.verify_server_cert(
+                tls.leaf_cert.der(),
+                &[tls.ca_cert.der().clone()],
+                &ServerName::DnsName("some-other-name".try_into().unwrap()),
+                &[],
+                UnixTime::now(),
+            ),
+            Err(rustls::Error::InvalidCertificate(
+                rustls::CertificateError::NotValidForNameContext {
+                    expected,
+                    presented
+                }
+            ))
+            if
+                expected == ServerName::DnsName("some-other-name".try_into().unwrap()) &&
+                presented == vec![ "DnsName(\"localhost\")", "IpAddress(127.0.0.1)" ]
+        );
+
+        let random_leaf_cert =
+            rcgen::generate_simple_self_signed(SUBJECT_ALT_NAMES.clone()).unwrap();
+
+        assert_matches!(
+            verifier.verify_server_cert(
+                random_leaf_cert.cert.der(),
+                &[tls.ca_cert.der().clone()],
+                &ServerName::DnsName("localhost".try_into().unwrap()),
+                &[],
+                UnixTime::now(),
+            ),
+            Err(rustls::Error::InvalidCertificate(
+                rustls::CertificateError::UnknownIssuer
+            ))
+        );
+    }
+}

--- a/crates/telio-relay/Cargo.toml
+++ b/crates/telio-relay/Cargo.toml
@@ -41,7 +41,6 @@ smart-default.workspace = true
 
 [dev-dependencies]
 env_logger.workspace = true
-hex.workspace = true
 ntest.workspace = true
 rstest.workspace = true
 tokio = { workspace = true, features = [
@@ -56,7 +55,7 @@ telio-nurse = { workspace = true, features = ["mockall"] }
 telio-task = { workspace = true, features = ["test-util"] }
 telio-test.workspace = true
 hyper = { version = "1.9.0", features = ["full", "http1"] }
-hyper-util.workspace = true
+hyper-util = { workspace = true, features = ["tokio"] }
 http-body-util = "0.1.3"
 
 [target.'cfg(windows)'.dependencies]

--- a/crates/telio-relay/src/derp/http.rs
+++ b/crates/telio-relay/src/derp/http.rs
@@ -20,8 +20,9 @@ use webpki_roots::TLS_SERVER_ROOTS;
 
 use crate::{Config, DerpKeepaliveConfig};
 
-use rustls_platform_verifier::ConfigVerifierExt;
+use rustls_platform_verifier::Verifier as PlatformVerifier;
 use telio_crypto::{PublicKey, SecretKey};
+use telio_proto::CertLoggingVerifier;
 use tokio::time::Interval;
 use tokio::{
     io::{split, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt},
@@ -29,7 +30,11 @@ use tokio::{
     time::timeout,
 };
 use tokio_rustls::{
-    rustls::{pki_types::ServerName, ClientConfig, RootCertStore},
+    rustls::{
+        client::{danger::ServerCertVerifier, WebPkiServerVerifier},
+        pki_types::ServerName,
+        ClientConfig, RootCertStore,
+    },
     TlsConnector,
 };
 use url::{Host, Url};
@@ -146,17 +151,29 @@ async fn try_connect(
             .await
         }
         _ => {
-            let config = if derp_config.use_built_in_root_certificates {
-                let root_store: RootCertStore = TLS_SERVER_ROOTS.iter().cloned().collect();
+            let builder = ClientConfig::builder();
+            let provider = builder.crypto_provider().clone();
 
-                let config = ClientConfig::builder()
-                    .with_root_certificates(root_store)
-                    .with_no_client_auth();
+            let verifier: Arc<dyn ServerCertVerifier> =
+                if derp_config.use_built_in_root_certificates {
+                    let root_store: RootCertStore = TLS_SERVER_ROOTS.iter().cloned().collect();
 
-                TlsConnector::from(Arc::new(config))
-            } else {
-                TlsConnector::from(Arc::new(ClientConfig::with_platform_verifier()?))
-            };
+                    WebPkiServerVerifier::builder_with_provider(Arc::new(root_store), provider)
+                        .build()
+                        // Can only fail on an empty root store or unparsable CRLs; roots are
+                        // compiled-in (never empty) and no CRLs are given, so this never errors
+                        .map_err(IoError::other)?
+                } else {
+                    Arc::new(PlatformVerifier::new(provider)?)
+                };
+
+            let config = builder
+                .dangerous()
+                .with_custom_certificate_verifier(Arc::new(CertLoggingVerifier::new(
+                    verifier, "DERP", false,
+                )))
+                .with_no_client_auth();
+            let config = TlsConnector::from(Arc::new(config));
 
             let server_name =
                 ServerName::try_from(hostname).map_err(|_| Error::InvalidServerName)?;


### PR DESCRIPTION
### Problem
We had a problem with debugging problems with DERP connections

### Solution
Let's add printing certs on failing Derp connections, so we have some more info what happens inside


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
