### PR TITLE
Increase openwrt-gw-03 healthcheck timeout

### DIFF
--- a/nat-lab/docker-compose.yml
+++ b/nat-lab/docker-compose.yml
@@ -809,8 +809,9 @@ services:
       test: /opt/bin/openwrt/openwrt-qemu-healthcheck.sh
       interval: 15s
       timeout: 5s
+      # Match the entrypoint's QEMU_CONFIG_TIMEOUT
       start_period: 120s
-      retries: 5
+      retries: 32
 
   windows-gw-01:
     hostname: windows-gw-01


### PR DESCRIPTION
### Problem
*--Current openwrt-gw-03 timeout is 195 seconds that is way less than 600 seconds we allocate on VM boot defined by QEMU_CONFIG_TIMEOUT. Docker kills container after 3 minutes and try to re-create it multiple times that causes nat-lab instability --*

### Solution
*--Align health check  timeout with 600 seconds timeout we set for VM--*


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
