### PR TITLE
Probe SSH in openwrt healthcheck

### DIFF
--- a/nat-lab/bin/openwrt/openwrt-qemu-healthcheck.sh
+++ b/nat-lab/bin/openwrt/openwrt-qemu-healthcheck.sh
@@ -3,6 +3,7 @@
 set -eu
 
 OPENWRT_GW_IP=${OPENWRT_VM_LAN_IP}
+SSH_TIMEOUT=20
 
 [ -S /tmp/qmp.sock ] || exit 1
 
@@ -15,19 +16,12 @@ OUT=$(
 
 echo "$OUT" | grep -q '"status"\s*:\s*"running"' || exit 1
 
-if [ -S /tmp/qga.sock ]; then
-  GAP=$(
-    { printf '%s\n' \
-        '{ "execute": "qmp_capabilities" }' \
-        '{ "execute": "guest-ping" }' \
-      | socat - UNIX-CONNECT:/tmp/qmp.sock; } 2>/dev/null || true
-  )
-  echo "$GAP" | grep -q '"return"\s*:\s*{}' || exit 1
-fi
-
 [ -f /var/lib/qemu/initialized ] || exit 1
 
-
-socat -T 2 - tcp:"$OPENWRT_GW_IP":22,connect-timeout=2 </dev/null >/dev/null 2>&1 || exit 1
+printf 'SSH-2.0-natlab_healthcheck\r\n' \
+  | socat -t "$SSH_TIMEOUT" -T "$SSH_TIMEOUT" - \
+      tcp:"$OPENWRT_GW_IP":22,connect-timeout="$SSH_TIMEOUT" 2>/dev/null \
+  | grep -q '^SSH-2\.0-' \
+  || { echo "no SSH identification from $OPENWRT_GW_IP:22"; exit 1; }
 
 exit 0

--- a/nat-lab/docker-compose.yml
+++ b/nat-lab/docker-compose.yml
@@ -747,7 +747,7 @@ services:
     healthcheck:
       test: /opt/bin/openwrt/openwrt-qemu-healthcheck.sh
       interval: 15s
-      timeout: 5s
+      timeout: 30s
       start_period: 45s
       retries: 5
 
@@ -785,7 +785,7 @@ services:
     healthcheck:
       test: /opt/bin/openwrt/openwrt-qemu-healthcheck.sh
       interval: 15s
-      timeout: 5s
+      timeout: 30s
       # Match the entrypoint's QEMU_CONFIG_TIMEOUT
       start_period: 120s
       retries: 32


### PR DESCRIPTION
### Problem
`test_openwrt_simulate_network_down` failed  in `openwrt-gw-03`: the test could not open an SSH session to the router and timed out after 30s.
The container was reported as healthy, because the healthcheck only opened a TCP connection to port 22.

### Solution
- Make the healthcheck ask for the SSH greeting instead of just opening a socket (drop it as SSH is more complete check in this case)
- Raise openwrt healthcheck timeouts to 30s, since the check can now wait up to 20s
- Drop the QEMU guest agent block: no guest agent socket is ever created, and it queried the QMP socket instead, so it could never have worked


### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
