### PR TITLE
LLT-6820: Use neptun peer spans in telio

### DIFF
--- a/.unreleased/LLT-7521
+++ b/.unreleased/LLT-7521
@@ -1,0 +1,1 @@
+Fix NepTUN roaming on Apple platforms

--- a/.unreleased/LLT-7562
+++ b/.unreleased/LLT-7562
@@ -1,0 +1,1 @@
+Fix nonet after Apple device wake-up

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2745,7 +2745,7 @@ dependencies = [
 [[package]]
 name = "neptun"
 version = "2.2.3"
-source = "git+https://github.com/NordSecurity/neptun.git?tag=v3.0.1#a45a31d28780695cb816d5e245a70bd520bd1293"
+source = "git+https://github.com/NordSecurity/neptun.git?tag=v3.0.4#0aebe247729574acc449f9debd62fc8d419dbf07"
 dependencies = [
  "aead",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,7 +179,7 @@ windows = { version = "0.62.2", features = [
 ] }
 winreg = "0.56.0"
 
-neptun = { git = "https://github.com/NordSecurity/neptun.git", tag = "v3.0.1", features = [
+neptun = { git = "https://github.com/NordSecurity/neptun.git", tag = "v3.0.4", features = [
   "device",
 ] }
 x25519-dalek = { version = "2.0.1", features = [

--- a/crates/telio-core/src/logging.rs
+++ b/crates/telio-core/src/logging.rs
@@ -125,6 +125,20 @@ where
             write!(writer, "{tid:?} {module_path}:{line} ",)?;
         }
 
+        if let Some(scope) = ctx.event_scope() {
+            for span in scope.from_root() {
+                write!(writer, "{}", span.name())?;
+                let ext = span.extensions();
+                if let Some(fields) = ext.get::<fmt::FormattedFields<N>>() {
+                    if !fields.is_empty() {
+                        write!(writer, "{{{fields}}}")?;
+                    }
+                }
+                write!(writer, ":")?;
+            }
+            write!(writer, " ")?;
+        }
+
         ctx.format_fields(writer.by_ref(), event)?;
 
         writeln!(writer)

--- a/nat-lab/tests/test_connection_states.py
+++ b/nat-lab/tests/test_connection_states.py
@@ -89,5 +89,5 @@ async def test_connected_state_after_routing(
 
     # LLT-5532: To be cleaned up...
     client_beta.allow_errors([
-        "neptun::device.*Decapsulate error error=UnexpectedPacket public_key=.*",
+        "neptun::device.*Decapsulate error error=UnexpectedPacket",
     ])


### PR DESCRIPTION
### Problem
Neptun added spans with masked public keys, but they are not printed in telio logs yet.

### Solution
Bump neptun version to one with peer tracing spans and adds support for them in logs.


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
