### PR TITLE
WG dynamic control bugfix

### DIFF
--- a/.unreleased/Dynamic_WG-NT_bugfix
+++ b/.unreleased/Dynamic_WG-NT_bugfix
@@ -1,0 +1,1 @@
+Dynamic WG-NT does not teardown adapter, when setting meshnet off and still connected to VPN

--- a/crates/telio-core/src/device.rs
+++ b/crates/telio-core/src/device.rs
@@ -1989,7 +1989,6 @@ impl Runtime {
             .iter()
             .map(|p| p.base.public_key)
             .collect();
-        let peers_cnt = peers.len();
 
         // Update for proxy and derp config
         if let Some(config) = config {
@@ -2150,6 +2149,22 @@ impl Runtime {
             }
         }
 
+        // Note: If the exit_node is a meshnet peer it will be counted twice
+        // (and it does not take into account magic_dns virtual peer),
+        // but since we only need this count for
+        // `ensure_expected_adapter_state()` to be `wg_peers_cnt > 0`,
+        // to NOT disable the wg-nt adapter, it does not really matter, how will
+        // exit_node will be counted, as long as it is taken into account.
+        let wg_peers_cnt = {
+            (self
+                .requested_state
+                .meshnet_config
+                .as_ref()
+                .and_then(|config| config.peers.as_ref())
+                .map_or(0, |peers| peers.len()))
+                + (self.requested_state.exit_node.as_ref().map_or(0, |_| 1))
+        };
+
         wg_controller::consolidate_wg_state(&self.requested_state, &self.entities, &self.features)
             .boxed()
             .await?;
@@ -2174,7 +2189,7 @@ impl Runtime {
             .entities
             .wireguard_interface
             .ensure_expected_adapter_state(
-                peers_cnt,
+                wg_peers_cnt,
                 self.features
                     .wireguard
                     .enable_dynamic_wg_nt_control

--- a/nat-lab/tests/test_adapter.py
+++ b/nat-lab/tests/test_adapter.py
@@ -325,6 +325,92 @@ class TestAdapterStateForVpnAndDns:
             state = await get_interface_state(client_conn, client_alpha)
             assert state == AdapterState.UP
 
+    @pytest.mark.parametrize(
+        "alpha_setup_params",
+        [
+            pytest.param(
+                SetupParameters(
+                    connection_tag=ConnectionTag.VM_WINDOWS_1,
+                    adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
+                    connection_tracker_config=generate_connection_tracker_config(
+                        connection_tag=ConnectionTag.VM_WINDOWS_1,
+                        derp_1_limits=(2, 2),
+                        vpn_1_limits=(1, 1),
+                    ),
+                    features=default_features(enable_dynamic_wg_nt_control=True),
+                ),
+                marks=[pytest.mark.windows],
+            ),
+            pytest.param(
+                SetupParameters(
+                    connection_tag=ConnectionTag.VM_WINDOWS_1,
+                    adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
+                    connection_tracker_config=generate_connection_tracker_config(
+                        connection_tag=ConnectionTag.VM_WINDOWS_1,
+                        derp_1_limits=(2, 2),
+                        vpn_1_limits=(1, 1),
+                    ),
+                    features=default_features(enable_dynamic_wg_nt_control=False),
+                ),
+                marks=[pytest.mark.windows],
+            ),
+        ],
+    )
+    async def test_adapter_state_for_meshnet_and_vpn(
+        self,
+        alpha_setup_params: SetupParameters,
+        env: Environment,
+    ) -> None:
+        # Creates and enables meshnet without any nodes
+        api = env.api
+        client_conn, *_ = [conn.connection for conn in env.connections]
+        client_alpha, *_ = env.clients
+
+        expected_idle_state = (
+            AdapterState.DOWN
+            if alpha_setup_params.features.wireguard.enable_dynamic_wg_nt_control
+            else AdapterState.UP
+        )
+
+        # If meshnet is enabled without any peers, adapter should still be Up
+        state = await get_interface_state(client_conn, client_alpha)
+        assert state == AdapterState.UP
+
+        await client_alpha.set_mesh_off()
+        state = await get_interface_state(client_conn, client_alpha)
+        assert state == expected_idle_state
+
+        # Add node to meshnet, adapter should go UP
+        api.default_config_two_nodes()
+        first_node_id = next(iter(api.nodes))
+        mesh_config = api.get_meshnet_config(
+            first_node_id, derp_servers=[config.DERP_PRIMARY]
+        )
+        await client_alpha.set_meshnet_config(mesh_config)
+        state = await get_interface_state(client_conn, client_alpha)
+        assert state == AdapterState.UP
+
+        # Connect to VPN
+        server_ip = config.WG_SERVER["ipv4"]
+        server_port = config.WG_SERVER["port"]
+        server_public_key = config.WG_SERVER["public_key"]
+        assert (
+            isinstance(server_ip, str)
+            and isinstance(server_port, int)
+            and isinstance(server_public_key, str)
+        )
+        await client_alpha.vpn.connect(server_ip, server_port, server_public_key)
+        state = await get_interface_state(client_conn, client_alpha)
+        assert state == AdapterState.UP
+
+        await client_alpha.set_mesh_off()
+        state = await get_interface_state(client_conn, client_alpha)
+        assert state == AdapterState.UP
+
+        await client_alpha.vpn.disconnect(server_public_key)
+        state = await get_interface_state(client_conn, client_alpha)
+        assert state == expected_idle_state
+
 
 @pytest.mark.parametrize(
     "alpha_setup_params",


### PR DESCRIPTION
### Problem
In recent PR https://github.com/NordSecurity/libtelio/pull/1891, there was a bug left out. When disabling meshnet, with VPN still connected, we tear down the adapter. Root cause - we were only countings meshnet peers in `set_config()`, but excluding the possible VPN peer.

### Solution
Added additional check (counting exit node as peer), when turning meshnet off. Added explicit test to address the case.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
