### PR TITLE
LLT-7068: Adapter MTU API

### DIFF
--- a/.unreleased/LLT-7068
+++ b/.unreleased/LLT-7068
@@ -1,0 +1,1 @@
+Added the `mtu` start option and `set_adapter_mtu`, for setting the adapter interface MTU. Supported on Windows only.

--- a/README.md
+++ b/README.md
@@ -320,8 +320,11 @@ We need to provide an instance of the `DeviceConfig` structure:
 pub struct DeviceConfig {
     pub private_key: SecretKey,
     pub adapter: AdapterType,
+    pub fwmark: Option<u32>,
     pub name: Option<String>,
     pub tun: Option<Tun>,
+    pub ext_if_filter: Option<Vec<String>>,
+    pub mtu: Option<u32>,
 }
 ```
 
@@ -329,8 +332,12 @@ Let's discuss its fields shortly:
 
 - `private_key` a `telio::crypto::SecretKey` instance containing a 256-bit key,
 - `adapter` indicating which Wireguard implementation we want to use,
+- `fwmark` the firewall mark to set on the sockets opened by Telio, Linux only,
 - `name` is the name of the network interface, when omitted, Telio uses the default one,
-- `tun` a file descriptor of the already opened tunnel, if it's not provided Telio will open a new one.
+- `tun` a file descriptor of the already opened tunnel, if it's not provided Telio will open a new one,
+- `ext_if_filter` names of the interfaces to skip while looking for the default interface,
+- `mtu` the MTU of the adapter interface, Windows native adapter only. It can also be
+  changed on a running device with `Device::set_adapter_mtu`.
 
 The API provides a default config which is almost sufficient for simple cases,
 the only need that needs to be done is the generation of a private key:

--- a/crates/telio-core/src/device.rs
+++ b/crates/telio-core/src/device.rs
@@ -723,8 +723,8 @@ impl Device {
         })
     }
 
-    /// Configure the MTU of the adapter interface.
-    pub fn set_adapter_mtu(&self, mtu: u32) -> Result {
+    /// Configure the MTU of the adapter interface, `None` restores the adapter's own handling.
+    pub fn set_adapter_mtu(&self, mtu: Option<u32>) -> Result {
         self.async_runtime()?.block_on(async {
             task_exec!(self.rt()?, async move |rt| {
                 Ok(rt.set_adapter_mtu(mtu).boxed().await)
@@ -1766,7 +1766,7 @@ impl Runtime {
         Ok(())
     }
 
-    async fn set_adapter_mtu(&mut self, mtu: u32) -> Result {
+    async fn set_adapter_mtu(&mut self, mtu: Option<u32>) -> Result {
         Ok(self
             .entities
             .wireguard_interface

--- a/crates/telio-core/src/device.rs
+++ b/crates/telio-core/src/device.rs
@@ -228,6 +228,7 @@ pub struct DeviceConfig {
     pub name: Option<String>,
     pub tun: Option<Tun>,
     pub ext_if_filter: Option<Vec<String>>,
+    pub mtu: Option<u32>,
 }
 
 pub struct Device {
@@ -717,6 +718,16 @@ impl Device {
         self.async_runtime()?.block_on(async {
             task_exec!(self.rt()?, async move |rt| {
                 Ok(rt.set_ext_if_filter(ext_if_filter).boxed().await)
+            })
+            .await?
+        })
+    }
+
+    /// Configure the MTU of the adapter interface.
+    pub fn set_adapter_mtu(&self, mtu: u32) -> Result {
+        self.async_runtime()?.block_on(async {
+            task_exec!(self.rt()?, async move |rt| {
+                Ok(rt.set_adapter_mtu(mtu).boxed().await)
             })
             .await?
         })
@@ -1267,6 +1278,7 @@ impl Runtime {
                         firewall_process_outbound_callback,
                         firewall_reset_connections,
                         enable_dynamic_wg_nt_control,
+                        mtu: config.mtu,
                         skt_buffer_size : Runtime::sanitize_neptun_config(features.wireguard.skt_buffer_size, config.adapter.clone()),
                         inter_thread_channel_size : Runtime::sanitize_neptun_config(features.wireguard.inter_thread_channel_size, config.adapter.clone()),
                         max_inter_thread_batched_pkts : Runtime::sanitize_neptun_config(features.wireguard.max_inter_thread_batched_pkts, config.adapter.clone()),
@@ -1292,6 +1304,7 @@ impl Runtime {
                             firewall_process_outbound_callback,
                             firewall_reset_connections,
                             enable_dynamic_wg_nt_control,
+                            mtu: config.mtu,
                             skt_buffer_size: features.wireguard.skt_buffer_size,
                             inter_thread_channel_size: features.wireguard.inter_thread_channel_size,
                             max_inter_thread_batched_pkts: features.wireguard.max_inter_thread_batched_pkts,
@@ -1751,6 +1764,14 @@ impl Runtime {
         self.entities.socket_pool.set_ext_if_filter(&ext_if_filter);
 
         Ok(())
+    }
+
+    async fn set_adapter_mtu(&mut self, mtu: u32) -> Result {
+        Ok(self
+            .entities
+            .wireguard_interface
+            .set_adapter_mtu(mtu)
+            .await?)
     }
 
     async fn set_private_key(&mut self, private_key: &SecretKey) -> Result {

--- a/crates/telio-traversal/src/endpoint_providers/stun.rs
+++ b/crates/telio-traversal/src/endpoint_providers/stun.rs
@@ -1027,7 +1027,6 @@ mod stun_msg {
 mod tests {
     use super::*;
     use maplit::hashmap;
-    use mockall::mock;
     use std::{
         cell::RefCell,
         net::{Ipv4Addr, Ipv6Addr, SocketAddr},
@@ -1042,16 +1041,15 @@ mod tests {
         PublicKey, SecretKey,
         encryption::{decrypt_request, decrypt_response, encrypt_request, encrypt_response},
     };
-    use telio_model::mesh::{IpNet, LinkState};
+    use telio_model::mesh::IpNet;
     use telio_proto::{CodecError, PacketRelayed, PartialPongerMsg, PingerMsg};
     use telio_sockets::NativeProtector;
     use telio_sockets::SocketPool;
     use telio_task::io::Chan;
     use telio_test::await_timeout;
     use telio_utils::exponential_backoff::MockBackoff;
-    use telio_utils::ip_stack::IpStack;
     use telio_wg::{
-        Error,
+        MockWireGuard,
         uapi::{Interface, Peer},
     };
     use tokio::{
@@ -1758,7 +1756,7 @@ mod tests {
 
     #[tokio::test(start_paused = true)]
     async fn exponential_backoff_is_applied_even_if_session_start_failed() {
-        let mut wg = MockWg::new();
+        let mut wg = MockWireGuard::new();
 
         // Expect a single call to get_interface when we enter the loop first and
         // and a second in the finished backoff
@@ -1800,7 +1798,7 @@ mod tests {
 
     #[tokio::test(start_paused = true)]
     async fn wait_with_session_start_until_stun_server_wg_peer_is_available() {
-        let mut wg = MockWg::default();
+        let mut wg = MockWireGuard::default();
         let wg_port = 12345;
 
         let peer_sock_v4 = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0))
@@ -1938,27 +1936,6 @@ mod tests {
 
     // Test helpers
 
-    mock! {
-        Wg {}
-        #[async_trait]
-        impl WireGuard for Wg {
-            async fn get_interface(&self) -> Result<Interface, Error>;
-            async fn get_adapter_luid(&self) -> Result<u64, Error>;
-            async fn wait_for_listen_port(&self, d: Duration) -> Result<u16, Error>;
-            async fn get_link_state(&self, key: PublicKey) -> Result<Option<LinkState>, Error>;
-            async fn set_secret_key(&self, key: SecretKey) -> Result<(), Error>;
-            async fn set_fwmark(&self, fwmark: u32) -> Result<(), Error>;
-            async fn add_peer(&self, peer: Peer) -> Result<(), Error>;
-            async fn del_peer(&self, key: PublicKey) -> Result<(), Error>;
-            async fn drop_connected_sockets(&self) -> Result<(), Error>;
-            async fn time_since_last_rx(&self, public_key: PublicKey) -> Result<Option<Duration>, Error>;
-            async fn stop(self);
-            async fn reset_existing_connections(&self, exit_pubkey: PublicKey) -> Result<(), Error>;
-            async fn set_ip_stack(&self, ip_stack: Option<IpStack>) -> Result<(), Error>;
-            async fn set_adapter_mtu(&self, mtu: u32) -> Result<(), Error>;
-        }
-    }
-
     struct StunPeerSockets {
         /// This socket represent a socket that is listening in remote peer.
         /// We will not fake entire tunnel, as it correct behavior would basically
@@ -1976,7 +1953,7 @@ mod tests {
         socket_pool: Arc<SocketPool>,
 
         // Tested system
-        stun_provider: StunEndpointProvider<MockWg, MockBackoff>,
+        stun_provider: StunEndpointProvider<MockWireGuard, MockBackoff>,
         ipv6: bool,
 
         // External behavior
@@ -2000,7 +1977,7 @@ mod tests {
         server_weights: Vec<u32>,
         ipv6: bool,
     ) -> Env {
-        let mut wg = MockWg::default();
+        let mut wg = MockWireGuard::default();
         let wg_port = 12345;
 
         let mut stun_servers = Vec::<Server>::new();
@@ -2102,7 +2079,7 @@ mod tests {
         backoff_array: Option<[u64; 6]>,
         stun_servers: Vec<Server>,
         stun_peers: Vec<StunPeerSockets>,
-        wg: MockWg,
+        wg: MockWireGuard,
         ipv6: bool,
     ) -> Env {
         let socket_pool = SocketPool::new(

--- a/crates/telio-traversal/src/endpoint_providers/stun.rs
+++ b/crates/telio-traversal/src/endpoint_providers/stun.rs
@@ -1955,6 +1955,7 @@ mod tests {
             async fn stop(self);
             async fn reset_existing_connections(&self, exit_pubkey: PublicKey) -> Result<(), Error>;
             async fn set_ip_stack(&self, ip_stack: Option<IpStack>) -> Result<(), Error>;
+            async fn set_adapter_mtu(&self, mtu: u32) -> Result<(), Error>;
         }
     }
 

--- a/crates/telio-traversal/src/endpoint_providers/upnp.rs
+++ b/crates/telio-traversal/src/endpoint_providers/upnp.rs
@@ -869,6 +869,7 @@ mod tests {
             async fn stop(self);
             async fn reset_existing_connections(&self, exit_pubkey: PublicKey) -> Result1<()>;
             async fn set_ip_stack(&self, ip_stack: Option<IpStack>) -> Result1<()>;
+            async fn set_adapter_mtu(&self, mtu: u32) -> Result1<()>;
         }
     }
 

--- a/crates/telio-traversal/src/endpoint_providers/upnp.rs
+++ b/crates/telio-traversal/src/endpoint_providers/upnp.rs
@@ -818,7 +818,6 @@ impl<Wg: WireGuard, I: UpnpEpCommands, E: Backoff> Runtime for State<Wg, I, E> {
 mod tests {
     use super::{
         EPHEMERAL_PORT_RANGE, EndpointCandidate, MockUpnpEpCommands, UpnpEndpointProvider,
-        async_trait,
     };
 
     use std::{
@@ -832,46 +831,21 @@ mod tests {
     use crate::endpoint_providers::Error;
     use crate::ping_pong_handler::PingPongHandler;
     use lazy_static::lazy_static;
-    use mockall::mock;
     use parking_lot::Mutex;
     use serial_test::serial;
     use telio_crypto::PublicKey;
     use telio_crypto::SecretKey;
-    use telio_model::mesh::LinkState;
     use telio_sockets::{NativeProtector, SocketPool};
     use telio_utils::exponential_backoff::{
         ExponentialBackoff, ExponentialBackoffBounds, MockBackoff,
     };
-    use telio_utils::ip_stack::IpStack;
     use telio_wg::{
-        Error as wgError, WireGuard,
+        MockWireGuard,
         uapi::{Interface, Peer},
     };
     use tokio::sync::Mutex as TMutex;
 
     type Result<T> = std::result::Result<T, Error>;
-    type Result1<T> = std::result::Result<T, wgError>;
-
-    mock! {
-        pub Wg {}
-        #[async_trait]
-        impl WireGuard for Wg {
-            async fn get_interface(&self) -> Result1<Interface,>;
-            async fn get_adapter_luid(&self) -> Result1<u64>;
-            async fn wait_for_listen_port(&self, d: Duration) -> Result1<u16>;
-            async fn get_link_state(&self, key: PublicKey) -> Result1<Option<LinkState>>;
-            async fn set_secret_key(&self, key: SecretKey) -> Result1<()>;
-            async fn set_fwmark(&self, fwmark: u32) -> Result1<()>;
-            async fn add_peer(&self, peer: Peer) -> Result1<()>;
-            async fn del_peer(&self, key: PublicKey) -> Result1<()>;
-            async fn drop_connected_sockets(&self) -> Result1<()>;
-            async fn time_since_last_rx(&self, public_key: PublicKey) -> Result1<Option<Duration>>;
-            async fn stop(self);
-            async fn reset_existing_connections(&self, exit_pubkey: PublicKey) -> Result1<()>;
-            async fn set_ip_stack(&self, ip_stack: Option<IpStack>) -> Result1<()>;
-            async fn set_adapter_mtu(&self, mtu: u32) -> Result1<()>;
-        }
-    }
 
     lazy_static! {
         static ref IGD_IS_AVAILABLE: Arc<Mutex<bool>> = Arc::new(Mutex::new(false));
@@ -922,7 +896,7 @@ mod tests {
 
     pub async fn prepare_test_setup(
         is_battery_optimization_on: bool,
-    ) -> UpnpEndpointProvider<MockWg, MockUpnpEpCommands, MockBackoff> {
+    ) -> UpnpEndpointProvider<MockWireGuard, MockUpnpEpCommands, MockBackoff> {
         let spool = SocketPool::new(
             NativeProtector::new(
                 #[cfg(target_os = "macos")]
@@ -954,7 +928,7 @@ mod tests {
         epc.udp.set_port(2000);
 
         // These are not properly used yet, just dummy variables
-        let mut wg = MockWg::default();
+        let mut wg = MockWireGuard::default();
         let wg_port = 55345;
         let wg_peers = Vec::<(PublicKey, Peer)>::new();
         let backoff_array = [100, 200, 400, 800, 1600, 3200];
@@ -1108,7 +1082,7 @@ mod tests {
         }
 
         // These are not properly used yet, just dummy variables
-        let mut wg = MockWg::default();
+        let mut wg = MockWireGuard::default();
         let wg_port = 55345;
 
         wg.expect_get_interface().returning(move || {

--- a/crates/telio-wg/src/adapter.rs
+++ b/crates/telio-wg/src/adapter.rs
@@ -92,8 +92,8 @@ pub trait Adapter: Send + Sync {
     /// Set the (u)tun file descriptor to be used by the adapter
     async fn set_tun(&self, tun: Tun) -> Result<(), Error>;
 
-    /// Set the MTU of the adapter interface
-    async fn set_adapter_mtu(&self, _mtu: u32) -> Result<(), Error> {
+    /// Set the MTU of the adapter interface, `None` restores the adapter's own handling
+    async fn set_adapter_mtu(&self, _mtu: Option<u32>) -> Result<(), Error> {
         Err(Error::UnsupportedAdapter)
     }
 

--- a/crates/telio-wg/src/adapter.rs
+++ b/crates/telio-wg/src/adapter.rs
@@ -112,6 +112,9 @@ pub trait Adapter: Send + Sync {
     }
 }
 
+/// IPv6 minimum link MTU, the interface MTU applies to both address families
+pub const MIN_MTU: u32 = 1280;
+
 /// Enumeration of `Error` types for `Adapter` struct
 #[derive(Debug, TError)]
 pub enum Error {
@@ -135,6 +138,10 @@ pub enum Error {
     /// Unsupported adapter
     #[error("Unsupported adapter")]
     UnsupportedAdapter,
+
+    /// MTU below the minimum any adapter accepts
+    #[error("MTU must be at least {min}, got {0}", min = MIN_MTU)]
+    MtuTooLow(u32),
 
     /// Unsupported on Windows adapter
     #[error("Mismatched windows adapter")]

--- a/crates/telio-wg/src/adapter.rs
+++ b/crates/telio-wg/src/adapter.rs
@@ -92,6 +92,11 @@ pub trait Adapter: Send + Sync {
     /// Set the (u)tun file descriptor to be used by the adapter
     async fn set_tun(&self, tun: Tun) -> Result<(), Error>;
 
+    /// Set the MTU of the adapter interface
+    async fn set_adapter_mtu(&self, _mtu: u32) -> Result<(), Error> {
+        Err(Error::UnsupportedAdapter)
+    }
+
     /// Make a copy of this adapter.
     ///
     /// Only the custom adapters can be cloned this way.

--- a/crates/telio-wg/src/adapter.rs
+++ b/crates/telio-wg/src/adapter.rs
@@ -304,8 +304,12 @@ pub(crate) async fn start(cfg: Config) -> Result<Box<dyn Adapter>, Error> {
 
             #[cfg(windows)]
             Ok(Box::new(
-                windows_native_wg::WindowsNativeWg::start(&name, cfg.enable_dynamic_wg_nt_control)
-                    .await?,
+                windows_native_wg::WindowsNativeWg::start(
+                    &name,
+                    cfg.enable_dynamic_wg_nt_control,
+                    cfg.mtu,
+                )
+                .await?,
             ))
         }
         AdapterType::Custom(adapter) => adapter.clone_box().ok_or(Error::UnsupportedAdapter),

--- a/crates/telio-wg/src/adapter/windows_native_wg.rs
+++ b/crates/telio-wg/src/adapter/windows_native_wg.rs
@@ -1,7 +1,10 @@
 use super::{Adapter, Error as AdapterError, IsMeshnetEnabledCb, Tun as NativeTun};
 use crate::{
     uapi::{Cmd, Cmd::Get, Cmd::Set, Interface, Peer, Response},
-    windows::{service, tunnel::interfacewatcher::InterfaceWatcher},
+    windows::{
+        service,
+        tunnel::{interfacewatcher::InterfaceWatcher, mtumonitor::set_interface_mtu},
+    },
 };
 use async_trait::async_trait;
 use sha2::{Digest, Sha256};
@@ -30,6 +33,7 @@ use tokio::sync::Notify;
 use tokio::time::{sleep, timeout};
 use utf16_lit::utf16_null;
 use uuid::Uuid;
+use winapi::shared::ws2def::{ADDRESS_FAMILY, AF_INET, AF_INET6};
 use windows::core::GUID;
 use windows::core::PCWSTR;
 use windows::Win32::Devices::DeviceAndDriverInstallation::GUID_DEVCLASS_NET;
@@ -51,6 +55,8 @@ use wireguard_nt::{
 use wireguard_uapi::xplatform;
 
 const REMOVAL_SLEEP_SECS: u64 = 2;
+// IPv6 minimum link MTU, the interface MTU applies to both address families
+const MIN_MTU: u32 = 1280;
 const SET_STATE_MAX_ATTEMPTS: usize = 10;
 const SET_STATE_INITIAL_BACKOFF: Duration = Duration::from_millis(200);
 const SET_STATE_MAX_BACKOFF: Duration = Duration::from_secs(2);
@@ -455,6 +461,7 @@ impl WindowsNativeWg {
     pub async fn start(
         name: &str,
         enable_dynamic_wg_nt_control: IsMeshnetEnabledCb,
+        mtu: Option<u32>,
     ) -> std::result::Result<Self, AdapterError> {
         const SWD_WIREGUARD: &str = r"SYSTEM\CurrentControlSet\Enum\SWD\WireGuard";
         telio_log_debug!("Print registry before adapter creation!");
@@ -511,6 +518,10 @@ impl WindowsNativeWg {
             return Err(AdapterError::WindowsNativeWg(Error::Fail(
                 "Adapter interface not ready".to_string(),
             )));
+        }
+
+        if let Some(mtu) = mtu {
+            wg_dev.set_adapter_mtu_inner(mtu)?;
         }
 
         if wg_dev.enable_dynamic_wg_nt_control.is_none() {
@@ -699,6 +710,48 @@ impl WindowsNativeWg {
             }
         }
     }
+
+    fn set_adapter_mtu_inner(&self, mtu: u32) -> std::result::Result<(), AdapterError> {
+        if mtu < MIN_MTU {
+            return Err(AdapterError::WindowsNativeWg(Error::Fail(format!(
+                "MTU must be at least {MIN_MTU}, got {mtu}",
+            ))));
+        }
+
+        // Stop the MTU monitors first, so they cannot overwrite the value set below
+        if let Ok(mut interface_watcher) = self.watcher.clone().lock() {
+            interface_watcher.set_forced_mtu(mtu);
+        } else {
+            return Err(AdapterError::WindowsNativeWg(Error::Fail(
+                "error obtaining lock".into(),
+            )));
+        }
+
+        // An address family whose interface is not up yet gets the MTU from the
+        // interface watcher once it appears, so fail only when both fail
+        let mut failed = false;
+        for family in [AF_INET as ADDRESS_FAMILY, AF_INET6 as ADDRESS_FAMILY] {
+            match set_interface_mtu(self.luid, family, mtu) {
+                Ok(()) => telio_log_info!("Set adapter MTU {} for family {}", mtu, family),
+                Err(err) => {
+                    telio_log_warn!(
+                        "Failed to set adapter MTU {} for family {}: {}",
+                        mtu,
+                        family,
+                        err
+                    );
+                    if failed {
+                        return Err(AdapterError::WindowsNativeWg(Error::Fail(format!(
+                            "Failed to set adapter MTU {mtu}, last error: {err}",
+                        ))));
+                    }
+                    failed = true;
+                }
+            }
+        }
+
+        Ok(())
+    }
 }
 
 #[async_trait::async_trait]
@@ -767,6 +820,10 @@ impl Adapter for WindowsNativeWg {
 
     async fn set_tun(&self, _tun: super::Tun) -> std::result::Result<(), AdapterError> {
         Err(AdapterError::UnsupportedAdapter)
+    }
+
+    async fn set_adapter_mtu(&self, mtu: u32) -> std::result::Result<(), AdapterError> {
+        self.set_adapter_mtu_inner(mtu)
     }
 
     fn clone_box(&self) -> Option<Box<dyn Adapter>> {

--- a/crates/telio-wg/src/adapter/windows_native_wg.rs
+++ b/crates/telio-wg/src/adapter/windows_native_wg.rs
@@ -518,7 +518,7 @@ impl WindowsNativeWg {
             )));
         }
 
-        if let Some(mtu) = mtu {
+        if mtu.is_some() {
             wg_dev.set_adapter_mtu_inner(mtu)?;
         }
 
@@ -709,8 +709,9 @@ impl WindowsNativeWg {
         }
     }
 
-    fn set_adapter_mtu_inner(&self, mtu: u32) -> std::result::Result<(), AdapterError> {
-        // Stop the MTU monitors first, so they cannot overwrite the value set below
+    fn set_adapter_mtu_inner(&self, mtu: Option<u32>) -> std::result::Result<(), AdapterError> {
+        // The watcher stops the MTU monitors first, so they cannot overwrite the
+        // value set below, or restarts them when the forced MTU is cleared
         if let Ok(mut interface_watcher) = self.watcher.clone().lock() {
             interface_watcher.set_forced_mtu(mtu);
         } else {
@@ -718,6 +719,9 @@ impl WindowsNativeWg {
                 "error obtaining lock".into(),
             )));
         }
+        let Some(mtu) = mtu else {
+            return Ok(());
+        };
 
         // An address family whose interface is not up yet gets the MTU from the
         // interface watcher once it appears, so fail only when both fail
@@ -814,7 +818,7 @@ impl Adapter for WindowsNativeWg {
         Err(AdapterError::UnsupportedAdapter)
     }
 
-    async fn set_adapter_mtu(&self, mtu: u32) -> std::result::Result<(), AdapterError> {
+    async fn set_adapter_mtu(&self, mtu: Option<u32>) -> std::result::Result<(), AdapterError> {
         self.set_adapter_mtu_inner(mtu)
     }
 

--- a/crates/telio-wg/src/adapter/windows_native_wg.rs
+++ b/crates/telio-wg/src/adapter/windows_native_wg.rs
@@ -55,8 +55,6 @@ use wireguard_nt::{
 use wireguard_uapi::xplatform;
 
 const REMOVAL_SLEEP_SECS: u64 = 2;
-// IPv6 minimum link MTU, the interface MTU applies to both address families
-const MIN_MTU: u32 = 1280;
 const SET_STATE_MAX_ATTEMPTS: usize = 10;
 const SET_STATE_INITIAL_BACKOFF: Duration = Duration::from_millis(200);
 const SET_STATE_MAX_BACKOFF: Duration = Duration::from_secs(2);
@@ -712,12 +710,6 @@ impl WindowsNativeWg {
     }
 
     fn set_adapter_mtu_inner(&self, mtu: u32) -> std::result::Result<(), AdapterError> {
-        if mtu < MIN_MTU {
-            return Err(AdapterError::WindowsNativeWg(Error::Fail(format!(
-                "MTU must be at least {MIN_MTU}, got {mtu}",
-            ))));
-        }
-
         // Stop the MTU monitors first, so they cannot overwrite the value set below
         if let Ok(mut interface_watcher) = self.watcher.clone().lock() {
             interface_watcher.set_forced_mtu(mtu);

--- a/crates/telio-wg/src/wg.rs
+++ b/crates/telio-wg/src/wg.rs
@@ -1161,6 +1161,10 @@ pub mod tests {
             Err(Error::UnsupportedAdapter)
         }
 
+        async fn set_adapter_mtu(&self, mtu: u32) -> Result<(), AdapterError> {
+            self.lock().await.set_adapter_mtu(mtu).await
+        }
+
         fn clone_box(&self) -> Option<Box<dyn Adapter>> {
             None
         }

--- a/crates/telio-wg/src/wg.rs
+++ b/crates/telio-wg/src/wg.rs
@@ -77,8 +77,8 @@ pub trait WireGuard: Send + Sync + 'static {
     async fn reset_existing_connections(&self, exit_pubkey: PublicKey) -> Result<(), Error>;
     /// Set the ip stack for the adapter
     async fn set_ip_stack(&self, ip_stack: Option<IpStack>) -> Result<(), Error>;
-    /// Set the MTU of the adapter interface
-    async fn set_adapter_mtu(&self, mtu: u32) -> Result<(), Error>;
+    /// Set the MTU of the adapter interface, `None` restores the adapter's own handling
+    async fn set_adapter_mtu(&self, mtu: Option<u32>) -> Result<(), Error>;
     /// Ensure that adapter is UP or DOWN
     async fn ensure_expected_adapter_state(
         &self,
@@ -490,8 +490,10 @@ impl WireGuard for DynamicWg {
         .await?)
     }
 
-    async fn set_adapter_mtu(&self, mtu: u32) -> Result<(), Error> {
-        check_mtu(mtu)?;
+    async fn set_adapter_mtu(&self, mtu: Option<u32>) -> Result<(), Error> {
+        if let Some(mtu) = mtu {
+            check_mtu(mtu)?;
+        }
         task_exec!(&self.task, async move |s| Ok(s
             .adapter
             .set_adapter_mtu(mtu)
@@ -1173,7 +1175,7 @@ pub mod tests {
             Err(Error::UnsupportedAdapter)
         }
 
-        async fn set_adapter_mtu(&self, mtu: u32) -> Result<(), AdapterError> {
+        async fn set_adapter_mtu(&self, mtu: Option<u32>) -> Result<(), AdapterError> {
             self.lock().await.set_adapter_mtu(mtu).await
         }
 
@@ -1381,10 +1383,20 @@ pub mod tests {
             .lock()
             .await
             .expect_set_adapter_mtu()
-            .with(predicate::eq(1400))
+            .with(predicate::eq(Some(1400)))
             .times(1)
             .returning(|_| Ok(()));
-        wg.set_adapter_mtu(1400).await.unwrap();
+        wg.set_adapter_mtu(Some(1400)).await.unwrap();
+        adapter.lock().await.checkpoint();
+
+        adapter
+            .lock()
+            .await
+            .expect_set_adapter_mtu()
+            .with(predicate::eq(None))
+            .times(1)
+            .returning(|_| Ok(()));
+        wg.set_adapter_mtu(None).await.unwrap();
         adapter.lock().await.checkpoint();
 
         adapter.lock().await.expect_stop().return_once(|| ());
@@ -1396,7 +1408,7 @@ pub mod tests {
         let Env { adapter, wg, .. } = setup().await;
 
         assert!(matches!(
-            wg.set_adapter_mtu(adapter::MIN_MTU - 1).await,
+            wg.set_adapter_mtu(Some(adapter::MIN_MTU - 1)).await,
             Err(Error::MtuTooLow(_))
         ));
 
@@ -1438,7 +1450,7 @@ pub mod tests {
             .times(1)
             .returning(|_| Err(AdapterError::UnsupportedAdapter));
         assert!(matches!(
-            wg.set_adapter_mtu(1400).await,
+            wg.set_adapter_mtu(Some(1400)).await,
             Err(Error::UnsupportedAdapter)
         ));
 

--- a/crates/telio-wg/src/wg.rs
+++ b/crates/telio-wg/src/wg.rs
@@ -480,7 +480,11 @@ impl WireGuard for DynamicWg {
     }
 
     async fn set_adapter_mtu(&self, mtu: u32) -> Result<(), Error> {
-        task_exec!(&self.task, async move |s| Ok(s.adapter.set_adapter_mtu(mtu).await)).await??;
+        task_exec!(&self.task, async move |s| Ok(s
+            .adapter
+            .set_adapter_mtu(mtu)
+            .await))
+        .await??;
         Ok(())
     }
 

--- a/crates/telio-wg/src/wg.rs
+++ b/crates/telio-wg/src/wg.rs
@@ -1362,6 +1362,43 @@ pub mod tests {
     }
 
     #[tokio::test(start_paused = true)]
+    async fn wg_sets_adapter_mtu() {
+        let Env { adapter, wg, .. } = setup().await;
+
+        adapter
+            .lock()
+            .await
+            .expect_set_adapter_mtu()
+            .with(predicate::eq(1400))
+            .times(1)
+            .returning(|_| Ok(()));
+        wg.set_adapter_mtu(1400).await.unwrap();
+        adapter.lock().await.checkpoint();
+
+        adapter.lock().await.expect_stop().return_once(|| ());
+        wg.stop().await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn wg_set_adapter_mtu_propagates_adapter_error() {
+        let Env { adapter, wg, .. } = setup().await;
+
+        adapter
+            .lock()
+            .await
+            .expect_set_adapter_mtu()
+            .times(1)
+            .returning(|_| Err(AdapterError::UnsupportedAdapter));
+        assert!(matches!(
+            wg.set_adapter_mtu(1400).await,
+            Err(Error::UnsupportedAdapter)
+        ));
+
+        adapter.lock().await.expect_stop().return_once(|| ());
+        wg.stop().await;
+    }
+
+    #[tokio::test(start_paused = true)]
     async fn wg_adds_peer() {
         let Env {
             adapter,

--- a/crates/telio-wg/src/wg.rs
+++ b/crates/telio-wg/src/wg.rs
@@ -77,6 +77,8 @@ pub trait WireGuard: Send + Sync + 'static {
     async fn reset_existing_connections(&self, exit_pubkey: PublicKey) -> Result<(), Error>;
     /// Set the ip stack for the adapter
     async fn set_ip_stack(&self, ip_stack: Option<IpStack>) -> Result<(), Error>;
+    /// Set the MTU of the adapter interface
+    async fn set_adapter_mtu(&self, mtu: u32) -> Result<(), Error>;
     /// Ensure that adapter is UP or DOWN
     async fn ensure_expected_adapter_state(
         &self,
@@ -113,6 +115,8 @@ pub struct Config {
     /// When present, the callback is consulted by the Windows native adapter
     /// to determine whether meshnet is currently enabled.
     pub enable_dynamic_wg_nt_control: IsMeshnetEnabledCb,
+    /// MTU to set on the adapter interface, if None the adapter picks its own
+    pub mtu: Option<u32>,
     /// Configurable socket buffer size, if None doesn't modify default OS set values
     pub skt_buffer_size: Option<u32>,
     /// Configurable socket buffer size, if None doesn't modify default OS set values
@@ -235,6 +239,7 @@ impl DynamicWg {
     ///                 Some(Arc::new(firewall_filter_outbound_packets)),
     ///             firewall_reset_connections: None,
     ///             enable_dynamic_wg_nt_control: None,
+    ///             mtu: None,
     ///             skt_buffer_size: None,
     ///             inter_thread_channel_size: None,
     ///             max_inter_thread_batched_pkts: None,
@@ -474,6 +479,11 @@ impl WireGuard for DynamicWg {
         .await?)
     }
 
+    async fn set_adapter_mtu(&self, mtu: u32) -> Result<(), Error> {
+        task_exec!(&self.task, async move |s| Ok(s.adapter.set_adapter_mtu(mtu).await)).await??;
+        Ok(())
+    }
+
     /// Ensure that adapter is UP or DOWN
     async fn ensure_expected_adapter_state(
         &self,
@@ -510,6 +520,7 @@ impl Config {
             firewall_process_outbound_callback: self.firewall_process_outbound_callback.clone(),
             firewall_reset_connections: self.firewall_reset_connections.clone(),
             enable_dynamic_wg_nt_control: self.enable_dynamic_wg_nt_control.clone(),
+            mtu: self.mtu,
             skt_buffer_size: self.skt_buffer_size,
             inter_thread_channel_size: self.inter_thread_channel_size,
             max_inter_thread_batched_pkts: self.max_inter_thread_batched_pkts,
@@ -1118,6 +1129,7 @@ pub mod tests {
                 firewall_process_outbound_callback: Default::default(),
                 firewall_reset_connections: None,
                 enable_dynamic_wg_nt_control: None,
+                mtu: None,
                 skt_buffer_size: None,
                 inter_thread_channel_size: None,
                 max_inter_thread_batched_pkts: None,

--- a/crates/telio-wg/src/wg.rs
+++ b/crates/telio-wg/src/wg.rs
@@ -89,6 +89,13 @@ pub trait WireGuard: Send + Sync + 'static {
     }
 }
 
+fn check_mtu(mtu: u32) -> Result<(), Error> {
+    if mtu < adapter::MIN_MTU {
+        return Err(Error::MtuTooLow(mtu));
+    }
+    Ok(())
+}
+
 /// WireGuard implementation allowing dynamic selection of implementation.
 pub struct DynamicWg {
     task: Task<State>,
@@ -115,7 +122,8 @@ pub struct Config {
     /// When present, the callback is consulted by the Windows native adapter
     /// to determine whether meshnet is currently enabled.
     pub enable_dynamic_wg_nt_control: IsMeshnetEnabledCb,
-    /// MTU to set on the adapter interface, if None the adapter picks its own
+    /// MTU to set on the adapter interface, at least [adapter::MIN_MTU]. If None the
+    /// adapter picks its own
     pub mtu: Option<u32>,
     /// Configurable socket buffer size, if None doesn't modify default OS set values
     pub skt_buffer_size: Option<u32>,
@@ -260,6 +268,9 @@ impl DynamicWg {
     where
         Self: Sized,
     {
+        if let Some(mtu) = cfg.mtu {
+            check_mtu(mtu)?;
+        }
         let adapter = Self::start_adapter(cfg.try_clone()?).await?;
         #[cfg(unix)]
         return Ok(Self::start_with(
@@ -480,6 +491,7 @@ impl WireGuard for DynamicWg {
     }
 
     async fn set_adapter_mtu(&self, mtu: u32) -> Result<(), Error> {
+        check_mtu(mtu)?;
         task_exec!(&self.task, async move |s| Ok(s
             .adapter
             .set_adapter_mtu(mtu)
@@ -1377,6 +1389,42 @@ pub mod tests {
 
         adapter.lock().await.expect_stop().return_once(|| ());
         wg.stop().await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn wg_rejects_too_low_adapter_mtu_before_reaching_adapter() {
+        let Env { adapter, wg, .. } = setup().await;
+
+        assert!(matches!(
+            wg.set_adapter_mtu(adapter::MIN_MTU - 1).await,
+            Err(Error::MtuTooLow(_))
+        ));
+
+        adapter.lock().await.expect_stop().return_once(|| ());
+        wg.stop().await;
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn wg_rejects_too_low_mtu_on_start() {
+        let cfg = Config {
+            mtu: Some(adapter::MIN_MTU - 1),
+            ..Config::new().unwrap()
+        };
+        let io = Io {
+            events: Chan::default().tx,
+            analytics_tx: None,
+            libtelio_wide_event_publisher: None,
+        };
+        let result = DynamicWg::start(
+            io,
+            cfg,
+            None,
+            Duration::from_millis(DEFAULT_POLLING_PERIOD_MS),
+            Duration::from_millis(DEFAULT_POLLING_PERIOD_AFTER_UPDATE_MS),
+        )
+        .await;
+        assert!(matches!(result, Err(Error::MtuTooLow(_))));
     }
 
     #[tokio::test(start_paused = true)]

--- a/crates/telio-wg/src/windows/tunnel/interfacewatcher.rs
+++ b/crates/telio-wg/src/windows/tunnel/interfacewatcher.rs
@@ -12,7 +12,7 @@
 //
 
 use super::addressconfig;
-use super::mtumonitor::MtuMonitor;
+use super::mtumonitor::{set_interface_mtu, MtuMonitor};
 use crate::{adapter::IsMeshnetEnabledCb, windows::cleanup::*};
 use std::sync::{Arc, Mutex};
 use telio_utils::{
@@ -46,6 +46,8 @@ struct AdapterConfiguration {
     stored_events: Vec<InterfaceWatcherEvent>,
 
     last_known_config: Option<Arc<WireGuardUapiSetDevice>>,
+    // MTU requested via the API, disables the default route MTU monitoring
+    forced_mtu: Option<u32>,
 
     mtu_monitor: Vec<Arc<Mutex<MtuMonitor>>>,
 }
@@ -84,6 +86,7 @@ impl AdapterConfiguration {
             adapter: None,
             stored_events: Vec::new(),
             last_known_config: None,
+            forced_mtu: None,
             mtu_monitor: Vec::new(),
         }
     }
@@ -141,17 +144,26 @@ impl InterfaceWatcher {
             }
         }
 
-        if let Ok(watched_adapter) = self.watched_adapter.clone().lock() {
-            for mtu_monitor in watched_adapter.mtu_monitor.as_slice() {
-                if let Ok(mut mtumon) = mtu_monitor.clone().lock() {
-                    mtumon.stop();
-                }
-            }
+        if let Ok(mut watched_adapter) = self.watched_adapter.clone().lock() {
+            Self::stop_mtu_monitors(&mut watched_adapter);
         } else {
             telio_log_error!("error obtaining lock");
         }
 
         telio_log_trace!("--- InterfaceWatcher::stop");
+    }
+
+    pub fn set_forced_mtu(&mut self, mtu: u32) {
+        telio_log_trace!("+++ InterfaceWatcher::set_forced_mtu");
+
+        if let Ok(mut watched_adapter) = self.watched_adapter.clone().lock() {
+            watched_adapter.forced_mtu = Some(mtu);
+            Self::stop_mtu_monitors(&mut watched_adapter);
+        } else {
+            telio_log_error!("error obtaining lock");
+        }
+
+        telio_log_trace!("--- InterfaceWatcher::set_forced_mtu");
     }
 
     pub fn configure(&mut self, adapter: Arc<wireguard_nt::Adapter>, luid: u64) {
@@ -223,6 +235,15 @@ impl InterfaceWatcher {
         telio_log_trace!("--- InterfaceWatcher::clear_last_known_configuration");
     }
 
+    fn stop_mtu_monitors(watched_adapter: &mut AdapterConfiguration) {
+        for mtu_monitor in watched_adapter.mtu_monitor.as_slice() {
+            if let Ok(mut mtumon) = mtu_monitor.clone().lock() {
+                mtumon.stop();
+            }
+        }
+        watched_adapter.mtu_monitor.clear();
+    }
+
     fn setup(watched_adapter: &mut AdapterConfiguration, family: ADDRESS_FAMILY) {
         telio_log_trace!("+++ InterfaceWatcher::setup");
 
@@ -236,8 +257,12 @@ impl InterfaceWatcher {
         // iw.watchdog.Stop()
 
         // OPTWGWINCONF: use MtuMonitor to dynamically adjust the MTU size, if it wasn't forced by config.
-        // if iw.conf.Interface.MTU == 0
-        {
+        if let Some(mtu) = watched_adapter.forced_mtu {
+            telio_log_info!("Setting forced MTU {} for {}", mtu, family_str);
+            if let Err(err) = set_interface_mtu(watched_adapter.luid, family, mtu) {
+                telio_log_error!("Failed to set forced MTU for {}: {}", family_str, err);
+            }
+        } else {
             telio_log_info!("Monitoring MTU of default routes for {}", family_str);
             let arc_mtu_monitor =
                 Arc::new(Mutex::new(MtuMonitor::new(watched_adapter.luid, family)));

--- a/crates/telio-wg/src/windows/tunnel/interfacewatcher.rs
+++ b/crates/telio-wg/src/windows/tunnel/interfacewatcher.rs
@@ -153,12 +153,20 @@ impl InterfaceWatcher {
         telio_log_trace!("--- InterfaceWatcher::stop");
     }
 
-    pub fn set_forced_mtu(&mut self, mtu: u32) {
+    /// Force the interface MTU, or go back to following the default route MTU with `None`
+    pub fn set_forced_mtu(&mut self, mtu: Option<u32>) {
         telio_log_trace!("+++ InterfaceWatcher::set_forced_mtu");
 
         if let Ok(mut watched_adapter) = self.watched_adapter.clone().lock() {
-            watched_adapter.forced_mtu = Some(mtu);
+            watched_adapter.forced_mtu = mtu;
             Self::stop_mtu_monitors(&mut watched_adapter);
+            if mtu.is_none() {
+                // A family whose interface is not up yet fails here and gets
+                // its monitor from `setup` once it appears
+                for family in [AF_INET as ADDRESS_FAMILY, AF_INET6 as ADDRESS_FAMILY] {
+                    Self::start_mtu_monitor(&mut watched_adapter, family);
+                }
+            }
         } else {
             telio_log_error!("error obtaining lock");
         }
@@ -244,14 +252,36 @@ impl InterfaceWatcher {
         watched_adapter.mtu_monitor.clear();
     }
 
-    fn setup(watched_adapter: &mut AdapterConfiguration, family: ADDRESS_FAMILY) {
-        telio_log_trace!("+++ InterfaceWatcher::setup");
-
-        let family_str: String = match family as i32 {
+    fn family_name(family: ADDRESS_FAMILY) -> String {
+        match family as i32 {
             AF_INET => "IPv4".to_string(),
             AF_INET6 => "IPv6".to_string(),
             _ => format!("unk {family}"),
+        }
+    }
+
+    fn start_mtu_monitor(watched_adapter: &mut AdapterConfiguration, family: ADDRESS_FAMILY) {
+        let family_str = Self::family_name(family);
+        telio_log_info!("Monitoring MTU of default routes for {}", family_str);
+        let arc_mtu_monitor = Arc::new(Mutex::new(MtuMonitor::new(watched_adapter.luid, family)));
+        if let Ok(mut mtu_monitor) = arc_mtu_monitor.lock() {
+            match mtu_monitor.start_monitoring() {
+                Ok(_) => {
+                    watched_adapter.mtu_monitor.push(arc_mtu_monitor.clone());
+                }
+                Err(err) => {
+                    // TODO: collect and broadcast errors?
+                    // iw.errors <- interfaceWatcherError{services.ErrorMonitorMTUChanges, err}
+                    telio_log_debug!("Not monitoring MTU for {}: {}", family_str, err);
+                }
+            }
         };
+    }
+
+    fn setup(watched_adapter: &mut AdapterConfiguration, family: ADDRESS_FAMILY) {
+        telio_log_trace!("+++ InterfaceWatcher::setup");
+
+        let family_str = Self::family_name(family);
 
         // TODO: we have successfully started the adapter, now stop watchdog
         // iw.watchdog.Stop()
@@ -263,20 +293,7 @@ impl InterfaceWatcher {
                 telio_log_error!("Failed to set forced MTU for {}: {}", family_str, err);
             }
         } else {
-            telio_log_info!("Monitoring MTU of default routes for {}", family_str);
-            let arc_mtu_monitor =
-                Arc::new(Mutex::new(MtuMonitor::new(watched_adapter.luid, family)));
-            if let Ok(mut mtu_monitor) = arc_mtu_monitor.lock() {
-                match mtu_monitor.start_monitoring() {
-                    Ok(_) => {
-                        watched_adapter.mtu_monitor.push(arc_mtu_monitor.clone());
-                    }
-                    Err(_err) => {
-                        // TODO: collect and broadcast errors?
-                        // iw.errors <- interfaceWatcherError{services.ErrorMonitorMTUChanges, err}
-                    }
-                }
-            };
+            Self::start_mtu_monitor(watched_adapter, family);
         }
 
         if let Some(last_known_config) = &watched_adapter.last_known_config {

--- a/crates/telio-wg/src/windows/tunnel/mtumonitor.rs
+++ b/crates/telio-wg/src/windows/tunnel/mtumonitor.rs
@@ -206,19 +206,11 @@ impl MtuMonitor {
         }
 
         if mtu > 0 && *last_mtu != mtu {
-            let own_luid = InterfaceLuid::new(self.own_luid);
-            telio_log_trace!("+++ MtuMonitor::do_it: get_ip_interface");
-            let mut own_iface = own_luid.get_ip_interface(self.family)?;
-            own_iface.NlMtu = mtu.saturating_sub(80);
-            if own_iface.NlMtu < self.min_mtu {
-                own_iface.NlMtu = self.min_mtu;
-            }
-
-            telio_log_trace!("+++ MtuMonitor::do_it: SetIpInterfaceEntry");
-            let result = unsafe { SetIpInterfaceEntry(&mut own_iface) };
-            if NO_ERROR != result {
-                return Err(result);
-            }
+            set_interface_mtu(
+                self.own_luid,
+                self.family,
+                mtu.saturating_sub(80).max(self.min_mtu),
+            )?;
             *last_mtu = mtu;
         }
 
@@ -283,6 +275,14 @@ impl MtuMonitor {
 
         Ok(luid)
     }
+}
+
+/// Set the MTU of the `family` IP interface of the adapter identified by `luid`
+pub fn set_interface_mtu(luid: u64, family: ADDRESS_FAMILY, mtu: u32) -> Result<(), NETIO_STATUS> {
+    let luid = InterfaceLuid::new(luid);
+    let mut iface = luid.get_ip_interface(family)?;
+    iface.NlMtu = mtu;
+    luid.set_ip_interface(&mut iface)
 }
 
 #[cfg(windows)]

--- a/nat-lab/tests/libtelio_client/client.py
+++ b/nat-lab/tests/libtelio_client/client.py
@@ -20,6 +20,7 @@ from tests.utils.bindings import (
     Config,
     Features,
     Server,
+    StartConfig,
     TelioAdapterType,
     TelioNode,
     default_features,
@@ -350,6 +351,21 @@ class Client:
             name=tun_name,
             ext_if_list=ext_if_filter,
         )
+
+    async def start_with_config(self, config: StartConfig):
+        # Defaulted in place, since every nat-lab client needs the router's name.
+        if config.name is None:
+            config.name = self.get_router().get_interface_name()
+        await self.get_proxy().start_with_config(
+            private_key=self._node.private_key,
+            adapter=self._adapter_type,
+            config=config,
+        )
+        if isinstance(self.get_router(), LinuxRouter):
+            await self.get_proxy().set_fwmark(int(LINUX_FWMARK_VALUE))
+
+    async def set_adapter_mtu(self, mtu: int):
+        await self.get_proxy().set_adapter_mtu(mtu)
 
     async def set_meshnet_config(self, meshnet_config: Config) -> None:
         made_changes = await self.configure_interface()

--- a/nat-lab/tests/libtelio_client/client.py
+++ b/nat-lab/tests/libtelio_client/client.py
@@ -364,7 +364,7 @@ class Client:
         if isinstance(self.get_router(), LinuxRouter):
             await self.get_proxy().set_fwmark(int(LINUX_FWMARK_VALUE))
 
-    async def set_adapter_mtu(self, mtu: int):
+    async def set_adapter_mtu(self, mtu: Optional[int]):
         await self.get_proxy().set_adapter_mtu(mtu)
 
     async def set_meshnet_config(self, meshnet_config: Config) -> None:

--- a/nat-lab/tests/test_adapter.py
+++ b/nat-lab/tests/test_adapter.py
@@ -9,6 +9,7 @@ from tests.utils.bindings import (
     ErrorEvent,
     ErrorCode,
     ErrorLevel,
+    StartConfig,
     TelioAdapterType,
     default_features,
 )
@@ -27,6 +28,10 @@ class AdapterState(Enum):
     UP = 1
 
 
+MTU_POLL_ATTEMPTS = 20
+MTU_POLL_INTERVAL_S = 0.5
+
+
 async def get_interface_state(client_conn, client):
     itf_name = client.get_router().get_interface_name()
     process = await client_conn.create_process([
@@ -43,6 +48,51 @@ async def get_interface_state(client_conn, client):
         return AdapterState.UP
 
     raise RuntimeError(f'Unexpected adapter state: "{output}"')
+
+
+async def get_interface_mtu(client_conn, client, address_family: str) -> int:
+    itf_name = client.get_router().get_interface_name()
+    process = await client_conn.create_process([
+        "powershell",
+        "-Command",
+        f'(Get-NetIPInterface -InterfaceAlias "{itf_name}"'
+        f" -AddressFamily {address_family}).NlMtu",
+    ]).execute()
+    output = process.get_stdout().strip()
+
+    if not output.isdigit():
+        raise RuntimeError(
+            f'Unexpected {address_family} MTU for "{itf_name}": "{output}"'
+        )
+
+    return int(output)
+
+
+async def wait_for_interface_mtu(client_conn, client, expected_mtu: int) -> None:
+    """
+    Wait for both address families to report `expected_mtu`.
+
+    The adapter sets each family separately and the interface watcher may
+    re-apply the MTU on interface events, so the value is not readable
+    immediately after the call that requested it.
+    """
+    expected = {"IPv4": expected_mtu, "IPv6": expected_mtu}
+    actual: dict = {}
+
+    for _ in range(MTU_POLL_ATTEMPTS):
+        try:
+            actual = {
+                family: await get_interface_mtu(client_conn, client, family)
+                for family in expected
+            }
+        except (ProcessExecError, RuntimeError):
+            # The interface is missing or still settling after a restart
+            actual = {}
+        if actual == expected:
+            break
+        await asyncio.sleep(MTU_POLL_INTERVAL_S)
+
+    assert actual == expected, f"Expected adapter MTUs {expected}, last read {actual}"
 
 
 @pytest.mark.parametrize(
@@ -487,3 +537,165 @@ async def test_adapter_state_for_meshnet(
     await client_alpha.set_mesh_off()
     state = await get_interface_state(client_conn, client_alpha)
     assert state == expected_idle_state
+
+
+@pytest.mark.windows
+class TestAdapterMtu:
+    """Setting the adapter MTU, supported on Windows only."""
+
+    @pytest.fixture
+    def alpha_setup_params(self) -> SetupParameters:
+        return SetupParameters(
+            connection_tag=ConnectionTag.VM_WINDOWS_1,
+            adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
+            is_meshnet=False,
+            features=default_features(enable_dynamic_wg_nt_control=False),
+        )
+
+    async def test_starts_with_configured_mtu(self, env: Environment) -> None:
+        client_conn, *_ = [conn.connection for conn in env.connections]
+        client_alpha, *_ = env.clients
+        expected_mtu = 1360
+
+        await client_alpha.stop_device()
+        await client_alpha.start_with_config(StartConfig(mtu=expected_mtu))
+
+        await wait_for_interface_mtu(client_conn, client_alpha, expected_mtu)
+
+    async def test_changes_mtu_at_runtime(self, env: Environment) -> None:
+        client_conn, *_ = [conn.connection for conn in env.connections]
+        client_alpha, *_ = env.clients
+        expected_mtu = 1320
+
+        for family in ("IPv4", "IPv6"):
+            current_mtu = await get_interface_mtu(client_conn, client_alpha, family)
+            assert current_mtu != expected_mtu
+
+        await client_alpha.set_adapter_mtu(expected_mtu)
+
+        await wait_for_interface_mtu(client_conn, client_alpha, expected_mtu)
+
+    async def test_rejects_too_low_mtu(self, env: Environment) -> None:
+        client_conn, *_ = [conn.connection for conn in env.connections]
+        client_alpha, *_ = env.clients
+        current_mtus = {
+            family: await get_interface_mtu(client_conn, client_alpha, family)
+            for family in ("IPv4", "IPv6")
+        }
+
+        with pytest.raises(RuntimeError, match="MTU must be at least 1280"):
+            await client_alpha.set_adapter_mtu(1279)
+
+        for family, mtu in current_mtus.items():
+            assert await get_interface_mtu(client_conn, client_alpha, family) == mtu
+
+
+@pytest.mark.windows
+class TestAdapterMtuWithDynamicWgNtControl:
+    """A set MTU must survive the adapter going up and down."""
+
+    @pytest.fixture(name="vpn_tags")
+    def _vpn_tags(self) -> list:
+        return [ConnectionTag.DOCKER_VPN_1]
+
+    @pytest.fixture
+    def alpha_setup_params(self) -> SetupParameters:
+        return SetupParameters(
+            connection_tag=ConnectionTag.VM_WINDOWS_1,
+            adapter_type_override=TelioAdapterType.WINDOWS_NATIVE_TUN,
+            connection_tracker_config=generate_connection_tracker_config(
+                connection_tag=ConnectionTag.VM_WINDOWS_1,
+                vpn_1_limits=(1, 1),
+            ),
+            is_meshnet=False,
+            features=default_features(enable_dynamic_wg_nt_control=True),
+        )
+
+    async def test_mtu_survives_adapter_state_changes(self, env: Environment) -> None:
+        client_conn, *_ = [conn.connection for conn in env.connections]
+        client_alpha, *_ = env.clients
+        expected_mtu = 1340
+
+        state = await get_interface_state(client_conn, client_alpha)
+        assert state == AdapterState.DOWN
+
+        await client_alpha.set_adapter_mtu(expected_mtu)
+        await wait_for_interface_mtu(client_conn, client_alpha, expected_mtu)
+
+        server_ip = config.WG_SERVER["ipv4"]
+        server_port = config.WG_SERVER["port"]
+        server_public_key = config.WG_SERVER["public_key"]
+        assert (
+            isinstance(server_ip, str)
+            and isinstance(server_port, int)
+            and isinstance(server_public_key, str)
+        )
+        await client_alpha.vpn.connect(server_ip, server_port, server_public_key)
+
+        state = await get_interface_state(client_conn, client_alpha)
+        assert state == AdapterState.UP
+        await wait_for_interface_mtu(client_conn, client_alpha, expected_mtu)
+
+        await client_alpha.vpn.disconnect(server_public_key)
+
+        state = await get_interface_state(client_conn, client_alpha)
+        assert state == AdapterState.DOWN
+        await wait_for_interface_mtu(client_conn, client_alpha, expected_mtu)
+
+
+@pytest.mark.parametrize(
+    "alpha_setup_params",
+    [
+        pytest.param(
+            SetupParameters(
+                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
+                adapter_type_override=TelioAdapterType.NEP_TUN,
+                is_meshnet=False,
+            ),
+        ),
+        pytest.param(
+            SetupParameters(
+                connection_tag=ConnectionTag.DOCKER_CONE_CLIENT_1,
+                adapter_type_override=TelioAdapterType.LINUX_NATIVE_TUN,
+                is_meshnet=False,
+            ),
+            marks=[pytest.mark.linux_native],
+        ),
+        pytest.param(
+            SetupParameters(
+                connection_tag=ConnectionTag.VM_MAC,
+                adapter_type_override=TelioAdapterType.NEP_TUN,
+                is_meshnet=False,
+            ),
+            marks=[pytest.mark.mac],
+        ),
+    ],
+)
+class TestAdapterMtuUnsupported:
+    """Only the Windows native adapter supports setting the MTU."""
+
+    async def test_rejects_mtu_at_runtime(
+        self,
+        alpha_setup_params: SetupParameters,  # pylint: disable=unused-argument
+        env: Environment,
+    ) -> None:
+        client_alpha, *_ = env.clients
+
+        with pytest.raises(RuntimeError, match="UnsupportedAdapter"):
+            await client_alpha.set_adapter_mtu(1340)
+
+    async def test_rejects_mtu_at_start(
+        self,
+        alpha_setup_params: SetupParameters,  # pylint: disable=unused-argument
+        env: Environment,
+    ) -> None:
+        client_alpha, *_ = env.clients
+
+        await client_alpha.stop_device()
+        with pytest.raises(
+            RuntimeError, match="MTU is only supported by the Windows native adapter"
+        ):
+            await client_alpha.start_with_config(StartConfig(mtu=1340))
+
+        # Leave the device running for the test cleanup
+        await client_alpha.start_with_config(StartConfig())

--- a/nat-lab/tests/test_adapter.py
+++ b/nat-lab/tests/test_adapter.py
@@ -68,23 +68,34 @@ async def get_interface_mtu(client_conn, client, address_family: str) -> int:
     return int(output)
 
 
+async def get_interface_mtus(client_conn, client) -> dict[str, int]:
+    return {
+        family: await get_interface_mtu(client_conn, client, family)
+        for family in ("IPv4", "IPv6")
+    }
+
+
 async def wait_for_interface_mtu(client_conn, client, expected_mtu: int) -> None:
+    await wait_for_interface_mtus(
+        client_conn, client, {"IPv4": expected_mtu, "IPv6": expected_mtu}
+    )
+
+
+async def wait_for_interface_mtus(
+    client_conn, client, expected: dict[str, int]
+) -> None:
     """
-    Wait for both address families to report `expected_mtu`.
+    Wait for the address families to report the MTUs in `expected`.
 
     The adapter sets each family separately and the interface watcher may
     re-apply the MTU on interface events, so the value is not readable
     immediately after the call that requested it.
     """
-    expected = {"IPv4": expected_mtu, "IPv6": expected_mtu}
     actual: dict = {}
 
     for _ in range(MTU_POLL_ATTEMPTS):
         try:
-            actual = {
-                family: await get_interface_mtu(client_conn, client, family)
-                for family in expected
-            }
+            actual = await get_interface_mtus(client_conn, client)
         except (ProcessExecError, RuntimeError):
             # The interface is missing or still settling after a restart
             actual = {}
@@ -575,13 +586,23 @@ class TestAdapterMtu:
 
         await wait_for_interface_mtu(client_conn, client_alpha, expected_mtu)
 
+    async def test_restores_automatic_mtu(self, env: Environment) -> None:
+        client_conn, *_ = [conn.connection for conn in env.connections]
+        client_alpha, *_ = env.clients
+        automatic_mtus = await get_interface_mtus(client_conn, client_alpha)
+        forced_mtu = 1320
+        assert forced_mtu not in automatic_mtus.values()
+
+        await client_alpha.set_adapter_mtu(forced_mtu)
+        await wait_for_interface_mtu(client_conn, client_alpha, forced_mtu)
+
+        await client_alpha.set_adapter_mtu(None)
+        await wait_for_interface_mtus(client_conn, client_alpha, automatic_mtus)
+
     async def test_rejects_too_low_mtu(self, env: Environment) -> None:
         client_conn, *_ = [conn.connection for conn in env.connections]
         client_alpha, *_ = env.clients
-        current_mtus = {
-            family: await get_interface_mtu(client_conn, client_alpha, family)
-            for family in ("IPv4", "IPv6")
-        }
+        current_mtus = await get_interface_mtus(client_conn, client_alpha)
 
         with pytest.raises(RuntimeError, match="MtuTooLow"):
             await client_alpha.set_adapter_mtu(1279)

--- a/nat-lab/tests/test_adapter.py
+++ b/nat-lab/tests/test_adapter.py
@@ -583,7 +583,7 @@ class TestAdapterMtu:
             for family in ("IPv4", "IPv6")
         }
 
-        with pytest.raises(RuntimeError, match="MTU must be at least 1280"):
+        with pytest.raises(RuntimeError, match="MtuTooLow"):
             await client_alpha.set_adapter_mtu(1279)
 
         for family, mtu in current_mtus.items():

--- a/nat-lab/tests/test_telio_start_methods.py
+++ b/nat-lab/tests/test_telio_start_methods.py
@@ -7,6 +7,7 @@ from tests.utils.bindings import (
     default_features,
     features_with_endpoint_providers,
     EndpointProvider,
+    StartConfig,
     TelioAdapterType,
 )
 from tests.utils.connection import ConnectionTag
@@ -84,6 +85,39 @@ async def test_start_with_tun_and_switch_it_at_runtime(alpha_tag) -> None:
         await alpha_client.get_proxy().set_tun(tun12)
         await alpha_client.restart_interface(new_name=tun_name_prefix + "12")
         await alpha_client.get_router().delete_interface(tun_name_prefix + "11")
+        await ping_between_all_nodes(env)
+
+
+@pytest.mark.parametrize(
+    "interface_name",
+    [
+        pytest.param(None, id="default_name"),
+        pytest.param("tun11", id="explicit_name"),
+    ],
+)
+async def test_start_with_config(interface_name) -> None:
+    setup_params = _generate_setup_parameters([
+        ConnectionTag.DOCKER_CONE_CLIENT_1,
+        ConnectionTag.DOCKER_CONE_CLIENT_2,
+    ])
+
+    async with AsyncExitStack() as exit_stack:
+        env = await setup_mesh_nodes(exit_stack, setup_params)
+        alpha_client, _ = env.clients
+        alpha, _ = env.nodes
+        router = alpha_client.get_router()
+        old_interface_name = router.get_interface_name()
+
+        await ping_between_all_nodes(env)
+        await alpha_client.stop_device()
+
+        # A `None` name leaves the current interface name to the client helper
+        await alpha_client.start_with_config(StartConfig(name=interface_name))
+        new_interface_name = interface_name or old_interface_name
+        router.set_interface_name(new_interface_name)
+        await alpha_client.set_meshnet_config(env.api.get_meshnet_config(alpha.id))
+        if new_interface_name != old_interface_name:
+            await router.delete_interface(old_interface_name)
         await ping_between_all_nodes(env)
 
 

--- a/nat-lab/tests/uniffi/libtelio_proxy.py
+++ b/nat-lab/tests/uniffi/libtelio_proxy.py
@@ -126,12 +126,22 @@ class LibtelioProxy:
         )
 
     @move_to_async_thread
+    def start_with_config(self, private_key, adapter, config: libtelio.StartConfig):
+        self._handle_remote_error(
+            lambda r: r.start_with_config(private_key, adapter.value, config)
+        )
+
+    @move_to_async_thread
     def set_fwmark(self, fwmark: int):
         self._handle_remote_error(lambda r: r.set_fwmark(fwmark))
 
     @move_to_async_thread
     def set_ext_if_filter(self, ext_if_list: List[str]):
         self._handle_remote_error(lambda r: r.set_ext_if_filter(ext_if_list))
+
+    @move_to_async_thread
+    def set_adapter_mtu(self, mtu: int):
+        self._handle_remote_error(lambda r: r.set_adapter_mtu(mtu))
 
     @move_to_async_thread
     def set_tun(self, tun: int):

--- a/nat-lab/tests/uniffi/libtelio_proxy.py
+++ b/nat-lab/tests/uniffi/libtelio_proxy.py
@@ -140,7 +140,7 @@ class LibtelioProxy:
         self._handle_remote_error(lambda r: r.set_ext_if_filter(ext_if_list))
 
     @move_to_async_thread
-    def set_adapter_mtu(self, mtu: int):
+    def set_adapter_mtu(self, mtu: Optional[int]):
         self._handle_remote_error(lambda r: r.set_adapter_mtu(mtu))
 
     @move_to_async_thread

--- a/nat-lab/tests/uniffi/libtelio_remote.py
+++ b/nat-lab/tests/uniffi/libtelio_remote.py
@@ -13,7 +13,7 @@ from serialization import (  # type: ignore # pylint: disable=import-error
     init_serialization,
 )
 from threading import Lock
-from typing import List, Tuple
+from typing import List, Tuple, Optional
 
 REMOTE_LOG = "remote.log"
 TCLI_LOG = "tcli.log"
@@ -197,7 +197,7 @@ class LibtelioWrapper:
         self._libtelio.set_ext_if_filter(ext_if_list)
 
     @serialize_error
-    def set_adapter_mtu(self, mtu: int):
+    def set_adapter_mtu(self, mtu: Optional[int]):
         self._libtelio.set_adapter_mtu(mtu)
 
     @serialize_error

--- a/nat-lab/tests/uniffi/libtelio_remote.py
+++ b/nat-lab/tests/uniffi/libtelio_remote.py
@@ -173,6 +173,12 @@ class LibtelioWrapper:
         )
 
     @serialize_error
+    def start_with_config(self, private_key, adapter, config: libtelio.StartConfig):
+        self._libtelio.start_with_config(
+            private_key, libtelio.TelioAdapterType(adapter), config
+        )
+
+    @serialize_error
     def create_tun(self, tun_id: int) -> int:
         return create_tun(tun_id)
 
@@ -189,6 +195,10 @@ class LibtelioWrapper:
     @serialize_error
     def set_ext_if_filter(self, ext_if_list: List[str]):
         self._libtelio.set_ext_if_filter(ext_if_list)
+
+    @serialize_error
+    def set_adapter_mtu(self, mtu: int):
+        self._libtelio.set_adapter_mtu(mtu)
 
     @serialize_error
     def set_tun(self, tun: int):

--- a/src/doc/integrating_telio.md
+++ b/src/doc/integrating_telio.md
@@ -337,10 +337,11 @@ let adapter = get_default_adapter();
 
 let telio = Telio::new(Default::default(), Box::new(EventHandler)).unwrap();
 
-// There are three ways to start telio:
+// There are four ways to start telio:
 // * start - telio does everything
 // * start_with_tun - use existing tun (android, apple)
 // * start_with_name - create tun with name (windows, linux)
+// * start_with_config - like start, with optional settings (name, ext_if_filter, mtu)
 telio.start(sk, adapter).unwrap();
 telio.stop().unwrap();
 
@@ -355,10 +356,11 @@ adapter := GetDefaultAdapter()
 
 telio, err := Telio {...}
 
-// There are three ways to start telio:
+// There are four ways to start telio:
 // * Start - telio does everything
 // * StartWithTun - use existing tun (android, apple)
 // * StartWithName - create tun with name (windows, linux)
+// * StartWithConfig - like start, with optional settings (name, ext_if_filter, mtu)
 _, err = telio.Start(sk, adapter)
 _, err = telio.Stop()
 
@@ -373,10 +375,11 @@ let adapter = getDefaultAdapter()
 
 let telio = Telio(...)
 
-// There are three ways to start telio:
+// There are four ways to start telio:
 // * start - telio does everything
 // * startWithTun - use existing tun (android, apple)
 // * startWithName - create tun with name (windows, linux)
+// * startWithConfig - like start, with optional settings (name, ext_if_filter, mtu)
 telio.start(sk, adapter)
 telio.stop()
 
@@ -391,10 +394,11 @@ var adapter = GetDefaultAdapter();
 
 Telio telio = new Telio(...);
 
-// There are three ways to start telio:
+// There are four ways to start telio:
 // * Start - telio does everything
 // * StartWithTun - use existing tun (android, apple)
 // * StartWithName - create tun with name (windows, linux)
+// * StartWithConfig - like start, with optional settings (name, ext_if_filter, mtu)
 telio.Start(sk, adapter);
 telio.Stop();
 
@@ -409,10 +413,11 @@ val adapter = getDefaultAdapter()
 
 val telio = Telio.new(...)!!
 
-// There are three ways to start telio:
+// There are four ways to start telio:
 // * start - telio does everything
 // * startWithTun - use existing tun (android, apple)
 // * startWithName - create tun with name (windows, linux)
+// * startWithConfig - like start, with optional settings (name, ext_if_filter, mtu)
 telio.start(sk, adapter)!!
 telio.stop()!!
 

--- a/src/doc/introduction.md
+++ b/src/doc/introduction.md
@@ -82,8 +82,10 @@ use telio_wg::Tun;
 pub struct DeviceConfig {
     pub private_key: SecretKey,
     pub adapter: AdapterType,
+    pub fwmark: Option<u32>,
     pub name: Option<String>,
     pub tun: Option<Tun>,
+    pub ext_if_filter: Option<Vec<String>>,
 }
 ```
 
@@ -91,8 +93,10 @@ Let's discuss its fields shortly:
 
 - `private_key` a `telio::crypto::SecretKey` instance containing a 256-bit key,
 - `adapter` indicating which Wireguard implementation we want to use,
+- `fwmark` the firewall mark to set on the sockets opened by Telio, Linux only,
 - `name` is the name of the network interface, when omitted, Telio uses the default one,
-- `tun` a file descriptor of the already opened tunnel, if it's not provided Telio will open a new one.
+- `tun` a file descriptor of the already opened tunnel, if it's not provided Telio will open a new one,
+- `ext_if_filter` names of the interfaces to skip while looking for the default interface.
 
 The API provides a default config which is almost sufficient for simple cases,
 the only need that needs to be done is the generation of a private key:

--- a/src/doc/introduction.md
+++ b/src/doc/introduction.md
@@ -86,6 +86,7 @@ pub struct DeviceConfig {
     pub name: Option<String>,
     pub tun: Option<Tun>,
     pub ext_if_filter: Option<Vec<String>>,
+    pub mtu: Option<u32>,
 }
 ```
 
@@ -96,7 +97,9 @@ Let's discuss its fields shortly:
 - `fwmark` the firewall mark to set on the sockets opened by Telio, Linux only,
 - `name` is the name of the network interface, when omitted, Telio uses the default one,
 - `tun` a file descriptor of the already opened tunnel, if it's not provided Telio will open a new one,
-- `ext_if_filter` names of the interfaces to skip while looking for the default interface.
+- `ext_if_filter` names of the interfaces to skip while looking for the default interface,
+- `mtu` the MTU of the adapter interface, Windows native adapter only. It can also be
+  changed on a running device with `Device::set_adapter_mtu`.
 
 The API provides a default config which is almost sufficient for simple cases,
 the only need that needs to be done is the generation of a private key:

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -145,6 +145,38 @@ pub extern "C" fn Java_com_nordsec_telio_TelioCert_initCertStore(
     })
 }
 
+/// Optional settings for starting the telio device.
+///
+/// Every field defaults to "not set", so supporting a new option requires a
+/// single additional field instead of an additional `start*` function.
+#[derive(Debug)]
+pub struct StartConfig {
+    /// Name of the tunnel interface opened by the adapter. When not set, telio
+    /// picks a platform default.
+    pub name: Option<String>,
+    /// Interfaces to skip while looking for the default interface.
+    pub ext_if_filter: Option<Vec<String>>,
+}
+
+impl StartConfig {
+    fn to_device_config(
+        &self,
+        private_key: SecretKey,
+        adapter: TelioAdapterType,
+    ) -> FfiResult<DeviceConfig> {
+        Ok(DeviceConfig {
+            private_key,
+            adapter: adapter
+                .try_into()
+                .map_err(|e| TelioError::UnknownError { inner: e })?,
+            fwmark: None,
+            name: self.name.clone(),
+            tun: None,
+            ext_if_filter: self.ext_if_filter.clone(),
+        })
+    }
+}
+
 pub struct Telio {
     inner: Mutex<Option<Device>>,
     id: usize,
@@ -454,6 +486,30 @@ impl Telio {
                     ext_if_filter: Some(ext_if_filter.clone()),
                 })
                 .log_result("Telio::start_named_ext_if_filter")
+            })
+        })
+    }
+
+    /// Start telio with the specified adapter and the options in `config`.
+    ///
+    /// Adapter will attempt to open its own tunnel.
+    pub fn start_with_config(
+        &self,
+        private_key: SecretKey,
+        adapter: TelioAdapterType,
+        config: StartConfig,
+    ) -> FfiResult<()> {
+        telio_log_info!(
+            "Telio::start entry with instance id: {}. Public key: {:?}. Adapter: {:?}. Config: {:?}",
+            self.id,
+            private_key.public(),
+            &adapter,
+            &config,
+        );
+        catch_ffi_panic(|| {
+            self.device_op(true, |dev| {
+                dev.start(config.to_device_config(private_key.clone(), adapter)?)
+                    .log_result("Telio::start_with_config")
             })
         })
     }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -156,9 +156,9 @@ pub struct StartConfig {
     pub name: Option<String>,
     /// Interfaces to skip while looking for the default interface.
     pub ext_if_filter: Option<Vec<String>>,
-    /// MTU to set on the adapter interface. When not set, the adapter picks
-    /// its own. Only supported by the Windows native adapter, starting any
-    /// other adapter with it set fails.
+    /// MTU to set on the adapter interface, at least 1280. When not set, the
+    /// adapter picks its own. Only supported by the Windows native adapter,
+    /// starting any other adapter with it set fails.
     pub mtu: Option<u32>,
     /// File descriptor of an already open tunnel, which telio takes ownership
     /// of and closes on stop. When not set, the adapter opens its own tunnel.
@@ -510,7 +510,7 @@ impl Telio {
         })
     }
 
-    /// Set the MTU of the adapter interface.
+    /// Set the MTU of the adapter interface, at least 1280.
     ///
     /// Only supported by the Windows native adapter, other adapters fail with
     /// an unsupported-adapter error.

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -149,7 +149,7 @@ pub extern "C" fn Java_com_nordsec_telio_TelioCert_initCertStore(
 ///
 /// Every field defaults to "not set", so supporting a new option requires a
 /// single additional field instead of an additional `start*` function.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct StartConfig {
     /// Name of the tunnel interface opened by the adapter. When not set, telio
     /// picks a platform default.
@@ -160,6 +160,10 @@ pub struct StartConfig {
     /// its own. Only supported by the Windows native adapter, starting any
     /// other adapter with it set fails.
     pub mtu: Option<u32>,
+    /// File descriptor of an already open tunnel, which telio takes ownership
+    /// of and closes on stop. When not set, the adapter opens its own tunnel.
+    /// Ignored on Windows.
+    pub tun: Option<i32>,
 }
 
 impl StartConfig {
@@ -168,6 +172,15 @@ impl StartConfig {
         private_key: SecretKey,
         adapter: TelioAdapterType,
     ) -> FfiResult<DeviceConfig> {
+        #[cfg(not(target_os = "windows"))]
+        let tun = self.tun.map(|fd| {
+            use std::os::fd::{FromRawFd, OwnedFd};
+            // SAFETY: the caller hands over an open descriptor it no longer uses
+            unsafe { OwnedFd::from_raw_fd(fd) }
+        });
+        #[cfg(target_os = "windows")]
+        let tun = None;
+
         if self.mtu.is_some() && !matches!(adapter, TelioAdapterType::WindowsNativeTun) {
             return Err(TelioError::UnknownError {
                 inner: "MTU is only supported by the Windows native adapter".to_owned(),
@@ -180,7 +193,7 @@ impl StartConfig {
                 .map_err(|e| TelioError::UnknownError { inner: e })?,
             fwmark: None,
             name: self.name.clone(),
-            tun: None,
+            tun,
             ext_if_filter: self.ext_if_filter.clone(),
             mtu: self.mtu,
         })
@@ -410,28 +423,7 @@ impl Telio {
     ///
     /// Adapter will attempt to open its own tunnel.
     pub fn start(&self, private_key: SecretKey, adapter: TelioAdapterType) -> FfiResult<()> {
-        telio_log_info!(
-            "Telio::start entry with instance id: {}. Public key: {:?}. Adapter: {:?}",
-            self.id,
-            private_key.public(),
-            &adapter
-        );
-        catch_ffi_panic(|| {
-            self.device_op(true, |dev| {
-                dev.start(DeviceConfig {
-                    private_key: private_key.clone(),
-                    adapter: adapter
-                        .try_into()
-                        .map_err(|e| TelioError::UnknownError { inner: e })?,
-                    fwmark: None,
-                    name: None,
-                    tun: None,
-                    ext_if_filter: None,
-                    mtu: None,
-                })
-                .log_result("Telio::start")
-            })
-        })
+        self.start_with_config(private_key, adapter, StartConfig::default())
     }
 
     /// Start telio with specified adapter and name.
@@ -443,29 +435,14 @@ impl Telio {
         adapter: TelioAdapterType,
         name: String,
     ) -> FfiResult<()> {
-        telio_log_info!(
-            "Telio::start entry with instance id: {}. Public key: {:?}. Adapter: {:?}. Name: {}",
-            self.id,
-            private_key.public(),
-            &adapter,
-            &name,
-        );
-        catch_ffi_panic(|| {
-            self.device_op(true, |dev| {
-                dev.start(DeviceConfig {
-                    private_key: private_key.clone(),
-                    adapter: adapter
-                        .try_into()
-                        .map_err(|e| TelioError::UnknownError { inner: e })?,
-                    fwmark: None,
-                    name: Some(name.clone()),
-                    tun: None,
-                    ext_if_filter: None,
-                    mtu: None,
-                })
-                .log_result("Telio::start_named")
-            })
-        })
+        self.start_with_config(
+            private_key,
+            adapter,
+            StartConfig {
+                name: Some(name),
+                ..Default::default()
+            },
+        )
     }
 
     /// Start telio with specified adapter type, adapter name
@@ -479,34 +456,20 @@ impl Telio {
         name: String,
         ext_if_filter: Vec<String>,
     ) -> FfiResult<()> {
-        telio_log_info!(
-            "Telio::start entry with instance id: {}. Public key: {:?}. Adapter: {:?}. Name: {}",
-            self.id,
-            private_key.public(),
-            &adapter,
-            &name,
-        );
-        catch_ffi_panic(|| {
-            self.device_op(true, |dev| {
-                dev.start(DeviceConfig {
-                    private_key: private_key.clone(),
-                    adapter: adapter
-                        .try_into()
-                        .map_err(|e| TelioError::UnknownError { inner: e })?,
-                    fwmark: None,
-                    name: Some(name.clone()),
-                    tun: None,
-                    ext_if_filter: Some(ext_if_filter.clone()),
-                    mtu: None,
-                })
-                .log_result("Telio::start_named_ext_if_filter")
-            })
-        })
+        self.start_with_config(
+            private_key,
+            adapter,
+            StartConfig {
+                name: Some(name),
+                ext_if_filter: Some(ext_if_filter),
+                ..Default::default()
+            },
+        )
     }
 
     /// Start telio with the specified adapter and the options in `config`.
     ///
-    /// Adapter will attempt to open its own tunnel.
+    /// Adapter will attempt to open its own tunnel unless `config.tun` is set.
     pub fn start_with_config(
         &self,
         private_key: SecretKey,
@@ -581,38 +544,16 @@ impl Telio {
         &self,
         private_key: SecretKey,
         adapter: TelioAdapterType,
-        _tun: i32,
+        tun: i32,
     ) -> FfiResult<()> {
-        telio_log_info!(
-            "Telio::start entry with instance id: {}. Public key: {:?}. Adapter: {:?}. Tun: {_tun}",
-            self.id,
-            private_key.public(),
-            &adapter
-        );
-
-        catch_ffi_panic(|| {
-            self.device_op(true, |dev| {
-                #[cfg(not(target_os = "windows"))]
-                let tun = {
-                    use std::os::fd::{FromRawFd, OwnedFd};
-                    Some(unsafe { OwnedFd::from_raw_fd(_tun) })
-                };
-                #[cfg(target_os = "windows")]
-                let tun = None;
-                dev.start(DeviceConfig {
-                    private_key: private_key.clone(),
-                    adapter: adapter
-                        .try_into()
-                        .map_err(|e| TelioError::UnknownError { inner: e })?,
-                    fwmark: None,
-                    name: None,
-                    tun,
-                    ext_if_filter: None,
-                    mtu: None,
-                })
-                .log_result("Telio::start_with_tun")
-            })
-        })
+        self.start_with_config(
+            private_key,
+            adapter,
+            StartConfig {
+                tun: Some(tun),
+                ..Default::default()
+            },
+        )
     }
 
     /// Stop telio device.
@@ -1268,9 +1209,8 @@ mod tests {
     #[test]
     fn test_start_config_mtu_requires_windows_native_adapter() {
         let config = StartConfig {
-            name: None,
-            ext_if_filter: None,
             mtu: Some(1400),
+            ..Default::default()
         };
         let key = SecretKey::gen();
 

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -510,13 +510,14 @@ impl Telio {
         })
     }
 
-    /// Set the MTU of the adapter interface, at least 1280.
+    /// Set the MTU of the adapter interface, at least 1280. `None` restores the
+    /// adapter's own MTU handling.
     ///
     /// Only supported by the Windows native adapter, other adapters fail with
     /// an unsupported-adapter error.
-    pub fn set_adapter_mtu(&self, mtu: u32) -> FfiResult<()> {
+    pub fn set_adapter_mtu(&self, mtu: Option<u32>) -> FfiResult<()> {
         telio_log_info!(
-            "Telio::set_adapter_mtu entry with instance id: {}. MTU: {}",
+            "Telio::set_adapter_mtu entry with instance id: {}. MTU: {:?}",
             self.id,
             mtu,
         );

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -156,6 +156,10 @@ pub struct StartConfig {
     pub name: Option<String>,
     /// Interfaces to skip while looking for the default interface.
     pub ext_if_filter: Option<Vec<String>>,
+    /// MTU to set on the adapter interface. When not set, the adapter picks
+    /// its own. Only supported by the Windows native adapter, starting any
+    /// other adapter with it set fails.
+    pub mtu: Option<u32>,
 }
 
 impl StartConfig {
@@ -164,6 +168,11 @@ impl StartConfig {
         private_key: SecretKey,
         adapter: TelioAdapterType,
     ) -> FfiResult<DeviceConfig> {
+        if self.mtu.is_some() && !matches!(adapter, TelioAdapterType::WindowsNativeTun) {
+            return Err(TelioError::UnknownError {
+                inner: "MTU is only supported by the Windows native adapter".to_owned(),
+            });
+        }
         Ok(DeviceConfig {
             private_key,
             adapter: adapter
@@ -173,6 +182,7 @@ impl StartConfig {
             name: self.name.clone(),
             tun: None,
             ext_if_filter: self.ext_if_filter.clone(),
+            mtu: self.mtu,
         })
     }
 }
@@ -389,6 +399,7 @@ impl Telio {
                     name: None,
                     tun: None,
                     ext_if_filter: None,
+                    mtu: None,
                 })
                 .log_result("Telio::start")
             })
@@ -416,6 +427,7 @@ impl Telio {
                     name: None,
                     tun: None,
                     ext_if_filter: None,
+                    mtu: None,
                 })
                 .log_result("Telio::start")
             })
@@ -449,6 +461,7 @@ impl Telio {
                     name: Some(name.clone()),
                     tun: None,
                     ext_if_filter: None,
+                    mtu: None,
                 })
                 .log_result("Telio::start_named")
             })
@@ -484,6 +497,7 @@ impl Telio {
                     name: Some(name.clone()),
                     tun: None,
                     ext_if_filter: Some(ext_if_filter.clone()),
+                    mtu: None,
                 })
                 .log_result("Telio::start_named_ext_if_filter")
             })
@@ -500,7 +514,7 @@ impl Telio {
         config: StartConfig,
     ) -> FfiResult<()> {
         telio_log_info!(
-            "Telio::start entry with instance id: {}. Public key: {:?}. Adapter: {:?}. Config: {:?}",
+            "Telio::start_with_config entry with instance id: {}. Public key: {:?}. Adapter: {:?}. Config: {:?}",
             self.id,
             private_key.public(),
             &adapter,
@@ -529,6 +543,23 @@ impl Telio {
             self.device_op(true, |dev| {
                 dev.set_ext_if_filter(ext_if_filter.clone())
                     .map_err(TelioError::from)
+            })
+        })
+    }
+
+    /// Set the MTU of the adapter interface.
+    ///
+    /// Only supported by the Windows native adapter, other adapters fail with
+    /// an unsupported-adapter error.
+    pub fn set_adapter_mtu(&self, mtu: u32) -> FfiResult<()> {
+        telio_log_info!(
+            "Telio::set_adapter_mtu entry with instance id: {}. MTU: {}",
+            self.id,
+            mtu,
+        );
+        catch_ffi_panic(|| {
+            self.device_op(true, |dev| {
+                dev.set_adapter_mtu(mtu).log_result("Telio::set_adapter_mtu")
             })
         })
     }
@@ -576,6 +607,7 @@ impl Telio {
                     name: None,
                     tun,
                     ext_if_filter: None,
+                    mtu: None,
                 })
                 .log_result("Telio::start_with_tun")
             })
@@ -1230,5 +1262,23 @@ mod tests {
         let actual =
             deserialize_feature_config(CORRECT_FEATURES_JSON_WITHOUT_IS_TEST_ENV.to_owned());
         assert!(actual.is_ok());
+    }
+
+    #[test]
+    fn test_start_config_mtu_requires_windows_native_adapter() {
+        let config = StartConfig {
+            name: None,
+            ext_if_filter: None,
+            mtu: Some(1400),
+        };
+        let key = SecretKey::gen();
+
+        assert!(config
+            .to_device_config(key.clone(), TelioAdapterType::WindowsNativeTun)
+            .is_ok());
+        assert!(matches!(
+            config.to_device_config(key, TelioAdapterType::NepTUN),
+            Err(TelioError::UnknownError { .. })
+        ));
     }
 }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -559,7 +559,8 @@ impl Telio {
         );
         catch_ffi_panic(|| {
             self.device_op(true, |dev| {
-                dev.set_adapter_mtu(mtu).log_result("Telio::set_adapter_mtu")
+                dev.set_adapter_mtu(mtu)
+                    .log_result("Telio::set_adapter_mtu")
             })
         })
     }

--- a/src/libtelio.udl
+++ b/src/libtelio.udl
@@ -331,6 +331,13 @@ interface Telio {
     [Throws=TelioError]
     void set_ext_if_filter(sequence<string> ext_if_filter);
 
+    /// Set the MTU of the adapter interface.
+    ///
+    /// Only supported by the Windows native adapter, other adapters fail with
+    /// an unsupported-adapter error.
+    [Throws=TelioError]
+    void set_adapter_mtu(u32 mtu);
+
     /// Sets private key for started device.
     ///
     /// If private_key is not set, device will never connect.
@@ -589,6 +596,11 @@ dictionary StartConfig {
 
     /// Interfaces to skip while looking for the default interface.
     sequence<string>? ext_if_filter = null;
+
+    /// MTU to set on the adapter interface. When not set, the adapter picks
+    /// its own. Only supported by the Windows native adapter, starting any
+    /// other adapter with it set fails.
+    u32? mtu = null;
 };
 
 /// A [Features] builder that allows a simpler initialization of

--- a/src/libtelio.udl
+++ b/src/libtelio.udl
@@ -331,12 +331,13 @@ interface Telio {
     [Throws=TelioError]
     void set_ext_if_filter(sequence<string> ext_if_filter);
 
-    /// Set the MTU of the adapter interface, at least 1280.
+    /// Set the MTU of the adapter interface, at least 1280. `None` restores the
+    /// adapter's own MTU handling.
     ///
     /// Only supported by the Windows native adapter, other adapters fail with
     /// an unsupported-adapter error.
     [Throws=TelioError]
-    void set_adapter_mtu(u32 mtu);
+    void set_adapter_mtu(u32? mtu);
 
     /// Sets private key for started device.
     ///

--- a/src/libtelio.udl
+++ b/src/libtelio.udl
@@ -331,7 +331,7 @@ interface Telio {
     [Throws=TelioError]
     void set_ext_if_filter(sequence<string> ext_if_filter);
 
-    /// Set the MTU of the adapter interface.
+    /// Set the MTU of the adapter interface, at least 1280.
     ///
     /// Only supported by the Windows native adapter, other adapters fail with
     /// an unsupported-adapter error.
@@ -597,9 +597,9 @@ dictionary StartConfig {
     /// Interfaces to skip while looking for the default interface.
     sequence<string>? ext_if_filter = null;
 
-    /// MTU to set on the adapter interface. When not set, the adapter picks
-    /// its own. Only supported by the Windows native adapter, starting any
-    /// other adapter with it set fails.
+    /// MTU to set on the adapter interface, at least 1280. When not set, the
+    /// adapter picks its own. Only supported by the Windows native adapter,
+    /// starting any other adapter with it set fails.
     u32? mtu = null;
 
     /// File descriptor of an already open tunnel, which telio takes ownership

--- a/src/libtelio.udl
+++ b/src/libtelio.udl
@@ -308,7 +308,7 @@ interface Telio {
 
     /// Start telio with the specified adapter and the options in `config`.
     ///
-    /// Adapter will attempt to open its own tunnel.
+    /// Adapter will attempt to open its own tunnel unless `config.tun` is set.
     [Throws=TelioError]
     void start_with_config(SecretKey secret_key, TelioAdapterType adapter, StartConfig config);
 
@@ -601,6 +601,11 @@ dictionary StartConfig {
     /// its own. Only supported by the Windows native adapter, starting any
     /// other adapter with it set fails.
     u32? mtu = null;
+
+    /// File descriptor of an already open tunnel, which telio takes ownership
+    /// of and closes on stop. When not set, the adapter opens its own tunnel.
+    /// Ignored on Windows.
+    i32? tun = null;
 };
 
 /// A [Features] builder that allows a simpler initialization of

--- a/src/libtelio.udl
+++ b/src/libtelio.udl
@@ -306,6 +306,12 @@ interface Telio {
     [Throws=TelioError]
     void start_named_ext_if_filter(SecretKey secret_key, TelioAdapterType adapter, string name, sequence<string> ext_if_filter);
 
+    /// Start telio with the specified adapter and the options in `config`.
+    ///
+    /// Adapter will attempt to open its own tunnel.
+    [Throws=TelioError]
+    void start_with_config(SecretKey secret_key, TelioAdapterType adapter, StartConfig config);
+
     /// Start telio device with specified adapter and already open tunnel.
     ///
     /// Telio will take ownership of tunnel , and close it on stop.
@@ -570,6 +576,19 @@ callback interface TelioLoggerCb {
 callback interface TelioProtectCb {
     [Throws=TelioError]
     void protect(i32 socket_id);
+};
+
+/// Optional settings for starting telio, consumed by [Telio::start_with_config].
+///
+/// Every field defaults to "not set", so supporting a new option requires a
+/// single additional field instead of an additional `start*` function.
+dictionary StartConfig {
+    /// Name of the tunnel interface opened by the adapter. When not set, telio
+    /// picks a platform default.
+    string? name = null;
+
+    /// Interfaces to skip while looking for the default interface.
+    sequence<string>? ext_if_filter = null;
 };
 
 /// A [Features] builder that allows a simpler initialization of


### PR DESCRIPTION
### Problem
Currently there is no way to set MTU for any adapter while it can be added and it would be useful for some telio users

### Solution
Two ways of configuring MTU are added: adding in during adapter startup and `set_mtu` usable on running device. Because there are already many adapter starting functions I think instead of adding to each of them another version with mtu argument I think it makes more sense to add a config with optional fields and MTU among them. The solution works currently only with WindowsNT adapter, returns an error when used with other one.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
