### PR TITLE
Save container logs in case of checks failure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1402,11 +1402,10 @@ checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]

--- a/nat-lab/docker-compose.yml
+++ b/nat-lab/docker-compose.yml
@@ -168,7 +168,7 @@ services:
       PASSWORD: "gates"
       NETWORK: "bridge"
       RAM_SIZE: "4G"
-      CPU_CORES: "1"
+      CPU_CORES: "2"
       EXTRA_SCRIPT: "/libtelio/nat-lab/bin/windows-client"
       CLIENT_GATEWAY_PRIMARY: 192.168.150.254
       CLIENT_GATEWAY_SECONDARY: 192.168.151.254
@@ -196,7 +196,7 @@ services:
       PASSWORD: "gates"
       NETWORK: "bridge"
       RAM_SIZE: "4G"
-      CPU_CORES: "1"
+      CPU_CORES: "2"
       EXTRA_SCRIPT: "/libtelio/nat-lab/bin/windows-client"
       CLIENT_GATEWAY_PRIMARY: 192.168.152.254
       CLIENT_GATEWAY_SECONDARY: 192.168.153.254

--- a/nat-lab/tests/conftest_helpers/setup_checks.py
+++ b/nat-lab/tests/conftest_helpers/setup_checks.py
@@ -1,11 +1,13 @@
 import asyncio
 import json
+import os
 import re
 import tests.config
 from collections import defaultdict
 from contextlib import AsyncExitStack
 from itertools import combinations
 from tests.config import LAN_ADDR_MAP
+from tests.conftest_helpers.log_collection import LOG_DIR
 from tests.interderp_cli import InterDerpClient
 from tests.utils.connection import ConnectionTag, TargetOS
 from tests.utils.connection.docker_connection import (
@@ -210,6 +212,32 @@ async def _run_cmd(cmd: list[str]) -> str:
     return out + err
 
 
+async def _save_container_log(container: str) -> str | None:
+    path = os.path.join(LOG_DIR, f"docker-{container}.log")
+    try:
+        os.makedirs(LOG_DIR, exist_ok=True)
+        with open(path, "wb") as log_file:
+            proc = await asyncio.create_subprocess_exec(
+                "docker",
+                "logs",
+                container,
+                stdout=log_file,
+                stderr=asyncio.subprocess.STDOUT,
+            )
+            returncode = await proc.wait()
+    except OSError as e:
+        setup_log.warning("Failed to save %s container log: %s", container, e)
+        return None
+    if returncode != 0:
+        setup_log.warning(
+            "'docker logs %s' exited with %s; %s may be incomplete",
+            container,
+            returncode,
+            path,
+        )
+    return path
+
+
 async def _dump_vm_connection_failure_diagnostics(conn_tag: ConnectionTag) -> None:
     """Dump container logs and host network state when a VM SSH connection fails.
 
@@ -220,8 +248,9 @@ async def _dump_vm_connection_failure_diagnostics(conn_tag: ConnectionTag) -> No
         return
 
     container = f"nat-lab-{DOCKER_VM_SERVICE_IDS[conn_tag]}-1"
-    logs = await _run_cmd(["docker", "logs", "--tail", "100", container])
-    setup_log.warning("Last 100 lines of %s container logs:\n%s", container, logs)
+    log_path = await _save_container_log(container)
+    if log_path is not None:
+        setup_log.warning("Full %s container log saved to %s", container, log_path)
 
     primary_ip = LAN_ADDR_MAP[conn_tag]["primary"]
     for cmd, label in [


### PR DESCRIPTION
### Problem
1. Printing last 100 log lines from container is not enough for debugging purposes
2. Suspect that 1 CPU core for windows VM is not enough to boot and CPU usage shows 100% from the logs
3. cargo-deny is [failing](https://github.com/NordSecurity/libtelio/actions/runs/30894909787/job/91945400784) RUSTSEC-2026-0221

### Solution
1. Save container logs to a separate file in case of failed `setup_check_duplicate_mac_addresses`
2. Increase CPU core to 2 for windows VMs in nat-lab
3. Bump event-listener to 5.4.2 


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
