### PR TITLE
Remove second Windows VM from nat-lab

### DIFF
--- a/nat-lab/README.md
+++ b/nat-lab/README.md
@@ -125,13 +125,6 @@ uv run python3 natlab.py start --lite-mode
 uv run python3 natlab.py start --skip-windows --skip-mac --skip-nlx --skip-fullcone
 ```
 
-- Skip an individual Windows VM:
-
-```bash
-uv run python3 natlab.py start --skip-windows-1
-uv run python3 natlab.py start --skip-windows-2
-```
-
 If a service is missing, the script prints compose logs for that service and fails. See [python.check_containers()](natlab.py).
 
 ## Running tests locally
@@ -389,7 +382,7 @@ uv run python3 run_local.py -k test_direct_connection -v
 
 - Credentials come from composition and SshConnection defaults:
   - Windows VMs: user bill / password gates (see [python.SshConnection.new_connection()](tests/utils/connection/ssh_connection.py))
-    - IPs: 192.168.150.54 (VM_WINDOWS_1), 192.168.152.54 (VM_WINDOWS_2) from [python.LAN_ADDR_MAP](tests/config.py)
+    - IP: 192.168.150.54 (VM_WINDOWS_1) from [python.LAN_ADDR_MAP](tests/config.py)
     - Example:
 
 ```bash

--- a/nat-lab/docker-compose.yml
+++ b/nat-lab/docker-compose.yml
@@ -178,29 +178,6 @@ services:
       windows-net-02:
         ipv4_address: 192.168.151.54
 
-  windows-client-02:
-    hostname: windows-client-02
-    <<: *windows-client
-    depends_on:
-      windows-gw-03:
-        condition: service_healthy
-      windows-gw-04:
-        condition: service_healthy
-    networks:
-      windows-net-03:
-        ipv4_address: 192.168.152.54
-      windows-net-04:
-        ipv4_address: 192.168.153.54
-    environment:
-      USERNAME: "bill"
-      PASSWORD: "gates"
-      NETWORK: "bridge"
-      RAM_SIZE: "4G"
-      CPU_CORES: "2"
-      EXTRA_SCRIPT: "/libtelio/nat-lab/bin/windows-client"
-      CLIENT_GATEWAY_PRIMARY: 192.168.152.254
-      CLIENT_GATEWAY_SECONDARY: 192.168.153.254
-
   cone-client-02:
     hostname: cone-client-02
     <<: *common-client
@@ -835,28 +812,6 @@ services:
         ipv4_address: 192.168.151.254
         priority: 900
 
-  windows-gw-03:
-    hostname: windows-gw-03
-    <<: *common-gw
-    networks:
-      internet:
-        ipv4_address: 10.0.254.17
-        priority: 1000
-      windows-net-03:
-        ipv4_address: 192.168.152.254
-        priority: 900
-
-  windows-gw-04:
-    hostname: windows-gw-04
-    <<: *common-gw
-    networks:
-      internet:
-        ipv4_address: 10.0.254.18
-        priority: 1000
-      windows-net-04:
-        ipv4_address: 192.168.153.254
-        priority: 900
-
   mac-gw-01:
     hostname: mac-gw-01
     <<: *common-gw
@@ -1369,20 +1324,6 @@ networks:
       driver: default
       config:
         - subnet: 192.168.151.0/24
-
-  windows-net-03:
-    driver: bridge
-    ipam:
-      driver: default
-      config:
-        - subnet: 192.168.152.0/24
-
-  windows-net-04:
-    driver: bridge
-    ipam:
-      driver: default
-      config:
-        - subnet: 192.168.153.0/24
 
   mac-net-01:
     driver: bridge

--- a/nat-lab/natlab.py
+++ b/nat-lab/natlab.py
@@ -470,10 +470,6 @@ def _resolve_skip_keywords(args) -> set:
         skip_keywords.add("fullcone")
     if args.skip_windows:
         skip_keywords.add("windows")
-    if args.skip_windows_1:
-        skip_keywords.update(["windows-client-01", "windows-gw-01", "windows-gw-02"])
-    if args.skip_windows_2:
-        skip_keywords.update(["windows-client-02", "windows-gw-03", "windows-gw-04"])
     if args.skip_mac:
         skip_keywords.add("mac")
     if args.skip_nlx:
@@ -511,16 +507,6 @@ def main():
         "--skip-windows",
         action="store_true",
         help="Skip starting all windows related containers (windows-client-*, windows-gw-*)",
-    )
-    start_parser.add_argument(
-        "--skip-windows-1",
-        action="store_true",
-        help="Skip starting windows-client-01 container and related gateways",
-    )
-    start_parser.add_argument(
-        "--skip-windows-2",
-        action="store_true",
-        help="Skip starting windows-client-02 container and related gateways",
     )
     start_parser.add_argument(
         "--skip-mac",

--- a/nat-lab/network.md
+++ b/nat-lab/network.md
@@ -220,28 +220,6 @@ graph LR
         192.168.151.254"])
   end
 
-  %% Network windows-net-03
-  subgraph windows-net-03[windows-net-03]
-  direction LR
-    windows-client-02("windows-client-02
-        192.168.152.54
-        192.168.153.54")
-    windows-gw-03(["windows-gw-03
-        10.0.254.17
-        192.168.152.254"])
-  end
-
-  %% Network windows-net-04
-  subgraph windows-net-04[windows-net-04]
-  direction LR
-    windows-client-02("windows-client-02
-        192.168.152.54
-        192.168.153.54")
-    windows-gw-04(["windows-gw-04
-        10.0.254.18
-        192.168.153.254"])
-  end
-
   %% Network mac-net-01
   subgraph mac-net-01[mac-net-01]
   direction LR
@@ -290,8 +268,6 @@ graph LR
   openwrt-gw-03 -..- internet
   windows-gw-01 -..- internet
   windows-gw-02 -..- internet
-  windows-gw-03 -..- internet
-  windows-gw-04 -..- internet
   mac-gw-01 -..- internet
   mac-gw-02 -..- internet
   android-gw-01 -..- internet
@@ -313,8 +289,6 @@ graph LR
   openwrt-client-03 -.- openwrt-gw-03
   windows-client-01 -.- windows-gw-01
   windows-client-01 -.- windows-gw-02
-  windows-client-02 -.- windows-gw-03
-  windows-client-02 -.- windows-gw-04
   mac-client-01 -.- mac-gw-01
   mac-client-01 -.- mac-gw-02
   android-client-01 -.- android-gw-01

--- a/nat-lab/pyproject.toml
+++ b/nat-lab/pyproject.toml
@@ -195,7 +195,6 @@ log_date_format = "%Y-%m-%d %H:%M:%S"
 markers = [
     "nat: the test only passes once, before environment needs to be restarted",
     "windows: tests that require Windows VM to be running",
-    "windows2: tests that require a second Windows VM to be running",
     "mac: tests that require Mac VM to be running",
     "android: tests that require the Android emulator (android-client-01) to be running",
     "linux_native: tests that use linux native WG implementation",

--- a/nat-lab/tests/config.py
+++ b/nat-lab/tests/config.py
@@ -70,10 +70,6 @@ LAN_ADDR_MAP: Dict[ConnectionTag, Dict[str, str]] = {
         "primary": "192.168.150.54",
         "secondary": "192.168.151.54",
     },
-    ConnectionTag.VM_WINDOWS_2: {
-        "primary": "192.168.152.54",
-        "secondary": "192.168.153.54",
-    },
     ConnectionTag.VM_MAC: {"primary": "192.168.154.54", "secondary": "192.168.155.54"},
     ConnectionTag.VM_ANDROID_1: {"primary": "192.168.118.54", "secondary": ""},
     ConnectionTag.DOCKER_CONE_GW_1: {"primary": "192.168.101.254", "secondary": ""},
@@ -185,10 +181,6 @@ GW_ADDR_MAP: Dict[ConnectionTag, Dict[str, str]] = {
     ConnectionTag.VM_WINDOWS_1: {
         "primary": "192.168.150.254",
         "secondary": "192.168.151.254",
-    },
-    ConnectionTag.VM_WINDOWS_2: {
-        "primary": "192.168.152.254",
-        "secondary": "192.168.153.254",
     },
     ConnectionTag.VM_MAC: {
         "primary": "192.168.154.254",

--- a/nat-lab/tests/conftest_helpers/pretest.py
+++ b/nat-lab/tests/conftest_helpers/pretest.py
@@ -176,10 +176,6 @@ async def _copy_android_binaries(tag: ConnectionTag):
 async def copy_vm_binaries_if_needed(session_vm_marks: set[str]):
     if "windows" in session_vm_marks:
         await _copy_vm_binaries(ConnectionTag.VM_WINDOWS_1)
-        try:
-            await _copy_vm_binaries(ConnectionTag.VM_WINDOWS_2)
-        except Exception as e:  # pylint: disable=broad-exception-caught
-            setup_log.warning("[Ignored] Couldn't copy binary to VM_WINDOWS_2: %s", e)
     if "mac" in session_vm_marks:
         await _copy_vm_binaries(ConnectionTag.VM_MAC)
     if "openwrt" in session_vm_marks:

--- a/nat-lab/tests/conftest_helpers/setup_checks.py
+++ b/nat-lab/tests/conftest_helpers/setup_checks.py
@@ -55,7 +55,6 @@ SESSION_MARK_TO_CONTAINERS = {
     "nlx": [ConnectionTag.VM_LINUX_NLX_1],
     "openwrt": OPENWRT_VM_TAGS,
     "windows": [ConnectionTag.VM_WINDOWS_1],
-    "windows2": [ConnectionTag.VM_WINDOWS_2],
 }
 
 

--- a/nat-lab/tests/conftest_helpers/windows_monitoring.py
+++ b/nat-lab/tests/conftest_helpers/windows_monitoring.py
@@ -15,7 +15,7 @@ async def start_windows_vms_resource_monitoring(
     tasks: List[asyncio.Task],
     end_tasks: threading.Event,
 ):
-    vms = [ConnectionTag.DOCKER_WINDOWS_VM_1, ConnectionTag.DOCKER_WINDOWS_VM_2]
+    vms = [ConnectionTag.DOCKER_WINDOWS_VM_1]
     for vm_tag in vms:
         is_vm_running = await is_running(vm_tag)
         if is_vm_running:

--- a/nat-lab/tests/test_node_state_flickering.py
+++ b/nat-lab/tests/test_node_state_flickering.py
@@ -122,14 +122,12 @@ CFG = [
         pytest.param(
             alpha_cfg[0],
             beta_cfg[0],
-            marks=(
-                [pytest.mark.windows2]
-                if alpha_cfg[1] == [pytest.mark.windows]
-                and beta_cfg[1] == [pytest.mark.windows]
-                else alpha_cfg[1] + beta_cfg[1]
-            ),
+            marks=alpha_cfg[1] + beta_cfg[1],
         )
         for alpha_cfg, beta_cfg in itertools.combinations_with_replacement(CFG, 2)
+        # nat-lab has a single Windows VM, so no windows<->windows pair
+        if alpha_cfg[0] != TelioAdapterType.WINDOWS_NATIVE_TUN
+        or beta_cfg[0] != TelioAdapterType.WINDOWS_NATIVE_TUN
     ],
 )
 async def test_node_state_flickering_direct(
@@ -142,11 +140,7 @@ async def test_node_state_flickering_direct(
             if alpha_adapter_type == TelioAdapterType.WINDOWS_NATIVE_TUN
             else ConnectionTag.DOCKER_CONE_CLIENT_1
         )
-        beta_conn_tag = (
-            ConnectionTag.VM_WINDOWS_2
-            if beta_adapter_type == TelioAdapterType.WINDOWS_NATIVE_TUN
-            else ConnectionTag.DOCKER_CONE_CLIENT_2
-        )
+        beta_conn_tag = ConnectionTag.DOCKER_CONE_CLIENT_2
 
         env = await setup_mesh_nodes(
             exit_stack,

--- a/nat-lab/tests/utils/connection/connection.py
+++ b/nat-lab/tests/utils/connection/connection.py
@@ -28,7 +28,6 @@ class ConnectionTag(Enum):
     DOCKER_OPENWRT_DHCP_CLIENT_3 = auto()
     DOCKER_INTERNAL_SYMMETRIC_CLIENT = auto()
     VM_WINDOWS_1 = auto()
-    VM_WINDOWS_2 = auto()
     VM_MAC = auto()
     VM_ANDROID_1 = auto()
     DOCKER_CONE_GW_1 = auto()
@@ -58,10 +57,7 @@ class ConnectionTag(Enum):
     DOCKER_PHOTO_ALBUM = auto()
     DOCKER_WINDOWS_GW_1 = auto()
     DOCKER_WINDOWS_GW_2 = auto()
-    DOCKER_WINDOWS_GW_3 = auto()
-    DOCKER_WINDOWS_GW_4 = auto()
     DOCKER_WINDOWS_VM_1 = auto()
-    DOCKER_WINDOWS_VM_2 = auto()
     DOCKER_MAC_GW_1 = auto()
     DOCKER_MAC_GW_2 = auto()
     DOCKER_CORE_API_1 = auto()
@@ -166,7 +162,7 @@ async def setup_ephemeral_ports(connection: Connection):
     start_port = random.randint(15000, 55000)
     num_ports = random.randint(2000, 5000)
 
-    if connection.tag in [ConnectionTag.VM_WINDOWS_1, ConnectionTag.VM_WINDOWS_2]:
+    if connection.tag is ConnectionTag.VM_WINDOWS_1:
         cmd = [
             "netsh",
             "int",

--- a/nat-lab/tests/utils/connection/docker_connection.py
+++ b/nat-lab/tests/utils/connection/docker_connection.py
@@ -56,10 +56,7 @@ DOCKER_SERVICE_IDS: Dict[ConnectionTag, str] = {
     ConnectionTag.DOCKER_PHOTO_ALBUM: "photo-album",
     ConnectionTag.DOCKER_WINDOWS_GW_1: "windows-gw-01",
     ConnectionTag.DOCKER_WINDOWS_GW_2: "windows-gw-02",
-    ConnectionTag.DOCKER_WINDOWS_GW_3: "windows-gw-03",
-    ConnectionTag.DOCKER_WINDOWS_GW_4: "windows-gw-04",
     ConnectionTag.DOCKER_WINDOWS_VM_1: "windows-client-01",
-    ConnectionTag.DOCKER_WINDOWS_VM_2: "windows-client-02",
     ConnectionTag.DOCKER_MAC_GW_1: "mac-gw-01",
     ConnectionTag.DOCKER_MAC_GW_2: "mac-gw-02",
     ConnectionTag.DOCKER_CORE_API_1: "core-api",
@@ -84,7 +81,6 @@ DOCKER_GW_MAP: Dict[ConnectionTag, ConnectionTag] = {
     ConnectionTag.DOCKER_UDP_BLOCK_CLIENT_1: ConnectionTag.DOCKER_UDP_BLOCK_GW_1,
     ConnectionTag.DOCKER_UDP_BLOCK_CLIENT_2: ConnectionTag.DOCKER_UDP_BLOCK_GW_2,
     ConnectionTag.VM_WINDOWS_1: ConnectionTag.DOCKER_WINDOWS_GW_1,
-    ConnectionTag.VM_WINDOWS_2: ConnectionTag.DOCKER_WINDOWS_GW_3,
     ConnectionTag.VM_MAC: ConnectionTag.DOCKER_MAC_GW_1,
     ConnectionTag.DOCKER_OPEN_INTERNET_CLIENT_1: (
         ConnectionTag.DOCKER_OPEN_INTERNET_CLIENT_1
@@ -102,7 +98,6 @@ DOCKER_GW_MAP: Dict[ConnectionTag, ConnectionTag] = {
 
 DOCKER_VM_MAP: Dict[ConnectionTag, ConnectionTag] = {
     ConnectionTag.VM_WINDOWS_1: ConnectionTag.DOCKER_WINDOWS_VM_1,
-    ConnectionTag.VM_WINDOWS_2: ConnectionTag.DOCKER_WINDOWS_VM_2,
 }
 
 DOCKER_SERVICE_SKIP_IPTABLES: list[ConnectionTag] = [
@@ -249,7 +244,6 @@ def container_id(tag: ConnectionTag) -> str:
 # hosts the guest, allowing the backing container to be controlled (e.g. paused).
 DOCKER_VM_SERVICE_IDS: Dict[ConnectionTag, str] = {
     ConnectionTag.VM_WINDOWS_1: "windows-client-01",
-    ConnectionTag.VM_WINDOWS_2: "windows-client-02",
     ConnectionTag.VM_MAC: "mac-client-01",
     ConnectionTag.VM_ANDROID_1: "android-client-01",
 }

--- a/nat-lab/tests/utils/connection/ssh_connection.py
+++ b/nat-lab/tests/utils/connection/ssh_connection.py
@@ -26,7 +26,7 @@ class SshConnection(Connection):
         tag: ConnectionTag,
         ip: str = "",
     ):
-        if tag in [ConnectionTag.VM_WINDOWS_1, ConnectionTag.VM_WINDOWS_2]:
+        if tag is ConnectionTag.VM_WINDOWS_1:
             target_os = TargetOS.Windows
         elif tag is ConnectionTag.VM_MAC:
             target_os = TargetOS.Mac
@@ -73,7 +73,7 @@ class SshConnection(Connection):
     def _credentials(tag: ConnectionTag) -> tuple[str, str | None]:
         if tag is ConnectionTag.VM_MAC:
             return "root", "jobs"
-        if tag in [ConnectionTag.VM_WINDOWS_1, ConnectionTag.VM_WINDOWS_2]:
+        if tag is ConnectionTag.VM_WINDOWS_1:
             return "bill", "gates"
         if tag in [
             ConnectionTag.VM_OPENWRT_GW_1,
@@ -142,7 +142,7 @@ class SshConnection(Connection):
 
                     yield connection
         except OSError:
-            if tag in [ConnectionTag.VM_WINDOWS_1, ConnectionTag.VM_WINDOWS_2]:
+            if tag is ConnectionTag.VM_WINDOWS_1:
                 try:
                     import tests.utils.connection_util  # pylint: disable=import-outside-toplevel
 

--- a/nat-lab/tests/utils/connection_util.py
+++ b/nat-lab/tests/utils/connection_util.py
@@ -102,7 +102,7 @@ async def create_network_switcher(
 ) -> NetworkSwitcher:
     if tag in DOCKER_SERVICE_IDS:
         return NetworkSwitcherDocker(connection)
-    if tag in [ConnectionTag.VM_WINDOWS_1, ConnectionTag.VM_WINDOWS_2]:
+    if tag is ConnectionTag.VM_WINDOWS_1:
         return await NetworkSwitcherWindows.create(connection)
     if tag == ConnectionTag.VM_MAC:
         return NetworkSwitcherMac(connection)
@@ -373,7 +373,6 @@ async def remove_traffic_control_rules(connection):
 def is_tag_valid_for_ssh_connection(tag: ConnectionTag) -> bool:
     return tag in [
         ConnectionTag.VM_WINDOWS_1,
-        ConnectionTag.VM_WINDOWS_2,
         ConnectionTag.VM_MAC,
         ConnectionTag.VM_OPENWRT_GW_1,
         ConnectionTag.VM_OPENWRT_GW_3,


### PR DESCRIPTION
## Problem
`windows-client-02` (plus `windows-gw-03/04` and `windows-net-03/04`) is only used by the windows<->windows combination of `test_node_state_flickering_direct`, which is `@pytest.mark.long`. No CI job runs `long` — both `PYTEST_MARKS` and `NIGHTLY_PYTEST_MARKS` in libtelio-build exclude it. So it is a second 4G/2-core Windows VM that never runs a test.

## Solution
Remove it.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
