### PR TITLE
LLT-7539: Censor logged domains

### DIFF
--- a/.unreleased/LLT-7539_censor_log_domains
+++ b/.unreleased/LLT-7539_censor_log_domains
@@ -1,0 +1,1 @@
+LLT-7539: Censor logged domains

--- a/crates/telio-utils/src/log_censor.rs
+++ b/crates/telio-utils/src/log_censor.rs
@@ -27,6 +27,9 @@ pub enum LogCensorMode {
     EmptyString,
 }
 
+const FILE_EXTENSION_ALLOWLIST: &[&str] =
+    &["rs", "json", "toml", "log", "so", "dylib", "dll", "exe"];
+
 impl Default for LogCensor {
     fn default() -> Self {
         #[allow(clippy::expect_used)]
@@ -68,8 +71,11 @@ impl Default for LogCensor {
                 )
                 |
                 (?<DOMAIN>
+                    (?<SCHEME>[a-zA-Z][a-zA-Z0-9+.\-]*://)?
+                    (\*?\.)?
                     (([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)+
-                    ([A-Za-z]|[A-Za-z][A-Za-z]*[A-Za-z])\.
+                    [a-zA-Z]{2,}
+                    \.?
                 )
                 ",
         )
@@ -102,12 +108,88 @@ impl LogCensor {
         self.is_enabled.load(std::sync::atomic::Ordering::Relaxed)
     }
 
-    fn incorret_chars_on_bounds(input: &str, m: &Match) -> bool {
-        // wrapping_sub is used here to make the call to nth return None by giving it usize::MAX
-        [m.start().wrapping_sub(1), m.end()]
-            .iter()
-            .flat_map(|pos| input.chars().nth(*pos))
-            .any(|c| c.is_alphanumeric() || c == '_' || c == '.')
+    /// Checks whether the regex match is a fragment of a
+    /// longer token, meaning it is a false positive that
+    /// must be left uncensored.
+    fn incorrect_chars_on_bounds(input: &str, m: &Match, reject_leading_slash: bool) -> bool {
+        let is_word_char = |c: char| c.is_alphanumeric() || c == '_' || c == '.';
+        // Using char boundaries, so slicing is safe.
+        let before = input[..m.start()].chars().next_back();
+        let after = input[m.end()..].chars().next();
+        before.is_some_and(|c| is_word_char(c) || (reject_leading_slash && c == '/'))
+            || after.is_some_and(is_word_char)
+    }
+
+    fn has_allowed_extension(candidate: &str) -> bool {
+        candidate.rsplit('.').next().is_some_and(|ext| {
+            FILE_EXTENSION_ALLOWLIST
+                .iter()
+                .any(|deny| ext.eq_ignore_ascii_case(deny))
+        })
+    }
+
+    /// A match is treated as a domain only when its casing is
+    /// unambiguous.
+    ///
+    /// Mixed forms like `TelioLogLevel.DEBUG`
+    /// are most likely enums that appear in logs.
+    fn has_ambiguous_casing(candidate: &str) -> bool {
+        let (has_lower, tld_all_lower) =
+            candidate
+                .chars()
+                .fold((false, true), |(has_lower, tld_all_lower), c| match c {
+                    '.' => (has_lower, true),
+                    _ if c.is_ascii_alphabetic() => (
+                        has_lower || c.is_ascii_lowercase(),
+                        tld_all_lower && c.is_ascii_lowercase(),
+                    ),
+                    _ => (has_lower, false),
+                });
+
+        if tld_all_lower {
+            return false;
+        }
+        has_lower
+    }
+
+    /// Censor a matched domain
+    ///
+    /// The wildcard prefix (`*.` / `.`) and
+    /// trailing dot are excluded from the hash.
+    /// Leading `www.` label is normalized away
+    /// as it's an alias for the apex domain).
+    fn censor_domain(&self, matched: &str) -> String {
+        if matches!(self.mode, LogCensorMode::EmptyString) {
+            return String::new();
+        }
+
+        let (notation, rest) = if let Some(rest) = matched.strip_prefix("*.") {
+            ("*.", rest)
+        } else if let Some(rest) = matched.strip_prefix('.') {
+            (".", rest)
+        } else {
+            ("", matched)
+        };
+
+        let (rest, trailing_dot) = match rest.strip_suffix('.') {
+            Some(host) => (host, "."),
+            None => (rest, ""),
+        };
+
+        let host = match (rest.get(..4), rest.get(4..)) {
+            (Some(prefix), Some(remainder))
+                if prefix.eq_ignore_ascii_case("www.") && remainder.contains('.') =>
+            {
+                remainder
+            }
+            _ => rest,
+        };
+
+        let canonical = host.to_ascii_lowercase();
+        format!(
+            "{notation}{}{trailing_dot}",
+            self.censor_input("DOMAIN", canonical.as_bytes())
+        )
     }
 
     fn hash(&self, name: &str, input: &[u8]) -> String {
@@ -156,15 +238,26 @@ impl LogCensor {
                 .name(name)
                 .and_then(|m| Ipv6Addr::from_str(m.as_str()).ok().map(|ip| (m, ip)))
             {
-                if Self::incorret_chars_on_bounds(&log, &m) {
+                if Self::incorrect_chars_on_bounds(&log, &m, false) {
                     return m.as_str().to_owned();
                 }
                 return self.censor_input(name, ip.octets().as_slice());
             }
 
-            let name = "DOMAIN";
-            if let Some(m) = captures.name(name) {
-                return self.censor_input(name, m.as_str().as_bytes());
+            if let Some(m) = captures.name("DOMAIN") {
+                // A leading scheme means the match can't be a file name or an enum variant
+                if let Some(scheme) = captures.name("SCHEME") {
+                    let (scheme, host) = m.as_str().split_at(scheme.end() - m.start());
+                    return format!("{}{}", scheme, self.censor_domain(host));
+                }
+
+                if Self::incorrect_chars_on_bounds(&log, &m, true)
+                    || Self::has_allowed_extension(m.as_str())
+                    || Self::has_ambiguous_casing(m.as_str())
+                {
+                    return m.as_str().to_owned();
+                }
+                return self.censor_domain(m.as_str());
             }
 
             captures.get(0).map(|s| s.as_str().to_owned()).unwrap_or(
@@ -185,83 +278,296 @@ mod test {
     use super::*;
     use rstest::*;
 
-    const EXAMPLES: [(&str, &str); 15] = [
+    /// LogCensor with a repeatable seed so token values are stable.
+    fn test_censor() -> LogCensor {
+        LogCensor {
+            mask_seed: [0; 32],
+            ..Default::default()
+        }
+    }
+
+    /// Expected token for an IPv4 address.
+    fn ip4(addr: &str) -> String {
+        test_censor().hash("IP4", &Ipv4Addr::from_str(addr).unwrap().octets())
+    }
+
+    /// Expected token for an IPv6 address.
+    fn ip6(addr: &str) -> String {
+        test_censor().hash("IP6", &Ipv6Addr::from_str(addr).unwrap().octets())
+    }
+
+    /// Expected token for a host in canonical form.
+    fn dom(canonical: &str) -> String {
+        test_censor().hash("DOMAIN", canonical.as_bytes())
+    }
+
+    fn examples() -> Vec<(String, String)> {
+        let same = |s: &str| (s.to_owned(), s.to_owned());
+        vec![
             (
-                "1999-09-09 [INFO] New endpoint (1.2.3.4:1234) created",
-                "1999-09-09 [INFO] New endpoint (IP4(959535cab4852bd4):1234) created",
+                "1999-09-09 [INFO] New endpoint (1.2.3.4:1234) created".to_owned(),
+                format!(
+                    "1999-09-09 [INFO] New endpoint ({}:1234) created",
+                    ip4("1.2.3.4")
+                ),
             ),
             (
-                "1999-09-09 [INFO] New endpoint ([::aabb]:1234) created",
-                "1999-09-09 [INFO] New endpoint ([IP6(e64601d879a35ebc)]:1234) created",
+                "1999-09-09 [INFO] New endpoint ([::aabb]:1234) created".to_owned(),
+                format!(
+                    "1999-09-09 [INFO] New endpoint ([{}]:1234) created",
+                    ip6("::aabb")
+                ),
             ),
             (
-                "1999-09-09 [INFO] New endpoint ([aabb:1234::]:1234) created",
-                "1999-09-09 [INFO] New endpoint ([IP6(3b50080d1fdc9e80)]:1234) created",
+                "1999-09-09 [INFO] New endpoint ([aabb:1234::]:1234) created".to_owned(),
+                format!(
+                    "1999-09-09 [INFO] New endpoint ([{}]:1234) created",
+                    ip6("aabb:1234::")
+                ),
             ),
             (
-                "1999-09-09 [INFO] New endpoint ([1:2:3:4:5:6:7:8]:1234) created",
-                "1999-09-09 [INFO] New endpoint ([IP6(6673d2027ae3aae5)]:1234) created",
+                "1999-09-09 [INFO] New endpoint ([1:2:3:4:5:6:7:8]:1234) created".to_owned(),
+                format!(
+                    "1999-09-09 [INFO] New endpoint ([{}]:1234) created",
+                    ip6("1:2:3:4:5:6:7:8")
+                ),
             ),
             (
-                "1999-09-09 [INFO] New endpoints: [1:2::8]:1234 and 4.3.2.1:1234 created",
-                "1999-09-09 [INFO] New endpoints: [IP6(dd87bb66675bdace)]:1234 and IP4(89e69e5aeec9ec9b):1234 created",
+                "1999-09-09 [INFO] New endpoints: [1:2::8]:1234 and 4.3.2.1:1234 created"
+                    .to_owned(),
+                format!(
+                    "1999-09-09 [INFO] New endpoints: [{}]:1234 and {}:1234 created",
+                    ip6("1:2::8"),
+                    ip4("4.3.2.1")
+                ),
             ),
-            (
+            same(
                 "1999-09-09 [INFO] \"telio::device::wg_controller\":295 peer \"YOla...oFc=\" proxying: true, state: Connected, last handshake: Some(1719486326.132445116s)",
-                "1999-09-09 [INFO] \"telio::device::wg_controller\":295 peer \"YOla...oFc=\" proxying: true, state: Connected, last handshake: Some(1719486326.132445116s)",
             ),
             (
-                "255.255.255.255 IPv4 at the beginning and at the end 0.0.0.0",
-                "IP4(8be193f535e5b88f) IPv4 at the beginning and at the end IP4(245097bfbd7049db)",
+                "255.255.255.255 IPv4 at the beginning and at the end 0.0.0.0".to_owned(),
+                format!(
+                    "{} IPv4 at the beginning and at the end {}",
+                    ip4("255.255.255.255"),
+                    ip4("0.0.0.0")
+                ),
+            ),
+            same("255.255.255.255aa we don't count these as IPv4s 0.0.0.0_a"),
+            (
+                "::cd IPv6 at the beginning and at the end a:b::c:d".to_owned(),
+                format!(
+                    "{} IPv6 at the beginning and at the end {}",
+                    ip6("::cd"),
+                    ip6("a:b::c:d")
+                ),
+            ),
+            same("mace::cdcd no IPv6 addresses here crypto_aead::aead"),
+            (
+                "A list of IPv6, IPv4 and some strange mix: [a:b:c::d:e:f, 1.2.3.4, 1.2::c:d]"
+                    .to_owned(),
+                format!(
+                    "A list of IPv6, IPv4 and some strange mix: [{}, {}, 1.2::c:d]",
+                    ip6("a:b:c::d:e:f"),
+                    ip4("1.2.3.4")
+                ),
             ),
             (
-                "255.255.255.255aa we don't count these as IPv4s 0.0.0.0_a",
-                "255.255.255.255aa we don't count these as IPv4s 0.0.0.0_a",
+                r#"2024-10-15 09:39:44.161127 TelioLogLevel.DEBUG "telio_dns::forward":220 forwarding lookup: example.com A"#.to_owned(),
+                format!(
+                    r#"2024-10-15 09:39:44.161127 TelioLogLevel.DEBUG "telio_dns::forward":220 forwarding lookup: {} A"#,
+                    dom("example.com")
+                ),
             ),
             (
-                "::cd IPv6 at the beginning and at the end a:b::c:d",
-                "IP6(c3d82cb949013623) IPv6 at the beginning and at the end IP6(0525ccdac7d4904a)",
+                r#"2024-10-15 09:39:44.161127 TelioLogLevel.DEBUG "telio_dns::forward":220 forwarding lookup: example.com. A"#.to_owned(),
+                format!(
+                    r#"2024-10-15 09:39:44.161127 TelioLogLevel.DEBUG "telio_dns::forward":220 forwarding lookup: {}. A"#,
+                    dom("example.com")
+                ),
+            ),
+            {
+                let original = r#"2024-10-15 09:39:44.160969 TelioLogLevel.DEBUG "telio_dns::nameserver":221 DNS request: Request { message: MessageRequest { header: Header { id: 43687, message_type: Query, op_code: Query, authoritative: false, truncation: false, recursion_desired: true, recursion_available: false, authentic_data: false, checking_disabled: false, response_code: NoError, query_count: 1, answer_count: 0, name_server_count: 0, additional_count: 0 }, query: WireQuery { query: LowerQuery { name: LowerName(Name("example.com.")), original: Query { name: Name("example.com."), query_type: A, query_class: IN } }, original: [6, 103, 111, 111, 103, 108, 101, 3, 99, 111, 109, 0, 0, 1, 0, 1] }, answers: [], name_servers: [], additionals: [], sig0: [], edns: None }, src: 100.127.234.27:41983, protocol: UDP }"#;
+                let expected = original
+                    .replace("example.com", &dom("example.com"))
+                    .replace("100.127.234.27", &ip4("100.127.234.27"));
+                (original.to_owned(), expected)
+            },
+            {
+                // The `www.` label is normalized away
+                let original = r#"2024-10-15 09:38:38.506464 TelioLogLevel.DEBUG "hickory_resolver::name_server::name_server_pool":374 got a request result: Ok(DnsResponse { message: Message { header: Header { id: 7817, message_type: Response, op_code: Query, authoritative: false, truncation: false, recursion_desired: false, recursion_available: true, authentic_data: false, checking_disabled: false, response_code: NoError, query_count: 1, answer_count: 1, name_server_count: 0, additional_count: 0 }, queries: [Query { name: Name("www.example.com."), query_type: A, query_class: IN }], answers: [Record { name_labels: Name("www.example.com."), rr_type: A, dns_class: IN, ttl: 0, rdata: Some(A(A(142.250.179.206))) }], name_servers: [], additionals: [], signature: [], edns: None }, buffer: [30, 137, 128, 128, 0, 1, 0, 1, 0, 0, 0, 0, 3, 119, 119, 119, 6, 103, 111, 111, 103, 108, 101, 3, 99, 111, 109, 0, 0, 1, 0, 1, 192, 12, 0, 1, 0, 1, 0, 0, 0, 0, 0, 4, 142, 250, 179, 206] })"#;
+                let expected = original
+                    .replace(
+                        "www.example.com",
+                        &dom("example.com"),
+                    )
+                    .replace("142.250.179.206", &ip4("142.250.179.206"));
+                (original.to_owned(), expected)
+            },
+            {
+                let original = r#"2024-10-15 09:39:25.924396 TelioLogLevel.DEBUG "hickory_resolver::name_server::name_server_pool":374 got a request result: Ok(DnsResponse { message: Message { header: Header { id: 2866, message_type: Response, op_code: Query, authoritative: false, truncation: false, recursion_desired: false, recursion_available: true, authentic_data: false, checking_disabled: false, response_code: NoError, query_count: 1, answer_count: 1, name_server_count: 0, additional_count: 0 }, queries: [Query { name: Name("www.microsoft.com."), query_type: CNAME, query_class: IN }], answers: [Record { name_labels: Name("www.microsoft.com."), rr_type: CNAME, dns_class: IN, ttl: 0, rdata: Some(CNAME(CNAME(Name("www.microsoft.com-c-3.edgekey.net.")))) }], name_servers: [], additionals: [], signature: [], edns: None }, buffer: [11, 50, 128, 128, 0, 1, 0, 1, 0, 0, 0, 0, 3, 119, 119, 119, 9, 109, 105, 99, 114, 111, 115, 111, 102, 116, 3, 99, 111, 109, 0, 0, 5, 0, 1, 192, 12, 0, 5, 0, 1, 0, 0, 0, 0, 0, 35, 3, 119, 119, 119, 9, 109, 105, 99, 114, 111, 115, 111, 102, 116, 7, 99, 111, 109, 45, 99, 45, 51, 7, 101, 100, 103, 101, 107, 101, 121, 3, 110, 101, 116, 0] })"#;
+                let expected = original
+                    .replace(
+                        "www.microsoft.com-c-3.edgekey.net",
+                        &dom("microsoft.com-c-3.edgekey.net"),
+                    )
+                    .replace(
+                        "www.microsoft.com",
+                        &dom("microsoft.com"),
+                    );
+                (original.to_owned(), expected)
+            },
+            {
+                let original = r#"2025-04-09 21:03:34 TelioLogLevel.INFO "telio::ffi":973 Telio::set_tp_lite_domain_whitelist entry with instance id: 7396187745541688151. domains: ["adsalsa.it", "stockfinate.com"], redirects: [DnsRedirect { blocking: 1.2.3.4:53, standard: 4.3.2.1:53 }]"#;
+                let expected = original
+                    .replace("adsalsa.it", &dom("adsalsa.it"))
+                    .replace("stockfinate.com", &dom("stockfinate.com"))
+                    .replace("1.2.3.4", &ip4("1.2.3.4"))
+                    .replace("4.3.2.1", &ip4("4.3.2.1"));
+                (original.to_owned(), expected)
+            },
+            (
+                "connecting to www.example.com now".to_owned(),
+                format!("connecting to {} now", dom("example.com")),
+            ),
+            same("panicked at crates/telio-utils/src/log_censor.rs:264"),
+            same("failed to parse config.json, reading Cargo.toml and main.rs:12"),
+            (
+                "forwarding lookup: main.rs. A".to_owned(),
+                format!("forwarding lookup: {}. A", dom("main.rs")),
             ),
             (
-                "mace::cdcd no IPv6 addresses here crypto_aead::aead",
-                "mace::cdcd no IPv6 addresses here crypto_aead::aead",
+                // Accepted over-censoring: with an extension not on the allowlist
+                "failed to download update.zip from server".to_owned(),
+                format!("failed to download {} from server", dom("update.zip")),
             ),
             (
-                "A list of IPv6, IPv4 and some strange mix: [a:b:c::d:e:f, 1.2.3.4, 1.2::c:d]",
-                "A list of IPv6, IPv4 and some strange mix: [IP6(46ba26199a45b3a1), IP4(959535cab4852bd4), 1.2::c:d]",
+                "loading .env.local file".to_owned(),
+                format!("loading .{} file", dom("env.local")),
+            ),
+            same("GET /assets/update.zip served"),
+            (
+                "fetching example.com/api/users".to_owned(),
+                format!("fetching {}/api/users", dom("example.com")),
             ),
             (
-                r#"2024-10-15 09:39:44.161127 TelioLogLevel.DEBUG "telio_dns::forward":220 forwarding lookup: google.com. A"#,
-                r#"2024-10-15 09:39:44.161127 TelioLogLevel.DEBUG "telio_dns::forward":220 forwarding lookup: DOMAIN(c6f130761097acd8) A"#
+                // Accepted over-censoring: relative path whose first
+                // segment looks like a domain
+                "listing update.zip/contents now".to_owned(),
+                format!("listing {}/contents now", dom("update.zip")),
+            ),
+            same("requires version 1.2.3 e.g the latest"),
+            (
+                "lookup EXAMPLE.COM failed".to_owned(),
+                format!("lookup {} failed", dom("example.com")),
             ),
             (
-                r#"2024-10-15 09:39:44.160969 TelioLogLevel.DEBUG "telio_dns::nameserver":221 DNS request: Request { message: MessageRequest { header: Header { id: 43687, message_type: Query, op_code: Query, authoritative: false, truncation: false, recursion_desired: true, recursion_available: false, authentic_data: false, checking_disabled: false, response_code: NoError, query_count: 1, answer_count: 0, name_server_count: 0, additional_count: 0 }, query: WireQuery { query: LowerQuery { name: LowerName(Name("google.com.")), original: Query { name: Name("google.com."), query_type: A, query_class: IN } }, original: [6, 103, 111, 111, 103, 108, 101, 3, 99, 111, 109, 0, 0, 1, 0, 1] }, answers: [], name_servers: [], additionals: [], sig0: [], edns: None }, src: 100.127.234.27:41983, protocol: UDP }"#,
-                r#"2024-10-15 09:39:44.160969 TelioLogLevel.DEBUG "telio_dns::nameserver":221 DNS request: Request { message: MessageRequest { header: Header { id: 43687, message_type: Query, op_code: Query, authoritative: false, truncation: false, recursion_desired: true, recursion_available: false, authentic_data: false, checking_disabled: false, response_code: NoError, query_count: 1, answer_count: 0, name_server_count: 0, additional_count: 0 }, query: WireQuery { query: LowerQuery { name: LowerName(Name("DOMAIN(c6f130761097acd8)")), original: Query { name: Name("DOMAIN(c6f130761097acd8)"), query_type: A, query_class: IN } }, original: [6, 103, 111, 111, 103, 108, 101, 3, 99, 111, 109, 0, 0, 1, 0, 1] }, answers: [], name_servers: [], additionals: [], sig0: [], edns: None }, src: IP4(5b06ebcfbb9e3791):41983, protocol: UDP }"#
+                "fetch http://stockfinate.com timed out".to_owned(),
+                format!("fetch http://{} timed out", dom("stockfinate.com")),
             ),
             (
-                r#"2024-10-15 09:38:38.506464 TelioLogLevel.DEBUG "hickory_resolver::name_server::name_server_pool":374 got a request result: Ok(DnsResponse { message: Message { header: Header { id: 7817, message_type: Response, op_code: Query, authoritative: false, truncation: false, recursion_desired: false, recursion_available: true, authentic_data: false, checking_disabled: false, response_code: NoError, query_count: 1, answer_count: 1, name_server_count: 0, additional_count: 0 }, queries: [Query { name: Name("www.google.com."), query_type: A, query_class: IN }], answers: [Record { name_labels: Name("www.google.com."), rr_type: A, dns_class: IN, ttl: 0, rdata: Some(A(A(142.250.179.206))) }], name_servers: [], additionals: [], signature: [], edns: None }, buffer: [30, 137, 128, 128, 0, 1, 0, 1, 0, 0, 0, 0, 3, 119, 119, 119, 6, 103, 111, 111, 103, 108, 101, 3, 99, 111, 109, 0, 0, 1, 0, 1, 192, 12, 0, 1, 0, 1, 0, 0, 0, 0, 0, 4, 142, 250, 179, 206] })"#,
-                r#"2024-10-15 09:38:38.506464 TelioLogLevel.DEBUG "hickory_resolver::name_server::name_server_pool":374 got a request result: Ok(DnsResponse { message: Message { header: Header { id: 7817, message_type: Response, op_code: Query, authoritative: false, truncation: false, recursion_desired: false, recursion_available: true, authentic_data: false, checking_disabled: false, response_code: NoError, query_count: 1, answer_count: 1, name_server_count: 0, additional_count: 0 }, queries: [Query { name: Name("DOMAIN(f30af60341878496)"), query_type: A, query_class: IN }], answers: [Record { name_labels: Name("DOMAIN(f30af60341878496)"), rr_type: A, dns_class: IN, ttl: 0, rdata: Some(A(A(IP4(555b05df3fa71ebb)))) }], name_servers: [], additionals: [], signature: [], edns: None }, buffer: [30, 137, 128, 128, 0, 1, 0, 1, 0, 0, 0, 0, 3, 119, 119, 119, 6, 103, 111, 111, 103, 108, 101, 3, 99, 111, 109, 0, 0, 1, 0, 1, 192, 12, 0, 1, 0, 1, 0, 0, 0, 0, 0, 4, 142, 250, 179, 206] })"#,
+                "GET https://www.example.com/search?q=x done".to_owned(),
+                format!("GET https://{}/search?q=x done", dom("example.com")),
             ),
             (
-                r#"2024-10-15 09:39:25.924396 TelioLogLevel.DEBUG "hickory_resolver::name_server::name_server_pool":374 got a request result: Ok(DnsResponse { message: Message { header: Header { id: 2866, message_type: Response, op_code: Query, authoritative: false, truncation: false, recursion_desired: false, recursion_available: true, authentic_data: false, checking_disabled: false, response_code: NoError, query_count: 1, answer_count: 1, name_server_count: 0, additional_count: 0 }, queries: [Query { name: Name("www.microsoft.com."), query_type: CNAME, query_class: IN }], answers: [Record { name_labels: Name("www.microsoft.com."), rr_type: CNAME, dns_class: IN, ttl: 0, rdata: Some(CNAME(CNAME(Name("www.microsoft.com-c-3.edgekey.net.")))) }], name_servers: [], additionals: [], signature: [], edns: None }, buffer: [11, 50, 128, 128, 0, 1, 0, 1, 0, 0, 0, 0, 3, 119, 119, 119, 9, 109, 105, 99, 114, 111, 115, 111, 102, 116, 3, 99, 111, 109, 0, 0, 5, 0, 1, 192, 12, 0, 5, 0, 1, 0, 0, 0, 0, 0, 35, 3, 119, 119, 119, 9, 109, 105, 99, 114, 111, 115, 111, 102, 116, 7, 99, 111, 109, 45, 99, 45, 51, 7, 101, 100, 103, 101, 107, 101, 121, 3, 110, 101, 116, 0] })"#,
-                r#"2024-10-15 09:39:25.924396 TelioLogLevel.DEBUG "hickory_resolver::name_server::name_server_pool":374 got a request result: Ok(DnsResponse { message: Message { header: Header { id: 2866, message_type: Response, op_code: Query, authoritative: false, truncation: false, recursion_desired: false, recursion_available: true, authentic_data: false, checking_disabled: false, response_code: NoError, query_count: 1, answer_count: 1, name_server_count: 0, additional_count: 0 }, queries: [Query { name: Name("DOMAIN(8b89951f30d3bd35)"), query_type: CNAME, query_class: IN }], answers: [Record { name_labels: Name("DOMAIN(8b89951f30d3bd35)"), rr_type: CNAME, dns_class: IN, ttl: 0, rdata: Some(CNAME(CNAME(Name("DOMAIN(67fab06dc801422c)")))) }], name_servers: [], additionals: [], signature: [], edns: None }, buffer: [11, 50, 128, 128, 0, 1, 0, 1, 0, 0, 0, 0, 3, 119, 119, 119, 9, 109, 105, 99, 114, 111, 115, 111, 102, 116, 3, 99, 111, 109, 0, 0, 5, 0, 1, 192, 12, 0, 5, 0, 1, 0, 0, 0, 0, 0, 35, 3, 119, 119, 119, 9, 109, 105, 99, 114, 111, 115, 111, 102, 116, 7, 99, 111, 109, 45, 99, 45, 51, 7, 101, 100, 103, 101, 107, 101, 121, 3, 110, 101, 116, 0] })"#,
-            )
-    ];
+                "proxy http://1.2.3.4:8080 used".to_owned(),
+                format!("proxy http://{}:8080 used", ip4("1.2.3.4")),
+            ),
+            (
+                r#"whitelist: ["*.adsalsa.it", ".stockfinate.com"]"#.to_owned(),
+                format!(
+                    r#"whitelist: ["*.{}", ".{}"]"#,
+                    dom("adsalsa.it"),
+                    dom("stockfinate.com")
+                ),
+            ),
+            (
+                "wss://relay.nordvpn.com. reconnect".to_owned(),
+                format!("wss://{}. reconnect", dom("relay.nordvpn.com")),
+            ),
+            (
+                "https://EXAMPLE.COM up".to_owned(),
+                format!("https://{} up", dom("example.com")),
+            ),
+            (
+                "https://example.com up".to_owned(),
+                format!("https://{} up", dom("example.com")),
+            ),
+            (
+                "open MAIN.RS failed".to_owned(),
+                "open MAIN.RS failed".to_owned(),
+            ),
+            (
+                // Accepted residual: mixed case forms are skipped
+                "peer Example.COM seen".to_owned(),
+                "peer Example.COM seen".to_owned(),
+            ),
+        ]
+    }
 
     #[test]
     fn test_log_censor() {
-        let censor = LogCensor {
-            // For the tests we need it repeatable and seed filled with zeros is good as any other
-            mask_seed: [0; 32],
-            ..Default::default()
-        };
+        let censor = test_censor();
 
-        for (original_log, expected_censored_log) in EXAMPLES {
-            assert_eq!(
-                expected_censored_log,
-                censor.censor_logs(original_log.to_owned())
-            );
+        for (original_log, expected_censored_log) in examples() {
+            assert_eq!(expected_censored_log, censor.censor_logs(original_log));
         }
+    }
+
+    #[test]
+    fn test_domain_hash_relatability() {
+        let censor = test_censor();
+        let token = dom("example.com");
+        // Every spelling of the same host must contain the same DOMAIN(..)
+        let cases = [
+            ("lookup example.com now", format!("lookup {token} now")),
+            ("lookup example.com. now", format!("lookup {token}. now")),
+            ("lookup www.example.com now", format!("lookup {token} now")),
+            (
+                "lookup www.example.com. now",
+                format!("lookup {token}. now"),
+            ),
+            ("lookup EXAMPLE.COM now", format!("lookup {token} now")),
+            (
+                "lookup http://example.com now",
+                format!("lookup http://{token} now"),
+            ),
+            (
+                r#"lookup "*.example.com" now"#,
+                format!(r#"lookup "*.{token}" now"#),
+            ),
+            (
+                "GET https://www.example.com/search?q=x done",
+                format!("GET https://{token}/search?q=x done"),
+            ),
+        ];
+        for (input, expected) in cases {
+            assert_eq!(expected, censor.censor_logs(input.to_owned()), "{input}");
+        }
+    }
+
+    #[test]
+    fn test_no_sensitive_domain_leak() {
+        let censor = test_censor();
+        let token = dom("example.co.uk");
+        let inputs = [
+            "visit example.co.uk now",
+            "visit www.example.co.uk now",
+            "visit example.co.uk. now",
+            r#"whitelist ["*.example.co.uk"] set"#,
+            r#"suffix ".example.co.uk" set"#,
+            "GET https://www.example.co.uk/news done",
+            "GET example.co.uk/news done",
+        ];
+        for input in inputs {
+            let censored = censor.censor_logs(input.to_owned());
+            assert!(!censored.contains("example"), "leaked: {censored}");
+            assert!(censored.contains(&token), "not relatable: {censored}");
+        }
+
+        let censored = censor.censor_logs("connect mail.example.com now".to_owned());
+        assert_eq!(censored, format!("connect {} now", dom("mail.example.com")));
+        assert!(!censored.contains("example"));
+        assert_ne!(dom("mail.example.com"), dom("example.com"));
     }
 
     #[test]
@@ -283,8 +589,8 @@ mod test {
     fn test_disabled_log_censor_makes_no_modifications() {
         let censor = LogCensor::default();
         censor.set_enabled(false);
-        for (original_log, _) in EXAMPLES {
-            let original_log_copy = original_log.to_owned();
+        for (original_log, _) in examples() {
+            let original_log_copy = original_log.clone();
             let original_log_ptr = original_log_copy.as_str().as_ptr();
             let new_log = censor.censor_logs(original_log_copy);
             assert_eq!(original_log, new_log);
@@ -300,19 +606,20 @@ mod test {
     fn test_hide_user_data_and_hide_thread_id_are_filtered_out_when_log_censor_is_enabled_and_disabled(
         #[case] set_enabled: bool,
     ) {
-        let original = r#"{hide_user_data:true, "hide_user_data": false, 'hide_user_data' :true,hide_thread_id:false,hide_the_cookies:false,something_else:None, 'some_domain': 'google.com.',IPv4:"255.255.255.255", "IPv6":"::cd"}"#.to_owned();
+        let original = r#"{hide_user_data:true, "hide_user_data": false, 'hide_user_data' :true,hide_thread_id:false,hide_the_cookies:false,something_else:None, 'some_domain': 'example.com.',IPv4:"255.255.255.255", "IPv6":"::cd"}"#.to_owned();
         let expected = if set_enabled {
-            r#"{hide_the_cookies:false,something_else:None, 'some_domain': 'DOMAIN(c6f130761097acd8)',IPv4:"IP4(8be193f535e5b88f)", "IPv6":"IP6(c3d82cb949013623)"}"#
+            format!(
+                r#"{{hide_the_cookies:false,something_else:None, 'some_domain': '{}.',IPv4:"{}", "IPv6":"{}"}}"#,
+                dom("example.com"),
+                ip4("255.255.255.255"),
+                ip6("::cd")
+            )
         } else {
-            r#"{hide_the_cookies:false,something_else:None, 'some_domain': 'google.com.',IPv4:"255.255.255.255", "IPv6":"::cd"}"#
-        }
-        .to_owned();
-
-        let censor = LogCensor {
-            // For the tests we need it repeatable and seed filled with zeros is good as any other
-            mask_seed: [0; 32],
-            ..Default::default()
+            r#"{hide_the_cookies:false,something_else:None, 'some_domain': 'example.com.',IPv4:"255.255.255.255", "IPv6":"::cd"}"#
+                .to_owned()
         };
+
+        let censor = test_censor();
         censor.set_enabled(set_enabled);
         let actual = censor.censor_logs(original);
 
@@ -321,16 +628,43 @@ mod test {
 
     #[test]
     fn test_log_censor_modes() {
-        let mut censor = LogCensor::default();
+        let mut censor = test_censor();
         censor.set_mode(LogCensorMode::Dots);
-        let input = EXAMPLES[0].0;
-        let censored = censor.censor_logs(input.to_owned());
+        let ip_input = "1999-09-09 [INFO] New endpoint (1.2.3.4:1234) created";
+        let censored = censor.censor_logs(ip_input.to_owned());
         assert_eq!(
             censored,
             "1999-09-09 [INFO] New endpoint (IP4(...):1234) created"
         );
+        let domain_input = "see www.example.com. and *.example.co.uk here";
+        let censored = censor.censor_logs(domain_input.to_owned());
+        assert_eq!(censored, "see DOMAIN(...). and *.DOMAIN(...) here");
+
         censor.set_mode(LogCensorMode::EmptyString);
-        let censored = censor.censor_logs(input.to_owned());
+        let censored = censor.censor_logs(ip_input.to_owned());
         assert_eq!(censored, "1999-09-09 [INFO] New endpoint (:1234) created");
+        // EmptyString drops the whole token, notation prefixes included.
+        let censored = censor.censor_logs(domain_input.to_owned());
+        assert_eq!(censored, "see  and  here");
+    }
+
+    // The multi-byte chars before the match used to shift the boundary
+    // check (byte offsets were used as char indices), so "ace::cdcd" was
+    // censored despite the alphanumeric 'm' right before it.
+    #[test]
+    fn test_boundary_check_handles_multibyte_chars() {
+        let censor = test_censor();
+        let input = "日志 mace::cdcd".to_owned();
+        assert_eq!(censor.censor_logs(input.clone()), input);
+    }
+
+    #[test]
+    fn test_has_ambiguous_casing_mixed_case() {
+        assert!(LogCensor::has_ambiguous_casing("Example.COM"));
+        assert!(LogCensor::has_ambiguous_casing("Example.Com"));
+        assert!(LogCensor::has_ambiguous_casing("example.COM"));
+        assert!(!LogCensor::has_ambiguous_casing("EXAMPLE.COM"));
+        assert!(!LogCensor::has_ambiguous_casing("example.com"));
+        assert!(!LogCensor::has_ambiguous_casing("example.com."));
     }
 }


### PR DESCRIPTION
### Problem
Domains without trailing dot (like `example.com`) were left uncensored in the logs.

### Solution
- Match domains with or without the trailing dot (`example.com` and `example.com.`), in URLs (`http:://example.com`), and in wildcard notation (`*.example.com`).
- The protocol, wildcard, and paths stay readable (`http://DOMAIN(H1)/search?q=x`).
- Hosts are canonicalized before hashing (lowercased, `www.` stripped), to produce the same DOMAIN(H1).
- False positives are filtered out: matches preceded with path segments (`telio-utils/src/lib.rs`), file names with extensions used in the codebase (`main.rs`, `config.json`, etc), and enum forms (`TelioLogLevel.DEBUG`).
- Accepted trade offs: unknown extensions are over censored (`update.zip`), and mixed-case domains (`Example.COM`) are leaked.
- Unit tests with deterministic helper functions
- Fixed multi byte char offset


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
