### PR TITLE
Register nat-lab log collector before client start steps

### DIFF
--- a/nat-lab/tests/libtelio_client/client.py
+++ b/nat-lab/tests/libtelio_client/client.py
@@ -197,6 +197,8 @@ class Client:
             try:
                 await self._process.wait_stdin_ready()
 
+                LOG_COLLECTORS.append(LogCollector(self))
+
                 # There are two scenarios when it comes to what port is being used to connect to the Pyro5 remote.
                 # Scenario 1 - docker with mapped ports:
                 #   In this case we just use the mapped ports.
@@ -229,8 +231,6 @@ class Client:
                 async with asyncio_util.run_async_context(self._event_request_loop()):
                     if meshnet_config:
                         await self.set_meshnet_config(meshnet_config)
-                    log_collector = LogCollector(self)
-                    LOG_COLLECTORS.append(log_collector)
                     yield self
             finally:
                 await self.cleanup()


### PR DESCRIPTION
### Problem
A client that fails during startup leaves no telio, system event, or setupapi logs in the test artifacts — `LogCollector` is registered only after the adapter is up, so exactly the failures that need device-side logs collect none.

### Solution
Register the collector right after the remote process is ready, before the start steps. Log fetching already tolerates a missing log file, and `LOG_COLLECTORS` is cleared per test, so nothing double-collects.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
