### PR TITLE
Enable client side keepalives for the ENS connection

### DIFF
--- a/.unreleased/LLT-7581
+++ b/.unreleased/LLT-7581
@@ -1,0 +1,1 @@
+Add client side keepalives to the ENS connections

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5084,6 +5084,7 @@ dependencies = [
  "protobuf",
  "protobuf-codegen",
  "rcgen",
+ "rstest",
  "rustls",
  "rustls-webpki",
  "sha2",

--- a/crates/telio-core/src/device.rs
+++ b/crates/telio-core/src/device.rs
@@ -8,7 +8,9 @@ use telio_lana::init_lana;
 use telio_network_monitors::monitor::LocalInterfacesObserver;
 use telio_network_monitors::{local_interfaces::SystemGetIfAddrs, monitor::NetworkMonitor};
 use telio_pq::PostQuantum;
-use telio_proto::{ConnectionError, Error as EnsError, ErrorNotificationService, HeartbeatMessage};
+use telio_proto::{
+    ConnectionError, Error as EnsError, ErrorNotificationService, HeartbeatMessage, KeepaliveConfig,
+};
 use telio_proxy::{Config as ProxyConfig, Io as ProxyIo, Proxy, UdpProxy};
 use telio_relay::{
     derp::Config as DerpConfig, multiplexer::Multiplexer, DerpKeepaliveConfig, DerpRelay,
@@ -1398,6 +1400,14 @@ impl Runtime {
                     socket_pool.clone(),
                     error_notification_service.allow_only_pq,
                     error_notification_service.root_certificate_override.clone(),
+                    KeepaliveConfig {
+                        interval: error_notification_service
+                            .keepalive_interval_s
+                            .map(|s| Duration::from_secs(s as u64)),
+                        timeout: error_notification_service
+                            .keepalive_timeout_s
+                            .map(|s| Duration::from_secs(s as u64)),
+                    },
                 );
                 (Some(ens), rx)
             } else {

--- a/crates/telio-model/src/features.rs
+++ b/crates/telio-model/src/features.rs
@@ -566,6 +566,21 @@ pub struct FeatureErrorNotificationService {
     /// DER encoded root certificate to be used for verification of all TLS connections
     /// to gRPC ENS endpoint in place of the hardcoded one
     pub root_certificate_override: Option<Vec<u8>>,
+
+    /// Interval between the keep alive messages sent over the ENS connection, in seconds.
+    /// When the underlying tcp connection stops working, the new connection will
+    /// be re-created after at most keepalive_interval_s + keepalive_timeout_s seconds.
+    /// When set to null, the keep alives are disabled.
+    /// Setting it to 0 is an error.
+    #[default(Some(120))]
+    pub keepalive_interval_s: Option<u32>,
+
+    /// How long to wait for a response to a keep alive message before considering the ENS
+    /// connection dead, in seconds. Only used when keepalive_interval_s is set.
+    /// When set to null, the underlying http client default is used
+    /// Setting it to 0 is an error.
+    #[default(Some(20))]
+    pub keepalive_timeout_s: Option<u32>,
 }
 
 impl std::fmt::Debug for FeatureErrorNotificationService {
@@ -574,6 +589,8 @@ impl std::fmt::Debug for FeatureErrorNotificationService {
             .field("buffer_size", &self.buffer_size)
             .field("allow_only_pq", &self.allow_only_pq)
             .field("backoff", &self.backoff)
+            .field("keepalive_interval_s", &self.keepalive_interval_s)
+            .field("keepalive_timeout_s", &self.keepalive_timeout_s)
             .field(
                 "root_certificate_override",
                 &self
@@ -867,7 +884,9 @@ mod tests {
                         buffer_size: 42,
                         allow_only_pq: true,
                         backoff: Default::default(),
-                        root_certificate_override: None
+                        root_certificate_override: None,
+                        keepalive_interval_s: Some(120),
+                        keepalive_timeout_s: Some(20),
                     })
                 }
             );
@@ -1061,6 +1080,8 @@ mod tests {
                         maximal_s: Some(120),
                     },
                     root_certificate_override: None,
+                    keepalive_interval_s: Some(120),
+                    keepalive_timeout_s: Some(20),
                 }),
                 error_notification_service
             );
@@ -1076,6 +1097,8 @@ mod tests {
                     allow_only_pq: true,
                     backoff: Default::default(),
                     root_certificate_override: None,
+                    keepalive_interval_s: Some(120),
+                    keepalive_timeout_s: Some(20),
                 }),
                 error_notification_service
             );
@@ -1093,6 +1116,8 @@ mod tests {
                         maximal_s: Some(120),
                     },
                     root_certificate_override: None,
+                    keepalive_interval_s: Some(120),
+                    keepalive_timeout_s: Some(20),
                 }),
                 error_notification_service
             );
@@ -1111,6 +1136,8 @@ mod tests {
                         maximal_s: None
                     },
                     root_certificate_override: None,
+                    keepalive_interval_s: Some(120),
+                    keepalive_timeout_s: Some(20),
                 }),
                 error_notification_service
             );
@@ -1129,8 +1156,78 @@ mod tests {
                         maximal_s: Some(67890)
                     },
                     root_certificate_override: None,
+                    keepalive_interval_s: Some(120),
+                    keepalive_timeout_s: Some(20),
                 }),
                 error_notification_service
+            );
+        }
+
+        #[test]
+        fn test_ens_keepalive_interval() {
+            assert_json!(
+                r#"{"error_notification_service": {}}"#,
+                Some(120),
+                error_notification_service.unwrap().keepalive_interval_s
+            );
+            assert_json!(
+                r#"{"error_notification_service": {"keepalive_interval_s": 42}}"#,
+                Some(42),
+                error_notification_service.unwrap().keepalive_interval_s
+            );
+            assert_json!(
+                r#"{"error_notification_service": {"keepalive_interval_s": null}}"#,
+                None,
+                error_notification_service.unwrap().keepalive_interval_s
+            );
+        }
+
+        #[test]
+        fn test_ens_keepalive_interval_default() {
+            assert_eq!(
+                FeatureErrorNotificationService::default().keepalive_interval_s,
+                Some(120)
+            );
+        }
+
+        #[test]
+        fn test_ens_keepalive_timeout() {
+            assert_json!(
+                r#"{"error_notification_service": {}}"#,
+                Some(20),
+                error_notification_service.unwrap().keepalive_timeout_s
+            );
+            assert_json!(
+                r#"{"error_notification_service": {"keepalive_timeout_s": 42}}"#,
+                Some(42),
+                error_notification_service.unwrap().keepalive_timeout_s
+            );
+            assert_json!(
+                r#"{"error_notification_service": {"keepalive_timeout_s": null}}"#,
+                None,
+                error_notification_service.unwrap().keepalive_timeout_s
+            );
+        }
+
+        #[test]
+        fn test_ens_keepalive_timeout_default() {
+            assert_eq!(
+                FeatureErrorNotificationService::default().keepalive_timeout_s,
+                Some(20)
+            );
+        }
+
+        #[test]
+        fn test_ens_keepalive_interval_and_timeout_are_independent() {
+            assert_json!(
+                r#"{"error_notification_service": {"keepalive_interval_s": 1}}"#,
+                Some(20),
+                error_notification_service.unwrap().keepalive_timeout_s
+            );
+            assert_json!(
+                r#"{"error_notification_service": {"keepalive_timeout_s": 1}}"#,
+                Some(120),
+                error_notification_service.unwrap().keepalive_interval_s
             );
         }
     }

--- a/crates/telio-model/src/features.rs
+++ b/crates/telio-model/src/features.rs
@@ -566,6 +566,22 @@ pub struct FeatureErrorNotificationService {
     /// DER encoded root certificate to be used for verification of all TLS connections
     /// to gRPC ENS endpoint in place of the hardcoded one
     pub root_certificate_override: Option<Vec<u8>>,
+
+    /// Interval between the keep alive messages sent over the ENS connection, in seconds.
+    /// When the underlying tcp connection stops working, the dead connection will be
+    /// detected after at most keepalive_interval_s + keepalive_timeout_s seconds and
+    /// a new connection will be created after the ENS backoff elapses.
+    /// When set to null, the keep alives are disabled.
+    /// Setting it to 0 is an error.
+    #[default(Some(120))]
+    pub keepalive_interval_s: Option<u32>,
+
+    /// How long to wait for a response to a keep alive message before considering the ENS
+    /// connection dead, in seconds. Only used when keepalive_interval_s is set.
+    /// When set to null, the underlying http client default is used
+    /// Setting it to 0 is an error.
+    #[default(Some(20))]
+    pub keepalive_timeout_s: Option<u32>,
 }
 
 impl std::fmt::Debug for FeatureErrorNotificationService {
@@ -574,6 +590,8 @@ impl std::fmt::Debug for FeatureErrorNotificationService {
             .field("buffer_size", &self.buffer_size)
             .field("allow_only_pq", &self.allow_only_pq)
             .field("backoff", &self.backoff)
+            .field("keepalive_interval_s", &self.keepalive_interval_s)
+            .field("keepalive_timeout_s", &self.keepalive_timeout_s)
             .field(
                 "root_certificate_override",
                 &self
@@ -867,7 +885,9 @@ mod tests {
                         buffer_size: 42,
                         allow_only_pq: true,
                         backoff: Default::default(),
-                        root_certificate_override: None
+                        root_certificate_override: None,
+                        keepalive_interval_s: Some(120),
+                        keepalive_timeout_s: Some(20),
                     })
                 }
             );
@@ -1061,6 +1081,8 @@ mod tests {
                         maximal_s: Some(120),
                     },
                     root_certificate_override: None,
+                    keepalive_interval_s: Some(120),
+                    keepalive_timeout_s: Some(20),
                 }),
                 error_notification_service
             );
@@ -1076,6 +1098,8 @@ mod tests {
                     allow_only_pq: true,
                     backoff: Default::default(),
                     root_certificate_override: None,
+                    keepalive_interval_s: Some(120),
+                    keepalive_timeout_s: Some(20),
                 }),
                 error_notification_service
             );
@@ -1093,6 +1117,8 @@ mod tests {
                         maximal_s: Some(120),
                     },
                     root_certificate_override: None,
+                    keepalive_interval_s: Some(120),
+                    keepalive_timeout_s: Some(20),
                 }),
                 error_notification_service
             );
@@ -1111,6 +1137,8 @@ mod tests {
                         maximal_s: None
                     },
                     root_certificate_override: None,
+                    keepalive_interval_s: Some(120),
+                    keepalive_timeout_s: Some(20),
                 }),
                 error_notification_service
             );
@@ -1129,8 +1157,78 @@ mod tests {
                         maximal_s: Some(67890)
                     },
                     root_certificate_override: None,
+                    keepalive_interval_s: Some(120),
+                    keepalive_timeout_s: Some(20),
                 }),
                 error_notification_service
+            );
+        }
+
+        #[test]
+        fn test_ens_keepalive_interval() {
+            assert_json!(
+                r#"{"error_notification_service": {}}"#,
+                Some(120),
+                error_notification_service.unwrap().keepalive_interval_s
+            );
+            assert_json!(
+                r#"{"error_notification_service": {"keepalive_interval_s": 42}}"#,
+                Some(42),
+                error_notification_service.unwrap().keepalive_interval_s
+            );
+            assert_json!(
+                r#"{"error_notification_service": {"keepalive_interval_s": null}}"#,
+                None,
+                error_notification_service.unwrap().keepalive_interval_s
+            );
+        }
+
+        #[test]
+        fn test_ens_keepalive_interval_default() {
+            assert_eq!(
+                FeatureErrorNotificationService::default().keepalive_interval_s,
+                Some(120)
+            );
+        }
+
+        #[test]
+        fn test_ens_keepalive_timeout() {
+            assert_json!(
+                r#"{"error_notification_service": {}}"#,
+                Some(20),
+                error_notification_service.unwrap().keepalive_timeout_s
+            );
+            assert_json!(
+                r#"{"error_notification_service": {"keepalive_timeout_s": 42}}"#,
+                Some(42),
+                error_notification_service.unwrap().keepalive_timeout_s
+            );
+            assert_json!(
+                r#"{"error_notification_service": {"keepalive_timeout_s": null}}"#,
+                None,
+                error_notification_service.unwrap().keepalive_timeout_s
+            );
+        }
+
+        #[test]
+        fn test_ens_keepalive_timeout_default() {
+            assert_eq!(
+                FeatureErrorNotificationService::default().keepalive_timeout_s,
+                Some(20)
+            );
+        }
+
+        #[test]
+        fn test_ens_keepalive_interval_and_timeout_are_independent() {
+            assert_json!(
+                r#"{"error_notification_service": {"keepalive_interval_s": 1}}"#,
+                Some(20),
+                error_notification_service.unwrap().keepalive_timeout_s
+            );
+            assert_json!(
+                r#"{"error_notification_service": {"keepalive_timeout_s": 1}}"#,
+                Some(120),
+                error_notification_service.unwrap().keepalive_interval_s
             );
         }
     }

--- a/crates/telio-proto/Cargo.toml
+++ b/crates/telio-proto/Cargo.toml
@@ -64,6 +64,7 @@ protobuf-codegen.workspace = true
 assert_matches = "1.5.0"
 async-channel = "2.5.0"
 rcgen = "0.14.8"
+rstest.workspace = true
 telio-utils = { workspace = true, features = ["mockall"] }
 test-log = { version = "0.2.20", features = ["trace"] }
 tokio = { workspace = true, features = ["sync"] }

--- a/crates/telio-proto/src/ens/ens_impl.rs
+++ b/crates/telio-proto/src/ens/ens_impl.rs
@@ -2,6 +2,7 @@ use std::{
     net::{IpAddr, ToSocketAddrs},
     str::FromStr,
     sync::Arc,
+    time::Duration,
 };
 
 use base64::prelude::{Engine, BASE64_STANDARD};
@@ -34,7 +35,10 @@ use tonic::{
 use tower::service_fn;
 use uuid::Uuid;
 
-use crate::ens::grpc::{ChallengeRequest, ConnectionErrorRequest};
+use crate::ens::{
+    grpc::{ChallengeRequest, ConnectionErrorRequest},
+    KeepaliveConfig,
+};
 
 pub(crate) mod grpc {
     pub use llt_proto::ens::{
@@ -72,6 +76,8 @@ pub struct ErrorNotificationService {
     allow_only_mlkem: bool,
     // DER encoded root certificate to be use for verification of TLS
     root_certificate: Vec<u8>,
+    // Configuration of the keep alive messages sent over the ENS connection
+    keepalive: KeepaliveConfig,
 }
 
 impl Drop for ErrorNotificationService {
@@ -87,6 +93,7 @@ impl ErrorNotificationService {
         socket_pool: Arc<SocketPool>,
         allow_only_mlkem: bool,
         root_certificate_override: Option<Vec<u8>>,
+        mut keepalive: KeepaliveConfig,
     ) -> (Self, Rx<(grpc::ConnectionError, PublicKey)>) {
         let Chan { rx, tx }: Chan<(grpc::ConnectionError, PublicKey)> = Chan::new(buffer_size);
         if let Some(cert) = &root_certificate_override {
@@ -94,6 +101,15 @@ impl ErrorNotificationService {
                 "Will use root certificate override: {:?}",
                 BASE64_STANDARD.encode(cert)
             );
+        }
+
+        if keepalive.interval == Some(Duration::ZERO) {
+            telio_log_warn!("Keepalive interval set to 0, resetting to default");
+            keepalive.interval = Some(Duration::from_secs(120));
+        }
+        if keepalive.timeout == Some(Duration::ZERO) {
+            telio_log_warn!("Keepalive timeout set to 0, resetting to default");
+            keepalive.timeout = Some(Duration::from_secs(20));
         }
 
         (
@@ -104,6 +120,7 @@ impl ErrorNotificationService {
                 allow_only_mlkem,
                 root_certificate: root_certificate_override
                     .unwrap_or_else(|| DEFAULT_ROOT_CERTIFICATE.to_vec()),
+                keepalive,
             },
             rx,
         )
@@ -143,6 +160,7 @@ impl ErrorNotificationService {
         let tx = self.tx.clone();
         let allow_only_mlkem = self.allow_only_mlkem;
         let root_certificate = self.root_certificate.clone();
+        let keepalive = self.keepalive;
 
         let join_handle = tokio::spawn(async move {
             // This future is too big for keeping it on the stack
@@ -156,6 +174,7 @@ impl ErrorNotificationService {
                 allow_only_mlkem,
                 backoff,
                 root_certificate,
+                keepalive,
             ))
             .await
             {
@@ -206,6 +225,7 @@ async fn task(
     allow_only_mlkem: bool,
     mut backoff: impl Backoff,
     root_certificate: Vec<u8>,
+    keepalive: KeepaliveConfig,
 ) -> anyhow::Result<()> {
     'outer: loop {
         macro_rules! restart {
@@ -239,7 +259,8 @@ async fn task(
                 vpn_uri,
                 pool,
                 allow_only_mlkem,
-                root_certificate.clone()
+                root_certificate.clone(),
+                keepalive
             ))
             .await,
             backoff
@@ -341,6 +362,8 @@ async fn create_external_channel(
     pool: Arc<SocketPool>,
     allow_only_mlkem: bool,
     root_certificate: Vec<u8>,
+
+    keepalive: KeepaliveConfig,
 ) -> anyhow::Result<Channel> {
     let socket_factory = move |uri: Uri| {
         let pool = pool.clone();
@@ -763,6 +786,15 @@ mod tests {
         errors_tx.send(Command::End).await.unwrap();
     }
 
+    impl Default for KeepaliveConfig {
+        fn default() -> Self {
+            Self {
+                interval: Default::default(),
+                timeout: Default::default(),
+            }
+        }
+    }
+
     #[tokio::test]
     #[test_log::test]
     async fn test_ens() {
@@ -789,6 +821,7 @@ mod tests {
             make_socket_pool(),
             allow_only_mlkem,
             Some(server_config.tls_config.ca_cert.der().to_vec()),
+            KeepaliveConfig::default(),
         );
 
         ens.start_monitor_on_port(
@@ -864,6 +897,7 @@ mod tests {
             make_socket_pool(),
             allow_only_mlkem,
             Some(server_config.tls_config.ca_cert.der().to_vec()),
+            KeepaliveConfig::default(),
         );
 
         let mut backoff = MockBackoff::new();
@@ -977,8 +1011,13 @@ mod tests {
         });
 
         let allow_only_mlkem = true;
-        let (mut ens, mut rx) =
-            ErrorNotificationService::new(10, make_socket_pool(), allow_only_mlkem, None);
+        let (mut ens, mut rx) = ErrorNotificationService::new(
+            10,
+            make_socket_pool(),
+            allow_only_mlkem,
+            None,
+            KeepaliveConfig::default(),
+        );
 
         let result = ens
             .start_monitor_on_port(

--- a/crates/telio-proto/src/ens/ens_impl.rs
+++ b/crates/telio-proto/src/ens/ens_impl.rs
@@ -160,6 +160,7 @@ impl ErrorNotificationService {
         let tx = self.tx.clone();
         let allow_only_mlkem = self.allow_only_mlkem;
         let root_certificate = self.root_certificate.clone();
+
         let keepalive = self.keepalive;
 
         let join_handle = tokio::spawn(async move {
@@ -362,7 +363,6 @@ async fn create_external_channel(
     pool: Arc<SocketPool>,
     allow_only_mlkem: bool,
     root_certificate: Vec<u8>,
-
     keepalive: KeepaliveConfig,
 ) -> anyhow::Result<Channel> {
     let socket_factory = move |uri: Uri| {
@@ -405,7 +405,28 @@ async fn create_external_channel(
         }
     };
 
-    Ok(Endpoint::try_from(vpn_uri.to_owned())?
+    let endpoint = Endpoint::try_from(vpn_uri.to_owned())?;
+    let endpoint = if let Some(interval) = keepalive.interval {
+        endpoint.http2_keep_alive_interval(interval)
+    } else {
+        endpoint
+    };
+    let endpoint = if let Some(timeout) = keepalive.timeout {
+        endpoint.keep_alive_timeout(timeout)
+    } else {
+        endpoint
+    };
+
+    // Strictly this is not needed in our case since we have a long lived connection
+    // that we want to keep alive. This setting helps in the case where there is
+    // **no** active rpc connection and we want to make a new rpc call after a while.
+    let endpoint = if keepalive.interval.is_some() || keepalive.timeout.is_some() {
+        endpoint.keep_alive_while_idle(true)
+    } else {
+        endpoint
+    };
+
+    Ok(endpoint
         .connect_with_connector(service_fn(socket_factory))
         .await?)
 }

--- a/crates/telio-proto/src/ens/ens_impl.rs
+++ b/crates/telio-proto/src/ens/ens_impl.rs
@@ -2,6 +2,7 @@ use std::{
     net::{IpAddr, ToSocketAddrs},
     str::FromStr,
     sync::Arc,
+    time::Duration,
 };
 
 use base64::prelude::{Engine, BASE64_STANDARD};
@@ -34,7 +35,10 @@ use tonic::{
 use tower::service_fn;
 use uuid::Uuid;
 
-use crate::ens::grpc::{ChallengeRequest, ConnectionErrorRequest};
+use crate::ens::{
+    grpc::{ChallengeRequest, ConnectionErrorRequest},
+    KeepaliveConfig,
+};
 
 pub(crate) mod grpc {
     pub use llt_proto::ens::{
@@ -72,6 +76,8 @@ pub struct ErrorNotificationService {
     allow_only_mlkem: bool,
     // DER encoded root certificate to be use for verification of TLS
     root_certificate: Vec<u8>,
+    // Configuration of the keep alive messages sent over the ENS connection
+    keepalive: KeepaliveConfig,
 }
 
 impl Drop for ErrorNotificationService {
@@ -87,6 +93,7 @@ impl ErrorNotificationService {
         socket_pool: Arc<SocketPool>,
         allow_only_mlkem: bool,
         root_certificate_override: Option<Vec<u8>>,
+        mut keepalive: KeepaliveConfig,
     ) -> (Self, Rx<(grpc::ConnectionError, PublicKey)>) {
         let Chan { rx, tx }: Chan<(grpc::ConnectionError, PublicKey)> = Chan::new(buffer_size);
         if let Some(cert) = &root_certificate_override {
@@ -94,6 +101,15 @@ impl ErrorNotificationService {
                 "Will use root certificate override: {:?}",
                 BASE64_STANDARD.encode(cert)
             );
+        }
+
+        if keepalive.interval == Some(Duration::ZERO) {
+            telio_log_warn!("Keepalive interval set to 0, reseting to default");
+            keepalive.interval = Some(Duration::from_secs(120));
+        }
+        if keepalive.timeout == Some(Duration::ZERO) {
+            telio_log_warn!("Keepalive timeout set to 0, reseting to default");
+            keepalive.timeout = Some(Duration::from_secs(20));
         }
 
         (
@@ -104,6 +120,7 @@ impl ErrorNotificationService {
                 allow_only_mlkem,
                 root_certificate: root_certificate_override
                     .unwrap_or_else(|| DEFAULT_ROOT_CERTIFICATE.to_vec()),
+                keepalive,
             },
             rx,
         )
@@ -143,6 +160,7 @@ impl ErrorNotificationService {
         let tx = self.tx.clone();
         let allow_only_mlkem = self.allow_only_mlkem;
         let root_certificate = self.root_certificate.clone();
+        let keepalive = self.keepalive;
 
         let join_handle = tokio::spawn(async move {
             // This future is too big for keeping it on the stack
@@ -156,6 +174,7 @@ impl ErrorNotificationService {
                 allow_only_mlkem,
                 backoff,
                 root_certificate,
+                keepalive,
             ))
             .await
             {
@@ -206,6 +225,7 @@ async fn task(
     allow_only_mlkem: bool,
     mut backoff: impl Backoff,
     root_certificate: Vec<u8>,
+    keepalive: KeepaliveConfig,
 ) -> anyhow::Result<()> {
     'outer: loop {
         macro_rules! restart {
@@ -239,7 +259,8 @@ async fn task(
                 vpn_uri,
                 pool,
                 allow_only_mlkem,
-                root_certificate.clone()
+                root_certificate.clone(),
+                keepalive
             ))
             .await,
             backoff
@@ -341,6 +362,8 @@ async fn create_external_channel(
     pool: Arc<SocketPool>,
     allow_only_mlkem: bool,
     root_certificate: Vec<u8>,
+
+    keepalive: KeepaliveConfig,
 ) -> anyhow::Result<Channel> {
     let socket_factory = move |uri: Uri| {
         let pool = pool.clone();
@@ -763,6 +786,15 @@ mod tests {
         errors_tx.send(Command::End).await.unwrap();
     }
 
+    impl Default for KeepaliveConfig {
+        fn default() -> Self {
+            Self {
+                interval: Default::default(),
+                timeout: Default::default(),
+            }
+        }
+    }
+
     #[tokio::test]
     #[test_log::test]
     async fn test_ens() {
@@ -789,6 +821,7 @@ mod tests {
             make_socket_pool(),
             allow_only_mlkem,
             Some(server_config.tls_config.ca_cert.der().to_vec()),
+            KeepaliveConfig::default(),
         );
 
         ens.start_monitor_on_port(
@@ -864,6 +897,7 @@ mod tests {
             make_socket_pool(),
             allow_only_mlkem,
             Some(server_config.tls_config.ca_cert.der().to_vec()),
+            KeepaliveConfig::default(),
         );
 
         let mut backoff = MockBackoff::new();
@@ -977,8 +1011,13 @@ mod tests {
         });
 
         let allow_only_mlkem = true;
-        let (mut ens, mut rx) =
-            ErrorNotificationService::new(10, make_socket_pool(), allow_only_mlkem, None);
+        let (mut ens, mut rx) = ErrorNotificationService::new(
+            10,
+            make_socket_pool(),
+            allow_only_mlkem,
+            None,
+            KeepaliveConfig::default(),
+        );
 
         let result = ens
             .start_monitor_on_port(

--- a/crates/telio-proto/src/ens/ens_impl.rs
+++ b/crates/telio-proto/src/ens/ens_impl.rs
@@ -160,6 +160,7 @@ impl ErrorNotificationService {
         let tx = self.tx.clone();
         let allow_only_mlkem = self.allow_only_mlkem;
         let root_certificate = self.root_certificate.clone();
+
         let keepalive = self.keepalive;
 
         let join_handle = tokio::spawn(async move {
@@ -362,7 +363,6 @@ async fn create_external_channel(
     pool: Arc<SocketPool>,
     allow_only_mlkem: bool,
     root_certificate: Vec<u8>,
-
     keepalive: KeepaliveConfig,
 ) -> anyhow::Result<Channel> {
     let socket_factory = move |uri: Uri| {
@@ -405,7 +405,28 @@ async fn create_external_channel(
         }
     };
 
-    Ok(Endpoint::try_from(vpn_uri.to_owned())?
+    let endpoint = Endpoint::try_from(vpn_uri.to_owned())?;
+    let endpoint = if let Some(interval) = keepalive.interval {
+        endpoint.http2_keep_alive_interval(interval)
+    } else {
+        endpoint
+    };
+    let endpoint = if let Some(timeout) = keepalive.timeout {
+        endpoint.keep_alive_timeout(timeout)
+    } else {
+        endpoint
+    };
+
+    // Strictly this is not needed in our case since we have a long lived connection
+    // that we want to keep alive. This setting helps in the case where there is
+    // **no** active rpc connection and we want to make a new rpc call after a while.
+    let endpoint = if keepalive.interval.is_some() {
+        endpoint.keep_alive_while_idle(true)
+    } else {
+        endpoint
+    };
+
+    Ok(endpoint
         .connect_with_connector(service_fn(socket_factory))
         .await?)
 }

--- a/crates/telio-proto/src/ens/ens_impl.rs
+++ b/crates/telio-proto/src/ens/ens_impl.rs
@@ -23,7 +23,7 @@ use telio_task::io::{
 };
 use telio_utils::{
     exponential_backoff::{self, Backoff},
-    telio_log_debug, telio_log_error, telio_log_info, telio_log_warn,
+    telio_log_debug, telio_log_error, telio_log_info, telio_log_warn, version_tag,
 };
 use tokio::{select, sync::watch, task::JoinHandle};
 use tokio_rustls::TlsConnector;
@@ -405,7 +405,8 @@ async fn create_external_channel(
         }
     };
 
-    let endpoint = Endpoint::try_from(vpn_uri.to_owned())?;
+    let endpoint = Endpoint::try_from(vpn_uri.to_owned())?.user_agent(make_user_agent())?;
+
     let endpoint = if let Some(interval) = keepalive.interval {
         endpoint.http2_keep_alive_interval(interval)
     } else {
@@ -559,6 +560,10 @@ pub fn install_default_crypto_provider() {
     if let Err(e) = rustls::crypto::aws_lc_rs::default_provider().install_default() {
         telio_log_warn!("Failed to install default crypto provider for rustls: {e:?}");
     }
+}
+
+fn make_user_agent() -> String {
+    format!("telio/{} {}", version_tag(), std::env::consts::OS,)
 }
 
 #[cfg(test)]
@@ -729,6 +734,17 @@ mod tests {
 
     impl Interceptor for CheckAuthenticationInterceptor {
         fn call(&mut self, req: Request<()>) -> Result<Request<()>, Status> {
+            match req.metadata().get("user-agent") {
+                Some(user_agent) => {
+                    if !user_agent.to_str().unwrap().starts_with("telio/") {
+                        return Err(Status::unauthenticated(format!(
+                            "incorrect user-agent: {user_agent:?}"
+                        )));
+                    }
+                }
+                None => return Err(Status::unauthenticated("missing user-agent")),
+            }
+
             match req.metadata().get(AUTHENTICATION_KEY) {
                 Some(t) => {
                     let decoded = BASE64_STANDARD.decode(&t).unwrap();

--- a/crates/telio-proto/src/ens/ens_impl.rs
+++ b/crates/telio-proto/src/ens/ens_impl.rs
@@ -545,8 +545,11 @@ mod tests {
     use std::{
         collections::HashSet,
         net::Ipv4Addr,
-        sync::{atomic::AtomicUsize, LazyLock, Mutex},
-        time::Duration,
+        sync::{
+            atomic::{AtomicBool, AtomicUsize, Ordering},
+            LazyLock, Mutex,
+        },
+        time::{Duration, Instant},
     };
 
     use assert_matches::assert_matches;
@@ -560,12 +563,16 @@ mod tests {
         generate_simple_self_signed, BasicConstraints, Certificate, CertificateParams,
         CertifiedKey, DistinguishedName, DnType, IsCa, Issuer, KeyPair,
     };
+    use rstest::rstest;
     use telio_crypto::SecretKey;
     use telio_sockets::NativeProtector;
     use telio_utils::exponential_backoff::{
         ExponentialBackoff, ExponentialBackoffBounds, MockBackoff,
     };
-    use tokio::sync::oneshot;
+    use tokio::{
+        sync::oneshot,
+        time::{error::Elapsed, timeout},
+    };
     use tokio_stream::wrappers::ReceiverStream;
     use tonic::{service::Interceptor, transport::Server};
 
@@ -666,10 +673,14 @@ mod tests {
             tokio::spawn(async move {
                 loop {
                     println!("next loop iteration...");
-                    match command_rx.recv().await.unwrap() {
-                        Command::Send(e) => tx.send(Ok(e)).await.unwrap(),
-                        Command::Error(status) => tx.send(Err(status)).await.unwrap(),
+                    let sent = match command_rx.recv().await.unwrap() {
+                        Command::Send(e) => tx.send(Ok(e)).await,
+                        Command::Error(status) => tx.send(Err(status)).await,
                         Command::End => break,
+                    };
+
+                    if sent.is_err() {
+                        break;
                     }
                 }
             });
@@ -776,6 +787,252 @@ mod tests {
             command_tx,
             tls_config,
         }
+    }
+
+    struct TcpRelay {
+        port: u16,
+
+        // After setting to true, all **existing** connections become silent (socket stay open, but
+        // no traffic is forwarded).
+        silent: Arc<AtomicBool>,
+    }
+
+    impl TcpRelay {
+        async fn spawn(server_port: u16) -> Self {
+            use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let port = listener.local_addr().unwrap().port();
+            let silent = Arc::new(AtomicBool::new(false));
+
+            tokio::spawn({
+                let silent = silent.clone();
+                async move {
+                    while let Ok((client, _)) = listener.accept().await {
+                        let connected_before_silent = !silent.load(Ordering::Relaxed);
+                        let server = tokio::net::TcpStream::connect(("127.0.0.1", server_port))
+                            .await
+                            .unwrap();
+                        let (mut client_rx, mut client_tx) = client.into_split();
+                        let (mut server_rx, mut server_tx) = server.into_split();
+
+                        // server -> client
+                        tokio::spawn({
+                            let silent = silent.clone();
+                            async move {
+                                let mut buf = [0u8; 4096];
+                                loop {
+                                    match server_rx.read(&mut buf).await {
+                                        Ok(0) | Err(_) => break,
+                                        Ok(n) => {
+                                            if connected_before_silent
+                                                && silent.load(Ordering::Relaxed)
+                                            {
+                                                continue;
+                                            }
+                                            if client_tx.write_all(&buf[..n]).await.is_err() {
+                                                break;
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        });
+
+                        // client -> server
+                        tokio::spawn({
+                            let silent = silent.clone();
+                            async move {
+                                let mut buf = [0u8; 4096];
+                                loop {
+                                    match client_rx.read(&mut buf).await {
+                                        Ok(0) | Err(_) => break,
+                                        Ok(n) => {
+                                            // Keep draining the client, just never let anything
+                                            // through - a silent server still reads its socket.
+                                            if connected_before_silent
+                                                && silent.load(Ordering::Relaxed)
+                                            {
+                                                continue;
+                                            }
+                                            if server_tx.write_all(&buf[..n]).await.is_err() {
+                                                break;
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        });
+                    }
+                }
+            });
+
+            Self { port, silent }
+        }
+    }
+
+    #[rstest]
+    #[tokio::test]
+    #[test_log::test]
+    async fn keepalives_trigger_reconnect_for_connections_that_become_silent(
+        #[values(1, 5, 10)] interval: u64,
+        #[values(1, 5, 10)] timeout: u64,
+    ) {
+        let client_private_key = SecretKey::gen();
+        let server_config = spawn_server().await;
+        let relay = TcpRelay::spawn(server_config.port).await;
+        let interval = Duration::from_secs(interval);
+        let timeout = Duration::from_secs(timeout);
+
+        let allow_only_mlkem = true;
+        let (mut ens, mut rx) = ErrorNotificationService::new(
+            10,
+            make_socket_pool(),
+            allow_only_mlkem,
+            Some(server_config.tls_config.ca_cert.der().to_vec()),
+            KeepaliveConfig {
+                interval: Some(interval),
+                timeout: Some(timeout),
+            },
+        );
+
+        ens.start_monitor_on_port(
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            relay.port,
+            server_config.public_key,
+            client_private_key,
+            ExponentialBackoff::new(Default::default()).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        server_config
+            .command_tx
+            .send(Command::Send(ConnectionError {
+                code: grpc::Error::Unauthenticated as i32,
+                additional_info: Some("before the silence".to_owned()),
+            }))
+            .await
+            .unwrap();
+        let (before_the_silence, _) = rx.recv().await.unwrap();
+        let before_timestamp = Instant::now();
+        assert_eq!(
+            before_the_silence.additional_info.as_deref(),
+            Some("before the silence")
+        );
+
+        relay.silent.store(true, Ordering::Relaxed);
+        telio_log_info!(
+            "server has gone silent, the client should give up on the connection and reconnect"
+        );
+
+        // We have no way to know when exactly the tonic/hyper reconnects. Which means
+        // we need to keep resending the event until it is delivered to a new connection.
+        let safety_margin = Duration::from_secs(3);
+        let deadline = interval + timeout + safety_margin;
+        let ((after_the_silence, _), after_timestamp) = tokio::time::timeout(deadline, async {
+            loop {
+                server_config
+                    .command_tx
+                    .send(Command::Send(ConnectionError {
+                        code: grpc::Error::ServerMaintenance as i32,
+                        additional_info: Some("after the silence".to_owned()),
+                    }))
+                    .await
+                    .unwrap();
+                if let Ok(notification) =
+                    tokio::time::timeout(Duration::from_millis(500), rx.recv()).await
+                {
+                    break (notification.unwrap(), Instant::now());
+                }
+            }
+        })
+        .await
+        .expect("nothing was received after the server went silent - the client stayed parked on the dead connection");
+
+        assert_eq!(
+            after_the_silence.additional_info.as_deref(),
+            Some("after the silence")
+        );
+
+        let reconnect_time = after_timestamp - before_timestamp;
+        assert!(reconnect_time >= (interval + timeout));
+        assert!(reconnect_time < (interval + timeout + safety_margin));
+
+        ens.stop().await;
+    }
+
+    #[rstest]
+    #[tokio::test]
+    #[test_log::test]
+    async fn ens_will_not_detect_silent_connections_if_keepalive_interval_is_none(
+        #[values(None, Some(1), Some(5), Some(10), Some(20))] keepalive_timeout: Option<u64>,
+    ) {
+        let client_private_key = SecretKey::gen();
+        let server_config = spawn_server().await;
+        let relay = TcpRelay::spawn(server_config.port).await;
+
+        let allow_only_mlkem = true;
+        let (mut ens, mut rx) = ErrorNotificationService::new(
+            10,
+            make_socket_pool(),
+            allow_only_mlkem,
+            Some(server_config.tls_config.ca_cert.der().to_vec()),
+            KeepaliveConfig {
+                interval: None,
+                timeout: keepalive_timeout.map(Duration::from_secs),
+            },
+        );
+
+        ens.start_monitor_on_port(
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            relay.port,
+            server_config.public_key,
+            client_private_key,
+            ExponentialBackoff::new(Default::default()).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        server_config
+            .command_tx
+            .send(Command::Send(ConnectionError {
+                code: grpc::Error::Unauthenticated as i32,
+                additional_info: Some("before the silence".to_owned()),
+            }))
+            .await
+            .unwrap();
+        let (before_the_silence, _) = rx.recv().await.unwrap();
+        assert_eq!(
+            before_the_silence.additional_info.as_deref(),
+            Some("before the silence")
+        );
+
+        relay.silent.store(true, Ordering::Relaxed);
+        telio_log_info!(
+            "server has gone silent, the client should give up on the connection and reconnect"
+        );
+
+        let next_notification = timeout(Duration::from_secs(30), async {
+            loop {
+                server_config
+                    .command_tx
+                    .send(Command::Send(ConnectionError {
+                        code: grpc::Error::ServerMaintenance as i32,
+                        additional_info: Some("after the silence".to_owned()),
+                    }))
+                    .await
+                    .unwrap();
+                if let Ok(notification) = timeout(Duration::from_millis(500), rx.recv()).await {
+                    break (notification.unwrap(), Instant::now());
+                }
+            }
+        })
+        .await;
+
+        assert_matches!(next_notification, Err(Elapsed { .. }));
+
+        ens.stop().await;
     }
 
     async fn send_errors(errors_to_emit: &[ConnectionError], errors_tx: Sender<Command>) {

--- a/crates/telio-proto/src/ens/ens_stub.rs
+++ b/crates/telio-proto/src/ens/ens_stub.rs
@@ -10,6 +10,8 @@ use telio_task::io::{
 use telio_utils::exponential_backoff::Backoff;
 use telio_utils::telio_log_warn;
 
+use crate::ens::KeepaliveConfig;
+
 pub(crate) mod grpc {
     /// Stub VPN connection error for when ENS is disabled at compile time.
     #[derive(Debug, Clone, Default)]
@@ -50,6 +52,7 @@ impl ErrorNotificationService {
         _socket_pool: Arc<SocketPool>,
         _allow_only_mlkem: bool,
         _root_certificate_override: Option<Vec<u8>>,
+        _keepalive: KeepaliveConfig,
     ) -> (Self, Rx<(grpc::ConnectionError, PublicKey)>) {
         let Chan { rx, tx }: Chan<(grpc::ConnectionError, PublicKey)> = Chan::new(buffer_size);
         (Self { _tx: tx }, rx)

--- a/crates/telio-proto/src/ens/mod.rs
+++ b/crates/telio-proto/src/ens/mod.rs
@@ -3,6 +3,18 @@
 //! This module provides a facade that conditionally includes either the full implementation
 //! (when `enable_ens` feature is on) or a stub implementation (when disabled).
 
+use std::time::Duration;
+
+/// Configuration of the keep alive messages sent over the ENS connection
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct KeepaliveConfig {
+    /// Interval between the keep alive messages, `None` disables the keep alives
+    pub interval: Option<Duration>,
+    /// How long to wait for a keep alive response before considering the connection dead,
+    /// `None` leaves the default of the underlying http client in place
+    pub timeout: Option<Duration>,
+}
+
 #[cfg(feature = "enable_ens")]
 mod ens_impl;
 #[cfg(feature = "enable_ens")]

--- a/crates/telio-proto/src/lib.rs
+++ b/crates/telio-proto/src/lib.rs
@@ -18,7 +18,7 @@ mod ens;
 
 pub use ens::{
     grpc::{ConnectionError, Error as GrpcError},
-    install_default_crypto_provider, Error, ErrorNotificationService,
+    install_default_crypto_provider, Error, ErrorNotificationService, KeepaliveConfig,
 };
 
 pub use codec::{Codec, Error as CodecError, Result as CodecResult};

--- a/src/libtelio.udl
+++ b/src/libtelio.udl
@@ -909,6 +909,21 @@ dictionary FeatureErrorNotificationService {
     /// DER encoded root certificate to be used for verification of all TLS connections
     /// to gRPC ENS endpoint in place of the hardcoded one
     bytes? root_certificate_override;
+
+    /// Interval between the keep alive messages sent over the ENS connection, in seconds.
+    /// When the underlying tcp connection stops working, the new connection will
+    /// be re-created after at most keepalive_interval_s + keepalive_timeout_s seconds.
+    /// When set to null, the keep alives are disabled.
+    /// Setting it to 0 is an error.
+    /// [default 120s]
+    u32? keepalive_interval_s = 120;
+
+    /// How long to wait for a response to a keep alive message before considering the ENS
+    /// connection dead, in seconds. Only used when keepalive_interval_s is set.
+    /// When set to null, the underlying http client default is used
+    /// Setting it to 0 is an error.
+    /// [default 20s]
+    u32? keepalive_timeout_s = 20;
 };
 
 /// Exponential backoff bounds

--- a/src/libtelio.udl
+++ b/src/libtelio.udl
@@ -909,6 +909,22 @@ dictionary FeatureErrorNotificationService {
     /// DER encoded root certificate to be used for verification of all TLS connections
     /// to gRPC ENS endpoint in place of the hardcoded one
     bytes? root_certificate_override;
+
+    /// Interval between the keep alive messages sent over the ENS connection, in seconds.
+    /// When the underlying tcp connection stops working, the dead connection will be
+    /// detected after at most keepalive_interval_s + keepalive_timeout_s seconds and
+    /// a new connection will be created after the ENS backoff elapses.
+    /// When set to null, the keep alives are disabled.
+    /// Setting it to 0 is an error.
+    /// [default 120s]
+    u32? keepalive_interval_s = 120;
+
+    /// How long to wait for a response to a keep alive message before considering the ENS
+    /// connection dead, in seconds. Only used when keepalive_interval_s is set.
+    /// When set to null, the underlying http client default is used
+    /// Setting it to 0 is an error.
+    /// [default 20s]
+    u32? keepalive_timeout_s = 20;
 };
 
 /// Exponential backoff bounds


### PR DESCRIPTION
### Problem
If after the ENS connection is established, the connection dies in a silent manner (socket is open but no traffic is received) we will not detect this and the ENS connection will stay useless.

### Solution
Enable client side keepalives on the grpc/http2 connection used by ENS. With the default configuration we should detect the problem and try to reconnect after (120+20) seconds.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
