### PR TITLE
[LLT-6785] Report DaemonIsNotRunning instead of raw IO errors

### DIFF
--- a/clis/nordvpnlite/src/main.rs
+++ b/clis/nordvpnlite/src/main.rs
@@ -3,6 +3,7 @@
 use clap::Parser;
 use daemonize::{Daemonize, Outcome};
 use std::fs::{self, OpenOptions};
+use std::io::{Error, ErrorKind};
 use tokio::time::{timeout, Duration};
 
 mod auth;
@@ -113,39 +114,37 @@ async fn client_main(cmd: Cmd) -> Result<(), NordVpnLiteError> {
     match cmd {
         Cmd::Client(cmd) => {
             let socket_path = DaemonSocket::get_ipc_socket_path()?;
-            if socket_path.exists() {
-                let response = timeout(
-                    Duration::from_secs(TIMEOUT_SEC),
-                    DaemonSocket::send_command(&socket_path, &serde_json::to_string(&cmd)?),
-                )
-                .await
-                .map_err(|_| NordVpnLiteError::ClientTimeoutError)?;
+            if !socket_path.exists() {
+                return handle_missing_daemon(cmd);
+            }
 
-                match CommandResponse::deserialize(&response?)? {
-                    CommandResponse::Ok => {
-                        println!("Command executed successfully");
-                        Ok(())
-                    }
-                    CommandResponse::StatusReport(status) => {
-                        println!("{}", serde_json::to_string_pretty(&status)?);
-                        Ok(())
-                    }
-                    CommandResponse::DaemonInitializing => {
-                        println!("Daemon is not ready, ignoring");
-                        Err(NordVpnLiteError::CommandFailed(cmd))
-                    }
-                    CommandResponse::Err(e) => {
-                        println!("Command executed failed: {e}");
-                        Err(NordVpnLiteError::CommandFailed(cmd))
-                    }
+            let response = timeout(
+                Duration::from_secs(TIMEOUT_SEC),
+                DaemonSocket::send_command(&socket_path, &serde_json::to_string(&cmd)?),
+            )
+            .await
+            .map_err(|_| NordVpnLiteError::ClientTimeoutError)?;
+
+            if response.as_ref().is_err_and(is_daemon_gone) {
+                return handle_missing_daemon(cmd);
+            }
+
+            match CommandResponse::deserialize(&response?)? {
+                CommandResponse::Ok => {
+                    println!("Command executed successfully");
+                    Ok(())
                 }
-            } else {
-                match cmd {
-                    ClientCmd::QuitDaemon => {
-                        println!("Daemon is already stopped");
-                        Ok(())
-                    }
-                    _ => Err(NordVpnLiteError::DaemonIsNotRunning),
+                CommandResponse::StatusReport(status) => {
+                    println!("{}", serde_json::to_string_pretty(&status)?);
+                    Ok(())
+                }
+                CommandResponse::DaemonInitializing => {
+                    println!("Daemon is not ready, ignoring");
+                    Err(NordVpnLiteError::CommandFailed(cmd))
+                }
+                CommandResponse::Err(e) => {
+                    println!("Command executed failed: {e}");
+                    Err(NordVpnLiteError::CommandFailed(cmd))
                 }
             }
         }
@@ -163,6 +162,31 @@ async fn client_main(cmd: Cmd) -> Result<(), NordVpnLiteError> {
 
         // Unexpected command, Cmd::Start should be handled by main
         _ => Err(NordVpnLiteError::InvalidCommand(format!("{cmd:?}"))),
+    }
+}
+
+/// Whether an IO error means nothing is listening on the socket anymore, either because
+/// the socket file is stale or because the daemon exited while the command was in flight.
+fn is_daemon_gone(err: &Error) -> bool {
+    matches!(
+        err.kind(),
+        ErrorKind::NotFound
+            | ErrorKind::ConnectionRefused
+            | ErrorKind::BrokenPipe
+            | ErrorKind::ConnectionReset
+            | ErrorKind::ConnectionAborted
+            | ErrorKind::UnexpectedEof
+    )
+}
+
+/// Report a client command that could not reach the daemon.
+fn handle_missing_daemon(cmd: ClientCmd) -> Result<(), NordVpnLiteError> {
+    match cmd {
+        ClientCmd::QuitDaemon => {
+            println!("Daemon is already stopped");
+            Ok(())
+        }
+        _ => Err(NordVpnLiteError::DaemonIsNotRunning),
     }
 }
 
@@ -310,6 +334,7 @@ mod tests {
     use assert_matches::assert_matches;
     use serial_test::serial;
     use temp_file::TempFile;
+    use tokio::net::UnixListener;
 
     /// Config JSON pointing its auth file at the given path.
     fn config_json(auth_file_path: &str) -> String {
@@ -347,6 +372,69 @@ mod tests {
                 Err(NordVpnLiteError::InvalidConfigToken { .. })
             );
         };
+    }
+
+    #[test]
+    fn test_daemon_gone_does_not_mask_other_errors() {
+        for kind in [
+            ErrorKind::NotFound,
+            ErrorKind::ConnectionRefused,
+            ErrorKind::BrokenPipe,
+            ErrorKind::ConnectionReset,
+            ErrorKind::ConnectionAborted,
+            ErrorKind::UnexpectedEof,
+        ] {
+            assert!(is_daemon_gone(&Error::from(kind)), "{kind:?}");
+        }
+
+        for kind in [
+            ErrorKind::PermissionDenied,
+            ErrorKind::InvalidData,
+            ErrorKind::TimedOut,
+        ] {
+            assert!(!is_daemon_gone(&Error::from(kind)), "{kind:?}");
+        }
+    }
+
+    #[test]
+    fn test_missing_daemon_reports_daemon_is_not_running() {
+        for cmd in [
+            ClientCmd::QuitDaemon,
+            ClientCmd::IsAlive,
+            ClientCmd::GetStatus,
+            ClientCmd::Reload,
+        ] {
+            // Matched exhaustively so that a new command has to pick a side here.
+            match cmd {
+                // Stopping an already stopped daemon is not an error, everything else is.
+                ClientCmd::QuitDaemon => assert_matches!(handle_missing_daemon(cmd), Ok(())),
+                ClientCmd::IsAlive | ClientCmd::GetStatus | ClientCmd::Reload => assert_matches!(
+                    handle_missing_daemon(cmd),
+                    Err(NordVpnLiteError::DaemonIsNotRunning)
+                ),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_stale_socket_file_reports_daemon_gone() {
+        let path = TempFile::new()
+            .expect("Failed to create temp socket file")
+            .path()
+            .with_extension("sock");
+
+        // Bind and drop a listener, leaving the socket file behind like a daemon that
+        // exited without cleaning up after itself. Unlike DaemonSocket, UnixListener
+        // does not reclaim the name on drop.
+        drop(UnixListener::bind(&path).expect("Failed to bind test socket"));
+        assert!(path.exists());
+
+        let err = DaemonSocket::send_command(&path, "\"IsAlive\"")
+            .await
+            .expect_err("connecting to a stale socket should fail");
+        assert!(is_daemon_gone(&err), "unexpected error: {err:?}");
+
+        let _ = fs::remove_file(&path);
     }
 
     #[test]

--- a/nat-lab/tests/nordvpnlite.py
+++ b/nat-lab/tests/nordvpnlite.py
@@ -27,7 +27,7 @@ from tests.utils.process import Process, ProcessExecError
 from tests.utils.router import IPStack
 from tests.utils.router.linux_router import LinuxRouter
 from tests.utils.testing import get_current_test_log_path
-from typing import AsyncIterator, Dict, List, Optional
+from typing import AsyncIterator, Awaitable, Callable, Dict, List, Optional
 
 
 class IgnoreableError(Exception):
@@ -210,6 +210,7 @@ class Config:
 class NordVpnLite:
     SOCKET_CHECK_INTERVAL_S = 0.5
     NORDVPNLITE_CMD_CHECK_INTERVAL_S = 10  # TODO (LLT-6693): revert back to 1
+    DAEMON_STOP_TIMEOUT_S = 10
 
     def __init__(
         self,
@@ -268,9 +269,6 @@ class NordVpnLite:
         self,
         cmd: list,
     ) -> tuple[str, str]:
-        # TODO(LLT-6785): remove the sleep
-        await asyncio.sleep(5)
-
         start_time = time.time()
         try:
             cmd = [str(self.config.paths.exec_path)] + cmd
@@ -413,16 +411,23 @@ class NordVpnLite:
 
     async def quit(self) -> None:
         stdout, stderr = await self.execute_command(["stop"])
+        daemon_already_stopped = "Daemon is already stopped" in stdout
         assert (
-            "Command executed successfully" in stdout
-            or "Daemon is already stopped" in stdout
+            "Command executed successfully" in stdout or daemon_already_stopped
         ), f"Failed to execute stop command: {stderr}"
 
-        assert (
-            not await self.is_alive()
+        if daemon_already_stopped:
+            if await self.socket_exists():
+                log.debug("Dangling socket found after stop no-op, removing it..")
+                await self.remove_socket()
+            return
+
+        # Daemon responds to stop before the process exits and the socket is removed
+        assert await self._wait_until_false(
+            self.is_alive, self.DAEMON_STOP_TIMEOUT_S
         ), "Quit command was sent successfully but daemon's still running"
-        assert (
-            not await self.socket_exists()
+        assert await self._wait_until_false(
+            self.socket_exists, self.DAEMON_STOP_TIMEOUT_S
         ), "Daemon's not running but socket still exists"
 
     async def kill(self) -> None:
@@ -436,12 +441,30 @@ class NordVpnLite:
                 await self.connection.create_process(
                     ["killall", "-w", "-s", "SIGTERM", "nordvpnlite"]
                 ).execute()
-            assert (
-                not await self.is_alive()
+            assert await self._wait_until_false(
+                self.is_alive, self.DAEMON_STOP_TIMEOUT_S
             ), "SIGTERM was sent but daemon's still running"
         except ProcessExecError as exc:
             if "nordvpnlite: no process found" not in exc.stderr:
                 raise
+
+    async def _wait_until_false(
+        self, check: Callable[[], Awaitable[bool]], timeout_s: float
+    ) -> bool:
+        """Poll `check` until it returns False, or until `timeout_s` elapses"""
+
+        async def poll() -> None:
+            while await check():
+                await asyncio.sleep(self.SOCKET_CHECK_INTERVAL_S)
+
+        task = asyncio.ensure_future(poll())
+        try:
+            await asyncio.wait_for(task, timeout_s)
+        except asyncio.TimeoutError:
+            if not task.cancelled():
+                raise
+            return False
+        return True
 
     async def remove_config(self, path: Path) -> None:
         await self.connection.create_process(["rm", "-f", str(path)]).execute()


### PR DESCRIPTION
### Problem
`nordvpnlite is-alive` issued right after `nordvpnlite stop` fails with a raw OS error instead of `DaemonIsNotRunning`:
`Error: Io(Os { code: 104, kind: ConnectionReset, message: "Connection reset by peer" })
`
Before sending a command, the CLI only checks that the daemon's socket file exists, and it reports `DaemonIsNotRunning` only when that check fails. 
The daemon answers stop before it exits and removes the socket file, so a command landing in that window passes the check, connects, gets reset, and the IO error is propagated as-is.

### Solution
Report IO errors that mean nothing is listening (refused, reset, aborted, broken pipe, EOF, not found) as `DaemonIsNotRunning`, same as a missing socket file.

In nat-lab: drop the sleep, return False from is_alive() instead of re-raising. Without the sleep, quit() and kill() now poll for the process to exit and the socket to disappear.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
