### PR TITLE
deps(nat-lab): bump asyncssh to 2.23.1 (GHSA-2wxc-x7rj-hg8f)

### DIFF
--- a/nat-lab/pyproject.toml
+++ b/nat-lab/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "aiosignal==1.3.1",
     "astroid==3.2.2",
     "async-timeout==4.0.3",
-    "asyncssh==2.21.0",
+    "asyncssh==2.23.1",
     "attrs==24.2.0",
     "autoflake==2.3.1",
     "black==24.1.1",

--- a/nat-lab/uv.lock
+++ b/nat-lab/uv.lock
@@ -134,15 +134,15 @@ wheels = [
 
 [[package]]
 name = "asyncssh"
-version = "2.21.0"
+version = "2.23.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e8/d6/823ed5a227f7da70b33681e49eec4a36fae31b9296b27a8d6aead2bd3f77/asyncssh-2.21.0.tar.gz", hash = "sha256:450fe13bb8d86a8f4e7d7b5fafce7791181ca3e7c92e15bbc45dfb25866e48b3", size = 539740, upload-time = "2025-05-03T13:42:05.945Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/95/212d3d394f2a6ccb3f95056d3b9a7ce13c2f58503cbd6a38d037ef48cb13/asyncssh-2.23.1.tar.gz", hash = "sha256:d9dc3bc0206f3e4b5d80d1c0e6a24af2b4ad4beb556884c41fb2ad1c7ca3f44f", size = 542883, upload-time = "2026-06-07T14:15:18.832Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/99/56/db25216aa7f385ec71fdc489af80812171515cddbe68c0e515e98a291390/asyncssh-2.21.0-py3-none-any.whl", hash = "sha256:cf7f3dfa52b2cb4ad31f0d77ff0d0a8fdd850203da84a0e72e62c36fdd4daf4b", size = 374919, upload-time = "2025-05-03T13:42:04.539Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/94/9aa81bde40627af70388d634152e7c53e7533788e662b8093047501a1473/asyncssh-2.23.1-py3-none-any.whl", hash = "sha256:f68e55476d41253d785bcac9a90834ae5fdea0f417bd6d7182608bda248de88e", size = 376054, upload-time = "2026-06-07T14:15:17.375Z" },
 ]
 
 [[package]]
@@ -1018,7 +1018,7 @@ requires-dist = [
     { name = "aiosignal", specifier = "==1.3.1" },
     { name = "astroid", specifier = "==3.2.2" },
     { name = "async-timeout", specifier = "==4.0.3" },
-    { name = "asyncssh", specifier = "==2.21.0" },
+    { name = "asyncssh", specifier = "==2.23.1" },
     { name = "attrs", specifier = "==24.2.0" },
     { name = "autoflake", specifier = "==2.3.1" },
     { name = "black", specifier = "==24.1.1" },


### PR DESCRIPTION
Updates asyncssh in nat-lab to address GHSA-2wxc-x7rj-hg8f (CVE-2026-54591, SCP path traversal to arbitrary file write) and GHSA-qr67-gv47-xwwh (AuthorizedKeysFile %u directory escape).

Evidence:
- `nat-lab/pyproject.toml` pinned `asyncssh==2.21.0`
- `pip-audit` reported GHSA-2wxc-x7rj-hg8f for asyncssh 2.21.0
- updated version: 2.23.1

Validation:
- `pip-audit` reports no known vulnerabilities for asyncssh 2.23.1
- `uv lock --check` passes in nat-lab
- the full test suite (`uv run python3 run_local.py`) builds libtelio binaries and brings up a Docker-compose environment, which I could not run here; `uv run python3 -m pytest --collect-only` fails at the same `tests.uniffi.telio_bindings` import on both main and this branch, since the bindings are generated by the build step

Scope: nat-lab/pyproject.toml and nat-lab/uv.lock only.
