### PR TITLE
Add extra debug messages in case of BadZipfile in fetch artifacts

### DIFF
--- a/ci/fetch_artifacts.py
+++ b/ci/fetch_artifacts.py
@@ -142,8 +142,15 @@ class ArtifactsDownloader:
         with open(str(full_path), "wb") as f:
             f.write(r.content)
 
-        with zipfile.ZipFile(full_path, "r") as zip_ref:
-            zip_ref.extractall(self.path_to_save)
+        try:
+            with zipfile.ZipFile(full_path, "r") as zip_ref:
+                zip_ref.extractall(self.path_to_save)
+        except zipfile.BadZipfile:
+            print("HTTP status:", r.status_code)
+            print("Response headers:", dict(r.headers))
+            print("Response size:", len(r.content), "bytes")
+            print("First 500 bytes:", repr(r.content[:500]))
+            raise
 
     def _get_pipeline_build_artifacts(self, tag_msg: str) -> None:
         tag_data = json.loads(tag_msg)


### PR DESCRIPTION
### Problem
In case we've got `BadZipfile` when fetching the artifacts - it's not clear why it's happening.

### Solution
Add extra debug messaged to `_get_artifacts` method


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
