### PR TITLE
Add perf test on android with libfirewall

### DIFF
--- a/nat-lab/bin/android/natlab-python
+++ b/nat-lab/bin/android/natlab-python
@@ -11,7 +11,7 @@ PREFIX=/data/data/com.termux/files/usr
 export PREFIX
 export HOME=/data/data/com.termux/files/home
 export PATH="$PREFIX/bin:/system/bin"
-export LD_LIBRARY_PATH="$PREFIX/lib"
+export LD_LIBRARY_PATH="$HOME/work:$PREFIX/lib"
 export LD_PRELOAD="$PREFIX/lib/libtermux-exec.so"
 export TMPDIR="$PREFIX/tmp"
 cd "$HOME/work"

--- a/nat-lab/performance_tests/conftest.py
+++ b/nat-lab/performance_tests/conftest.py
@@ -12,6 +12,7 @@ from tests.utils.connection import ConnectionTag, clear_ephemeral_setups_set
 from tests.utils.logger import log
 from tests.utils.router import IPStack
 from tests.utils.testing import get_current_test_log_path
+from tests.utils.vm import android_vm_util
 
 
 def _cancel_all_tasks(loop: asyncio.AbstractEventLoop):
@@ -154,6 +155,27 @@ async def collect_kernel_logs(items, suffix):
     os.makedirs(log_dir, exist_ok=True)
     save_dmesg_from_host(suffix)
     save_audit_log_from_host(suffix)
+
+
+def _skip_android_libfirewall_tests(items):
+    if os.path.exists(android_vm_util.LIBFIREWALL_SO):
+        return
+    for item in items:
+        if item.get_closest_marker("android") and item.get_closest_marker(
+            "libfirewall"
+        ):
+            item.add_marker(
+                pytest.mark.skip(
+                    reason=(
+                        "libfirewall not available at"
+                        f" {android_vm_util.LIBFIREWALL_SO}"
+                    )
+                )
+            )
+
+
+def pytest_collection_modifyitems(items):
+    _skip_android_libfirewall_tests(items)
 
 
 def pytest_runtestloop(session):

--- a/nat-lab/performance_tests/test_vpn_connection_performance.py
+++ b/nat-lab/performance_tests/test_vpn_connection_performance.py
@@ -249,6 +249,18 @@ async def collect_download_metrics(
             marks=pytest.mark.android,
             id="android_neptun",
         ),
+        pytest.param(
+            SetupParameters(
+                connection_tag=ConnectionTag.VM_ANDROID_1,
+                adapter_type_override=TelioAdapterType.NEP_TUN,
+                features=_features_with_firewall(),
+                is_meshnet=False,
+                run_tcpdump=False,
+                ip_stack=IPStack.IPv4,
+            ),
+            marks=[pytest.mark.android, pytest.mark.libfirewall],
+            id="android_neptun_enabled_libfirewall",
+        ),
     ],
 )
 async def test_vpn_connection_performance(setup_params: SetupParameters) -> None:

--- a/nat-lab/tests/utils/connection/adb_connection.py
+++ b/nat-lab/tests/utils/connection/adb_connection.py
@@ -28,7 +28,8 @@ TERMUX_PACKAGE = "com.termux"
 # exports in bin/android/natlab-python (the root/exec variant of the same env).
 _TERMUX_ENV = (
     f"export PREFIX={TERMUX_PREFIX} HOME={TERMUX_HOME} "
-    f'PATH="{TERMUX_PREFIX}/bin:$PATH" LD_LIBRARY_PATH={TERMUX_PREFIX}/lib '
+    f'PATH="{TERMUX_PREFIX}/bin:$PATH" '
+    f"LD_LIBRARY_PATH={TERMUX_HOME}/work:{TERMUX_PREFIX}/lib "
     f"LD_PRELOAD={TERMUX_PREFIX}/lib/libtermux-exec.so TMPDIR={TERMUX_PREFIX}/tmp; "
 )
 

--- a/nat-lab/tests/utils/vm/android_vm_util.py
+++ b/nat-lab/tests/utils/vm/android_vm_util.py
@@ -1,6 +1,7 @@
 import os
-from tests.config import ANDROID_DEVICE_TMP, UNIFFI_PATH_VM_ANDROID
+from tests.config import ANDROID_DEVICE_TMP, get_root_path, UNIFFI_PATH_VM_ANDROID
 from tests.utils.connection.adb_connection import AdbConnection
+from tests.utils.logger import log
 
 # Where the libtelio runtime files land on the guest (inside Termux).
 WORK_DIR = UNIFFI_PATH_VM_ANDROID.rstrip("/")
@@ -9,9 +10,9 @@ WORK_DIR = UNIFFI_PATH_VM_ANDROID.rstrip("/")
 # android-client-01 volumes), so the files are read straight from the mount and
 # `adb push`ed - no host->container copy, same as the other nat-lab containers.
 _MOUNT = "/libtelio"
-_DIST_ANDROID = (
-    f"{_MOUNT}/dist/android/{os.getenv('TELIO_BIN_PROFILE', 'release')}/x86_64"
-)
+_DIST_SUBPATH = f"dist/android/{os.getenv('TELIO_BIN_PROFILE', 'release')}/x86_64"
+_DIST_ANDROID = f"{_MOUNT}/{_DIST_SUBPATH}"
+LIBFIREWALL_SO = get_root_path(f"{_DIST_SUBPATH}/libfirewall.so")
 _UNIFFI = f"{_MOUNT}/nat-lab/tests/uniffi"
 _BIN = f"{_MOUNT}/nat-lab/bin/android"
 
@@ -33,6 +34,14 @@ async def copy_binaries(connection: AdbConnection) -> None:
         (f"{_UNIFFI}/libtelio_remote.py", "libtelio_remote.py"),
         (f"{_UNIFFI}/serialization.py", "serialization.py"),
     ]
+
+    if os.path.exists(LIBFIREWALL_SO):
+        runtime_files.append((f"{_DIST_ANDROID}/libfirewall.so", "libfirewall.so"))
+    else:
+        log.warning(
+            "libfirewall.so not found at %s, libfirewall tests will be skipped",
+            LIBFIREWALL_SO,
+        )
 
     for src, name in runtime_files:
         await connection.push_from_container(src, f"{ANDROID_DEVICE_TMP}{name}")


### PR DESCRIPTION
### Problem
Android platform is one of the main users of libfirewall. After enabling it android team started seeing some performance degradations but there was no proof it was caused by libfirewall. We want to make sure that performance isn't affected by enabled libfirewall

### Solution
Download libfirewall android artifact, upload to nat-lab android VM and measure performance with iperf


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
