### PR TITLE
LLT-5433: make the per-test error allowlist actually apply

### DIFF
--- a/nat-lab/tests/libtelio_client/client.py
+++ b/nat-lab/tests/libtelio_client/client.py
@@ -76,7 +76,7 @@ class Client:
         self._libtelio_proxy: Optional[LibtelioProxy] = None
         self._proxy_port = ""
         self._fingerprint: Optional[tuple[str, str]] = None
-        self._allowed_errors: Optional[List[re.Pattern]] = None
+        self._allowed_errors: List[re.Pattern] = []
         self._log = ClientLog(self)
         self._events_facade = ClientEvents(self)
         self._vpn = ClientVpn(self)
@@ -438,8 +438,6 @@ class Client:
         return self._telio_features
 
     def allow_errors(self, allowed_errors: List[str]) -> None:
-        if self._allowed_errors is None:
-            self._allowed_errors = []
         self._allowed_errors.extend(re.compile(e) for e in allowed_errors)
 
     async def stop_device(self) -> None:

--- a/nat-lab/tests/libtelio_client_test.py
+++ b/nat-lab/tests/libtelio_client_test.py
@@ -1,0 +1,30 @@
+from tests.libtelio_client import Client
+from tests.utils.connection import TargetOS
+from tests.utils.router import IPStack
+
+
+class _StubConnection:
+    target_os = TargetOS.Linux
+
+
+class _StubNode:
+    ip_stack = IPStack.IPv4
+
+
+def test_allowlist_registered_after_client_start_is_visible():
+    client = Client(_StubConnection(), _StubNode())  # type: ignore[arg-type]
+
+    captured = client._allowed_errors  # pylint: disable=protected-access
+    assert not captured
+
+    client.allow_errors(["neptun::device.*Fatal read error"])
+
+    assert [p.pattern for p in captured] == ["neptun::device.*Fatal read error"]
+
+
+def test_allowlists_are_isolated_between_clients():
+    first = Client(_StubConnection(), _StubNode())  # type: ignore[arg-type]
+    second = Client(_StubConnection(), _StubNode())  # type: ignore[arg-type]
+
+    first.allow_errors(["neptun::device.*Fatal read error"])
+    assert not second._allowed_errors  # pylint: disable=protected-access

--- a/nat-lab/tests/log_collector.py
+++ b/nat-lab/tests/log_collector.py
@@ -414,7 +414,7 @@ class LogCollector:
     node_name: str
     start_time: object
     router: Router
-    allowed_errors: Optional[List[Pattern[str]]]
+    allowed_errors: List[Pattern[str]]
 
     def __init__(self, client):
         log.info(


### PR DESCRIPTION
### Problem
The per-test error allowlist never applied. `Client._allowed_errors` started as `None` and `allow_errors()` replaced the list instead of extending it, so `LogCollector` - which captures the list when the client starts, before any test body runs - kept the initial `None`.

### Solution
Initialise `_allowed_errors` to an empty list and extend it in place, so the reference `LogCollector` holds stays valid.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
