### PR TITLE
LLT-6855: Separation of daemon lifecycle from VPN connection state management

### DIFF
--- a/clis/nordvpnlite/README.md
+++ b/clis/nordvpnlite/README.md
@@ -37,6 +37,7 @@ There is a command for running the daemon:
   * `--config-file <path_to_config_file>` - specify alternative configuration file,
   * `--no-detach` - run the nordvpnlite in the foreground as a regular process,
   without detaching from the terminal.
+  * `--do-not-connect` - starts daemon without establishing VPN connection.
   * `--stdout-path` - Redirect daemon standard output to the specified file,
   Defaults to `/var/log/nordvpnlite.log`, ignored when used with `--no-detach`
   Some early logs may still be printed to stdout before redirection.

--- a/clis/nordvpnlite/README.md
+++ b/clis/nordvpnlite/README.md
@@ -94,6 +94,8 @@ And following cli commands:
 * `nordvpnlite is-alive` - query if the daemon is running
 * `nordvpnlite stop` - stop daemon execution
 * `nordvpnlite reload` - reload the configuration file and restart the daemon
+* `nordvpnlite connect` - connect to the VPN exit node (non-blocking). Use `nordvpnlite status` to check the connection status
+* `nordvpnlite disconnect` - disconnect from the current VPN exit node
 * `nordvpnlite countries` - list countries with available VPN servers
 * `nordvpnlite login <token>` (or `nordvpnlite login --token <token>`) - store the authentication token obtained
   from [my.nordaccount.com](https://my.nordaccount.com) into the auth file

--- a/clis/nordvpnlite/openwrt/feed/net/nordvpnlite/files/nordvpnlite.init
+++ b/clis/nordvpnlite/openwrt/feed/net/nordvpnlite/files/nordvpnlite.init
@@ -7,7 +7,7 @@ STOP=01
 start_service() {
   echo "Starting nordvpnlite service"
   procd_open_instance
-  procd_set_param command /usr/sbin/nordvpnlite start --no-detach
+  procd_set_param command /usr/sbin/nordvpnlite daemon --no-detach
   procd_set_param stdout 1
   procd_set_param stderr 1
   # By default procd will try to respawn the process every 5 seconds.

--- a/clis/nordvpnlite/openwrt/feed/net/nordvpnlite/files/nordvpnlite.init
+++ b/clis/nordvpnlite/openwrt/feed/net/nordvpnlite/files/nordvpnlite.init
@@ -16,11 +16,6 @@ start_service() {
   procd_close_instance
 }
 
-stop_service() {
-  echo "Stopping nordvpnlite service"
-  /usr/sbin/nordvpnlite stop
-}
-
 reload_service() {
   echo "Reloading nordvpnlite configuration"
   /usr/sbin/nordvpnlite reload

--- a/clis/nordvpnlite/src/command_listener.rs
+++ b/clis/nordvpnlite/src/command_listener.rs
@@ -26,8 +26,6 @@ pub enum ClientCmd {
     GetStatus,
     #[clap(hide = true)]
     IsAlive,
-    #[clap(name = "stop", about = "Stop daemon execution")]
-    QuitDaemon,
     #[clap(name = "reload", about = "Reload config file and restart the daemon")]
     Reload,
 }
@@ -267,22 +265,6 @@ impl CommandListener {
                 })
                 .await
             }
-            ClientCmd::QuitDaemon => {
-                trace!("Quitting telio task");
-                let (response_tx, response_rx) = oneshot::channel();
-                #[allow(mpsc_blocking_send)]
-                self.telio_task_tx
-                    .send(TelioTaskCmd::Quit(response_tx))
-                    .await
-                    .map_err(|e| {
-                        error!("Error sending command: {}", e);
-                        NordVpnLiteError::CommandFailed(ClientCmd::QuitDaemon)
-                    })?;
-                // Wait for a response from TelioTask
-                // this essentially blocks the client quit command until the daemon initiated
-                // cleanup
-                handle_response(response_rx, |_| Ok(CommandResponse::Ok)).await
-            }
             ClientCmd::Reload => {
                 match RunningConfig::from_file(&self.config.path) {
                     Err(e) => {
@@ -344,7 +326,6 @@ impl CommandListener {
                 } else {
                     // Early command handling before TelioTask is initialized
                     match &command {
-                        ClientCmd::QuitDaemon => CommandResponse::Ok,
                         ClientCmd::IsAlive => CommandResponse::Ok,
                         ClientCmd::GetStatus
                         | ClientCmd::Reload
@@ -574,14 +555,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_command_quit() {
-        let (response, cmd) = test_command_helper(ClientCmd::QuitDaemon, true, false).await;
-
-        assert_eq!(response.unwrap(), CommandResponse::Ok);
-        assert_eq!(cmd.unwrap(), ClientCmd::QuitDaemon);
-    }
-
-    #[tokio::test]
     async fn test_command_is_alive() {
         let (response, cmd) = test_command_helper(ClientCmd::IsAlive, true, false).await;
 
@@ -638,14 +611,6 @@ mod tests {
         let (_, cmd) = test_command_helper(ClientCmd::GetStatus, true, true).await;
 
         assert_matches!(cmd, Err(NordVpnLiteError::Io(_)));
-    }
-
-    #[tokio::test]
-    async fn test_command_early_quit() {
-        let (response, cmd) = test_command_helper(ClientCmd::QuitDaemon, false, false).await;
-
-        assert_eq!(cmd.unwrap(), ClientCmd::QuitDaemon);
-        assert_eq!(response.unwrap(), CommandResponse::Ok);
     }
 
     #[tokio::test]

--- a/clis/nordvpnlite/src/command_listener.rs
+++ b/clis/nordvpnlite/src/command_listener.rs
@@ -71,6 +71,10 @@ pub(crate) struct DaemonOpts {
     /// Ignored with no-detach flag.
     #[clap(long = "stdout-path", default_value = "/var/log/nordvpnlite.log")]
     pub stdout_path: String,
+
+    /// Do not connect to the exit node
+    #[clap(long = "do-not-connect")]
+    pub do_not_connect: bool,
 }
 
 #[derive(Parser, Debug)]
@@ -128,8 +132,8 @@ pub(crate) struct LogoutOpts {
 #[command(version = concat!(env!("CARGO_PKG_VERSION"), " (", env!("LIBTELIO_COMMIT_SHA"), ") ", env!("BUILD_PROFILE")))]
 pub enum Cmd {
     #[clap(about = "Runs the nordvpnlite event loop")]
-    Start(DaemonOpts),
-    #[clap(flatten)]
+    Daemon(DaemonOpts),
+    #[command(flatten)]
     Client(ClientCmd),
     #[clap(about = "Show countries with available VPN servers")]
     Countries,

--- a/clis/nordvpnlite/src/command_listener.rs
+++ b/clis/nordvpnlite/src/command_listener.rs
@@ -71,6 +71,10 @@ pub(crate) struct DaemonOpts {
     /// Ignored with no-detach flag.
     #[clap(long = "stdout-path", default_value = "/var/log/nordvpnlite.log")]
     pub stdout_path: String,
+
+    /// Do not connect to the exit node
+    #[clap(long = "do-not-connect")]
+    pub do_not_connect: bool,
 }
 
 #[derive(Parser, Debug)]

--- a/clis/nordvpnlite/src/command_listener.rs
+++ b/clis/nordvpnlite/src/command_listener.rs
@@ -1,16 +1,15 @@
 use std::net::IpAddr;
 
-use clap::Parser;
-use serde::{Deserialize, Serialize};
-use telio_core::telio_task::io::chan;
-use tokio::sync::oneshot;
-use tracing::{error, info, trace};
-
 use crate::{
     comms::{DaemonConnection, DaemonSocket},
     config::{Endpoint, RunningConfig},
     daemon::{NordVpnLiteError, TelioStatusReport},
 };
+use clap::Parser;
+use serde::{Deserialize, Serialize};
+use telio_core::telio_task::io::chan;
+use tokio::sync::oneshot;
+use tracing::{error, info, trace};
 
 pub(crate) const TIMEOUT_SEC: u64 = 60;
 const DEFAULT_CONFIG_PATH: &str = "/etc/nordvpnlite/config.json";
@@ -19,6 +18,10 @@ const DEFAULT_CONFIG_PATH: &str = "/etc/nordvpnlite/config.json";
 #[clap()]
 #[derive(Serialize, Deserialize)]
 pub enum ClientCmd {
+    #[clap(about = "Connect to the exit node")]
+    Connect,
+    #[clap(about = "Disconnect from the exit node")]
+    Disconnect,
     #[clap(name = "status", about = "Retrieve the status report")]
     GetStatus,
     #[clap(hide = true)]
@@ -40,8 +43,8 @@ pub struct ExitNodeConfig {
 pub enum TelioTaskCmd {
     // Get telio status
     GetStatus(oneshot::Sender<TelioStatusReport>),
-    // Connect to exit node with endpoint and optional hostname
-    ConnectToExitNode(ExitNodeConfig),
+    Connect(oneshot::Sender<Result<(), String>>),
+    Disconnect(oneshot::Sender<Result<(), String>>),
     // Break the receive loop to quit the daemon and exit gracefully
     Quit(oneshot::Sender<()>),
 }
@@ -230,6 +233,40 @@ impl CommandListener {
                 })
                 .await
             }
+            ClientCmd::Connect => {
+                trace!("Connect");
+                let (response_tx, response_rx) = oneshot::channel();
+                #[allow(mpsc_blocking_send)]
+                self.telio_task_tx
+                    .send(TelioTaskCmd::Connect(response_tx))
+                    .await
+                    .map_err(|_| {
+                        error!("Failed to send Connect command to telio task");
+                        NordVpnLiteError::CommandFailed(ClientCmd::Connect)
+                    })?;
+                handle_response(response_rx, |result| match result {
+                    Ok(()) => Ok(CommandResponse::Ok),
+                    Err(e) => Ok(CommandResponse::Err(e)),
+                })
+                .await
+            }
+            ClientCmd::Disconnect => {
+                trace!("Disconnect");
+                let (response_tx, response_rx) = oneshot::channel();
+                #[allow(mpsc_blocking_send)]
+                self.telio_task_tx
+                    .send(TelioTaskCmd::Disconnect(response_tx))
+                    .await
+                    .map_err(|_| {
+                        error!("Failed to send Disconnect command to telio task");
+                        NordVpnLiteError::CommandFailed(ClientCmd::Disconnect)
+                    })?;
+                handle_response(response_rx, |result| match result {
+                    Ok(()) => Ok(CommandResponse::Ok),
+                    Err(e) => Ok(CommandResponse::Err(e)),
+                })
+                .await
+            }
             ClientCmd::QuitDaemon => {
                 trace!("Quitting telio task");
                 let (response_tx, response_rx) = oneshot::channel();
@@ -309,9 +346,10 @@ impl CommandListener {
                     match &command {
                         ClientCmd::QuitDaemon => CommandResponse::Ok,
                         ClientCmd::IsAlive => CommandResponse::Ok,
-                        ClientCmd::GetStatus | ClientCmd::Reload => {
-                            CommandResponse::DaemonInitializing
-                        }
+                        ClientCmd::GetStatus
+                        | ClientCmd::Reload
+                        | ClientCmd::Connect
+                        | ClientCmd::Disconnect => CommandResponse::DaemonInitializing,
                     }
                 };
                 connection.respond(response.serialize()).await?;
@@ -378,10 +416,15 @@ mod tests {
                     let status_report = TelioStatusReport::default();
                     response_tx_channel.send(status_report).unwrap();
                 }
+                TelioTaskCmd::Connect(response_tx_channel) => {
+                    response_tx_channel.send(Ok(())).unwrap();
+                }
+                TelioTaskCmd::Disconnect(response_tx_channel) => {
+                    response_tx_channel.send(Ok(())).unwrap();
+                }
                 TelioTaskCmd::Quit(response_tx_channel) => {
                     response_tx_channel.send(()).unwrap();
                 }
-                _ => {}
             }
         });
 
@@ -469,6 +512,65 @@ mod tests {
 
         let error_response = CommandResponse::Err("Test error".to_string());
         assert_eq!(error_response.serialize(), "{\"Err\":\"Test error\"}");
+    }
+
+    #[tokio::test]
+    async fn test_command_connect() {
+        let (response, cmd) = test_command_helper(ClientCmd::Connect, true, false).await;
+
+        assert_eq!(response.unwrap(), CommandResponse::Ok);
+        assert_eq!(cmd.unwrap(), ClientCmd::Connect);
+    }
+
+    async fn test_command_error_helper(command: ClientCmd, error_msg: &str) {
+        let path = make_socket_path();
+        let (tx, mut task_rx) = mpsc::channel::<TelioTaskCmd>(1);
+
+        let err = error_msg.to_string();
+        task::spawn(async move {
+            match task_rx.recv().await.unwrap() {
+                TelioTaskCmd::Connect(response_tx) => {
+                    response_tx.send(Err(err)).unwrap();
+                }
+                TelioTaskCmd::Disconnect(response_tx) => {
+                    response_tx.send(Err(err)).unwrap();
+                }
+                _ => {}
+            }
+        });
+
+        let socket = DaemonSocket::new(Path::new(&path)).unwrap();
+        let (config, _config_file) = make_running_config();
+        let mut listener = CommandListener::new(socket, tx, config);
+
+        let command_str = serde_json::to_string(&command).unwrap();
+        let daemon = tokio::spawn(async move {
+            let connection = listener.accept_client_connection().await.unwrap();
+            listener.handle_client_command(true, connection).await
+        });
+
+        let response = client_send_command(&path, &command_str).await;
+        let cmd = daemon.await.unwrap();
+
+        assert_eq!(
+            response.unwrap(),
+            CommandResponse::Err(error_msg.to_string())
+        );
+        assert_eq!(cmd.unwrap(), command);
+    }
+
+    #[tokio::test]
+    async fn test_command_connect_disconnect_error() {
+        test_command_error_helper(ClientCmd::Connect, "simulated connect failure").await;
+        test_command_error_helper(ClientCmd::Disconnect, "simulated disconnect failure").await;
+    }
+
+    #[tokio::test]
+    async fn test_command_disconnect() {
+        let (response, cmd) = test_command_helper(ClientCmd::Disconnect, true, false).await;
+
+        assert_eq!(response.unwrap(), CommandResponse::Ok);
+        assert_eq!(cmd.unwrap(), ClientCmd::Disconnect);
     }
 
     #[tokio::test]

--- a/clis/nordvpnlite/src/command_listener.rs
+++ b/clis/nordvpnlite/src/command_listener.rs
@@ -1,16 +1,15 @@
 use std::net::IpAddr;
 
-use clap::Parser;
-use serde::{Deserialize, Serialize};
-use telio_core::telio_task::io::chan;
-use tokio::sync::oneshot;
-use tracing::{error, info, trace};
-
 use crate::{
     comms::{DaemonConnection, DaemonSocket},
     config::{Endpoint, RunningConfig},
     daemon::{NordVpnLiteError, TelioStatusReport},
 };
+use clap::Parser;
+use serde::{Deserialize, Serialize};
+use telio_core::telio_task::io::chan;
+use tokio::sync::oneshot;
+use tracing::{error, info, trace};
 
 pub(crate) const TIMEOUT_SEC: u64 = 60;
 const DEFAULT_CONFIG_PATH: &str = "/etc/nordvpnlite/config.json";
@@ -19,6 +18,10 @@ const DEFAULT_CONFIG_PATH: &str = "/etc/nordvpnlite/config.json";
 #[clap()]
 #[derive(Serialize, Deserialize)]
 pub enum ClientCmd {
+    #[clap(about = "Connect to the exit node")]
+    Connect,
+    #[clap(about = "Disconnect from the exit node")]
+    Disconnect,
     #[clap(name = "status", about = "Retrieve the status report")]
     GetStatus,
     #[clap(hide = true)]
@@ -40,8 +43,10 @@ pub struct ExitNodeConfig {
 pub enum TelioTaskCmd {
     // Get telio status
     GetStatus(oneshot::Sender<TelioStatusReport>),
-    // Connect to exit node with endpoint and optional hostname
-    ConnectToExitNode(ExitNodeConfig),
+    Connect(oneshot::Sender<Result<(), String>>),
+    ConnectToExitNode(ExitNodeConfig, Option<oneshot::Sender<Result<(), String>>>),
+    ConnectFailed,
+    Disconnect(oneshot::Sender<Result<(), String>>),
     // Break the receive loop to quit the daemon and exit gracefully
     Quit(oneshot::Sender<()>),
 }
@@ -230,6 +235,51 @@ impl CommandListener {
                 })
                 .await
             }
+            ClientCmd::Connect => {
+                trace!("Connect");
+                let (response_tx, response_rx) = oneshot::channel();
+                #[allow(mpsc_blocking_send)]
+                self.telio_task_tx
+                    .send(TelioTaskCmd::Connect(response_tx))
+                    .await
+                    .map_err(|_| {
+                        error!("Failed to send Connect command to telio task");
+                        NordVpnLiteError::CommandFailed(ClientCmd::Connect)
+                    })?;
+
+                tokio::spawn(async move {
+                    match response_rx.await {
+                        Ok(Ok(())) => {
+                            info!("Connect succeeded");
+                        }
+                        Ok(Err(e)) => {
+                            error!("Connect failed: {e}");
+                        }
+                        Err(_) => {
+                            error!("Connect response sender dropped");
+                        }
+                    }
+                });
+
+                Ok(CommandResponse::Ok)
+            }
+            ClientCmd::Disconnect => {
+                trace!("Disconnect");
+                let (response_tx, response_rx) = oneshot::channel();
+                #[allow(mpsc_blocking_send)]
+                self.telio_task_tx
+                    .send(TelioTaskCmd::Disconnect(response_tx))
+                    .await
+                    .map_err(|_| {
+                        error!("Failed to send Disconnect command to telio task");
+                        NordVpnLiteError::CommandFailed(ClientCmd::Disconnect)
+                    })?;
+                handle_response(response_rx, |result| match result {
+                    Ok(()) => Ok(CommandResponse::Ok),
+                    Err(e) => Ok(CommandResponse::Err(e)),
+                })
+                .await
+            }
             ClientCmd::QuitDaemon => {
                 trace!("Quitting telio task");
                 let (response_tx, response_rx) = oneshot::channel();
@@ -309,9 +359,10 @@ impl CommandListener {
                     match &command {
                         ClientCmd::QuitDaemon => CommandResponse::Ok,
                         ClientCmd::IsAlive => CommandResponse::Ok,
-                        ClientCmd::GetStatus | ClientCmd::Reload => {
-                            CommandResponse::DaemonInitializing
-                        }
+                        ClientCmd::GetStatus
+                        | ClientCmd::Reload
+                        | ClientCmd::Connect
+                        | ClientCmd::Disconnect => CommandResponse::DaemonInitializing,
                     }
                 };
                 connection.respond(response.serialize()).await?;
@@ -378,10 +429,20 @@ mod tests {
                     let status_report = TelioStatusReport::default();
                     response_tx_channel.send(status_report).unwrap();
                 }
+                TelioTaskCmd::Connect(response_tx_channel) => {
+                    response_tx_channel.send(Ok(())).unwrap();
+                }
+                TelioTaskCmd::ConnectToExitNode(_, Some(response_tx_channel)) => {
+                    response_tx_channel.send(Ok(())).unwrap();
+                }
+                TelioTaskCmd::ConnectToExitNode(_, None) => {}
+                TelioTaskCmd::ConnectFailed => {}
+                TelioTaskCmd::Disconnect(response_tx_channel) => {
+                    response_tx_channel.send(Ok(())).unwrap();
+                }
                 TelioTaskCmd::Quit(response_tx_channel) => {
                     response_tx_channel.send(()).unwrap();
                 }
-                _ => {}
             }
         });
 
@@ -433,6 +494,9 @@ mod tests {
         Ok(())
     }
 
+    /// Sends `command` to a fake daemon and returns the client response and the daemon-side result.
+    /// `is_ready` simulates daemon initialisation state.
+    /// `broken_client` drops the connection before reading the response.
     async fn test_command_helper(
         command: ClientCmd,
         is_ready: bool,
@@ -460,6 +524,76 @@ mod tests {
         let client_command = daemon.await.unwrap();
 
         (daemon_response, client_command)
+    }
+
+    /// Sends `command` to a fake daemon that replies with `error_msg`
+    /// and asserts that the error is propagated to the client.
+    async fn test_command_error_helper(command: ClientCmd, error_msg: &str) {
+        let path = make_socket_path();
+        let (tx, mut task_rx) = mpsc::channel::<TelioTaskCmd>(1);
+
+        let err = error_msg.to_string();
+        task::spawn(async move {
+            match task_rx.recv().await.unwrap() {
+                TelioTaskCmd::Connect(response_tx) => {
+                    response_tx.send(Err(err)).unwrap();
+                }
+                TelioTaskCmd::Disconnect(response_tx) => {
+                    response_tx.send(Err(err)).unwrap();
+                }
+                _ => {}
+            }
+        });
+
+        let socket = DaemonSocket::new(Path::new(&path)).unwrap();
+        let (config, _config_file) = make_running_config();
+        let mut listener = CommandListener::new(socket, tx, config);
+
+        let command_str = serde_json::to_string(&command).unwrap();
+        let daemon = tokio::spawn(async move {
+            let connection = listener.accept_client_connection().await.unwrap();
+            listener.handle_client_command(true, connection).await
+        });
+
+        let response = client_send_command(&path, &command_str).await;
+        let cmd = daemon.await.unwrap();
+
+        assert_eq!(
+            response.unwrap(),
+            CommandResponse::Err(error_msg.to_string())
+        );
+        assert_eq!(cmd.unwrap(), command);
+    }
+
+    #[tokio::test]
+    async fn test_command_connect() {
+        let (response, cmd) = test_command_helper(ClientCmd::Connect, true, false).await;
+
+        assert_eq!(response.unwrap(), CommandResponse::Ok);
+        assert_eq!(cmd.unwrap(), ClientCmd::Connect);
+    }
+
+    #[tokio::test]
+    async fn test_command_disconnect_error() {
+        // Check that the telio error raised during disconnecting is propagated to the client
+        test_command_error_helper(ClientCmd::Disconnect, "disconnect failure").await;
+    }
+
+    #[tokio::test]
+    async fn test_command_connect_returns_ok_immediately() {
+        // Connect now returns Ok immediately (fire-and-forget); errors are only logged, not sent back to client
+        let (response, cmd) = test_command_helper(ClientCmd::Connect, true, false).await;
+
+        assert_eq!(response.unwrap(), CommandResponse::Ok);
+        assert_eq!(cmd.unwrap(), ClientCmd::Connect);
+    }
+
+    #[tokio::test]
+    async fn test_command_disconnect() {
+        let (response, cmd) = test_command_helper(ClientCmd::Disconnect, true, false).await;
+
+        assert_eq!(response.unwrap(), CommandResponse::Ok);
+        assert_eq!(cmd.unwrap(), ClientCmd::Disconnect);
     }
 
     #[tokio::test]

--- a/clis/nordvpnlite/src/daemon.rs
+++ b/clis/nordvpnlite/src/daemon.rs
@@ -544,10 +544,6 @@ async fn run_daemon(
                     match connection_result {
                         Ok(connection) => {
                             match cmd_listener.handle_client_command(false, connection).await {
-                                Ok(ClientCmd::QuitDaemon) => {
-                                    info!("Received quit command, exiting");
-                                    return Ok(LoopOutcome::Exit)
-                                },
                                 Ok(command) => {
                                     debug!("Received command {command:?} while obtaining service credentials, ignoring");
                                 },

--- a/clis/nordvpnlite/src/daemon.rs
+++ b/clis/nordvpnlite/src/daemon.rs
@@ -368,9 +368,10 @@ enum LoopOutcome {
 pub async fn daemon_event_loop(
     mut config: RunningConfig,
     logging_handle: &mut logging::LoggingHandle,
+    connect_on_startup: bool,
 ) -> Result<(), NordVpnLiteError> {
     loop {
-        match run_daemon(config.clone()).await? {
+        match run_daemon(config.clone(), connect_on_startup).await? {
             LoopOutcome::Exit => break,
             LoopOutcome::Reload(new_config) => {
                 info!("Reloading config from {}", config.path.display());
@@ -403,7 +404,10 @@ pub async fn daemon_event_loop(
     Ok(())
 }
 
-async fn run_daemon(config: RunningConfig) -> Result<LoopOutcome, NordVpnLiteError> {
+async fn run_daemon(
+    config: RunningConfig,
+    connect_on_startup: bool,
+) -> Result<LoopOutcome, NordVpnLiteError> {
     debug!("started with config: {:?}", config.parsed);
 
     let mut signals = Signals::new([SIGHUP, SIGTERM, SIGINT, SIGQUIT])?;
@@ -466,15 +470,16 @@ async fn run_daemon(config: RunningConfig) -> Result<LoopOutcome, NordVpnLiteErr
         context.start_listening_commands(telio_rx)
     });
 
-    // Wait for interface setup to complete before making API calls.
-    if init_done_rx.await.is_ok() {
-        // TODO: This can be triggered through nordvpnlite command to allow the user to stop/restart.
-        let config_clone = config.parsed.clone();
-        let tx_clone = telio_tx.clone();
-        tokio::spawn(async move {
-            handle_exit_node_connection(&config_clone, tx_clone).await;
-            debug!("Exit node connection task completed");
-        });
+    if connect_on_startup {
+        if init_done_rx.await.is_ok() {
+            let config_clone = config.parsed.clone();
+            let tx_clone = telio_tx.clone();
+            // Without blocking the main thread select (HTTP request) and connect to exit node
+            tokio::spawn(async move {
+                handle_exit_node_connection(&config_clone, tx_clone).await;
+                debug!("Exit node connection task completed");
+            });
+        }
     }
 
     info!("Entering event loop");

--- a/clis/nordvpnlite/src/daemon.rs
+++ b/clis/nordvpnlite/src/daemon.rs
@@ -368,9 +368,10 @@ enum LoopOutcome {
 pub async fn daemon_event_loop(
     mut config: RunningConfig,
     logging_handle: &mut logging::LoggingHandle,
+    do_not_connect: bool,
 ) -> Result<(), NordVpnLiteError> {
     loop {
-        match run_daemon(config.clone()).await? {
+        match run_daemon(config.clone(), do_not_connect).await? {
             LoopOutcome::Exit => break,
             LoopOutcome::Reload(new_config) => {
                 info!("Reloading config from {}", config.path.display());
@@ -403,7 +404,10 @@ pub async fn daemon_event_loop(
     Ok(())
 }
 
-async fn run_daemon(config: RunningConfig) -> Result<LoopOutcome, NordVpnLiteError> {
+async fn run_daemon(
+    config: RunningConfig,
+    do_not_connect: bool,
+) -> Result<LoopOutcome, NordVpnLiteError> {
     debug!("started with config: {:?}", config.parsed);
 
     let mut signals = Signals::new([SIGHUP, SIGTERM, SIGINT, SIGQUIT])?;
@@ -466,15 +470,16 @@ async fn run_daemon(config: RunningConfig) -> Result<LoopOutcome, NordVpnLiteErr
         context.start_listening_commands(telio_rx)
     });
 
-    // Wait for interface setup to complete before making API calls.
-    if init_done_rx.await.is_ok() {
-        // TODO: This can be triggered through nordvpnlite command to allow the user to stop/restart.
-        let config_clone = config.parsed.clone();
-        let tx_clone = telio_tx.clone();
-        tokio::spawn(async move {
-            handle_exit_node_connection(&config_clone, tx_clone).await;
-            debug!("Exit node connection task completed");
-        });
+    if !do_not_connect {
+        // Wait for interface setup to complete before initiating connection.
+        if init_done_rx.await.is_ok() {
+            let config_clone = config.parsed.clone();
+            let tx_clone = telio_tx.clone();
+            tokio::spawn(async move {
+                handle_exit_node_connection(&config_clone, tx_clone).await;
+                debug!("Exit node connection task completed");
+            });
+        }
     }
 
     info!("Entering event loop");

--- a/clis/nordvpnlite/src/daemon.rs
+++ b/clis/nordvpnlite/src/daemon.rs
@@ -92,6 +92,10 @@ pub enum NordVpnLiteError {
     IpRoute,
     #[error("Endpoint has no PublicKey")]
     EndpointNoPublicKey,
+    #[error("Already connected to exit node")]
+    AlreadyConnected,
+    #[error("Not connected to exit node")]
+    NotConnected,
 }
 
 /// Libtelio and VPN status report
@@ -132,6 +136,13 @@ impl ExitNodeStatus {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ApplicationState {
+    LoggedOut,
+    Disconnected,
+    Connected,
+}
+
 /// Outcome of executing a TelioTaskCmd, indicating whether TelioTask should keep listening
 /// for commands or not
 #[derive(Debug, PartialEq, Eq)]
@@ -145,12 +156,18 @@ struct TelioContext {
     interface_config_provider: Box<dyn ConfigureInterface>,
     config: NordVpnLiteConfig,
     exit_node: Option<ExitNodeStatus>,
+    application_state: ApplicationState,
+    /// Handle to the tokio runtime. Used to run async tasks (e.g. HTTP calls) from
+    /// within the spawn_blocking context of start_listening_commands
+    tokio_handle: tokio::runtime::Handle,
 }
 
 impl TelioContext {
     fn new(
         config: NordVpnLiteConfig,
         nordlynx_private_key: SecretKey,
+        tokio_handle: tokio::runtime::Handle,
+        application_state: ApplicationState,
     ) -> Result<Self, NordVpnLiteError> {
         debug!("Initializing telio device");
 
@@ -178,13 +195,15 @@ impl TelioContext {
             interface_config_provider,
             config,
             exit_node: None,
+            application_state,
+            tokio_handle,
         })
     }
 
     fn start_listening_commands(
         &mut self,
         mut rx_channel: mpsc::Receiver<TelioTaskCmd>,
-    ) -> Result<(), NordVpnLiteError> {
+    ) -> Result<ApplicationState, NordVpnLiteError> {
         while let Some(cmd) = rx_channel.blocking_recv() {
             trace!("TelioTask got command {:?}", cmd);
             match cmd.execute(self)? {
@@ -192,7 +211,7 @@ impl TelioContext {
                 TelioTaskOutcome::Continue => continue,
             }
         }
-        Ok(())
+        Ok(self.application_state)
     }
 
     fn start_telio(
@@ -244,6 +263,60 @@ impl TelioContext {
         }
         Ok(())
     }
+
+    fn connect_to_exit_node(
+        &mut self,
+        exit_node_config: ExitNodeConfig,
+    ) -> Result<(), NordVpnLiteError> {
+        if self.exit_node.is_some() {
+            error!("Already connected to exit node");
+            return Err(NordVpnLiteError::AlreadyConnected);
+        }
+        self.interface_config_provider
+            .set_exit_routes(&exit_node_config.endpoint.address, &exit_node_config.dns)
+            .inspect_err(|e| error!("Failed to set routes for exit routing with error '{e:?}'"))?;
+        let node = ExitNode {
+            identifier: uuid::Uuid::new_v4().to_string(),
+            public_key: exit_node_config.endpoint.public_key,
+            allowed_ips: None,
+            endpoint: Some(SocketAddr::new(
+                exit_node_config.endpoint.address,
+                self.config
+                    .override_default_wg_port
+                    .unwrap_or(DEFAULT_WIREGUARD_PORT),
+            )),
+        };
+        let (connect, kind): (fn(_, _) -> _, _) = if exit_node_config.post_quantum {
+            (Device::connect_vpn_post_quantum, "post quantum ")
+        } else {
+            (Device::connect_exit_node, "")
+        };
+        match connect(&self.telio, &node) {
+            Ok(_) => {
+                info!(
+                    "Connected to {kind}exit node: {} ({}) [{}]",
+                    exit_node_config.endpoint.address,
+                    exit_node_config.endpoint.public_key,
+                    exit_node_config
+                        .endpoint
+                        .hostname
+                        .as_deref()
+                        .unwrap_or_default()
+                );
+                let external_nodes = self.telio.external_nodes()?;
+                let exit_node_status =
+                    external_nodes.iter().find(|node| node.is_exit).map(|node| {
+                        ExitNodeStatus::from_node(node, exit_node_config.endpoint.hostname)
+                    });
+                self.exit_node = exit_node_status;
+            }
+            Err(e) => {
+                error!("Failed to connect to VPN with error: {e:?}");
+                return Err(NordVpnLiteError::DeviceError(e));
+            }
+        }
+        Ok(())
+    }
 }
 
 impl TelioTaskCmd {
@@ -262,46 +335,69 @@ impl TelioTaskCmd {
                 }
                 Ok(TelioTaskOutcome::Continue)
             }
-            TelioTaskCmd::ConnectToExitNode(exit_node) => {
-                ctx.interface_config_provider
-                    .set_exit_routes(&exit_node.endpoint.address, &exit_node.dns)
-                    .inspect_err(|e| {
-                        error!("Failed to set routes for exit routing with error '{e:?}'")
-                    })?;
-                let node = ExitNode {
-                    identifier: uuid::Uuid::new_v4().to_string(),
-                    public_key: exit_node.endpoint.public_key,
-                    allowed_ips: None,
-                    endpoint: Some(SocketAddr::new(
-                        exit_node.endpoint.address,
-                        ctx.config
-                            .override_default_wg_port
-                            .unwrap_or(DEFAULT_WIREGUARD_PORT),
-                    )),
-                };
-                let (connect, kind): (fn(_, _) -> _, _) = if exit_node.post_quantum {
-                    (Device::connect_vpn_post_quantum, "post quantum ")
-                } else {
-                    (Device::connect_exit_node, "")
-                };
-                match connect(&ctx.telio, &node) {
-                    Ok(_) => {
-                        info!(
-                            "Connected to {kind}exit node: {} ({}) [{}]",
-                            exit_node.endpoint.address,
-                            exit_node.endpoint.public_key,
-                            exit_node.endpoint.hostname.as_deref().unwrap_or_default()
-                        );
-                        let external_nodes = ctx.telio.external_nodes()?;
-                        let exit_node =
-                            external_nodes.iter().find(|node| node.is_exit).map(|node| {
-                                ExitNodeStatus::from_node(node, exit_node.endpoint.hostname)
+            TelioTaskCmd::Disconnect(response_tx) => {
+                let result = (|| {
+                    if let Some(exit_node) = &ctx.exit_node {
+                        ctx.telio
+                            .disconnect_exit_node(&exit_node.public_key)
+                            .map_err(|_| NordVpnLiteError::CommandFailed(ClientCmd::Disconnect))?;
+                        let _ = ctx.interface_config_provider
+                            .cleanup()
+                            .inspect_err(|e| {
+                                error!("Failed to cleanup routes for exit routing when disconnecting with error '{e:?}'")
                             });
-                        ctx.exit_node = exit_node;
+                        ctx.exit_node = None;
+                        ctx.application_state = ApplicationState::Disconnected;
+                        Ok(())
+                    } else {
+                        error!("No connection to exit node");
+                        Err(NordVpnLiteError::NotConnected)
                     }
-                    Err(e) => {
-                        error!("Failed to connect to VPN with error: {e:?}");
+                })();
+                if response_tx
+                    .send(result.as_ref().map_err(|e| e.to_string()).map(|_| ()))
+                    .is_err()
+                {
+                    error!("Disconnect: receiver dropped before result could be sent");
+                }
+                Ok(TelioTaskOutcome::Continue)
+            }
+            TelioTaskCmd::Connect(response_tx) => {
+                let result: Result<(), NordVpnLiteError> = (|| {
+                    if ctx.exit_node.is_some() {
+                        error!("Already connected to exit node");
+                        return Err(NordVpnLiteError::AlreadyConnected);
                     }
+
+                    // Drive the async HTTP endpoint resolution from this spawn_blocking thread.
+                    // block_on() is safe here: we are on a dedicated OS thread (not inside an
+                    // async task), so we cannot deadlock the runtime.
+                    let endpoint = ctx
+                        .tokio_handle
+                        .block_on(get_server_endpoints_list(&ctx.config))
+                        .map_err(NordVpnLiteError::CoreApiError)
+                        .and_then(|endpoints| {
+                            endpoints.into_iter().next().ok_or_else(|| {
+                                error!("Getting exit node endpoint failed: empty list");
+                                NordVpnLiteError::CommandFailed(ClientCmd::Connect)
+                            })
+                        })?;
+
+                    debug!("Selected exit node: {:#?}", endpoint);
+                    ctx.connect_to_exit_node(ExitNodeConfig {
+                        endpoint,
+                        dns: ctx.config.dns.clone(),
+                        post_quantum: ctx.config.post_quantum,
+                    })
+                })();
+                if result.is_ok() {
+                    ctx.application_state = ApplicationState::Connected;
+                }
+                if response_tx
+                    .send(result.as_ref().map_err(|e| e.to_string()).map(|_| ()))
+                    .is_err()
+                {
+                    error!("Connect: receiver dropped before result could be sent");
                 }
                 Ok(TelioTaskOutcome::Continue)
             }
@@ -320,49 +416,54 @@ impl TelioTaskCmd {
     }
 }
 
-/// Handles establishing a connection to a VPN exit node based on the given configuration.
+/// Handles establishing a connection to a VPN exit node at daemon startup.
 ///
-/// If the config contains a specific server, it uses that directly, otherwise if
-/// a country is provided, it queries the API to find a recommended server.
-/// Sends a `ConnectToExitNode` command via the provided channel on success.
-/// Sends a `Quit` command via the provided channel on failure.
-async fn handle_exit_node_connection(config: &NordVpnLiteConfig, tx: mpsc::Sender<TelioTaskCmd>) {
-    let (response_tx, _) = oneshot::channel();
-    let command = match get_server_endpoints_list(config).await {
-        Ok(endpoints) => {
-            // TODO: LLT-6460 - We can store the recommended server list, just in case
-            // one server fails to connect, try the next one.
-            if let Some(endpoint) = endpoints.first() {
-                debug!("Selected exit node: {:#?}", endpoint);
-                // initiate the VPN connection
-                TelioTaskCmd::ConnectToExitNode(ExitNodeConfig {
-                    endpoint: endpoint.to_owned(),
-                    dns: config.dns.clone(),
-                    post_quantum: config.post_quantum,
-                })
-            } else {
-                error!("Getting exit node endpoint failed: empty list");
-                TelioTaskCmd::Quit(response_tx)
-            }
+/// Sends a `Connect` command via the provided channel and awaits its result.
+/// Sends a `Quit` command on failure so the daemon exits cleanly.
+/// Returns `Ok(())` only when successfully connected to the exit node.
+async fn handle_exit_node_connection(
+    tx: mpsc::Sender<TelioTaskCmd>,
+) -> Result<(), NordVpnLiteError> {
+    /// Sends a `Quit` command on the given channel, logging any send error.
+    async fn quit(tx: mpsc::Sender<TelioTaskCmd>) {
+        let (response_tx, _) = oneshot::channel();
+        #[allow(mpsc_blocking_send)]
+        if let Err(e) = tx.send(TelioTaskCmd::Quit(response_tx)).await {
+            error!("Failed to send Quit command to telio task: {e}");
+        }
+    }
+
+    let (response_tx, response_rx) = oneshot::channel();
+
+    #[allow(mpsc_blocking_send)]
+    if let Err(e) = tx.send(TelioTaskCmd::Connect(response_tx)).await {
+        error!("Failed to send Connect command to telio task: {e}");
+        return Err(NordVpnLiteError::CommandFailed(ClientCmd::Connect));
+    }
+
+    match response_rx.await {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(e)) => {
+            error!("Exit node connection failed: {e}");
+            quit(tx).await;
+            Err(NordVpnLiteError::CommandFailed(ClientCmd::Connect))
         }
         Err(e) => {
-            error!("Getting exit node endpoint failed: {e}");
-            TelioTaskCmd::Quit(response_tx)
+            error!("Failed to receive exit node connection result: {e}");
+            quit(tx).await;
+            Err(NordVpnLiteError::CommandFailed(ClientCmd::Connect))
         }
-    };
-
-    // Send the command to the telio task
-    #[allow(mpsc_blocking_send)]
-    if let Err(e) = tx.send(command).await {
-        error!("Failed to send exit node command to telio task: {e}");
     }
 }
 
 /// Outcome of a single daemon run
 enum LoopOutcome {
     Exit,
-    /// Carries new configuration
-    Reload(Box<RunningConfig>),
+    /// Carries new configuration and the application state at the time of reload.
+    Reload {
+        config: Box<RunningConfig>,
+        application_state: ApplicationState,
+    },
 }
 
 pub async fn daemon_event_loop(
@@ -370,16 +471,21 @@ pub async fn daemon_event_loop(
     logging_handle: &mut logging::LoggingHandle,
     do_not_connect: bool,
 ) -> Result<(), NordVpnLiteError> {
+    let mut application_state = ApplicationState::LoggedOut;
     loop {
-        match run_daemon(config.clone(), do_not_connect).await? {
+        match run_daemon(config.clone(), application_state, do_not_connect).await? {
             LoopOutcome::Exit => break,
-            LoopOutcome::Reload(new_config) => {
+            LoopOutcome::Reload {
+                config: new_config,
+                application_state: new_state,
+            } => {
                 info!("Reloading config from {}", config.path.display());
 
                 let logging_configuration_changed =
                     config.parsed.logging_params_changed(&new_config.parsed);
 
                 config = *new_config;
+                application_state = new_state;
 
                 if logging_configuration_changed {
                     if let Err(e) = logging::reload_logging(
@@ -406,6 +512,7 @@ pub async fn daemon_event_loop(
 
 async fn run_daemon(
     config: RunningConfig,
+    application_state: ApplicationState,
     do_not_connect: bool,
 ) -> Result<LoopOutcome, NordVpnLiteError> {
     debug!("started with config: {:?}", config.parsed);
@@ -463,21 +570,36 @@ async fn run_daemon(
     };
 
     let config_clone = config.parsed.clone();
+
+    let tokio_handle = tokio::runtime::Handle::current();
     let (init_done_tx, init_done_rx) = oneshot::channel::<()>();
     let mut telio_task_handle = tokio::task::spawn_blocking(move || {
-        let mut context = TelioContext::new(config_clone, nordlynx_private_key)?;
+        let mut context = TelioContext::new(
+            config_clone,
+            nordlynx_private_key,
+            tokio_handle,
+            application_state,
+        )?;
         let _ = init_done_tx.send(());
         context.start_listening_commands(telio_rx)
     });
 
-    if !do_not_connect {
+    // For the initial launch (LoggedOut), respect the --do-not-connect flag.
+    // For subsequent runs after a reload, the state directly encodes the intent
+    let should_connect = match application_state {
+        ApplicationState::LoggedOut => !do_not_connect,
+        ApplicationState::Connected => true,
+        ApplicationState::Disconnected => false,
+    };
+    if should_connect {
         // Wait for interface setup to complete before initiating connection.
         if init_done_rx.await.is_ok() {
-            let config_clone = config.parsed.clone();
             let tx_clone = telio_tx.clone();
             tokio::spawn(async move {
-                handle_exit_node_connection(&config_clone, tx_clone).await;
-                debug!("Exit node connection task completed");
+                match handle_exit_node_connection(tx_clone).await {
+                    Ok(()) => debug!("Exit node connection task completed successfully"),
+                    Err(e) => error!("Exit node connection task failed: {e}"),
+                }
             });
         }
     }
@@ -488,10 +610,13 @@ async fn run_daemon(
             // Check if telio_task completes and exit if it fails
             join_result = &mut telio_task_handle => {
                 match join_result {
-                    Ok(Ok(_)) => {
+                    Ok(Ok(final_state)) => {
                         if let Some(new_config) = cmd_listener.take_pending_config() {
                             trace!("Telio task thread completed after reload request, restarting");
-                            break Ok(LoopOutcome::Reload(Box::new(new_config)))
+                            break Ok(LoopOutcome::Reload {
+                                config: Box::new(new_config),
+                                application_state: final_state,
+                            })
                         } else {
                             trace!("Telio task thread completed, exiting");
                             break Ok(LoopOutcome::Exit)
@@ -545,7 +670,18 @@ async fn run_daemon(
                                 if let Err(e) = response_rx.await {
                                     error!("Error receiving quit response from telio task: {e}");
                                 }
-                                break Ok(LoopOutcome::Reload(Box::new(new_config)));
+
+                                let final_state = match telio_task_handle.await {
+                                    Ok(Ok(state)) => state,
+                                    err => {
+                                        error!("Telio task did not complete cleanly during reload: {err:?}, defaulting to Disconnected state");
+                                        ApplicationState::Disconnected
+                                    }
+                                };
+                                break Ok(LoopOutcome::Reload {
+                                    config: Box::new(new_config),
+                                    application_state: final_state,
+                                });
                             }
                         }
                     }

--- a/clis/nordvpnlite/src/daemon.rs
+++ b/clis/nordvpnlite/src/daemon.rs
@@ -92,6 +92,10 @@ pub enum NordVpnLiteError {
     IpRoute,
     #[error("Endpoint has no PublicKey")]
     EndpointNoPublicKey,
+    #[error("Already connected to exit node")]
+    AlreadyConnected,
+    #[error("Not connected to exit node")]
+    NotConnected,
 }
 
 /// Libtelio and VPN status report
@@ -184,15 +188,30 @@ impl TelioContext {
     fn start_listening_commands(
         &mut self,
         mut rx_channel: mpsc::Receiver<TelioTaskCmd>,
-    ) -> Result<(), NordVpnLiteError> {
+    ) -> Result<bool, NordVpnLiteError> {
+        let mut was_connected = false;
         while let Some(cmd) = rx_channel.blocking_recv() {
             trace!("TelioTask got command {:?}", cmd);
+
+            if matches!(cmd, TelioTaskCmd::Quit(_)) {
+                was_connected = self.is_connected()?;
+            }
+
             match cmd.execute(self)? {
                 TelioTaskOutcome::Exit => break,
                 TelioTaskOutcome::Continue => continue,
             }
         }
-        Ok(())
+        Ok(was_connected)
+    }
+
+    // This function is called in the context of configuration reload.
+    // Returns true if exit node is in connected or connecting state.
+    fn is_connected(&self) -> Result<bool, NordVpnLiteError> {
+        let external_nodes = self.telio.external_nodes()?;
+        Ok(external_nodes.iter().any(|node| {
+            node.is_exit && matches!(node.state, NodeState::Connected | NodeState::Connecting)
+        }))
     }
 
     fn start_telio(
@@ -297,6 +316,7 @@ impl TelioTaskCmd {
                             external_nodes.iter().find(|node| node.is_exit).map(|node| {
                                 ExitNodeStatus::from_node(node, exit_node.endpoint.hostname)
                             });
+
                         ctx.exit_node = exit_node;
                     }
                     Err(e) => {
@@ -361,25 +381,40 @@ async fn handle_exit_node_connection(config: &NordVpnLiteConfig, tx: mpsc::Sende
 /// Outcome of a single daemon run
 enum LoopOutcome {
     Exit,
-    /// Carries new configuration
-    Reload(Box<RunningConfig>),
+    /// Carries new configuration and whether the VPN was connected at the time of reload.
+    Reload {
+        config: Box<RunningConfig>,
+        was_connected: bool,
+    },
 }
 
 pub async fn daemon_event_loop(
     mut config: RunningConfig,
     logging_handle: &mut logging::LoggingHandle,
-    connect_on_startup: bool,
+    auto_connect: bool,
 ) -> Result<(), NordVpnLiteError> {
+    let mut was_connected_before_reload = None;
     loop {
+        // For the initial launch, respect the --do-not-connect flag.
+        // For subsequent runs after a reload, the pre reload state directly encodes the intent
+        let connect_on_startup = match was_connected_before_reload {
+            None => auto_connect,
+            Some(connected) => connected,
+        };
+
         match run_daemon(config.clone(), connect_on_startup).await? {
             LoopOutcome::Exit => break,
-            LoopOutcome::Reload(new_config) => {
+            LoopOutcome::Reload {
+                config: new_config,
+                was_connected,
+            } => {
                 info!("Reloading config from {}", config.path.display());
 
                 let logging_configuration_changed =
                     config.parsed.logging_params_changed(&new_config.parsed);
 
                 config = *new_config;
+                was_connected_before_reload = Some(was_connected);
 
                 if logging_configuration_changed {
                     if let Err(e) = logging::reload_logging(
@@ -463,6 +498,7 @@ async fn run_daemon(
     };
 
     let config_clone = config.parsed.clone();
+
     let (init_done_tx, init_done_rx) = oneshot::channel::<()>();
     let mut telio_task_handle = tokio::task::spawn_blocking(move || {
         let mut context = TelioContext::new(config_clone, nordlynx_private_key)?;
@@ -470,16 +506,14 @@ async fn run_daemon(
         context.start_listening_commands(telio_rx)
     });
 
-    if connect_on_startup {
-        if init_done_rx.await.is_ok() {
-            let config_clone = config.parsed.clone();
-            let tx_clone = telio_tx.clone();
-            // Without blocking the main thread select (HTTP request) and connect to exit node
-            tokio::spawn(async move {
-                handle_exit_node_connection(&config_clone, tx_clone).await;
-                debug!("Exit node connection task completed");
-            });
-        }
+    if connect_on_startup && init_done_rx.await.is_ok() {
+        let config_clone = config.parsed.clone();
+        let tx_clone = telio_tx.clone();
+        // Without blocking the main thread select (HTTP request) and connect to exit node
+        tokio::spawn(async move {
+            handle_exit_node_connection(&config_clone, tx_clone).await;
+            debug!("Exit node connection task completed");
+        });
     }
 
     info!("Entering event loop");
@@ -488,10 +522,13 @@ async fn run_daemon(
             // Check if telio_task completes and exit if it fails
             join_result = &mut telio_task_handle => {
                 match join_result {
-                    Ok(Ok(_)) => {
+                    Ok(Ok(was_connected)) => {
                         if let Some(new_config) = cmd_listener.take_pending_config() {
                             trace!("Telio task thread completed after reload request, restarting");
-                            break Ok(LoopOutcome::Reload(Box::new(new_config)))
+                            break Ok(LoopOutcome::Reload {
+                                config: Box::new(new_config),
+                                was_connected,
+                            })
                         } else {
                             trace!("Telio task thread completed, exiting");
                             break Ok(LoopOutcome::Exit)
@@ -545,7 +582,17 @@ async fn run_daemon(
                                 if let Err(e) = response_rx.await {
                                     error!("Error receiving quit response from telio task: {e}");
                                 }
-                                break Ok(LoopOutcome::Reload(Box::new(new_config)));
+                                let was_connected = match telio_task_handle.await {
+                                    Ok(Ok(state)) => state,
+                                    err => {
+                                        error!("Telio task did not complete cleanly during reload: {err:?}, defaulting to disconnected state");
+                                        false
+                                    }
+                                };
+                                break Ok(LoopOutcome::Reload {
+                                    config: Box::new(new_config),
+                                    was_connected,
+                                });
                             }
                         }
                     }

--- a/clis/nordvpnlite/src/daemon.rs
+++ b/clis/nordvpnlite/src/daemon.rs
@@ -94,6 +94,8 @@ pub enum NordVpnLiteError {
     EndpointNoPublicKey,
     #[error("Already connected to exit node")]
     AlreadyConnected,
+    #[error("Connection to exit node already in progress")]
+    ConnectionPending,
     #[error("Not connected to exit node")]
     NotConnected,
 }
@@ -149,12 +151,21 @@ struct TelioContext {
     interface_config_provider: Box<dyn ConfigureInterface>,
     config: NordVpnLiteConfig,
     exit_node: Option<ExitNodeStatus>,
+    /// Handle to the tokio runtime. Used to run async tasks (e.g. HTTP calls) from
+    /// within the spawn_blocking context of start_listening_commands
+    tokio_handle: tokio::runtime::Handle,
+    /// Sender to send commands back to the telio task loop
+    telio_tx: mpsc::Sender<TelioTaskCmd>,
+    /// Flag to track if a connect is pending to avoid double-connect race
+    pending_connect: bool,
 }
 
 impl TelioContext {
     fn new(
         config: NordVpnLiteConfig,
         nordlynx_private_key: SecretKey,
+        tokio_handle: tokio::runtime::Handle,
+        telio_tx: mpsc::Sender<TelioTaskCmd>,
     ) -> Result<Self, NordVpnLiteError> {
         debug!("Initializing telio device");
 
@@ -182,6 +193,9 @@ impl TelioContext {
             interface_config_provider,
             config,
             exit_node: None,
+            tokio_handle,
+            telio_tx,
+            pending_connect: false,
         })
     }
 
@@ -263,6 +277,66 @@ impl TelioContext {
         }
         Ok(())
     }
+    fn connect_to_exit_node(
+        &mut self,
+        exit_node_config: ExitNodeConfig,
+    ) -> Result<(), NordVpnLiteError> {
+        self.interface_config_provider
+            .set_exit_routes(&exit_node_config.endpoint.address, &exit_node_config.dns)
+            .inspect_err(|e| error!("Failed to set routes for exit routing with error '{e:?}'"))?;
+        let node = ExitNode {
+            identifier: uuid::Uuid::new_v4().to_string(),
+            public_key: exit_node_config.endpoint.public_key,
+            allowed_ips: None,
+            endpoint: Some(SocketAddr::new(
+                exit_node_config.endpoint.address,
+                self.config
+                    .override_default_wg_port
+                    .unwrap_or(DEFAULT_WIREGUARD_PORT),
+            )),
+        };
+        let (connect, kind): (fn(_, _) -> _, _) = if exit_node_config.post_quantum {
+            (Device::connect_vpn_post_quantum, "post quantum ")
+        } else {
+            (Device::connect_exit_node, "")
+        };
+        match connect(&self.telio, &node) {
+            Ok(_) => {
+                info!(
+                    "Connected to {kind}exit node: {} ({}) [{}]",
+                    exit_node_config.endpoint.address,
+                    exit_node_config.endpoint.public_key,
+                    exit_node_config
+                        .endpoint
+                        .hostname
+                        .as_deref()
+                        .unwrap_or_default()
+                );
+                let external_nodes = self.telio.external_nodes()?;
+                let exit_node_status =
+                    external_nodes.iter().find(|node| node.is_exit).map(|node| {
+                        ExitNodeStatus::from_node(node, exit_node_config.endpoint.hostname)
+                    });
+                self.exit_node = exit_node_status;
+            }
+            Err(e) => {
+                error!("Failed to connect to VPN with error: {e:?}");
+                return Err(NordVpnLiteError::DeviceError(e));
+            }
+        }
+        Ok(())
+    }
+}
+
+fn reject_connect(
+    tx: oneshot::Sender<Result<(), String>>,
+    err: NordVpnLiteError,
+) -> Result<TelioTaskOutcome, NordVpnLiteError> {
+    warn!("{err}");
+    if tx.send(Err(err.to_string())).is_err() {
+        error!("Connect: receiver dropped before result could be sent");
+    }
+    Ok(TelioTaskOutcome::Continue)
 }
 
 impl TelioTaskCmd {
@@ -281,55 +355,126 @@ impl TelioTaskCmd {
                 }
                 Ok(TelioTaskOutcome::Continue)
             }
-            TelioTaskCmd::ConnectToExitNode(exit_node) => {
-                ctx.interface_config_provider
-                    .set_exit_routes(&exit_node.endpoint.address, &exit_node.dns)
-                    .inspect_err(|e| {
-                        error!("Failed to set routes for exit routing with error '{e:?}'")
-                    })?;
-                let node = ExitNode {
-                    identifier: uuid::Uuid::new_v4().to_string(),
-                    public_key: exit_node.endpoint.public_key,
-                    allowed_ips: None,
-                    endpoint: Some(SocketAddr::new(
-                        exit_node.endpoint.address,
-                        ctx.config
-                            .override_default_wg_port
-                            .unwrap_or(DEFAULT_WIREGUARD_PORT),
-                    )),
-                };
-                let (connect, kind): (fn(_, _) -> _, _) = if exit_node.post_quantum {
-                    (Device::connect_vpn_post_quantum, "post quantum ")
-                } else {
-                    (Device::connect_exit_node, "")
-                };
-                match connect(&ctx.telio, &node) {
-                    Ok(_) => {
-                        info!(
-                            "Connected to {kind}exit node: {} ({}) [{}]",
-                            exit_node.endpoint.address,
-                            exit_node.endpoint.public_key,
-                            exit_node.endpoint.hostname.as_deref().unwrap_or_default()
-                        );
-                        let external_nodes = ctx.telio.external_nodes()?;
-                        let exit_node =
-                            external_nodes.iter().find(|node| node.is_exit).map(|node| {
-                                ExitNodeStatus::from_node(node, exit_node.endpoint.hostname)
+            TelioTaskCmd::Disconnect(response_tx) => {
+                let result = (|| {
+                    if let Some(exit_node) = &ctx.exit_node {
+                        ctx.telio
+                            .disconnect_exit_node(&exit_node.public_key)
+                            .map_err(|_| NordVpnLiteError::CommandFailed(ClientCmd::Disconnect))?;
+                        let _ = ctx.interface_config_provider
+                            .cleanup()
+                            .inspect_err(|e| {
+                                error!("Failed to cleanup routes for exit routing when disconnecting with error '{e:?}'")
                             });
 
-                        ctx.exit_node = exit_node;
+                        ctx.exit_node = None;
+                        Ok(())
+                    } else {
+                        error!("No connection to exit node");
+                        Err(NordVpnLiteError::NotConnected)
                     }
-                    Err(e) => {
-                        error!("Failed to connect to VPN with error: {e:?}");
+                })();
+                if response_tx
+                    .send(result.as_ref().map_err(|e| e.to_string()).map(|_| ()))
+                    .is_err()
+                {
+                    error!("Disconnect: receiver dropped before result could be sent");
+                }
+                Ok(TelioTaskOutcome::Continue)
+            }
+            TelioTaskCmd::Connect(response_tx) => {
+                if ctx.exit_node.is_some() {
+                    return reject_connect(response_tx, NordVpnLiteError::AlreadyConnected);
+                }
+
+                if ctx.pending_connect {
+                    return reject_connect(response_tx, NordVpnLiteError::ConnectionPending);
+                }
+
+                ctx.pending_connect = true;
+                let config = ctx.config.clone();
+                let telio_tx = ctx.telio_tx.clone();
+                ctx.tokio_handle.spawn(async move {
+                    let exit_node_result: Result<ExitNodeConfig, NordVpnLiteError> =
+                        match get_server_endpoints_list(&config).await {
+                            Ok(endpoints) => match endpoints.into_iter().next() {
+                                Some(endpoint) => {
+                                    debug!("Selected exit node endpoint: {:#?}", endpoint);
+                                    Ok(ExitNodeConfig {
+                                        endpoint,
+                                        dns: config.dns,
+                                        post_quantum: config.post_quantum,
+                                    })
+                                }
+                                None => {
+                                    error!("Getting exit node endpoint failed: empty list");
+                                    Err(NordVpnLiteError::CommandFailed(ClientCmd::Connect))
+                                }
+                            },
+                            Err(e) => {
+                                error!("Getting exit node endpoint failed: {e}");
+                                Err(NordVpnLiteError::CoreApiError(e))
+                            }
+                        };
+
+                    match exit_node_result {
+                        Ok(exit_node_config) => {
+                            #[allow(mpsc_blocking_send)]
+                            if let Err(e) = telio_tx
+                                .send(TelioTaskCmd::ConnectToExitNode(
+                                    exit_node_config,
+                                    Some(response_tx),
+                                ))
+                                .await
+                            {
+                                error!("Failed to send ConnectToExitNode to telio task: {e}");
+                                #[allow(mpsc_blocking_send)]
+                                let _ = telio_tx.send(TelioTaskCmd::ConnectFailed).await;
+                            }
+                        }
+                        Err(err) => {
+                            if response_tx.send(Err(err.to_string())).is_err() {
+                                error!("Connect: receiver dropped before result could be sent");
+                            }
+
+                            #[allow(mpsc_blocking_send)]
+                            let _ = telio_tx.send(TelioTaskCmd::ConnectFailed).await;
+                        }
+                    }
+                });
+
+                Ok(TelioTaskOutcome::Continue)
+            }
+            TelioTaskCmd::ConnectToExitNode(exit_node_config, response_tx) => {
+                debug!(
+                    "Connecting to exit node endpoint: {:#?}",
+                    exit_node_config.endpoint
+                );
+                let result = ctx.connect_to_exit_node(exit_node_config);
+                ctx.pending_connect = false;
+
+                if let Some(tx) = response_tx {
+                    if tx
+                        .send(result.as_ref().map_err(|e| e.to_string()).map(|_| ()))
+                        .is_err()
+                    {
+                        error!("ConnectToExitNode: receiver dropped before result could be sent");
                     }
                 }
                 Ok(TelioTaskOutcome::Continue)
             }
+            TelioTaskCmd::ConnectFailed => {
+                debug!("Connect failed");
+                ctx.pending_connect = false;
+                Ok(TelioTaskOutcome::Continue)
+            }
             TelioTaskCmd::Quit(response_tx_channel) => {
-                ctx.telio.stop();
                 _ = ctx.interface_config_provider.cleanup().inspect_err(|e| {
                     error!("Failed to cleanup interface and routes with error '{e:?}'")
                 });
+
+                // Has to be after cleanup to avoid issues with missing device
+                ctx.telio.stop();
 
                 if response_tx_channel.send(()).is_err() {
                     error!("Telio task failed sending quit response: receiver dropped")
@@ -337,44 +482,6 @@ impl TelioTaskCmd {
                 Ok(TelioTaskOutcome::Exit)
             }
         }
-    }
-}
-
-/// Handles establishing a connection to a VPN exit node based on the given configuration.
-///
-/// If the config contains a specific server, it uses that directly, otherwise if
-/// a country is provided, it queries the API to find a recommended server.
-/// Sends a `ConnectToExitNode` command via the provided channel on success.
-/// Sends a `Quit` command via the provided channel on failure.
-async fn handle_exit_node_connection(config: &NordVpnLiteConfig, tx: mpsc::Sender<TelioTaskCmd>) {
-    let (response_tx, _) = oneshot::channel();
-    let command = match get_server_endpoints_list(config).await {
-        Ok(endpoints) => {
-            // TODO: LLT-6460 - We can store the recommended server list, just in case
-            // one server fails to connect, try the next one.
-            if let Some(endpoint) = endpoints.first() {
-                debug!("Selected exit node: {:#?}", endpoint);
-                // initiate the VPN connection
-                TelioTaskCmd::ConnectToExitNode(ExitNodeConfig {
-                    endpoint: endpoint.to_owned(),
-                    dns: config.dns.clone(),
-                    post_quantum: config.post_quantum,
-                })
-            } else {
-                error!("Getting exit node endpoint failed: empty list");
-                TelioTaskCmd::Quit(response_tx)
-            }
-        }
-        Err(e) => {
-            error!("Getting exit node endpoint failed: {e}");
-            TelioTaskCmd::Quit(response_tx)
-        }
-    };
-
-    // Send the command to the telio task
-    #[allow(mpsc_blocking_send)]
-    if let Err(e) = tx.send(command).await {
-        error!("Failed to send exit node command to telio task: {e}");
     }
 }
 
@@ -498,21 +605,48 @@ async fn run_daemon(
     };
 
     let config_clone = config.parsed.clone();
-
+    let tokio_handle = tokio::runtime::Handle::current();
     let (init_done_tx, init_done_rx) = oneshot::channel::<()>();
+    let telio_tx_clone = telio_tx.clone();
     let mut telio_task_handle = tokio::task::spawn_blocking(move || {
-        let mut context = TelioContext::new(config_clone, nordlynx_private_key)?;
+        let mut context = TelioContext::new(
+            config_clone,
+            nordlynx_private_key,
+            tokio_handle,
+            telio_tx_clone,
+        )?;
         let _ = init_done_tx.send(());
         context.start_listening_commands(telio_rx)
     });
 
     if connect_on_startup && init_done_rx.await.is_ok() {
-        let config_clone = config.parsed.clone();
-        let tx_clone = telio_tx.clone();
-        // Without blocking the main thread select (HTTP request) and connect to exit node
+        let telio_tx_clone = telio_tx.clone();
+
         tokio::spawn(async move {
-            handle_exit_node_connection(&config_clone, tx_clone).await;
-            debug!("Exit node connection task completed");
+            let (response_tx, response_rx) = oneshot::channel();
+            #[allow(mpsc_blocking_send)]
+            if let Err(e) = telio_tx_clone
+                .send(TelioTaskCmd::Connect(response_tx))
+                .await
+            {
+                error!("Failed to send Connect on startup: {e}");
+                return;
+            }
+
+            match response_rx.await {
+                Ok(Ok(())) => {
+                    debug!("Connect on startup succeeded");
+                }
+                Ok(Err(e)) => {
+                    error!("Connect on startup failed: {e}, shutting down daemon");
+                    let (quit_tx, _) = oneshot::channel();
+                    #[allow(mpsc_blocking_send)]
+                    let _ = telio_tx_clone.send(TelioTaskCmd::Quit(quit_tx)).await;
+                }
+                Err(_) => {
+                    // receiver dropped — ConnectToExitNode already handled it
+                }
+            }
         });
     }
 

--- a/clis/nordvpnlite/src/interface.rs
+++ b/clis/nordvpnlite/src/interface.rs
@@ -392,6 +392,18 @@ impl ConfigureInterface for Iproute {
         if let Some(table) = &self.table {
             execute(Command::new("ip").args(["route", "flush", "table", table]))?;
         }
+
+        if let Err(e) = execute(Command::new("ip").args([
+            "-6",
+            "route",
+            "del",
+            "default",
+            "dev",
+            &self.interface_name,
+        ])) {
+            error!("Failed to remove IPv6 default route: {e}");
+        }
+
         self.ipv6_support_manager.reenable()
     }
 }

--- a/clis/nordvpnlite/src/main.rs
+++ b/clis/nordvpnlite/src/main.rs
@@ -33,7 +33,7 @@ fn main() -> Result<(), NordVpnLiteError> {
     let mut cmd = Cmd::parse();
 
     // Pre-daemonizing setup
-    if let Cmd::Start(opts) = &mut cmd {
+    if let Cmd::Daemon(opts) = &mut cmd {
         // Check if daemon already is running before forking
         if DaemonSocket::get_ipc_socket_path()?.exists() {
             return Err(NordVpnLiteError::DaemonIsRunning);
@@ -102,7 +102,11 @@ fn main() -> Result<(), NordVpnLiteError> {
 
         // Run the daemon event loop.
         let rt = tokio::runtime::Runtime::new()?;
-        rt.block_on(daemon::daemon_event_loop(config, &mut logging_handle))
+        rt.block_on(daemon::daemon_event_loop(
+            config,
+            &mut logging_handle,
+            opts.do_not_connect,
+        ))
     } else {
         client_main(cmd)
     }

--- a/clis/nordvpnlite/src/main.rs
+++ b/clis/nordvpnlite/src/main.rs
@@ -16,7 +16,7 @@ mod logging;
 
 use crate::{
     auth::{NordToken, NordVpnLiteAuth},
-    command_listener::{ClientCmd, Cmd, CommandResponse, LoginOpts, LogoutOpts, TIMEOUT_SEC},
+    command_listener::{Cmd, CommandResponse, LoginOpts, LogoutOpts, TIMEOUT_SEC},
     comms::DaemonSocket,
     config::{NordVpnLiteConfig, RunningConfig},
     core_api::get_countries_with_exp_backoff,
@@ -144,13 +144,7 @@ async fn client_main(cmd: Cmd) -> Result<(), NordVpnLiteError> {
                     }
                 }
             } else {
-                match cmd {
-                    ClientCmd::QuitDaemon => {
-                        println!("Daemon is already stopped");
-                        Ok(())
-                    }
-                    _ => Err(NordVpnLiteError::DaemonIsNotRunning),
-                }
+                Err(NordVpnLiteError::DaemonIsNotRunning)
             }
         }
         // Display list of available countries with VPN servers

--- a/clis/nordvpnlite/src/main.rs
+++ b/clis/nordvpnlite/src/main.rs
@@ -103,7 +103,11 @@ fn main() -> Result<(), NordVpnLiteError> {
 
         // Run the daemon event loop.
         let rt = tokio::runtime::Runtime::new()?;
-        rt.block_on(daemon::daemon_event_loop(config, &mut logging_handle))
+        rt.block_on(daemon::daemon_event_loop(
+            config,
+            &mut logging_handle,
+            !opts.do_not_connect,
+        ))
     } else {
         client_main(cmd)
     }

--- a/nat-lab/tests/nordvpnlite.py
+++ b/nat-lab/tests/nordvpnlite.py
@@ -210,6 +210,7 @@ class Config:
 class NordVpnLite:
     SOCKET_CHECK_INTERVAL_S = 0.5
     NORDVPNLITE_CMD_CHECK_INTERVAL_S = 10  # TODO (LLT-6693): revert back to 1
+    KILL_TIMEOUT_S = 30.0
 
     def __init__(
         self,
@@ -333,26 +334,23 @@ class NordVpnLite:
                 log.info("NordVPN Lite skipping cleanup")
 
     async def clean_up(self) -> None:
-        log.info("NordVPN Lite cleanup: exiting and removing socket (if exists)")
+        log.info(
+            "NordVPN Lite cleanup: sending SIGTERM and removing socket (if exists)"
+        )
         try:
-            await self.quit()
-        except ProcessExecError as exc:
-            if "Error: DaemonIsNotRunning" not in exc.stderr:
-                log.error(exc)
-                await self.kill()
-            else:
-                log.info("Tried to quit but daemon is already not running")
-            if await self.socket_exists():
-                log.debug("Dangling socket found, removing it..")
-                await self.remove_socket()
-        finally:
-            if self.config.config_path:
-                log.info(
-                    "NordVPN Lite cleanup: removing config %s", self.config.config_path
-                )
-                await self.remove_config(self.config.config_path)
-            log.info("NordVPN Lite cleanup: saving logs")
-            await self._save_logs()
+            await self.kill()
+        except ProcessExecError:
+            log.info("Daemon is already not running")
+        if await self.socket_exists():
+            log.debug("Dangling socket found, removing it..")
+            await self.remove_socket()
+        if self.config.config_path:
+            log.info(
+                "NordVPN Lite cleanup: removing config %s", self.config.config_path
+            )
+            await self.remove_config(self.config.config_path)
+        log.info("NordVPN Lite cleanup: saving logs")
+        await self._save_logs()
 
     async def is_alive(self) -> bool:
         try:
@@ -412,36 +410,23 @@ class NordVpnLite:
         await self.wait_for_nordvpnlite_start()
 
     async def quit(self) -> None:
-        stdout, stderr = await self.execute_command(["stop"])
-        assert (
-            "Command executed successfully" in stdout
-            or "Daemon is already stopped" in stdout
-        ), f"Failed to execute stop command: {stderr}"
-
-        assert (
-            not await self.is_alive()
-        ), "Quit command was sent successfully but daemon's still running"
-        assert (
-            not await self.socket_exists()
-        ), "Daemon's not running but socket still exists"
+        await self.kill()
 
     async def kill(self) -> None:
         try:
-            # OpenWrt doesn't support killall -w
-            if self.config.paths.exec_path.parent == Path("."):
-                await self.connection.create_process(
-                    ["killall", "-s", "SIGTERM", "nordvpn"]
-                ).execute()
-            else:
-                await self.connection.create_process(
-                    ["killall", "-w", "-s", "SIGTERM", "nordvpnlite"]
-                ).execute()
-            assert (
-                not await self.is_alive()
-            ), "SIGTERM was sent but daemon's still running"
+            await self.connection.create_process(
+                ["killall", "-s", "SIGTERM", "nordvpnlite"]
+            ).execute()
         except ProcessExecError as exc:
-            if "nordvpnlite: no process found" not in exc.stderr:
+            if (
+                "no process killed" not in exc.stderr
+                and "no process found" not in exc.stderr
+            ):
                 raise
+            log.info("kill(): no nordvpnlite process was running")
+            return
+
+        await self.wait_for_nordvpnlite_stop()
 
     async def remove_config(self, path: Path) -> None:
         await self.connection.create_process(["rm", "-f", str(path)]).execute()
@@ -491,6 +476,23 @@ class NordVpnLite:
             except IgnoreableError:
                 await asyncio.sleep(self.NORDVPNLITE_CMD_CHECK_INTERVAL_S)
                 continue
+
+    async def wait_for_nordvpnlite_stop(self) -> None:
+        """Wait for the daemon socket to disappear, indicating the daemon has fully exited."""
+        deadline = asyncio.get_event_loop().time() + self.KILL_TIMEOUT_S
+        while await self.socket_exists():
+            remaining = deadline - asyncio.get_event_loop().time()
+            if remaining <= 0:
+                raise TimeoutError(
+                    f"nordvpnlite did not stop within {self.KILL_TIMEOUT_S}s after SIGTERM"
+                )
+            log.debug(
+                "kill(): socket still exists, checking again in %.1fs (%.1fs remaining)",
+                self.SOCKET_CHECK_INTERVAL_S,
+                remaining,
+            )
+            await asyncio.sleep(min(self.SOCKET_CHECK_INTERVAL_S, remaining))
+        log.info("kill(): daemon socket gone — process has exited")
 
     async def wait_for_nordvpnlite_socket(self):
         while True:

--- a/nat-lab/tests/nordvpnlite.py
+++ b/nat-lab/tests/nordvpnlite.py
@@ -165,6 +165,7 @@ class Config:
         auth_path: Optional[Path] = None,
         config_name: ConfigPresetName = ConfigPresetName.DEFAULT,
         no_detach: bool = False,
+        do_not_connect: bool = False,
         paths=Paths(),
     ):
         self.paths: Paths = paths
@@ -174,6 +175,7 @@ class Config:
         self.config_data: NordVpnLiteConfig = copy.deepcopy(config_data)
         self.config_data.auth_file_path = str(self.auth_path)
         self.no_detach: bool = no_detach
+        self.do_not_connect: bool = do_not_connect
 
     async def assert_match_daemon_start(
         self,
@@ -233,6 +235,7 @@ class NordVpnLite:
         config_name: ConfigPresetName = ConfigPresetName.DEFAULT,
         config_path: Optional[Path] = None,
         no_detach: bool = False,
+        do_not_connect: bool = False,
         connection_tag: ConnectionTag = ConnectionTag.DOCKER_CONE_CLIENT_1,
         connection: Optional[Connection] = None,
     ) -> "NordVpnLite":
@@ -248,6 +251,7 @@ class NordVpnLite:
                 config_path=config_path,
                 config_name=config_name,
                 no_detach=no_detach,
+                do_not_connect=do_not_connect,
             ),
         )
         return nordvpnlite
@@ -311,6 +315,8 @@ class NordVpnLite:
             await self.login()
 
             cmd = ["daemon"]
+            if self.config.do_not_connect:
+                cmd.append("--do-not-connect")
             if not self.config.no_detach:
                 cmd.append("--config-file")
                 cmd.append(str(self.config.config_path))
@@ -408,6 +414,18 @@ class NordVpnLite:
             "Command executed successfully" in stdout
         ), f"Reload failed: stdout={stdout!r}, stderr={stderr!r}"
         await self.wait_for_nordvpnlite_start()
+
+    async def connect(self) -> None:
+        stdout, stderr = await self.execute_command(["connect"])
+        assert (
+            "Command executed successfully" in stdout
+        ), f"Connect failed: stdout={stdout!r}, stderr={stderr!r}"
+
+    async def disconnect(self) -> None:
+        stdout, stderr = await self.execute_command(["disconnect"])
+        assert (
+            "Command executed successfully" in stdout
+        ), f"Disconnect failed: stdout={stdout!r}, stderr={stderr!r}"
 
     async def quit(self) -> None:
         await self.kill()
@@ -517,6 +535,20 @@ class NordVpnLite:
                 if status["exit_node"]:
                     if status["exit_node"]["state"] == "connected":
                         return
+                await asyncio.sleep(self.NORDVPNLITE_CMD_CHECK_INTERVAL_S)
+            except IgnoreableError:
+                await asyncio.sleep(self.NORDVPNLITE_CMD_CHECK_INTERVAL_S)
+                continue
+
+    async def wait_for_vpn_disconnected_state(self):
+        """Wait until the daemon reports no active exit node (exit_node is None)."""
+        # TODO: remove after LLT-6693
+        await asyncio.sleep(self.NORDVPNLITE_CMD_CHECK_INTERVAL_S)
+        while True:
+            try:
+                status = json.loads(await self.get_status())
+                if status.get("exit_node") is None:
+                    return
                 await asyncio.sleep(self.NORDVPNLITE_CMD_CHECK_INTERVAL_S)
             except IgnoreableError:
                 await asyncio.sleep(self.NORDVPNLITE_CMD_CHECK_INTERVAL_S)

--- a/nat-lab/tests/nordvpnlite.py
+++ b/nat-lab/tests/nordvpnlite.py
@@ -309,7 +309,7 @@ class NordVpnLite:
             await self.save_config()
             await self.login()
 
-            cmd = ["start"]
+            cmd = ["daemon"]
             if not self.config.no_detach:
                 cmd.append("--config-file")
                 cmd.append(str(self.config.config_path))

--- a/nat-lab/tests/nordvpnlite.py
+++ b/nat-lab/tests/nordvpnlite.py
@@ -415,6 +415,18 @@ class NordVpnLite:
         ), f"Reload failed: stdout={stdout!r}, stderr={stderr!r}"
         await self.wait_for_nordvpnlite_start()
 
+    async def connect(self) -> None:
+        stdout, stderr = await self.execute_command(["connect"])
+        assert (
+            "Command executed successfully" in stdout
+        ), f"Connect failed: stdout={stdout!r}, stderr={stderr!r}"
+
+    async def disconnect(self) -> None:
+        stdout, stderr = await self.execute_command(["disconnect"])
+        assert (
+            "Command executed successfully" in stdout
+        ), f"Disconnect failed: stdout={stdout!r}, stderr={stderr!r}"
+
     async def quit(self) -> None:
         stdout, stderr = await self.execute_command(["stop"])
         daemon_already_stopped = "Daemon is already stopped" in stdout
@@ -544,6 +556,20 @@ class NordVpnLite:
                 if status["exit_node"]:
                     if status["exit_node"]["state"] == "connected":
                         return
+                await asyncio.sleep(self.NORDVPNLITE_CMD_CHECK_INTERVAL_S)
+            except IgnoreableError:
+                await asyncio.sleep(self.NORDVPNLITE_CMD_CHECK_INTERVAL_S)
+                continue
+
+    async def wait_for_vpn_disconnected_state(self):
+        """Wait until the daemon reports no active exit node (exit_node is None)."""
+        # TODO: remove after LLT-6693
+        await asyncio.sleep(self.NORDVPNLITE_CMD_CHECK_INTERVAL_S)
+        while True:
+            try:
+                status = json.loads(await self.get_status())
+                if status.get("exit_node") is None:
+                    return
                 await asyncio.sleep(self.NORDVPNLITE_CMD_CHECK_INTERVAL_S)
             except IgnoreableError:
                 await asyncio.sleep(self.NORDVPNLITE_CMD_CHECK_INTERVAL_S)

--- a/nat-lab/tests/nordvpnlite.py
+++ b/nat-lab/tests/nordvpnlite.py
@@ -165,6 +165,7 @@ class Config:
         auth_path: Optional[Path] = None,
         config_name: ConfigPresetName = ConfigPresetName.DEFAULT,
         no_detach: bool = False,
+        do_not_connect: bool = False,
         paths=Paths(),
     ):
         self.paths: Paths = paths
@@ -174,6 +175,7 @@ class Config:
         self.config_data: NordVpnLiteConfig = copy.deepcopy(config_data)
         self.config_data.auth_file_path = str(self.auth_path)
         self.no_detach: bool = no_detach
+        self.do_not_connect: bool = do_not_connect
 
     async def assert_match_daemon_start(
         self,
@@ -233,6 +235,7 @@ class NordVpnLite:
         config_name: ConfigPresetName = ConfigPresetName.DEFAULT,
         config_path: Optional[Path] = None,
         no_detach: bool = False,
+        do_not_connect: bool = False,
         connection_tag: ConnectionTag = ConnectionTag.DOCKER_CONE_CLIENT_1,
         connection: Optional[Connection] = None,
     ) -> "NordVpnLite":
@@ -248,6 +251,7 @@ class NordVpnLite:
                 config_path=config_path,
                 config_name=config_name,
                 no_detach=no_detach,
+                do_not_connect=do_not_connect,
             ),
         )
         return nordvpnlite
@@ -308,6 +312,8 @@ class NordVpnLite:
             await self.login()
 
             cmd = ["start"]
+            if self.config.do_not_connect:
+                cmd.append("--do-not-connect")
             if not self.config.no_detach:
                 cmd.append("--config-file")
                 cmd.append(str(self.config.config_path))

--- a/nat-lab/tests/test_nordvpnlite.py
+++ b/nat-lab/tests/test_nordvpnlite.py
@@ -248,11 +248,11 @@ async def test_nordvpnlite_config_created(
         try:
             if request.node.callspec.id == "default":
                 # Start nordvpnlite without a config-file parameter
-                await nordvpnlite.execute_command(["start"])
+                await nordvpnlite.execute_command(["daemon"])
             else:
                 # Start nordvpnlite with a custom config-file parameter
                 await nordvpnlite.execute_command(
-                    ["start", "--config-file", str(config_path)]
+                    ["daemon", "--config-file", str(config_path)]
                 )
             pytest.fail("Start should not succeed with default config")
         except ProcessExecError as exc:

--- a/nat-lab/tests/test_nordvpnlite.py
+++ b/nat-lab/tests/test_nordvpnlite.py
@@ -1,5 +1,6 @@
 import asyncio
 import copy
+import json
 import pytest
 from contextlib import AsyncExitStack
 from pathlib import Path
@@ -311,3 +312,60 @@ async def test_nordvpnlite_pq_vpn_connection(config_provider: str) -> None:
             # connection would leave it unset.
             async with new_connection_by_tag(ConnectionTag.VM_LINUX_NLX_1) as nlx_conn:
                 await inspect_preshared_key(nlx_conn)
+
+
+async def test_nordvpnlite_reload_preserves_connected_state() -> None:
+    """VPN was connected (PL) before reload, after reload stays connected to DE."""
+    async with AsyncExitStack() as exit_stack:
+        nordvpnlite = await NordVpnLite.new(
+            exit_stack,
+            config_data=NordVpnLiteConfig(vpn=VPNConfig(country="pl")),
+            do_not_connect=True,
+        )
+        await nordvpnlite.request_credentials_from_core()
+
+        async with nordvpnlite.start():
+            await nordvpnlite.wait_for_telio_running_status()
+            await nordvpnlite.connect()
+            await nordvpnlite.wait_for_vpn_connected_state()
+
+            nordvpnlite.config.config_data = NordVpnLiteConfig(
+                vpn=VPNConfig(country="de")
+            )
+            await nordvpnlite.save_config()
+            await nordvpnlite.reload()
+
+            await nordvpnlite.wait_for_vpn_connected_state()
+            status = json.loads(await nordvpnlite.get_status())
+            assert status.get("exit_node") is not None
+            assert status["exit_node"]["state"] == "connected"
+            report = await nordvpnlite.get_status()
+            assert "de1263.nordvpn.com" in report, report
+
+
+async def test_nordvpnlite_reload_preserves_disconnected_state() -> None:
+    """VPN was disconnected before reload and stays disconnected after reload."""
+    async with AsyncExitStack() as exit_stack:
+        nordvpnlite = await NordVpnLite.new(
+            exit_stack,
+            config_data=NordVpnLiteConfig(vpn=VPNConfig(country="pl")),
+            do_not_connect=True,
+        )
+        await nordvpnlite.request_credentials_from_core()
+
+        async with nordvpnlite.start():
+            await nordvpnlite.wait_for_telio_running_status()
+
+            status = json.loads(await nordvpnlite.get_status())
+            assert status.get("exit_node") is None
+
+            nordvpnlite.config.config_data = NordVpnLiteConfig(
+                vpn=VPNConfig(country="de")
+            )
+            await nordvpnlite.save_config()
+            await nordvpnlite.reload()
+
+            await nordvpnlite.wait_for_telio_running_status()
+            status = json.loads(await nordvpnlite.get_status())
+
+            assert status.get("exit_node") is None

--- a/nat-lab/tests/test_nordvpnlite.py
+++ b/nat-lab/tests/test_nordvpnlite.py
@@ -36,12 +36,12 @@ async def test_nordvpnlite_start(no_detach) -> None:
             no_detach=no_detach,
         )
 
-        await nordvpnlite.quit()
+        await nordvpnlite.kill()
 
         async with nordvpnlite.start() as nordvpnlite_client:
             assert await nordvpnlite_client.is_alive()
 
-        await nordvpnlite.quit()
+        await nordvpnlite.kill()
 
 
 async def test_nordvpnlite_logs() -> None:

--- a/nat-lab/tests/test_nordvpnlite.py
+++ b/nat-lab/tests/test_nordvpnlite.py
@@ -1,5 +1,6 @@
 import asyncio
 import copy
+import json
 import pytest
 from contextlib import AsyncExitStack
 from pathlib import Path
@@ -311,3 +312,239 @@ async def test_nordvpnlite_pq_vpn_connection(config_provider: str) -> None:
             # connection would leave it unset.
             async with new_connection_by_tag(ConnectionTag.VM_LINUX_NLX_1) as nlx_conn:
                 await inspect_preshared_key(nlx_conn)
+
+
+async def test_nordvpnlite_connect_when_already_connected() -> None:
+    """Calling connect while VPN is already established must return a CLI error
+    but must NOT break the existing VPN connection."""
+    async with AsyncExitStack() as exit_stack:
+        nordvpnlite = await NordVpnLite.new(
+            exit_stack,
+            config_data=CONFIG_PRESETS[ConfigPresetName.DEFAULT],
+        )
+        await nordvpnlite.request_credentials_from_core()
+
+        async with nordvpnlite.start():
+            log.debug("NordVPN Lite started, waiting for VPN connected state...")
+            await nordvpnlite.wait_for_vpn_connected_state()
+
+            status = json.loads(await nordvpnlite.get_status())
+            assert (
+                status.get("exit_node") is not None
+            ), "Expected an active VPN connection"
+            assert status["exit_node"]["state"] == "connected", (
+                f"Expected exit_node state 'connected', "
+                f"got {status['exit_node']['state']!r}"
+            )
+
+            log.debug("VPN is connected; sending duplicate connect command...")
+
+            # The second connect must fail with a CLI error.
+            try:
+                await nordvpnlite.execute_command(["connect"])
+                pytest.fail(
+                    "Expected a ProcessExecError when calling connect on an "
+                    "already-connected VPN, but the command succeeded."
+                )
+            except ProcessExecError as exc:
+                log.debug(
+                    "Got expected CLI error on duplicate connect: "
+                    "stdout=%r stderr=%r",
+                    exc.stdout,
+                    exc.stderr,
+                )
+
+            log.debug(
+                "Duplicate connect raised CLI error; verifying connection is intact..."
+            )
+
+            # The daemon must still be running.
+            assert (
+                await nordvpnlite.is_alive()
+            ), "Daemon should still be alive after duplicate connect error"
+
+            # The VPN connection must still be established.
+            status = json.loads(await nordvpnlite.get_status())
+            assert status.get("exit_node") is not None, (
+                "Expected VPN connection to remain active, "
+                f"but exit_node={status.get('exit_node')}"
+            )
+            assert status["exit_node"]["state"] == "connected", (
+                f"Expected exit_node state 'connected', "
+                f"got {status['exit_node']['state']!r}"
+            )
+
+            log.debug("Confirmed: VPN connection intact after duplicate connect")
+
+
+async def test_nordvpnlite_disconnect_when_not_connected() -> None:
+    """Calling disconnect while VPN is not established must return a CLI error
+    but the daemon must remain alive."""
+    async with AsyncExitStack() as exit_stack:
+        nordvpnlite = await NordVpnLite.new(
+            exit_stack,
+            config_data=CONFIG_PRESETS[ConfigPresetName.DEFAULT],
+            do_not_connect=True,
+        )
+
+        await nordvpnlite.request_credentials_from_core()
+
+        async with nordvpnlite.start():
+            # Daemon is running but VPN connection is NOT established.
+            log.debug(
+                "NordVPN Lite started with --do-not-connect, "
+                "waiting for telio running status..."
+            )
+            await nordvpnlite.wait_for_telio_running_status()
+
+            assert (
+                await nordvpnlite.is_alive()
+            ), "Daemon should be alive before disconnect"
+
+            status = json.loads(await nordvpnlite.get_status())
+            assert status.get("exit_node") is None, (
+                f"Expected no VPN connection before disconnect attempt, "
+                f"but exit_node={status.get('exit_node')}"
+            )
+
+            log.debug("VPN is not connected; sending disconnect command...")
+
+            # Disconnect must fail with a CLI error since there is nothing to disconnect.
+            try:
+                await nordvpnlite.execute_command(["disconnect"])
+                pytest.fail(
+                    "Expected a ProcessExecError when calling disconnect with no "
+                    "active VPN connection, but the command succeeded."
+                )
+            except ProcessExecError as exc:
+                log.debug(
+                    "Got expected CLI error on disconnect with no connection: "
+                    "stdout=%r stderr=%r",
+                    exc.stdout,
+                    exc.stderr,
+                )
+
+            log.debug(
+                "Disconnect raised CLI error; verifying daemon is still running..."
+            )
+
+            # The daemon must still be running after the failed disconnect.
+            assert (
+                await nordvpnlite.is_alive()
+            ), "Daemon should still be alive after disconnect error"
+
+            log.debug("Confirmed: daemon is still alive after failed disconnect")
+
+
+async def test_nordvpnlite_reload_preserves_connected_state() -> None:
+    """VPN was connected (PL) before reload, after reload stays connected to DE."""
+    async with AsyncExitStack() as exit_stack:
+        nordvpnlite = await NordVpnLite.new(
+            exit_stack,
+            config_data=NordVpnLiteConfig(vpn=VPNConfig(country="pl")),
+            do_not_connect=True,
+        )
+        await nordvpnlite.request_credentials_from_core()
+
+        async with nordvpnlite.start():
+            await nordvpnlite.wait_for_telio_running_status()
+            await nordvpnlite.connect()
+            await nordvpnlite.wait_for_vpn_connected_state()
+
+            nordvpnlite.config.config_data = NordVpnLiteConfig(
+                vpn=VPNConfig(country="de")
+            )
+            await nordvpnlite.save_config()
+            await nordvpnlite.reload()
+
+            await nordvpnlite.wait_for_vpn_connected_state()
+            status = json.loads(await nordvpnlite.get_status())
+            assert status.get("exit_node") is not None
+            assert status["exit_node"]["state"] == "connected"
+            report = await nordvpnlite.get_status()
+            assert "de1263.nordvpn.com" in report, report
+
+
+async def test_nordvpnlite_reload_preserves_disconnected_state() -> None:
+    """VPN was disconnected before reload and stays disconnected after reload."""
+    async with AsyncExitStack() as exit_stack:
+        nordvpnlite = await NordVpnLite.new(
+            exit_stack,
+            config_data=NordVpnLiteConfig(vpn=VPNConfig(country="pl")),
+            do_not_connect=True,
+        )
+        await nordvpnlite.request_credentials_from_core()
+
+        async with nordvpnlite.start():
+            await nordvpnlite.wait_for_telio_running_status()
+
+            nordvpnlite.config.config_data = NordVpnLiteConfig(
+                vpn=VPNConfig(country="de")
+            )
+            await nordvpnlite.save_config()
+            await nordvpnlite.reload()
+
+            await nordvpnlite.wait_for_telio_running_status()
+            status = json.loads(await nordvpnlite.get_status())
+            assert status["telio_is_running"]
+            assert status.get("exit_node") is None
+
+
+async def test_nordvpnlite_connect_disconnect() -> None:
+    """Start daemon with --do-not-connect, verify VPN is not established,
+    then explicitly connect and disconnect via CLI commands."""
+    async with AsyncExitStack() as exit_stack:
+        nordvpnlite = await NordVpnLite.new(
+            exit_stack,
+            config_data=CONFIG_PRESETS[ConfigPresetName.DEFAULT],
+            do_not_connect=True,
+        )
+
+        await nordvpnlite.request_credentials_from_core()
+
+        async with nordvpnlite.start():
+            # Step 1: daemon is running but VPN connection is NOT established
+            log.debug(
+                "NordVPN Lite started with --do-not-connect, "
+                "waiting for telio running status..."
+            )
+            await nordvpnlite.wait_for_telio_running_status()
+
+            assert await nordvpnlite.is_alive(), "Daemon should be alive"
+
+            status = json.loads(await nordvpnlite.get_status())
+            assert status["telio_is_running"], "telio should be running"
+            assert (
+                status.get("exit_node") is None
+            ), f"Expected no VPN connection, but exit_node={status.get('exit_node')}"
+
+            log.debug("Confirmed: daemon running, VPN not connected")
+
+            # Step 2: connect and verify VPN is established
+            log.debug("Sending connect command...")
+            await nordvpnlite.connect()
+            await nordvpnlite.wait_for_vpn_connected_state()
+
+            status = json.loads(await nordvpnlite.get_status())
+            assert (
+                status.get("exit_node") is not None
+            ), "Expected an active VPN exit_node after connect"
+            assert status["exit_node"]["state"] == "connected", (
+                f"Expected exit_node state 'connected', "
+                f"got {status['exit_node']['state']!r}"
+            )
+
+            log.debug("Confirmed: VPN connected")
+
+            # Step 3: disconnect and verify VPN connection is stopped
+            log.debug("Sending disconnect command...")
+            await nordvpnlite.disconnect()
+            await nordvpnlite.wait_for_vpn_disconnected_state()
+
+            status = json.loads(await nordvpnlite.get_status())
+            assert status.get("exit_node") is None, (
+                f"Expected no VPN connection after disconnect, "
+                f"but exit_node={status.get('exit_node')}"
+            )
+
+            log.debug("Confirmed: VPN disconnected")

--- a/nat-lab/tests/test_nordvpnlite.py
+++ b/nat-lab/tests/test_nordvpnlite.py
@@ -314,6 +314,123 @@ async def test_nordvpnlite_pq_vpn_connection(config_provider: str) -> None:
                 await inspect_preshared_key(nlx_conn)
 
 
+async def test_nordvpnlite_connect_when_already_connected() -> None:
+    """Calling connect while VPN connection is already established must NOT break the
+    existing VPN connection.
+
+    connect is fire-and-forget: the CLI always returns 'Command executed
+    successfully' immediately. The daemon silently rejects the duplicate
+    (AlreadyConnected) internally, so the test verifies connection integrity
+    via a status poll rather than a CLI error.
+    """
+    async with AsyncExitStack() as exit_stack:
+        nordvpnlite = await NordVpnLite.new(
+            exit_stack,
+            config_data=CONFIG_PRESETS[ConfigPresetName.DEFAULT],
+        )
+        await nordvpnlite.request_credentials_from_core()
+
+        async with nordvpnlite.start():
+            log.debug("NordVPN Lite started, waiting for VPN connected state...")
+            await nordvpnlite.wait_for_vpn_connected_state()
+
+            status = json.loads(await nordvpnlite.get_status())
+            assert (
+                status.get("exit_node") is not None
+            ), "Expected an active VPN connection"
+            assert status["exit_node"]["state"] == "connected", (
+                f"Expected exit_node state 'connected', "
+                f"got {status['exit_node']['state']!r}"
+            )
+
+            log.debug("VPN is connected; sending duplicate connect command...")
+
+            # connect is fire-and-forget: always returns Ok immediately.
+            # The daemon drops the duplicate internally (AlreadyConnected).
+            await nordvpnlite.connect()
+
+            log.debug(
+                "Duplicate connect returned Ok; verifying connection is intact..."
+            )
+
+            # The daemon must still be running.
+            assert (
+                await nordvpnlite.is_alive()
+            ), "Daemon should still be alive after duplicate connect"
+
+            # The VPN connection must still be established.
+            status = json.loads(await nordvpnlite.get_status())
+            assert status.get("exit_node") is not None, (
+                "Expected VPN connection to remain active, "
+                f"but exit_node={status.get('exit_node')}"
+            )
+            assert status["exit_node"]["state"] == "connected", (
+                f"Expected exit_node state 'connected', "
+                f"got {status['exit_node']['state']!r}"
+            )
+
+            log.debug("Confirmed: VPN connection intact after duplicate connect")
+
+
+async def test_nordvpnlite_disconnect_when_not_connected() -> None:
+    """Calling disconnect while VPN connection is not established must return a CLI error
+    but the daemon must remain alive."""
+    async with AsyncExitStack() as exit_stack:
+        nordvpnlite = await NordVpnLite.new(
+            exit_stack,
+            config_data=CONFIG_PRESETS[ConfigPresetName.DEFAULT],
+            do_not_connect=True,
+        )
+
+        await nordvpnlite.request_credentials_from_core()
+
+        async with nordvpnlite.start():
+            # Daemon is running but VPN connection is NOT established.
+            log.debug(
+                "NordVPN Lite started with --do-not-connect, "
+                "waiting for telio running status..."
+            )
+            await nordvpnlite.wait_for_telio_running_status()
+
+            assert (
+                await nordvpnlite.is_alive()
+            ), "Daemon should be alive before disconnect"
+
+            status = json.loads(await nordvpnlite.get_status())
+            assert status.get("exit_node") is None, (
+                f"Expected no VPN connection before disconnect attempt, "
+                f"but exit_node={status.get('exit_node')}"
+            )
+
+            log.debug("VPN is not connected; sending disconnect command...")
+
+            # Disconnect must fail with a CLI error since there is nothing to disconnect.
+            try:
+                await nordvpnlite.execute_command(["disconnect"])
+                pytest.fail(
+                    "Expected a ProcessExecError when calling disconnect with no "
+                    "active VPN connection, but the command succeeded."
+                )
+            except ProcessExecError as exc:
+                log.debug(
+                    "Got expected CLI error on disconnect with no connection: "
+                    "stdout=%r stderr=%r",
+                    exc.stdout,
+                    exc.stderr,
+                )
+
+            log.debug(
+                "Disconnect raised CLI error; verifying daemon is still running..."
+            )
+
+            # The daemon must still be running after the failed disconnect.
+            assert (
+                await nordvpnlite.is_alive()
+            ), "Daemon should still be alive after disconnect error"
+
+            log.debug("Confirmed: daemon is still alive after failed disconnect")
+
+
 async def test_nordvpnlite_reload_preserves_connected_state() -> None:
     """VPN was connected (PL) before reload, after reload stays connected to DE."""
     async with AsyncExitStack() as exit_stack:
@@ -369,3 +486,63 @@ async def test_nordvpnlite_reload_preserves_disconnected_state() -> None:
             status = json.loads(await nordvpnlite.get_status())
 
             assert status.get("exit_node") is None
+
+
+async def test_nordvpnlite_connect_disconnect() -> None:
+    """Start daemon with --do-not-connect, verify VPN connection is not established,
+    then explicitly connect and disconnect via CLI commands."""
+    async with AsyncExitStack() as exit_stack:
+        nordvpnlite = await NordVpnLite.new(
+            exit_stack,
+            config_data=CONFIG_PRESETS[ConfigPresetName.DEFAULT],
+            do_not_connect=True,
+        )
+
+        await nordvpnlite.request_credentials_from_core()
+
+        async with nordvpnlite.start():
+            # Step 1: daemon is running but VPN connection is NOT established
+            log.debug(
+                "NordVPN Lite started with --do-not-connect, "
+                "waiting for telio running status..."
+            )
+            await nordvpnlite.wait_for_telio_running_status()
+
+            assert await nordvpnlite.is_alive(), "Daemon should be alive"
+
+            status = json.loads(await nordvpnlite.get_status())
+            assert status["telio_is_running"], "telio should be running"
+            assert (
+                status.get("exit_node") is None
+            ), f"Expected no VPN connection, but exit_node={status.get('exit_node')}"
+
+            log.debug("Confirmed: daemon running, VPN not connected")
+
+            # Step 2: connect and verify VPN is established
+            log.debug("Sending connect command...")
+            await nordvpnlite.connect()
+            await nordvpnlite.wait_for_vpn_connected_state()
+
+            status = json.loads(await nordvpnlite.get_status())
+            assert (
+                status.get("exit_node") is not None
+            ), "Expected an active VPN exit_node after connect"
+            assert status["exit_node"]["state"] == "connected", (
+                f"Expected exit_node state 'connected', "
+                f"got {status['exit_node']['state']!r}"
+            )
+
+            log.debug("Confirmed: VPN connected")
+
+            # Step 3: disconnect and verify VPN connection is stopped
+            log.debug("Sending disconnect command...")
+            await nordvpnlite.disconnect()
+            await nordvpnlite.wait_for_vpn_disconnected_state()
+
+            status = json.loads(await nordvpnlite.get_status())
+            assert status.get("exit_node") is None, (
+                f"Expected no VPN connection after disconnect, "
+                f"but exit_node={status.get('exit_node')}"
+            )
+
+            log.debug("Confirmed: VPN disconnected")


### PR DESCRIPTION
### Problem

Currently the VPN connection state is tightly coupled with the daemon lifecycle and there is not way to connect/disconnect VPN exit node without changing the NordVPN Lite daemon state.

### Solution

* Separate nordvpnlite daemon lifecycle management from VPN connection state management.
  *  Introduced `nordvpnlite start --do-not-connect` flag to allow separate launching the daemon from establishing VPN connection.
  * Introduced dedicated CLI `connect`/`disconnect` commands that allows to control the VPN connection state


### Testing

1. Run daemon without establishing VPN connection
```
# ./nordvpnlite start --do-not-connect -c config.json
```
Check that daemon is running but VPN connection is not established
```
# ./nordvpnlite status
{
  "telio_is_running": true,
  "ip_address": null,
  "exit_node": null
}
```

Connect to the VPN exit node & check that VPN connection is established
```
# ./nordvpnlite connect
Command executed successfully
# /nordvpnlite status
{
  "telio_is_running": true,
  "ip_address": null,
  "exit_node": {
    "identifier": "2432424-234536f34f3-4235f34-323",
    "public_key": "cnwurvevke4747tb43y3v74659g45gh45vd5e",
    "hostname": "lt.nordvpn.com",
    "endpoint": "181.88.88.88:51320",
    "state": "connected"
  }
}
```
Disconnect from the VPN exit node
```
# ./nordvpnlite disconnect
Command executed successfully
# ./nordvpnlite status
{
  "telio_is_running": true,
  "ip_address": null,
  "exit_node": null
}
```
2. Check legacy behavior

```
# ./nordvpnlite stop
# ./nordvpnlite start -c config.json
...
# /nordvpnlite status
{
  "telio_is_running": true,
  "ip_address": null,
  "exit_node": {
    "identifier": "2432424-234536f34f3-4235f34-323",
    "public_key": "cnwurvevke4747tb43y3v74659g45gh45vd5e",
    "hostname": "lt.nordvpn.com",
    "endpoint": "181.88.88.88:51320",
    "state": "connected"
  }
}
```

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
