### PR TITLE
Extend nat-lab.sh for natlab-subset sharding

### DIFF
--- a/nat-lab/README.md
+++ b/nat-lab/README.md
@@ -113,7 +113,8 @@ uv run python3 natlab.py check-containers
 
 ### Start modifiers (skip heavy services)
 
-- Lightweight bring-up (skips Windows, macOS, fullcone, NLX):
+- Lightweight bring-up — starts the 38 docker-only services and no QEMU/KVM guest at
+  all (skips Windows, macOS, NLX, fullcone, Android, OpenWrt and Playwright):
 
 ```bash
 uv run python3 natlab.py start --lite-mode
@@ -122,7 +123,7 @@ uv run python3 natlab.py start --lite-mode
 - Skip specific groups:
 
 ```bash
-uv run python3 natlab.py start --skip-windows --skip-mac --skip-nlx --skip-fullcone
+uv run python3 natlab.py start --skip-windows --skip-mac --skip-nlx --skip-fullcone --skip-android --skip-openwrt
 ```
 
 - Skip an individual Windows VM:
@@ -131,6 +132,14 @@ uv run python3 natlab.py start --skip-windows --skip-mac --skip-nlx --skip-fullc
 uv run python3 natlab.py start --skip-windows-1
 uv run python3 natlab.py start --skip-windows-2
 ```
+
+Skip keywords are matched as substrings against the compose service names, so
+`--skip-windows` also drops `windows-gw-*`. Note that `--skip-openwrt` implies
+`--skip-playwright`: `playwright-runner-01` `depends_on` `openwrt-gw-01`, so leaving it
+in would make compose boot the OpenWrt VM regardless.
+
+Add `--force-recreate` to recreate the selected containers even when their config and
+image are unchanged (this is `recreate-all`, scoped to the services you asked for).
 
 If a service is missing, the script prints compose logs for that service and fails. See [python.check_containers()](natlab.py).
 

--- a/nat-lab/README.md
+++ b/nat-lab/README.md
@@ -113,7 +113,8 @@ uv run python3 natlab.py check-containers
 
 ### Start modifiers (skip heavy services)
 
-- Lightweight bring-up (skips Windows, macOS, fullcone, NLX):
+- Lightweight bring-up — starts the 38 docker-only services and no QEMU/KVM guest at
+  all (skips Windows, macOS, NLX, fullcone, Android, OpenWrt and Playwright):
 
 ```bash
 uv run python3 natlab.py start --lite-mode
@@ -122,8 +123,13 @@ uv run python3 natlab.py start --lite-mode
 - Skip specific groups:
 
 ```bash
-uv run python3 natlab.py start --skip-windows --skip-mac --skip-nlx --skip-fullcone
+uv run python3 natlab.py start --skip-windows --skip-mac --skip-nlx --skip-fullcone --skip-android --skip-openwrt
 ```
+
+Skip keywords are matched as substrings against the compose service names, so
+`--skip-windows` also drops `windows-gw-*`. Note that `--skip-openwrt` implies
+skipping playwright: `playwright-runner-01` `depends_on` `openwrt-gw-01`, so
+leaving it in would make compose boot the OpenWrt VM regardless.
 
 If a service is missing, the script prints compose logs for that service and fails. See [python.check_containers()](natlab.py).
 

--- a/nat-lab/natlab.py
+++ b/nat-lab/natlab.py
@@ -479,7 +479,12 @@ def _resolve_skip_keywords(args) -> set:
     if args.skip_nlx:
         skip_keywords.add("nlx")
     if args.skip_openwrt:
-        skip_keywords.add("openwrt")
+        # playwright-runner-01 `depends_on` openwrt-gw-01, so leaving it in the
+        # service list would make docker compose boot the OpenWrt VM anyway.
+        # Playwright only serves the OpenWrt LuCI tests, so it goes with them.
+        skip_keywords.update(["openwrt", "playwright"])
+    if args.skip_playwright:
+        skip_keywords.add("playwright")
     if args.skip_android:
         skip_keywords.add("android")
     return skip_keywords
@@ -536,6 +541,14 @@ def main():
         help="Skip starting openwrt related containers",
     )
     start_parser.add_argument(
+        "--skip-playwright",
+        action="store_true",
+        help=(
+            "Skip starting playwright-runner-01 (implied by --skip-openwrt, since it"
+            " depends_on openwrt-gw-01)"
+        ),
+    )
+    start_parser.add_argument(
         "--skip-android",
         action="store_true",
         help="Skip starting the android-client-01 emulator container",
@@ -556,6 +569,14 @@ def main():
         "--rebuild",
         action="store_true",
         help="Force a no-cache rebuild of the base image (same as NATLAB_BUILD_NO_CACHE=1)",
+    )
+    start_parser.add_argument(
+        "--force-recreate",
+        action="store_true",
+        help=(
+            "Recreate containers even if their config and image are unchanged"
+            " (`recreate-all` scoped to the selected services)"
+        ),
     )
 
     subparsers.add_parser("restart", help="Restart (already existing) containers")
@@ -585,11 +606,16 @@ def main():
                 )
             start(
                 skip_keywords,
+                force_recreate=args.force_recreate,
                 services_to_start=args.services_to_start,
                 rebuild=args.rebuild,
             )
         else:
-            start(skip_keywords, rebuild=args.rebuild)
+            start(
+                skip_keywords,
+                force_recreate=args.force_recreate,
+                rebuild=args.rebuild,
+            )
     elif args.command == "restart":
         restart()
     elif args.command == "recreate":

--- a/nat-lab/natlab.py
+++ b/nat-lab/natlab.py
@@ -471,8 +471,18 @@ def restart():
     run_command(["docker", "compose", "restart"])
 
 
-def recreate():
-    """Recreate existing containers (only recreates running containers)"""
+def recreate(skip_keywords=None):
+    """Recreate containers, forcing recreation even if config and image are unchanged.
+
+    With skip keywords (the same --lite-mode/--skip-* flags `start` takes), recreates
+    exactly that subset - use this on a CI shard to rebuild only the services it needs
+    without paying for the ones it skips. With none, recreates the containers that
+    already exist.
+    """
+    if skip_keywords:
+        start(skip_keywords, True)
+        return
+
     running_services = run_command_with_output(
         ["docker", "compose", "ps", "-a", "--services"], True
     ).splitlines()
@@ -488,6 +498,26 @@ def recreate_all():
     start(None, True)
 
 
+def shard_args():
+    """Print the --skip-* flags for this shard, per $NATLAB_SHARD_PLAN.
+
+    The same plan decides which tests land here (see
+    tests/conftest_helpers/sharding.py), so the services a shard starts and the
+    tests it runs cannot disagree. Prints nothing when unsharded, which leaves
+    `natlab.py recreate` starting everything.
+    """
+    sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
+    from tests.conftest_helpers.sharding import (  # pylint: disable=import-outside-toplevel
+        plan_from_env,
+    )
+
+    plan = plan_from_env()
+    if plan is None:
+        return
+    shards, position = plan
+    print(" ".join(f"--skip-{keyword}" for keyword in sorted(shards[position].skip)))
+
+
 def _resolve_skip_keywords(args) -> set:
     if args.lite_mode:
         return {"fullcone", "windows", "mac", "nlx", "openwrt", "android", "playwright"}
@@ -501,7 +531,10 @@ def _resolve_skip_keywords(args) -> set:
     if args.skip_nlx:
         skip_keywords.add("nlx")
     if args.skip_openwrt:
-        skip_keywords.add("openwrt")
+        # playwright-runner-01 `depends_on` openwrt-gw-01, so leaving it in the
+        # service list would make docker compose boot the OpenWrt VM anyway.
+        # Playwright only serves the OpenWrt LuCI tests, so it goes with them.
+        skip_keywords.update(["openwrt", "playwright"])
     if args.skip_android:
         skip_keywords.add("android")
     return skip_keywords
@@ -520,42 +553,46 @@ def main():
     )
     subparsers = parser.add_subparsers(dest="command", help="Available commands")
 
-    start_parser = subparsers.add_parser(
-        "start",
-        help="Build and start the environment (run `start --help` for skip/scope flags)",
-    )
-    start_parser.add_argument(
+    # Service selection, shared by `start` and `recreate`.
+    scope_flags = argparse.ArgumentParser(add_help=False)
+    scope_flags.add_argument(
         "--skip-fullcone",
         action="store_true",
         help="Skip starting fullcone related containers (fullcone-client-*, fullcone-gw-*)",
     )
-    start_parser.add_argument(
+    scope_flags.add_argument(
         "--skip-windows",
         action="store_true",
         help="Skip starting all windows related containers (windows-client-*, windows-gw-*)",
     )
-    start_parser.add_argument(
+    scope_flags.add_argument(
         "--skip-mac",
         action="store_true",
         help="Skip starting mac-client-01 container and related gateways",
     )
-    start_parser.add_argument(
+    scope_flags.add_argument(
         "--skip-nlx", action="store_true", help="Skip starting nlx-01 container"
     )
-    start_parser.add_argument(
+    scope_flags.add_argument(
         "--skip-openwrt",
         action="store_true",
         help="Skip starting openwrt related containers",
     )
-    start_parser.add_argument(
+    scope_flags.add_argument(
         "--skip-android",
         action="store_true",
         help="Skip starting the android-client-01 emulator container",
     )
-    start_parser.add_argument(
+    scope_flags.add_argument(
         "--lite-mode",
         action="store_true",
         help="Skip all heavy containers (windows, mac, fullcone, nlx, openwrt and android)",
+    )
+
+    start_parser = subparsers.add_parser(
+        "start",
+        parents=[scope_flags],
+        help="Build and start the environment (run `start --help` for skip/scope flags)",
     )
 
     start_parser.add_argument(
@@ -571,8 +608,16 @@ def main():
     )
 
     subparsers.add_parser("restart", help="Restart (already existing) containers")
-    subparsers.add_parser("recreate", help="Recreate (already existing) containers")
+    subparsers.add_parser(
+        "recreate",
+        parents=[scope_flags],
+        help="Recreate containers - the subset the skip/scope flags select, or the already existing ones",
+    )
     subparsers.add_parser("recreate-all", help="Recreate all containers")
+    subparsers.add_parser(
+        "shard-args",
+        help="Print this CI shard's --skip-* flags, per $NATLAB_SHARD_PLAN",
+    )
     subparsers.add_parser("stop", help="Stop the environment")
     subparsers.add_parser("kill", help="Kill the environment")
     subparsers.add_parser(
@@ -605,9 +650,11 @@ def main():
     elif args.command == "restart":
         restart()
     elif args.command == "recreate":
-        recreate()
+        recreate(_resolve_skip_keywords(args))
     elif args.command == "recreate-all":
         recreate_all()
+    elif args.command == "shard-args":
+        shard_args()
     elif args.command == "stop":
         stop()
     elif args.command == "kill":

--- a/nat-lab/run_local.py
+++ b/nat-lab/run_local.py
@@ -218,22 +218,23 @@ def _run_tests(args) -> None:
     original_durations_data = {}
     input_path = None
 
+    durations_path: Optional[Path] = None
+
+    if args.input_durations:
+        input_path = Path(args.input_durations)
+        original_durations_data = load_json(input_path)
+        durations_path = input_path
+    elif args.output_durations:
+        durations_path = Path(args.output_durations)
+
+    if durations_path is not None:
+        pytest_cmd.extend([
+            "--store-durations",
+            f"--durations-path={durations_path.absolute()}",
+        ])
+
     if "splits" in pytest_opts:
-        if args.input_durations:
-            input_path = Path(args.input_durations)
-            original_durations_data = load_json(input_path)
-            pytest_cmd.extend([
-                "--store-durations",
-                f"--durations-path={input_path.absolute()}",
-                "--splitting-algorithm=least_duration",
-            ])
-        elif args.output_durations:
-            output_path = Path(args.output_durations)
-            pytest_cmd.extend([
-                "--store-durations",
-                f"--durations-path={output_path.absolute()}",
-                "--splitting-algorithm=least_duration",
-            ])
+        pytest_cmd.append("--splitting-algorithm=least_duration")
 
     pytest_cmd += get_pytest_arguments(args)
 
@@ -242,7 +243,7 @@ def _run_tests(args) -> None:
 
     pytest_result = run_command(pytest_cmd, allow_failure=True)
 
-    if "splits" in pytest_opts and args.output_durations and args.input_durations:
+    if args.output_durations and args.input_durations:
         output_path = Path(args.output_durations)
         if input_path:
             merged_data = load_json(input_path)

--- a/nat-lab/run_local.py
+++ b/nat-lab/run_local.py
@@ -218,22 +218,27 @@ def _run_tests(args) -> None:
     original_durations_data = {}
     input_path = None
 
+    if args.input_durations:
+        input_path = Path(args.input_durations)
+        original_durations_data = load_json(input_path)
+        durations_path: Optional[Path] = input_path
+    elif args.output_durations:
+        durations_path = Path(args.output_durations)
+    else:
+        durations_path = None
+
+    # Record timings whenever a durations path was given, even if this run is not
+    # split. Buckets small enough to fit a single CI shard have no `parallel:` and
+    # so never see --splits; gating storage on splitting would leave them absent
+    # from compiled_test_durations.json and impossible to rebalance later.
+    if durations_path is not None:
+        pytest_cmd.extend([
+            "--store-durations",
+            f"--durations-path={durations_path.absolute()}",
+        ])
+
     if "splits" in pytest_opts:
-        if args.input_durations:
-            input_path = Path(args.input_durations)
-            original_durations_data = load_json(input_path)
-            pytest_cmd.extend([
-                "--store-durations",
-                f"--durations-path={input_path.absolute()}",
-                "--splitting-algorithm=least_duration",
-            ])
-        elif args.output_durations:
-            output_path = Path(args.output_durations)
-            pytest_cmd.extend([
-                "--store-durations",
-                f"--durations-path={output_path.absolute()}",
-                "--splitting-algorithm=least_duration",
-            ])
+        pytest_cmd.append("--splitting-algorithm=least_duration")
 
     pytest_cmd += get_pytest_arguments(args)
 
@@ -242,7 +247,7 @@ def _run_tests(args) -> None:
 
     pytest_result = run_command(pytest_cmd, allow_failure=True)
 
-    if "splits" in pytest_opts and args.output_durations and args.input_durations:
+    if args.output_durations and args.input_durations:
         output_path = Path(args.output_durations)
         if input_path:
             merged_data = load_json(input_path)

--- a/nat-lab/tests/conftest.py
+++ b/nat-lab/tests/conftest.py
@@ -20,6 +20,7 @@ from tests.conftest_helpers.setup_checks import (
     check_all_containers_running,
     get_session_vm_marks,
 )
+from tests.conftest_helpers.sharding import select_for_this_shard
 from tests.helpers import SetupParameters
 from tests.log_collector import LOG_COLLECTORS
 from tests.utils.bindings import TelioAdapterType
@@ -151,7 +152,8 @@ def pytest_make_parametrize_id(config, val):
     return param_id
 
 
-def pytest_collection_modifyitems(items):
+@pytest.hookimpl(trylast=True)
+def pytest_collection_modifyitems(config, items):
     libfirewall_missing = not os.path.exists(_LIBFIREWALL_SO)
     for item in items:
         # Apply 5 minutes timeout to windows tests (due to constant lag)
@@ -159,6 +161,16 @@ def pytest_collection_modifyitems(items):
             item.add_marker(pytest.mark.timeout(300))
         if libfirewall_missing and item.get_closest_marker("libfirewall"):
             item.add_marker(pytest.mark.skip(reason="libfirewall.so not available"))
+
+    # Keep only this shard's slice. trylast, so pytest's own -m deselection has
+    # already run and every shard is dividing up an identical set of items.
+    mine, others, summary = select_for_this_shard(items)
+    if summary is None:
+        return
+    log.info(summary)
+    items[:] = mine
+    if others:
+        config.hook.pytest_deselected(items=others)
 
 
 @pytest.hookimpl(hookwrapper=True)

--- a/nat-lab/tests/conftest_helpers/sharding.py
+++ b/nat-lab/tests/conftest_helpers/sharding.py
@@ -1,0 +1,185 @@
+"""Deterministic assignment of collected tests to CI shards.
+
+Every shard runs this same code over the same inputs and derives the same
+assignment, then keeps its own slice - so the shards need no coordination and
+nothing has to be recorded in the repository.
+
+Inputs, all identical across shards:
+  * the collected items, after pytest has applied `-m`
+  * $NATLAB_SHARD_PLAN - the shard topology, set by .gitlab-ci.yml
+  * compiled_test_durations.json - published by a previous pipeline
+
+A test's requirements are its markers; a shard's capabilities are whatever it
+did not skip. The marker names are deliberately the same strings natlab.py
+skips by (see `_resolve_skip_keywords`), so eligibility is a set intersection
+and there is no mapping table to keep in sync.
+"""
+
+import json
+import os
+import statistics
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Sequence, Tuple
+
+# Markers that mean "this test needs a service some shards do not start". Every
+# other marker (ipv4, moose, linux_native, ...) says nothing about placement.
+CAPABILITIES = frozenset({"windows", "mac", "android", "nlx", "fullcone", "openwrt"})
+
+DURATIONS_FILE = "compiled_test_durations.json"
+
+
+@dataclass(frozen=True)
+class Shard:
+    """One CI job instance: what it will not start, and what it costs to boot."""
+
+    name: str
+    skip: frozenset
+    startup_seconds: float
+
+
+def parse_plan(raw: str) -> List[Shard]:
+    """Expand the plan JSON into one Shard per job instance.
+
+    `count` repeats a class in place, so the resulting list index is the
+    1-based CI_NODE_INDEX minus one - the same on every shard.
+    """
+    shards: List[Shard] = []
+    for entry in json.loads(raw):
+        skip = frozenset(entry.get("skip", []))
+        unknown = skip - CAPABILITIES
+        if unknown:
+            raise ValueError(
+                f"shard {entry.get('name')!r} skips unknown capabilities:"
+                f" {sorted(unknown)} (known: {sorted(CAPABILITIES)})"
+            )
+        for _ in range(int(entry.get("count", 1))):
+            shards.append(
+                Shard(
+                    name=str(entry["name"]),
+                    skip=skip,
+                    startup_seconds=float(entry.get("startup_seconds", 0)),
+                )
+            )
+    if not shards:
+        raise ValueError("NATLAB_SHARD_PLAN expanded to zero shards")
+    return shards
+
+
+def load_durations(directory: str = ".") -> Dict[str, float]:
+    """Per-test seconds from the published durations, or {} when unavailable.
+
+    $NATLAB_DURATIONS_FILE overrides the path, so a caller outside nat-lab can
+    point this at the same file it reports from.
+    """
+    path = os.environ.get("NATLAB_DURATIONS_FILE", "").strip() or os.path.join(
+        directory, DURATIONS_FILE
+    )
+    try:
+        with open(path, encoding="utf-8") as file:
+            data = json.load(file)
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return {k: float(v) for k, v in data.items()}
+
+
+def requirements(item) -> frozenset:
+    """The capability markers a single test carries."""
+    return frozenset(mark.name for mark in item.iter_markers()) & CAPABILITIES
+
+
+def unserved(shards: Sequence[Shard]) -> List[str]:
+    """Capabilities every shard skips, so tests needing them have nowhere to run.
+
+    Only single capabilities: whether a *combination* matters depends on which
+    tests exist, which the plan cannot know. A test needing an unservable
+    combination fails loudly at collection time instead.
+    """
+    return sorted(
+        capability
+        for capability in CAPABILITIES
+        if all(capability in shard.skip for shard in shards)
+    )
+
+
+def assign(items: Sequence, shards: Sequence[Shard], durations: Dict[str, float]):
+    """Distribute items across shards. Returns one list of items per shard.
+
+    Constrained-LPT: tests that few shards can run are placed first, longest
+    first within that, so the VM tests claim their shards before the movable
+    docker-only ones fill whatever is left. The sort key ends in nodeid, making
+    the order total - two shards cannot disagree because of a tie.
+    """
+    default = statistics.median(durations.values()) if durations else 1.0
+
+    def seconds(item) -> float:
+        return durations.get(item.nodeid, default)
+
+    eligible: Dict[str, List[int]] = {}
+    for item in items:
+        needs = requirements(item)
+        eligible[item.nodeid] = [
+            i for i, shard in enumerate(shards) if not (needs & shard.skip)
+        ]
+        if not eligible[item.nodeid]:
+            raise RuntimeError(
+                f"no shard can run {item.nodeid}: it needs {sorted(needs)},"
+                " and every shard skips at least one of those."
+                " Add a shard that starts them, or the test cannot run in CI."
+            )
+
+    load = [shard.startup_seconds for shard in shards]
+    buckets: List[List] = [[] for _ in shards]
+
+    ordered = sorted(
+        items,
+        key=lambda it: (len(eligible[it.nodeid]), -seconds(it), it.nodeid),
+    )
+    for item in ordered:
+        candidates = eligible[item.nodeid]
+        target = min(candidates, key=lambda i: (load[i], i))
+        load[target] += seconds(item)
+        buckets[target].append(item)
+
+    return buckets, load
+
+
+def plan_from_env() -> Optional[Tuple[List[Shard], int]]:
+    """(shards, zero-based index) when CI asked for sharding, else None.
+
+    Absent or incomplete configuration means "run everything", which is what a
+    developer running the suite locally wants.
+    """
+    raw = os.environ.get("NATLAB_SHARD_PLAN", "").strip()
+    index = os.environ.get("CI_NODE_INDEX", "").strip()
+    if not raw or not index:
+        return None
+
+    shards = parse_plan(raw)
+    position = int(index) - 1
+    if not 0 <= position < len(shards):
+        raise ValueError(
+            f"CI_NODE_INDEX={index} is outside the {len(shards)} shards in"
+            " NATLAB_SHARD_PLAN - `parallel:` and the plan disagree"
+        )
+    return shards, position
+
+
+def select_for_this_shard(items: Sequence, durations_dir: str = "."):
+    """Split items into (mine, other_shards'). Both empty-handed when unsharded."""
+    plan = plan_from_env()
+    if plan is None:
+        return list(items), [], None
+
+    shards, position = plan
+    durations = load_durations(durations_dir)
+    buckets, load = assign(items, shards, durations)
+
+    mine = buckets[position]
+    keep = {item.nodeid for item in mine}
+    others = [item for item in items if item.nodeid not in keep]
+    summary = (
+        f"shard {position + 1}/{len(shards)} ({shards[position].name}): "
+        f"{len(mine)} of {len(items)} tests, ~{load[position] / 60:.1f} min predicted"
+        f"{'' if durations else ' (no durations file - balancing by count)'}"
+    )
+    return mine, others, summary

--- a/nat-lab/tests/test_ens.py
+++ b/nat-lab/tests/test_ens.py
@@ -803,7 +803,7 @@ async def test_ens_connection_error_unknown(
             setup_environment(
                 exit_stack,
                 [alpha_setup_params],
-                vpn=[ConnectionTag.VM_LINUX_NLX_1, ConnectionTag.DOCKER_VPN_1],
+                vpn=[ConnectionTag.DOCKER_VPN_1],
             )
         )
 


### PR DESCRIPTION
### Problem
Every nat-lab shard is quite heavy running the whole nat-lab

### Solution
Let's add additional options for running nat-lab, so we can divide tests into shards which run only particular subset of all nat-lab containers, thus reducing the overall load


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
