### PR TITLE
Filter onion queries and do not let them to hickory

### DIFF
--- a/.unreleased/forward_onion_dns_queries
+++ b/.unreleased/forward_onion_dns_queries
@@ -1,0 +1,1 @@
+Forward .onion DNS queries to the configured upstream resolver instead of returning NXDOMAIN.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -729,7 +729,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1248,7 +1248,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1391,7 +1391,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1711,9 +1711,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2924,7 +2924,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3612,7 +3612,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3993,7 +3993,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4052,7 +4052,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4073,7 +4073,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5377,7 +5377,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6361,7 +6361,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6738,7 +6738,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d6f32a0ff4a9f6f01231eb2059cc85479330739333e0e58cadf03b6af2cca10"
 dependencies = [
  "cfg-if",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/crates/telio-dns/src/nameserver.rs
+++ b/crates/telio-dns/src/nameserver.rs
@@ -1,7 +1,9 @@
 use crate::error::Result as DnsResult;
 use crate::{
     forwarder::RawForwarder,
-    packet_decoder::{find_nord_query, normalize_qname, parse_dns_query_packet, DnsParseError},
+    packet_decoder::{
+        find_nord_query, is_onion_query, normalize_qname, parse_dns_query_packet, DnsParseError,
+    },
     packet_encoder::{DnsBuildError, DnsResponseBuilder},
     resolver::Resolver,
     zone::{AuthoritativeZone, ClonableZones, ForwardZone, NordZone, Records, NORD_ZONE},
@@ -150,13 +152,13 @@ async fn update_wg_timers(
 }
 
 /// Local name server.
-#[derive(Default)]
 pub struct LocalNameServer {
     /// .nord peers zone
     nord_zone: NordZone,
     zones: Arc<ClonableZones>,
     task_handle: Option<JoinHandle<()>>,
-    forwarder: Option<RawForwarder>,
+    forwarder: RawForwarder,
+    use_raw_forwarder: bool,
 }
 
 impl LocalNameServer {
@@ -166,16 +168,13 @@ impl LocalNameServer {
         forward_ips: &[IpAddr],
         use_raw_forwarder: bool,
     ) -> DnsResult<Arc<RwLock<Self>>> {
-        let raw_forwarder: Option<RawForwarder> = if use_raw_forwarder {
-            Some(RawForwarder::new().await?)
-        } else {
-            None
-        };
+        let raw_forwarder = RawForwarder::new().await?;
         let ns = Arc::new(RwLock::new(LocalNameServer {
             nord_zone: NordZone::new(),
             zones: Arc::new(ClonableZones::new()),
             task_handle: None,
             forwarder: raw_forwarder,
+            use_raw_forwarder,
         }));
         ns.forward(forward_ips).await?;
         Ok(ns)
@@ -361,12 +360,15 @@ impl LocalNameServer {
                     .build()
                     .map_err(PacketError::DnsResponseBuildFailed)?
             }
-            PayloadDestination::Forward(raw_query) => {
-                let raw_forwarder = {
+            PayloadDestination::Forward {
+                raw_query,
+                is_onion,
+            } => {
+                let (raw_forwarder, use_raw_forwarder) = {
                     let ns = nameserver.read().await;
-                    ns.forwarder.clone()
+                    (ns.forwarder.clone(), ns.use_raw_forwarder || is_onion)
                 };
-                if let Some(forwarder) = raw_forwarder {
+                if use_raw_forwarder {
                     telio_log_debug!(
                         "Forwarding raw DNS request from port {:?}",
                         request_info.dns_source_port(),
@@ -392,7 +394,7 @@ impl LocalNameServer {
                         }
                     }
 
-                    let response = forwarder
+                    let response = raw_forwarder
                         .query(&raw_query)
                         .await
                         .map_err(|e| PacketError::LookupFailed(Box::new(e)))?;
@@ -513,7 +515,10 @@ impl LocalNameServer {
                     })
                 } else {
                     // not .nord, forward unchanged
-                    Some(PayloadDestination::Forward(payload.to_vec()))
+                    Some(PayloadDestination::Forward {
+                        raw_query: payload.to_vec(),
+                        is_onion: is_onion_query(&packet),
+                    })
                 }
             }
             Err(e) => {
@@ -588,7 +593,10 @@ enum PayloadDestination {
         recursion_desired: bool,
         query: DnsQuery,
     },
-    Forward(Vec<u8>),
+    Forward {
+        raw_query: Vec<u8>,
+        is_onion: bool,
+    },
 }
 
 enum PayloadRequestInfo {
@@ -908,9 +916,7 @@ impl NameServer for Arc<RwLock<LocalNameServer>> {
 
     async fn forward_to_addrs(&self, to: &[SocketAddr]) -> DnsResult<()> {
         let ns = self.read().await;
-        if let Some(forwarder) = &ns.forwarder {
-            forwarder.set_upstreams(to.to_vec()).await;
-        }
+        ns.forwarder.set_upstreams(to.to_vec()).await;
 
         Ok(())
     }
@@ -1059,24 +1065,24 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn nameserver_creates_forwarder_when_raw_flag_set() {
+    async fn nameserver_uses_raw_forwarder_when_flag_set() {
         let nameserver =
             LocalNameServer::new(&[IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))], USE_RAW_FORWARDER)
                 .await
                 .unwrap();
 
         let ns = nameserver.read().await;
-        assert!(ns.forwarder.is_some());
+        assert!(ns.use_raw_forwarder);
     }
 
     #[tokio::test]
-    async fn nameserver_skips_forwarder_by_default() {
+    async fn nameserver_uses_hickory_forwarder_by_default() {
         let nameserver = LocalNameServer::new(&[IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))], false)
             .await
             .unwrap();
 
         let ns = nameserver.read().await;
-        assert!(ns.forwarder.is_none());
+        assert!(!ns.use_raw_forwarder);
     }
 
     // PacketError internal unit tests

--- a/crates/telio-dns/src/packet_decoder.rs
+++ b/crates/telio-dns/src/packet_decoder.rs
@@ -83,6 +83,24 @@ pub fn find_nord_query(dns_packet: &DnsPacket) -> Option<DnsQuery> {
     }
 }
 
+/// Check whether the first query is for the `.onion` top-level domain.
+pub(crate) fn is_onion_query(dns_packet: &DnsPacket) -> bool {
+    let Some(query) = dns_packet
+        .get_queries_iter()
+        .next()
+        .map(|query| query.from_packet())
+    else {
+        return false;
+    };
+
+    if query.qclass != DnsClasses::IN {
+        return false;
+    }
+
+    let qname = normalize_qname(&query.get_qname_parsed());
+    qname == "onion." || qname.ends_with(".onion.")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -186,5 +204,24 @@ mod tests {
         assert!(!is_nord_name("testnord"));
         assert!(!is_nord_name(""));
         assert!(!is_nord_name("."));
+    }
+
+    #[test]
+    fn test_onion_query() {
+        for qname in ["onion", "service.onion", "SERVICE.ONION"] {
+            let bytes = build_dns_query_bytes(&[qname], QueryType::A);
+            let packet = parse_dns_query_packet(&bytes).unwrap();
+            assert!(is_onion_query(&packet), "expected {} to be .onion", qname);
+        }
+
+        for qname in ["notonion", "onion.example", "service.onion.test"] {
+            let bytes = build_dns_query_bytes(&[qname], QueryType::A);
+            let packet = parse_dns_query_packet(&bytes).unwrap();
+            assert!(
+                !is_onion_query(&packet),
+                "did not expect {} to be .onion",
+                qname
+            );
+        }
     }
 }

--- a/crates/telio-dns/tests/nameserver.rs
+++ b/crates/telio-dns/tests/nameserver.rs
@@ -1385,6 +1385,40 @@ async fn dns_request_forward_to_stub_upstream() {
     assert_eq!(response.a_addrs(), vec![expected_ip]);
 }
 
+#[rstest]
+#[case::hickory(false)]
+#[case::raw(true)]
+#[tokio::test]
+async fn dns_request_onion_forwarded_to_stub_upstream(#[case] use_raw_forwarder: bool) {
+    let expected_ip = Ipv4Addr::new(10, 20, 30, 40);
+    let (stub_addr, _stub_handle) =
+        spawn_upstream_dns_stub(UpstreamStubBehavior::Reply(expected_ip)).await;
+
+    let nameserver = LocalNameServer::new(&[], use_raw_forwarder)
+        .await
+        .expect("Failed to create a LocalNameServer");
+    nameserver
+        .forward_to_addrs(&[stub_addr])
+        .await
+        .expect("Failed to set stub upstream");
+
+    let response = timeout(
+        TEST_TIMEOUT,
+        dns_test_with_server(
+            "example.onion",
+            DnsTestType::CorrectIpv4,
+            None,
+            nameserver,
+            TtlValue(60),
+        ),
+    )
+    .await
+    .expect("Test timeout")
+    .expect("Expected some DNS response");
+
+    assert_a_records!(response, vec![expected_ip]);
+}
+
 #[tokio::test]
 async fn dns_request_forward_fallback_to_second_stub() {
     let expected_ip = Ipv4Addr::new(10, 0, 0, 1);


### PR DESCRIPTION
Hickory treats onion queries as special case and drops them

### Problem
*--describe problem being solved--*

### Solution
*--describe selected solution--*
