### PR TITLE
LLT-7632: Use private key from requested state to configure DERP

### DIFF
--- a/crates/telio-core/src/device.rs
+++ b/crates/telio-core/src/device.rs
@@ -2070,7 +2070,7 @@ impl Runtime {
             }
 
             let derp_config = DerpConfig {
-                secret_key,
+                secret_key: self.requested_state.device_config.private_key.clone(),
                 servers: SortedServers::new(config.derp_servers.clone().unwrap_or_default()),
                 meshnet_peers: peers,
                 timeout: Duration::from_secs(10), //TODO: make configurable


### PR DESCRIPTION
### Problem

If a DERP peer sets a secret key on its WG interface incorrectly (due to, for example, error returned by WG interface), other DERP peers, will not be able to identify this peer with a public key derived from its secret key.

This happens because DERP relay receives the incorrect secret key in the DERP config and uses this key to establish direct connection between peers.

### Solution
A secret key from `RequestedState::device_config` is used to configure DERP. This key in turn is used for WG interface reconfiguration in `consolidate_wg_state` function.

Fixes LLT-7632.

### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
