### PR TITLE
LLT-7558: Domain accessible after being removed from whitelist

### DIFF
--- a/.unreleased/LLT-7558_domain_available_after_removing_from_whitelist
+++ b/.unreleased/LLT-7558_domain_available_after_removing_from_whitelist
@@ -1,0 +1,1 @@
+Flush DNS resolver cache when whitelist is modified.

--- a/crates/telio-core/src/device.rs
+++ b/crates/telio-core/src/device.rs
@@ -796,7 +796,7 @@ impl Device {
     ) -> Result {
         self.async_runtime()?.block_on(async {
             task_exec!(self.rt()?, async move |rt| {
-                Ok(rt.set_tp_lite_domain_whitelist(domains, redirects))
+                Ok(rt.set_tp_lite_domain_whitelist(domains, redirects).await)
             })
             .await?
         })
@@ -2244,7 +2244,7 @@ impl Runtime {
     ///
     /// Requires firewall to be enabled through setting firewall field of Features
     /// object to a non-null value.
-    pub fn set_tp_lite_domain_whitelist(
+    pub async fn set_tp_lite_domain_whitelist(
         &self,
         #[allow(unused_variables)] domains: Vec<String>,
         #[allow(unused_variables)] redirects: Vec<DnsRedirect>,
@@ -2252,7 +2252,19 @@ impl Runtime {
         #[cfg(feature = "enable_firewall")]
         match &self.entities.firewall {
             Some(fw) => {
-                fw.set_tp_lite_domain_whitelist(domains, redirects);
+                let domains_changed = fw.set_tp_lite_domain_whitelist(domains, redirects);
+
+                // LLT-7558: the firewall only ever sees DNS queries that miss the
+                // MagicDNS resolver cache - a cache hit is answered before any
+                // packet is emitted. So a whitelist change has no effect on
+                // already-cached names until their TTL expires, and the cache has
+                // to be dropped here. This also clears negative entries, because
+                // re-blocking is not the only broken direction.
+                if domains_changed {
+                    if let Some(dns) = &self.entities.dns.lock().await.resolver {
+                        dns.flush_cache().await;
+                    }
+                }
                 Ok(())
             }
             None => Err(Error::FirewallDisabled),

--- a/crates/telio-core/src/device.rs
+++ b/crates/telio-core/src/device.rs
@@ -798,7 +798,7 @@ impl Device {
     ) -> Result {
         self.async_runtime()?.block_on(async {
             task_exec!(self.rt()?, async move |rt| {
-                Ok(rt.set_tp_lite_domain_whitelist(domains, redirects))
+                Ok(rt.set_tp_lite_domain_whitelist(domains, redirects).await)
             })
             .await?
         })
@@ -2254,7 +2254,7 @@ impl Runtime {
     ///
     /// Requires firewall to be enabled through setting firewall field of Features
     /// object to a non-null value.
-    pub fn set_tp_lite_domain_whitelist(
+    pub async fn set_tp_lite_domain_whitelist(
         &self,
         #[allow(unused_variables)] domains: Vec<String>,
         #[allow(unused_variables)] redirects: Vec<DnsRedirect>,
@@ -2263,6 +2263,16 @@ impl Runtime {
         match &self.entities.firewall {
             Some(fw) => {
                 fw.set_tp_lite_domain_whitelist(domains, redirects);
+
+                // LLT-7558: the firewall only ever sees DNS queries that miss the
+                // MagicDNS resolver cache - a cache hit is answered before any
+                // packet is emitted. So a whitelist change has no effect on
+                // already-cached names until their TTL expires, and the cache has
+                // to be dropped here. This also clears negative entries, because
+                // re-blocking is not the only broken direction.
+                if let Some(dns) = &self.entities.dns.lock().await.resolver {
+                    dns.flush_cache().await;
+                }
                 Ok(())
             }
             None => Err(Error::FirewallDisabled),

--- a/crates/telio-dns/src/dns.rs
+++ b/crates/telio-dns/src/dns.rs
@@ -32,6 +32,8 @@ pub trait DnsResolver {
     async fn upsert(&self, zone: &str, records: &Records, ttl_value: TtlValue) -> Result<()>;
     /// Configure list of forward DNS servers for zone '.'.
     async fn forward(&self, to: &[IpAddr]) -> Result<()>;
+    /// Drop every entry from the forwarding resolver's cache.
+    async fn flush_cache(&self);
     /// Get public key of this DNS server.
     fn public_key(&self) -> PublicKey;
     /// Get Peer of this DNS server with selected allowed IPs.
@@ -134,6 +136,11 @@ impl DnsResolver for LocalDnsResolver {
     async fn forward(&self, to: &[IpAddr]) -> Result<()> {
         telio_log_debug!("Dns - forward {:?}", to);
         self.nameserver.forward(to).await
+    }
+
+    async fn flush_cache(&self) {
+        telio_log_debug!("Dns - flush_cache");
+        self.nameserver.flush_forward_cache().await;
     }
 
     fn public_key(&self) -> PublicKey {

--- a/crates/telio-dns/src/forward.rs
+++ b/crates/telio-dns/src/forward.rs
@@ -178,6 +178,17 @@ impl ForwardAuthority {
             resolver,
         })
     }
+
+    /// Drop every entry from the resolver's cache.
+    ///
+    /// Removes both positive and negative (NXDOMAIN) entries. Needed when
+    /// something outside DNS changes what an answer ought to be - see LLT-7558,
+    /// where a TP-Lite whitelist change alters whether a query gets redirected,
+    /// but a cached answer would be returned without the query ever reaching
+    /// the firewall.
+    pub fn flush_cache(&self) {
+        self.resolver.clear_cache();
+    }
 }
 
 #[async_trait::async_trait]

--- a/crates/telio-dns/src/nameserver.rs
+++ b/crates/telio-dns/src/nameserver.rs
@@ -122,6 +122,8 @@ pub trait NameServer {
     async fn forward_to_addrs(&self, to: &[SocketAddr]) -> DnsResult<()>;
     /// Insert or update zone records used by the server.
     async fn upsert(&self, zone: &str, records: &Records, ttl_value: TtlValue) -> DnsResult<()>;
+    /// Drop every entry from the forward zone's resolver cache.
+    async fn flush_forward_cache(&self);
 }
 
 /// Helper to update wg timers
@@ -157,6 +159,11 @@ pub struct LocalNameServer {
     zones: Arc<ClonableZones>,
     task_handle: Option<JoinHandle<()>>,
     forwarder: Option<RawForwarder>,
+    /// Typed handle to the same forward zone that is stored, type-erased, in
+    /// `zones`. Both hold the same `Arc`, so this stays in sync across the
+    /// copy-on-write clones of `ClonableZones`. Kept so the resolver cache can
+    /// be flushed without downcasting out of `Box<dyn AuthorityObject>`.
+    forward_zone: Option<Arc<ForwardZone>>,
 }
 
 impl LocalNameServer {
@@ -176,6 +183,7 @@ impl LocalNameServer {
             zones: Arc::new(ClonableZones::new()),
             task_handle: None,
             forwarder: raw_forwarder,
+            forward_zone: None,
         }));
         ns.forward(forward_ips).await?;
         Ok(ns)
@@ -894,16 +902,38 @@ impl NameServer for Arc<RwLock<LocalNameServer>> {
     }
 
     async fn forward(&self, to: &[IpAddr]) -> DnsResult<()> {
-        self.zones_mut().await.upsert(
-            LowerName::from_str(".")?,
-            Box::new(Arc::new(ForwardZone::new(".", to).await?)),
-        );
+        let forward_zone = Arc::new(ForwardZone::new(".", to).await?);
+        let root = LowerName::from_str(".")?;
+
+        // Scope each guard explicitly: `zones_mut` holds a write guard on the
+        // whole LocalNameServer, so it must be released before taking `write()`
+        // below, otherwise this would deadlock on itself.
+        {
+            self.zones_mut()
+                .await
+                .upsert(root, Box::new(forward_zone.clone()));
+        }
+        {
+            // Both copies share one Arc, so flushing through this handle affects
+            // the zone that actually serves queries.
+            self.write().await.forward_zone = Some(forward_zone);
+        }
 
         let upstreams: Vec<SocketAddr> =
             to.iter().map(|ip| SocketAddr::new(*ip, DNS_PORT)).collect();
         self.forward_to_addrs(&upstreams).await?;
 
         Ok(())
+    }
+
+    async fn flush_forward_cache(&self) {
+        // Clone the handle and release the read guard before touching the
+        // resolver, so the nameserver lock is never held across the cache lock.
+        let forward_zone = self.read().await.forward_zone.clone();
+        if let Some(forward_zone) = forward_zone {
+            forward_zone.flush_cache();
+            telio_log_debug!("Flushed MagicDNS forward resolver cache");
+        }
     }
 
     async fn forward_to_addrs(&self, to: &[SocketAddr]) -> DnsResult<()> {

--- a/crates/telio-dns/src/nameserver.rs
+++ b/crates/telio-dns/src/nameserver.rs
@@ -122,6 +122,8 @@ pub trait NameServer {
     async fn forward_to_addrs(&self, to: &[SocketAddr]) -> DnsResult<()>;
     /// Insert or update zone records used by the server.
     async fn upsert(&self, zone: &str, records: &Records, ttl_value: TtlValue) -> DnsResult<()>;
+    /// Drop every entry from the forward zone's resolver cache.
+    async fn flush_forward_cache(&self);
 }
 
 /// Helper to update wg timers
@@ -157,6 +159,11 @@ pub struct LocalNameServer {
     zones: Arc<ClonableZones>,
     task_handle: Option<JoinHandle<()>>,
     forwarder: Option<UdpForwarder>,
+    /// Typed handle to the same forward zone that is stored, type-erased, in
+    /// `zones`. Both hold the same `Arc`, so this stays in sync across the
+    /// copy-on-write clones of `ClonableZones`. Kept so the resolver cache can
+    /// be flushed without downcasting out of `Box<dyn AuthorityObject>`.
+    forward_zone: Option<Arc<ForwardZone>>,
 }
 
 impl LocalNameServer {
@@ -176,6 +183,7 @@ impl LocalNameServer {
             zones: Arc::new(ClonableZones::new()),
             task_handle: None,
             forwarder: raw_forwarder,
+            forward_zone: None,
         }));
         ns.forward(forward_ips).await?;
         Ok(ns)
@@ -895,16 +903,38 @@ impl NameServer for Arc<RwLock<LocalNameServer>> {
     }
 
     async fn forward(&self, to: &[IpAddr]) -> DnsResult<()> {
-        self.zones_mut().await.upsert(
-            LowerName::from_str(".")?,
-            Box::new(Arc::new(ForwardZone::new(".", to).await?)),
-        );
+        let forward_zone = Arc::new(ForwardZone::new(".", to).await?);
+        let root = LowerName::from_str(".")?;
+
+        // Scope each guard explicitly: `zones_mut` holds a write guard on the
+        // whole LocalNameServer, so it must be released before taking `write()`
+        // below, otherwise this would deadlock on itself.
+        {
+            self.zones_mut()
+                .await
+                .upsert(root, Box::new(forward_zone.clone()));
+        }
+        {
+            // Both copies share one Arc, so flushing through this handle affects
+            // the zone that actually serves queries.
+            self.write().await.forward_zone = Some(forward_zone);
+        }
 
         let upstreams: Vec<SocketAddr> =
             to.iter().map(|ip| SocketAddr::new(*ip, DNS_PORT)).collect();
         self.forward_to_addrs(&upstreams).await?;
 
         Ok(())
+    }
+
+    async fn flush_forward_cache(&self) {
+        // Clone the handle and release the read guard before touching the
+        // resolver, so the nameserver lock is never held across the cache lock.
+        let forward_zone = self.read().await.forward_zone.clone();
+        if let Some(forward_zone) = forward_zone {
+            forward_zone.flush_cache();
+            telio_log_debug!("Flushed MagicDNS forward resolver cache");
+        }
     }
 
     async fn forward_to_addrs(&self, to: &[SocketAddr]) -> DnsResult<()> {

--- a/crates/telio-dns/src/zone.rs
+++ b/crates/telio-dns/src/zone.rs
@@ -349,6 +349,11 @@ impl ForwardZone {
         .await?;
         Ok(ForwardZone { zone })
     }
+
+    /// Drop every entry from the underlying resolver's cache.
+    pub(crate) fn flush_cache(&self) {
+        self.zone.flush_cache();
+    }
 }
 
 #[async_trait]

--- a/crates/telio-firewall/src/firewall.rs
+++ b/crates/telio-firewall/src/firewall.rs
@@ -429,10 +429,27 @@ impl StatefulFirewall {
     /// Set the TP-Lite DNS whitelisting configuration: the whitelisted domains
     /// and the (blocking, standard) DNS server redirect pairs. Both are applied
     /// together, reconfiguring the firewall to DNAT-redirect matching queries.
-    pub fn set_tp_lite_domain_whitelist(&self, domains: Vec<String>, redirects: Vec<DnsRedirect>) {
-        self.configured_state.write().tp_lite_whitelisted_domains = domains;
-        self.configured_state.write().tp_lite_dns_redirects = redirects;
+    ///
+    /// Returns `true` when the set of whitelisted domains differs from the one
+    /// previously configured. Callers use this to decide whether caches keyed on
+    /// the whitelist need invalidating - see LLT-7558. Changing only the
+    /// redirects does not affect which domains bypass blocking, so it does not
+    /// set the flag.
+    pub fn set_tp_lite_domain_whitelist(
+        &self,
+        domains: Vec<String>,
+        redirects: Vec<DnsRedirect>,
+    ) -> bool {
+        let domains_changed = {
+            let mut configured_state = self.configured_state.write();
+            let changed = configured_state.tp_lite_whitelisted_domains != domains;
+            configured_state.tp_lite_whitelisted_domains = domains;
+            configured_state.tp_lite_dns_redirects = redirects;
+            changed
+        };
+
         self.refresh_chain();
+        domains_changed
     }
 }
 

--- a/nat-lab/bin/dns-server
+++ b/nat-lab/bin/dns-server
@@ -18,7 +18,13 @@ KNOWN = {
         b"error-with-noerror-return-code.com": None,
         b"api.nordvpn.com": dns.Record_A(address="10.0.80.86"),
         b"mqtt.nordvpn.com": dns.Record_A(address="10.0.80.85"),
-        b"blocked-malware.com": dns.Record_A(address="123.123.123.123"),
+        # LLT-7558: an explicit, long TTL is required here. This record is the
+        # "unblocked" answer used by the TP-Lite DNS whitelisting tests, which
+        # need it to be cacheable by the MagicDNS (hickory) resolver. Without an
+        # explicit TTL the answer is served with RRHeader's default of 0, hickory
+        # stores it as already-expired and evicts it on the next lookup, and the
+        # stale-cache test would silently pass for the wrong reason.
+        b"blocked-malware.com": dns.Record_A(address="123.123.123.123", ttl=3600),
     },
     dns.CNAME: {
         b"www.microsoft.com": dns.Record_CNAME(name="www.microsoft.com-c-3.edgekey.net.")
@@ -35,7 +41,14 @@ class DNSResolver:
         logging.info(f"Resolving name: {name} => {record}")
         if record is None:
             return [], [], []
-        answer = dns.RRHeader(name=name, type=type, payload=record)
+        # Propagate an explicit per-record TTL to the resource record header when
+        # one was configured. Twisted leaves Record_*.ttl as None unless it was
+        # passed to the constructor, and RRHeader rejects None, so fall back to
+        # RRHeader's own default of 0 to keep every other record unchanged.
+        ttl = getattr(record, "ttl", None)
+        if ttl is None:
+            ttl = 0
+        answer = dns.RRHeader(name=name, type=type, ttl=ttl, payload=record)
         return [answer], [], []
 
     def query(self, query, timeout=None):

--- a/nat-lab/tests/test_tp_lite_stats.py
+++ b/nat-lab/tests/test_tp_lite_stats.py
@@ -35,6 +35,9 @@ NON_PLAINTEXT_DNS_PORTS = ["443", "853"]
 STANDARD_DNS_IP = config.LAN_ADDR_MAP[ConnectionTag.DOCKER_DNS_SERVER_1]["primary"]
 # Address the standrd dns-server returns for blocked-malware.com
 WHITELIST_RESOLVED_IP = "123.123.123.123"
+# TTL the standard dns-server attaches to its blocked-malware.com answer.
+# Must match the explicit ttl configured in nat-lab/bin/dns-server.
+WHITELIST_RESOLVED_TTL = 3600
 
 CALLBACK_INTERVAL_S = 1  # Use short interval for all tests
 
@@ -90,6 +93,82 @@ async def _query_blocked_expect_failure(connection: Connection) -> None:
     with pytest.raises(Exception):
         await query_dns(
             connection, BLOCKED_NXDOMAIN, dns_server=TP_LITE_DNS_IP, options=["-type=a"]
+        )
+
+
+async def _dig_magic_dns(connection: Connection, domain: str) -> tuple[str, str]:
+    """Resolve `domain` through MagicDNS with dig and return (stdout, stderr).
+
+    Unlike nslookup, dig prints the TTL of the answer, which lets the caller
+    tell a freshly fetched answer apart from one replayed out of the resolver
+    cache. `+noall +answer` reduces the output to just the answer section, so
+    the TTL is the second whitespace-separated field, same as in
+    test_dns.py::test_dns_ttl_value.
+    """
+    process = await connection.create_process([
+        "dig",
+        "+noall",
+        "+nocmd",
+        "+answer",
+        "+timeout=5",
+        domain,
+        f"@{config.LIBTELIO_DNS_IPV4}",
+    ]).execute()
+    return process.get_stdout(), process.get_stderr()
+
+
+def _parse_dig_a_answer(dig_stdout: str) -> tuple[Optional[int], Optional[str]]:
+    """Extract (ttl, address) from the first A record of a `dig +noall +answer`
+    output, or (None, None) when there is no A record (e.g. NXDOMAIN)."""
+    for line in dig_stdout.splitlines():
+        fields = line.split()
+        # <name> <ttl> <class> <type> <rdata>
+        if len(fields) >= 5 and fields[3] == "A":
+            return int(fields[1]), fields[4]
+    return None, None
+
+
+async def _assert_served_from_cache(
+    client, domain: str, log_offset: int, expected: bool
+) -> None:
+    """Assert whether the most recent lookup of `domain` was answered from the
+    MagicDNS (hickory) resolver cache rather than by querying upstream.
+
+    Only log lines produced after `log_offset` are considered, so the caller can
+    scope the check to a single query.
+
+    Two markers straddle the cache branch in hickory's CachingClient::inner_lookup
+    (crates/resolver/src/caching_client.rs:180):
+
+        telio_dns::forward:220  "forwarding lookup: <domain> <type>"
+            -> logged before the cache is consulted, so it appears either way
+        hickory_proto::xfer::dns_handle:67  "querying: <domain> <type>"
+            -> logged inside DnsHandle::lookup, which is only reached when
+               lookup_from_cache() returned None
+
+    So "forwarding lookup" present + "querying" absent means the answer came out
+    of the cache and no DNS packet was ever emitted - which also means the
+    firewall never had a chance to act on the query.
+    """
+    logs = (await client.log.get())[log_offset:]
+    forwarded = f"forwarding lookup: {domain}" in logs
+    queried_upstream = f"querying: {domain}" in logs
+
+    assert forwarded, (
+        f"expected a 'forwarding lookup: {domain}' entry, meaning the request"
+        " reached the MagicDNS forward zone; found none, so the test did not"
+        " exercise the resolver at all"
+    )
+
+    if expected:
+        assert not queried_upstream, (
+            f"expected '{domain}' to be answered from the resolver cache, but"
+            " an upstream query was sent ('querying:' present in the log)"
+        )
+    else:
+        assert queried_upstream, (
+            f"expected '{domain}' to be resolved upstream, but no 'querying:'"
+            " entry was logged, so it was answered from the resolver cache"
         )
 
 
@@ -761,3 +840,135 @@ class TestDnsWhitelisting:
                 dns_server=TP_LITE_DNS_IP,
                 options=["-type=a"],
             )
+
+    @pytest.mark.parametrize(
+        "alpha_setup_params",
+        [
+            pytest.param(
+                SetupParameters(
+                    connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
+                    adapter_type_override=TelioAdapterType.NEP_TUN,
+                    features=_features_with_firewall(),
+                )
+            )
+        ],
+    )
+    @pytest.mark.asyncio
+    @pytest.mark.libfirewall
+    async def test_dns_whitelisting_reblock_is_effective(
+        self,
+        alpha_setup_params: SetupParameters,  # pylint: disable=unused-argument
+        env: Environment,
+    ) -> None:
+        """LLT-7558: clearing the TP-Lite whitelist must make the domain blocked
+        again, even if it was resolved - and cached by MagicDNS - while it was
+        whitelisted.
+
+        The fix must invalidate the MagicDNS resolver cache when the whitelist
+        changes: the firewall only ever sees queries that miss the cache, so as
+        long as a whitelisted answer stays cached the domain remains reachable
+        no matter what the firewall chain says.
+
+        Steps:
+            1. Connect the VPN and enable MagicDNS pointed at the TP-Lite server.
+            2. Whitelist the domain. The firewall DNATs the query to the standard
+               DNS server, which answers with a long-lived (TTL 3600) record that
+               the resolver caches.
+            3. Clear the whitelist and query again. The domain must be blocked,
+               and the query must actually reach the firewall rather than being
+               answered from the cache.
+
+        NOTE: there is deliberately no "confirm it is blocked first" query before
+        step 2. The nat-lab TP-Lite server answers NXDOMAIN with an SOA carrying
+        ttl=300 and minimum=300 (nat-lab/bin/tp-lite-dns-server), so hickory
+        derives a negative_ttl of min(ttl, minimum) = 300 and caches the NXDOMAIN
+        for five minutes. Such a query would poison the cache and make step 2 fail,
+        because the whitelisted lookup would be served from that negative entry
+        instead of reaching the firewall.
+
+        NOTE: this depends on FeatureDns::use_raw_forwarder being left at its
+        default of false (crates/telio-dns/src/dns.rs:86), which selects the
+        hickory forwarder. The alternative RawForwarder has no cache, so the
+        behaviour asserted here would already hold.
+        """
+
+        [alpha] = env.nodes
+        [client] = env.clients
+        [connection] = [c.connection for c in env.connections]
+
+        await connect_vpn(
+            connection,
+            None,
+            client,
+            alpha.ip_addresses[0],
+            config.WG_SERVER,
+        )
+
+        # Route client DNS through MagicDNS, which forwards to the TP-Lite server.
+        # This is what puts the resolver cache in front of the firewall.
+        await client.enable_magic_dns([TP_LITE_DNS_IP])
+
+        redirects = [
+            DnsRedirect(
+                blocking=f"{TP_LITE_DNS_IP}:53",
+                standard=f"{STANDARD_DNS_IP}:53",
+            )
+        ]
+
+        # Step 2: whitelist the domain so the firewall DNATs the query to the
+        # standard DNS server, and the resolver caches the answer it returns.
+        #
+        # This is the first lookup of BLOCKED_NXDOMAIN in the test, on purpose:
+        # see the note in the docstring about the nat-lab TP-Lite server caching
+        # its NXDOMAIN for 300s.
+        await client.tp_lite.set_domain_whitelist([BLOCKED_NXDOMAIN], redirects)
+        stdout, stderr = await _dig_magic_dns(connection, BLOCKED_NXDOMAIN)
+        ttl, address = _parse_dig_a_answer(stdout)
+        assert address == WHITELIST_RESOLVED_IP, (
+            f"expected {BLOCKED_NXDOMAIN} to be redirected to the standard DNS"
+            f" server after whitelisting, got {address}. An empty answer here"
+            " usually means a cached NXDOMAIN was served instead of the query"
+            " reaching the firewall - check that nothing looked this domain up"
+            " earlier in the test (see the docstring)."
+            f"\ndig stdout:\n{stdout}\ndig stderr:\n{stderr}"
+        )
+        # Guard the precondition: the answer has to be cacheable for this test to
+        # be meaningful. If it is served with a different (likely 0) TTL the
+        # resolver would not retain it and the assertions below would hold
+        # trivially, for the wrong reason.
+        assert ttl == WHITELIST_RESOLVED_TTL, (
+            f"expected a freshly resolved answer with TTL {WHITELIST_RESOLVED_TTL},"
+            f" got {ttl}; the answer must be cacheable for this test to be"
+            f" meaningful\ndig stdout:\n{stdout}\ndig stderr:\n{stderr}"
+        )
+
+        # Step 3: clear the whitelist. The firewall drops the DNAT rule, so the
+        # domain must be blocked again.
+        await client.tp_lite.set_domain_whitelist([], redirects)
+
+        # Match the timing of the counterpart test so both observe the cache in
+        # the same state.
+        await asyncio.sleep(2)
+
+        # Only look at log output produced by the query below.
+        log_offset = len(await client.log.get())
+        stdout, stderr = await _dig_magic_dns(connection, BLOCKED_NXDOMAIN)
+        _, address = _parse_dig_a_answer(stdout)
+
+        # With an empty whitelist the query is no longer DNATed, so it reaches
+        # the blocking TP-Lite server and comes back NXDOMAIN, i.e. no A record.
+        assert address is None, (
+            f"expected {BLOCKED_NXDOMAIN} to be blocked again after the whitelist"
+            f" was cleared, but it resolved to {address}. The MagicDNS resolver"
+            " is still serving the answer cached while the domain was"
+            " whitelisted (LLT-7558)."
+            f"\ndig stdout:\n{stdout}\ndig stderr:\n{stderr}"
+        )
+
+        # Being blocked is not enough on its own - the query also has to have
+        # reached the firewall. Without this the test could pass for the wrong
+        # reason, e.g. if the entry had simply been evicted from the 32-entry
+        # LRU rather than deliberately invalidated.
+        await _assert_served_from_cache(
+            client, BLOCKED_NXDOMAIN, log_offset, expected=False
+        )

--- a/nat-lab/tests/test_tp_lite_stats.py
+++ b/nat-lab/tests/test_tp_lite_stats.py
@@ -35,6 +35,9 @@ NON_PLAINTEXT_DNS_PORTS = ["443", "853"]
 STANDARD_DNS_IP = config.LAN_ADDR_MAP[ConnectionTag.DOCKER_DNS_SERVER_1]["primary"]
 # Address the standrd dns-server returns for blocked-malware.com
 WHITELIST_RESOLVED_IP = "123.123.123.123"
+# TTL the standard dns-server attaches to its blocked-malware.com answer.
+# Must match the explicit ttl configured in nat-lab/bin/dns-server.
+WHITELIST_RESOLVED_TTL = 3600
 
 CALLBACK_INTERVAL_S = 1  # Use short interval for all tests
 
@@ -90,6 +93,82 @@ async def _query_blocked_expect_failure(connection: Connection) -> None:
     with pytest.raises(Exception):
         await query_dns(
             connection, BLOCKED_NXDOMAIN, dns_server=TP_LITE_DNS_IP, options=["-type=a"]
+        )
+
+
+async def _dig_magic_dns(connection: Connection, domain: str) -> tuple[str, str]:
+    """Resolve `domain` through MagicDNS with dig and return (stdout, stderr).
+
+    Unlike nslookup, dig prints the TTL of the answer, which lets the caller
+    tell a freshly fetched answer apart from one replayed out of the resolver
+    cache. `+noall +answer` reduces the output to just the answer section, so
+    the TTL is the second whitespace-separated field, same as in
+    test_dns.py::test_dns_ttl_value.
+    """
+    process = await connection.create_process([
+        "dig",
+        "+noall",
+        "+nocmd",
+        "+answer",
+        "+timeout=5",
+        domain,
+        f"@{config.LIBTELIO_DNS_IPV4}",
+    ]).execute()
+    return process.get_stdout(), process.get_stderr()
+
+
+def _parse_dig_a_answer(dig_stdout: str) -> tuple[Optional[int], Optional[str]]:
+    """Extract (ttl, address) from the first A record of a `dig +noall +answer`
+    output, or (None, None) when there is no A record (e.g. NXDOMAIN)."""
+    for line in dig_stdout.splitlines():
+        fields = line.split()
+        # <name> <ttl> <class> <type> <rdata>
+        if len(fields) >= 5 and fields[3] == "A":
+            return int(fields[1]), fields[4]
+    return None, None
+
+
+async def _assert_served_from_cache(
+    client, domain: str, log_offset: int, expected: bool
+) -> None:
+    """Assert whether the most recent lookup of `domain` was answered from the
+    MagicDNS (hickory) resolver cache rather than by querying upstream.
+
+    Only log lines produced after `log_offset` are considered, so the caller can
+    scope the check to a single query.
+
+    Two markers straddle the cache branch in hickory's CachingClient::inner_lookup
+    (crates/resolver/src/caching_client.rs:180):
+
+        telio_dns::forward:220  "forwarding lookup: <domain> <type>"
+            -> logged before the cache is consulted, so it appears either way
+        hickory_proto::xfer::dns_handle:67  "querying: <domain> <type>"
+            -> logged inside DnsHandle::lookup, which is only reached when
+               lookup_from_cache() returned None
+
+    So "forwarding lookup" present + "querying" absent means the answer came out
+    of the cache and no DNS packet was ever emitted - which also means the
+    firewall never had a chance to act on the query.
+    """
+    logs = (await client.log.get())[log_offset:]
+    forwarded = f"forwarding lookup: {domain}" in logs
+    queried_upstream = f"querying: {domain}" in logs
+
+    assert forwarded, (
+        f"expected a 'forwarding lookup: {domain}' entry, meaning the request"
+        " reached the MagicDNS forward zone; found none, so the test did not"
+        " exercise the resolver at all"
+    )
+
+    if expected:
+        assert not queried_upstream, (
+            f"expected '{domain}' to be answered from the resolver cache, but"
+            " an upstream query was sent ('querying:' present in the log)"
+        )
+    else:
+        assert queried_upstream, (
+            f"expected '{domain}' to be resolved upstream, but no 'querying:'"
+            " entry was logged, so it was answered from the resolver cache"
         )
 
 
@@ -761,3 +840,296 @@ class TestDnsWhitelisting:
                 dns_server=TP_LITE_DNS_IP,
                 options=["-type=a"],
             )
+
+    @pytest.mark.parametrize(
+        "alpha_setup_params",
+        [
+            pytest.param(
+                SetupParameters(
+                    connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
+                    adapter_type_override=TelioAdapterType.NEP_TUN,
+                    features=_features_with_firewall(),
+                )
+            )
+        ],
+    )
+    @pytest.mark.asyncio
+    @pytest.mark.libfirewall
+    async def test_dns_whitelisting_stale_cache_after_reblock(
+        self,
+        alpha_setup_params: SetupParameters,  # pylint: disable=unused-argument
+        env: Environment,
+    ) -> None:
+        """LLT-7558: re-blocking a previously whitelisted domain has no effect
+        while the MagicDNS resolver still has the whitelisted answer cached.
+
+        Unlike test_dns_whitelisting_redirects_blocked_domain, which queries the
+        TP-Lite server directly, this test resolves through MagicDNS. That puts
+        hickory's DnsLru in front of the firewall, and the firewall can only act
+        on queries that actually reach it - a cache hit is answered before any
+        packet is emitted (crates/resolver/src/caching_client.rs:180).
+
+        Steps:
+            1. Connect the VPN and enable MagicDNS pointed at the TP-Lite server.
+            2. Whitelist the domain. The firewall DNATs the query to the standard
+               DNS server, which answers with a long-lived (TTL 3600) record that
+               the resolver caches.
+            3. Clear the whitelist. The firewall stops redirecting, but the
+               cached answer keeps the domain resolvable, so it stays reachable
+               even though it is supposed to be blocked again.
+
+        NOTE: this test asserts the *current, buggy* behaviour so the defect is
+        pinned. See the assertions in step 3 for what to change once it is fixed.
+
+        NOTE: there is deliberately no "confirm it is blocked first" query before
+        step 2. The nat-lab TP-Lite server answers NXDOMAIN with an SOA carrying
+        ttl=300 and minimum=300 (nat-lab/bin/tp-lite-dns-server), so hickory
+        derives a negative_ttl of min(ttl, minimum) = 300
+        (crates/proto/src/xfer/dns_response.rs:227) and caches the NXDOMAIN for
+        five minutes. Such a query would poison the cache and make step 2 fail,
+        because the whitelisted lookup would be served from that negative entry
+        instead of reaching the firewall. The production TP-Lite server sends
+        minimum=0 instead, so its NXDOMAIN is never retained - which is exactly
+        why block -> unblock works in the field while unblock -> re-block does
+        not. test_dns_whitelisting_redirects_blocked_domain already covers the
+        blocked-first direction.
+
+        NOTE: this depends on FeatureDns::use_raw_forwarder being left at its
+        default of false (crates/telio-dns/src/dns.rs:86), which selects the
+        hickory forwarder. The alternative RawForwarder has no cache and would
+        not reproduce this.
+        """
+
+        [alpha] = env.nodes
+        [client] = env.clients
+        [connection] = [c.connection for c in env.connections]
+
+        await connect_vpn(
+            connection,
+            None,
+            client,
+            alpha.ip_addresses[0],
+            config.WG_SERVER,
+        )
+
+        # Route client DNS through MagicDNS, which forwards to the TP-Lite server.
+        # This is what puts the resolver cache in front of the firewall.
+        await client.enable_magic_dns([TP_LITE_DNS_IP])
+
+        redirects = [
+            DnsRedirect(
+                blocking=f"{TP_LITE_DNS_IP}:53",
+                standard=f"{STANDARD_DNS_IP}:53",
+            )
+        ]
+
+        # Step 2: whitelist the domain. The firewall now DNATs the query to the
+        # standard DNS server, which resolves it - and the resolver caches that
+        # answer for its full TTL.
+        #
+        # This is the first lookup of BLOCKED_NXDOMAIN in the test, on purpose:
+        # see the note in the docstring about the nat-lab TP-Lite server caching
+        # its NXDOMAIN for 300s.
+        await client.tp_lite.set_domain_whitelist([BLOCKED_NXDOMAIN], redirects)
+        stdout, stderr = await _dig_magic_dns(connection, BLOCKED_NXDOMAIN)
+        ttl, address = _parse_dig_a_answer(stdout)
+        assert address == WHITELIST_RESOLVED_IP, (
+            f"expected {BLOCKED_NXDOMAIN} to be redirected to the standard DNS"
+            f" server after whitelisting, got {address}. An empty answer here"
+            " usually means a cached NXDOMAIN was served instead of the query"
+            " reaching the firewall - check that nothing looked this domain up"
+            " earlier in the test (see the docstring)."
+            f"\ndig stdout:\n{stdout}\ndig stderr:\n{stderr}"
+        )
+        # A fresh upstream answer carries the TTL configured in nat-lab/bin/dns-server.
+        # If this ever fails, the record is being served with a different (likely 0)
+        # TTL, the resolver would not retain it, and the rest of the test would pass
+        # for the wrong reason.
+        assert ttl == WHITELIST_RESOLVED_TTL, (
+            f"expected a freshly resolved answer with TTL {WHITELIST_RESOLVED_TTL},"
+            f" got {ttl}; the answer must be cacheable for this test to be"
+            f" meaningful\ndig stdout:\n{stdout}\ndig stderr:\n{stderr}"
+        )
+
+        # Step 3: clear the whitelist. The firewall drops the DNAT rule, so a
+        # query that reaches it would be blocked again.
+        await client.tp_lite.set_domain_whitelist([], redirects)
+
+        # Give the cached entry a moment to visibly age. DnsLru reports the
+        # remaining lifetime truncated to whole seconds, so this makes the
+        # "TTL went down" assertion below unambiguous rather than relying on
+        # sub-second truncation.
+        await asyncio.sleep(2)
+
+        # Only look at log output produced by the query below.
+        log_offset = len(await client.log.get())
+        stdout, stderr = await _dig_magic_dns(connection, BLOCKED_NXDOMAIN)
+        ttl, address = _parse_dig_a_answer(stdout)
+
+        # CURRENT (BUGGY) BEHAVIOUR - LLT-7558.
+        # The whitelist is empty, so libfirewall no longer DNATs this query and
+        # the domain should be NXDOMAIN again. Instead MagicDNS still holds the
+        # positive answer cached from step 2 and returns it without emitting a
+        # packet, so the firewall never sees the query.
+        # WHEN FIXED: assert `address is None` here, and flip the
+        # _assert_served_from_cache call below to expected=False.
+        assert address == WHITELIST_RESOLVED_IP, (
+            f"expected the stale cached answer {WHITELIST_RESOLVED_IP} for"
+            f" {BLOCKED_NXDOMAIN} after re-blocking (LLT-7558), got"
+            f" {address}\ndig stdout:\n{stdout}\ndig stderr:\n{stderr}"
+        )
+
+        # A decremented TTL is the signature of a cache replay: DnsLru::get
+        # rewrites the record TTL to the entry's remaining lifetime
+        # (crates/resolver/src/dns_lru.rs:46). A fresh upstream answer would
+        # carry the full WHITELIST_RESOLVED_TTL again.
+        assert ttl is not None and ttl < WHITELIST_RESOLVED_TTL, (
+            f"expected a decremented TTL indicating a cached answer, got {ttl}"
+            f"\ndig stdout:\n{stdout}\ndig stderr:\n{stderr}"
+        )
+
+        # And the direct evidence: no upstream query was sent for this lookup.
+        await _assert_served_from_cache(
+            client, BLOCKED_NXDOMAIN, log_offset, expected=True
+        )
+
+    @pytest.mark.parametrize(
+        "alpha_setup_params",
+        [
+            pytest.param(
+                SetupParameters(
+                    connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
+                    adapter_type_override=TelioAdapterType.NEP_TUN,
+                    features=_features_with_firewall(),
+                )
+            )
+        ],
+    )
+    @pytest.mark.asyncio
+    @pytest.mark.libfirewall
+    async def test_dns_whitelisting_reblock_is_effective(
+        self,
+        alpha_setup_params: SetupParameters,  # pylint: disable=unused-argument
+        env: Environment,
+    ) -> None:
+        """LLT-7558: clearing the TP-Lite whitelist must make the domain blocked
+        again, even if it was resolved - and cached by MagicDNS - while it was
+        whitelisted.
+
+        *** THIS TEST IS EXPECTED TO FAIL UNTIL LLT-7558 IS FIXED. ***
+        It asserts the correct, intended behaviour. Its counterpart,
+        test_dns_whitelisting_stale_cache_after_reblock, pins the current broken
+        behaviour; when the fix lands this test turns green and that one must be
+        updated.
+
+        The fix must invalidate the MagicDNS resolver cache when the whitelist
+        changes: the firewall only ever sees queries that miss the cache
+        (crates/resolver/src/caching_client.rs:180), so as long as a whitelisted
+        answer stays cached the domain remains reachable no matter what the
+        firewall chain says.
+
+        Steps:
+            1. Connect the VPN and enable MagicDNS pointed at the TP-Lite server.
+            2. Whitelist the domain. The firewall DNATs the query to the standard
+               DNS server, which answers with a long-lived (TTL 3600) record that
+               the resolver caches.
+            3. Clear the whitelist and query again. The domain must be blocked,
+               and the query must actually reach the firewall rather than being
+               answered from the cache.
+
+        NOTE: there is deliberately no "confirm it is blocked first" query before
+        step 2. The nat-lab TP-Lite server answers NXDOMAIN with an SOA carrying
+        ttl=300 and minimum=300 (nat-lab/bin/tp-lite-dns-server), so hickory
+        derives a negative_ttl of min(ttl, minimum) = 300
+        (crates/proto/src/xfer/dns_response.rs:227) and caches the NXDOMAIN for
+        five minutes. Such a query would poison the cache and make step 2 fail,
+        because the whitelisted lookup would be served from that negative entry
+        instead of reaching the firewall.
+
+        NOTE: this depends on FeatureDns::use_raw_forwarder being left at its
+        default of false (crates/telio-dns/src/dns.rs:86), which selects the
+        hickory forwarder. The alternative RawForwarder has no cache, so the
+        behaviour asserted here would already hold.
+        """
+
+        [alpha] = env.nodes
+        [client] = env.clients
+        [connection] = [c.connection for c in env.connections]
+
+        await connect_vpn(
+            connection,
+            None,
+            client,
+            alpha.ip_addresses[0],
+            config.WG_SERVER,
+        )
+
+        # Route client DNS through MagicDNS, which forwards to the TP-Lite server.
+        # This is what puts the resolver cache in front of the firewall.
+        await client.enable_magic_dns([TP_LITE_DNS_IP])
+
+        redirects = [
+            DnsRedirect(
+                blocking=f"{TP_LITE_DNS_IP}:53",
+                standard=f"{STANDARD_DNS_IP}:53",
+            )
+        ]
+
+        # Step 2: whitelist the domain so the firewall DNATs the query to the
+        # standard DNS server, and the resolver caches the answer it returns.
+        #
+        # This is the first lookup of BLOCKED_NXDOMAIN in the test, on purpose:
+        # see the note in the docstring about the nat-lab TP-Lite server caching
+        # its NXDOMAIN for 300s.
+        await client.tp_lite.set_domain_whitelist([BLOCKED_NXDOMAIN], redirects)
+        stdout, stderr = await _dig_magic_dns(connection, BLOCKED_NXDOMAIN)
+        ttl, address = _parse_dig_a_answer(stdout)
+        assert address == WHITELIST_RESOLVED_IP, (
+            f"expected {BLOCKED_NXDOMAIN} to be redirected to the standard DNS"
+            f" server after whitelisting, got {address}. An empty answer here"
+            " usually means a cached NXDOMAIN was served instead of the query"
+            " reaching the firewall - check that nothing looked this domain up"
+            " earlier in the test (see the docstring)."
+            f"\ndig stdout:\n{stdout}\ndig stderr:\n{stderr}"
+        )
+        # Guard the precondition: the answer has to be cacheable for this test to
+        # be meaningful. If it is served with a different (likely 0) TTL the
+        # resolver would not retain it and the assertions below would hold
+        # trivially, for the wrong reason.
+        assert ttl == WHITELIST_RESOLVED_TTL, (
+            f"expected a freshly resolved answer with TTL {WHITELIST_RESOLVED_TTL},"
+            f" got {ttl}; the answer must be cacheable for this test to be"
+            f" meaningful\ndig stdout:\n{stdout}\ndig stderr:\n{stderr}"
+        )
+
+        # Step 3: clear the whitelist. The firewall drops the DNAT rule, so the
+        # domain must be blocked again.
+        await client.tp_lite.set_domain_whitelist([], redirects)
+
+        # Match the timing of the counterpart test so both observe the cache in
+        # the same state.
+        await asyncio.sleep(2)
+
+        # Only look at log output produced by the query below.
+        log_offset = len(await client.log.get())
+        stdout, stderr = await _dig_magic_dns(connection, BLOCKED_NXDOMAIN)
+        _, address = _parse_dig_a_answer(stdout)
+
+        # EXPECTED BEHAVIOUR - currently fails, see LLT-7558.
+        # With an empty whitelist the query is no longer DNATed, so it reaches
+        # the blocking TP-Lite server and comes back NXDOMAIN, i.e. no A record.
+        assert address is None, (
+            f"expected {BLOCKED_NXDOMAIN} to be blocked again after the whitelist"
+            f" was cleared, but it resolved to {address}. The MagicDNS resolver"
+            " is still serving the answer cached while the domain was"
+            " whitelisted (LLT-7558)."
+            f"\ndig stdout:\n{stdout}\ndig stderr:\n{stderr}"
+        )
+
+        # Being blocked is not enough on its own - the query also has to have
+        # reached the firewall. Without this the test could pass for the wrong
+        # reason, e.g. if the entry had simply been evicted from the 32-entry
+        # LRU rather than deliberately invalidated.
+        await _assert_served_from_cache(
+            client, BLOCKED_NXDOMAIN, log_offset, expected=False
+        )


### PR DESCRIPTION
### Problem

Domain is still accessible after it has been removed from whitelist.
The following use case trigger the bug:
1. Enable libtelio with libfirewall;
2. Try to access a domain. Whitelist is empty initially so the DNS query is sent to the blocking TP-Lite DNS server. The query result is NXDOMAIN that indicates that the domain is blocked. 
3. Whitelist the domain. Nonblocking DNS server responds with an IP address that is cached in DNS resolver cache.
4. Reblock the domain by clearing the whitelist with an empty domain list.
5. Try to access the domain again. Bug: the IP address is served from resolver cache that was written is step 3. Expected behaviour should be that blocking TP-Lite DNS server is queried for an IP address and response should be NXDOMAIN.

### Solution

Flush DNS resolver's cache when whitelist is set. This was no stale cache entries will be present and correct TP-Lite DNS server with be consulted for blocked domain's IP address.

AI disclosure: Claude was used for the following:
- log analysis and rootcausing,
- natlab test generation,
- fix suggestion and generation.

The work was also human-reviewed.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
