### PR TITLE
LLT-7637: natlab link detection test fails due to timeout

### DIFF
--- a/nat-lab/tests/utils/ping.py
+++ b/nat-lab/tests/utils/ping.py
@@ -64,6 +64,8 @@ class Ping:
                     "-t",
                     "-l",
                     str(size),
+                    "-w",
+                    "1000",
                     ip,
                 ],
                 quiet=True,


### PR DESCRIPTION
### Problem

By default on Windows, ping has its wait time for reply set to 4000ms (4s). For natlab test `test_event_link_state_peer_doesnt_respond`, on Windows, that ping is sent every ~5s which colludes with session_keeper's ICMPv6 keepalive messages sent every 5s.

If such collision happens then within wg's 1s polling window data is both sent and received. This in turn prevents `BytesAndTimestamps::first_tx_after_rx` to be set to `Some`. This variable is set to `Some` when within a polling window data is only sent and no data is received.

Test `test_event_link_state_peer_doesnt_respond` waits for `BytesAndTimestamps:: first_tx_after_rx` to be set to `Some`. If that doesn't happen in 300s, `Timeout` exception is thrown and the test crashes.

Fixes LLT-Fixes LLT-7637.

### Solution
Set ping wait for reply to 1s for Windows natlab tests.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
