### PR TITLE
Temporary disable openwrt-gw-03 in natlab

### DIFF
--- a/nat-lab/docker-compose.yml
+++ b/nat-lab/docker-compose.yml
@@ -440,17 +440,18 @@ services:
     environment:
       CLIENT_GATEWAY_PRIMARY: 192.168.115.254
 
-  openwrt-client-03:
-    hostname: openwrt-client-03
-    <<: *common-client
-    depends_on:
-      openwrt-gw-03:
-        condition: service_healthy
-    networks:
-      openwrt-net-03:
-        ipv4_address: 192.168.117.100
-    environment:
-      CLIENT_GATEWAY_PRIMARY: 192.168.117.254
+  # TMP DISABLED (openwrt-gw-03): re-enable together with openwrt-gw-03 below.
+  # openwrt-client-03:
+  #   hostname: openwrt-client-03
+  #   <<: *common-client
+  #   depends_on:
+  #     openwrt-gw-03:
+  #       condition: service_healthy
+  #   networks:
+  #     openwrt-net-03:
+  #       ipv4_address: 192.168.117.100
+  #   environment:
+  #     CLIENT_GATEWAY_PRIMARY: 192.168.117.254
 
   # Client that obtains its address from the OpenWRT gateway over DHCP (LLT-6852),
   # used to verify DHCP-advertised options such as the interface MTU (option 26).
@@ -467,18 +468,19 @@ services:
     environment:
       CLIENT_GATEWAY_PRIMARY: none
 
-  openwrt-dhcp-client-03:
-    hostname: openwrt-dhcp-client-03
-    <<: *common-client
-    image: nat-lab:dhcp-client
-    entrypoint: /opt/bin/dhcp-client
-    depends_on:
-      openwrt-gw-03:
-        condition: service_healthy
-    networks:
-      openwrt-net-03: {}
-    environment:
-      CLIENT_GATEWAY_PRIMARY: none
+  # TMP DISABLED (openwrt-gw-03): re-enable together with openwrt-gw-03 below.
+  # openwrt-dhcp-client-03:
+  #   hostname: openwrt-dhcp-client-03
+  #   <<: *common-client
+  #   image: nat-lab:dhcp-client
+  #   entrypoint: /opt/bin/dhcp-client
+  #   depends_on:
+  #     openwrt-gw-03:
+  #       condition: service_healthy
+  #   networks:
+  #     openwrt-net-03: {}
+  #   environment:
+  #     CLIENT_GATEWAY_PRIMARY: none
 
   ###########################################################
   #                        GATEWAYS                         #
@@ -774,44 +776,45 @@ services:
       start_period: 45s
       retries: 5
 
-  openwrt-gw-03:
-    <<: *common-openwrt-gw
-    hostname: openwrt-gw-03
-    build:
-      context: .
-      dockerfile: openwrt.Dockerfile
-      args:
-        LIBTELIO_ENV_SEC_CONTAINER_REGISTRY: $LIBTELIO_ENV_SEC_CONTAINER_REGISTRY
-        OPENWRT_IMAGE: natlab-openwrt-24.10.4-malta-le:v0.8.0
-        OPENWRT_IMG_GZ: rootfs.raw
-    devices:
-      - "/dev/net/tun"
-    environment:
-      OPENWRT_WAN_IP: "10.0.254.23/16"
-      OPENWRT_LAN_BRIDGE_IP: "192.168.117.253/24"
-      OPENWRT_VM_LAN_IP: "192.168.117.254"
-      OPENWRT_VM_WAN_IP: "10.0.0.4"
-      OPENWRT_VM_MAC0: "52:54:9B:96:3F:00"
-      OPENWRT_VM_MAC1: "52:54:9B:96:3F:01"
-      OPENWRT_QEMU_ARCH: "mipsel"
-      # Mipsel is slower due to full QEMU emulation
-      QEMU_CONFIG_TIMEOUT: "600"
-    networks:
-      internet:
-        ipv4_address: 10.0.254.23
-        driver_opts:
-          com.docker.network.endpoint.ifname: 'eth0'
-      openwrt-net-03:
-        ipv4_address: 192.168.117.254
-        driver_opts:
-          com.docker.network.endpoint.ifname: 'eth1'
-    healthcheck:
-      test: /opt/bin/openwrt/openwrt-qemu-healthcheck.sh
-      interval: 15s
-      timeout: 5s
-      # Match the entrypoint's QEMU_CONFIG_TIMEOUT
-      start_period: 120s
-      retries: 32
+  # TMP DISABLED (openwrt-gw-03)
+  # openwrt-gw-03:
+  #   <<: *common-openwrt-gw
+  #   hostname: openwrt-gw-03
+  #   build:
+  #     context: .
+  #     dockerfile: openwrt.Dockerfile
+  #     args:
+  #       LIBTELIO_ENV_SEC_CONTAINER_REGISTRY: $LIBTELIO_ENV_SEC_CONTAINER_REGISTRY
+  #       OPENWRT_IMAGE: natlab-openwrt-24.10.4-malta-le:v0.8.0
+  #       OPENWRT_IMG_GZ: rootfs.raw
+  #   devices:
+  #     - "/dev/net/tun"
+  #   environment:
+  #     OPENWRT_WAN_IP: "10.0.254.23/16"
+  #     OPENWRT_LAN_BRIDGE_IP: "192.168.117.253/24"
+  #     OPENWRT_VM_LAN_IP: "192.168.117.254"
+  #     OPENWRT_VM_WAN_IP: "10.0.0.4"
+  #     OPENWRT_VM_MAC0: "52:54:9B:96:3F:00"
+  #     OPENWRT_VM_MAC1: "52:54:9B:96:3F:01"
+  #     OPENWRT_QEMU_ARCH: "mipsel"
+  #     # Mipsel is slower due to full QEMU emulation
+  #     QEMU_CONFIG_TIMEOUT: "600"
+  #   networks:
+  #     internet:
+  #       ipv4_address: 10.0.254.23
+  #       driver_opts:
+  #         com.docker.network.endpoint.ifname: 'eth0'
+  #     openwrt-net-03:
+  #       ipv4_address: 192.168.117.254
+  #       driver_opts:
+  #         com.docker.network.endpoint.ifname: 'eth1'
+  #   healthcheck:
+  #     test: /opt/bin/openwrt/openwrt-qemu-healthcheck.sh
+  #     interval: 15s
+  #     timeout: 5s
+  #     # Match the entrypoint's QEMU_CONFIG_TIMEOUT
+  #     start_period: 120s
+  #     retries: 32
 
   windows-gw-01:
     hostname: windows-gw-01
@@ -1349,12 +1352,13 @@ networks:
       config:
         - subnet: 192.168.115.0/24
 
-  openwrt-net-03:
-    driver: bridge
-    ipam:
-      driver: default
-      config:
-        - subnet: 192.168.117.0/24
+  # TMP DISABLED (openwrt-gw-03): re-enable together with openwrt-gw-03.
+  # openwrt-net-03:
+  #   driver: bridge
+  #   ipam:
+  #     driver: default
+  #     config:
+  #       - subnet: 192.168.117.0/24
 
   windows-net-01:
     driver: bridge

--- a/nat-lab/network.md
+++ b/nat-lab/network.md
@@ -187,17 +187,6 @@ graph LR
         192.168.115.101")
   end
 
-  %% Network openwrt-net-03
-  subgraph openwrt-net-03[openwrt-net-03]
-  direction LR
-    openwrt-client-03("openwrt-client-03
-        192.168.117.100")
-    openwrt-dhcp-client-03("openwrt-dhcp-client-03")
-    openwrt-gw-03(["openwrt-gw-03
-        10.0.254.23
-        192.168.117.254"])
-  end
-
   %% Network windows-net-01
   subgraph windows-net-01[windows-net-01]
   direction LR
@@ -287,7 +276,6 @@ graph LR
   udp-block-gw-01 -..- internet
   udp-block-gw-02 -..- internet
   openwrt-gw-01 -..- internet
-  openwrt-gw-03 -..- internet
   windows-gw-01 -..- internet
   windows-gw-02 -..- internet
   windows-gw-03 -..- internet
@@ -310,7 +298,6 @@ graph LR
   udp-block-client-01 -.- udp-block-gw-01
   udp-block-client-02 -.- udp-block-gw-02
   openwrt-client-01 -.- openwrt-gw-01
-  openwrt-client-03 -.- openwrt-gw-03
   windows-client-01 -.- windows-gw-01
   windows-client-01 -.- windows-gw-02
   windows-client-02 -.- windows-gw-03

--- a/nat-lab/tests/conftest_helpers/setup_checks.py
+++ b/nat-lab/tests/conftest_helpers/setup_checks.py
@@ -47,7 +47,8 @@ SETUP_CHECK_DUPLICATE_IP_RETRIES = 1
 
 OPENWRT_VM_TAGS = [
     ConnectionTag.VM_OPENWRT_GW_1,
-    ConnectionTag.VM_OPENWRT_GW_3,
+    # TMP DISABLED (openwrt-gw-03)
+    # ConnectionTag.VM_OPENWRT_GW_3,
 ]
 
 SESSION_MARK_TO_CONTAINERS = {

--- a/nat-lab/tests/test_openwrt.py
+++ b/nat-lab/tests/test_openwrt.py
@@ -49,11 +49,11 @@ OPENWRT_TAGS = [
         ConnectionTag.VM_OPENWRT_GW_1,
         id="openwrt-25.12",
     ),
-    pytest.param(
-        ConnectionTag.DOCKER_OPENWRT_CLIENT_3,
-        ConnectionTag.VM_OPENWRT_GW_3,
-        id="openwrt-24.10-malta",
-    ),
+    # pytest.param(
+    #     ConnectionTag.DOCKER_OPENWRT_CLIENT_3,
+    #     ConnectionTag.VM_OPENWRT_GW_3,
+    #     id="openwrt-24.10-malta",
+    # ),
 ]
 
 OPENWRT_DHCP_TAGS = [
@@ -62,11 +62,11 @@ OPENWRT_DHCP_TAGS = [
         ConnectionTag.VM_OPENWRT_GW_1,
         id="openwrt-25.12",
     ),
-    pytest.param(
-        ConnectionTag.DOCKER_OPENWRT_DHCP_CLIENT_3,
-        ConnectionTag.VM_OPENWRT_GW_3,
-        id="openwrt-24.10-malta",
-    ),
+    # pytest.param(
+    #     ConnectionTag.DOCKER_OPENWRT_DHCP_CLIENT_3,
+    #     ConnectionTag.VM_OPENWRT_GW_3,
+    #     id="openwrt-24.10-malta",
+    # ),
 ]
 
 


### PR DESCRIPTION
### Problem
We suspect that we hit CPU limit on a runners.

### Solution
This is a tmp solution to disable openwrt-gw-03 container and see how nightlies behaves over the weekend.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
