### PR TITLE
Restart nordvpnlite instead of start in test_openwrt_router_restart

### DIFF
--- a/nat-lab/tests/test_openwrt.py
+++ b/nat-lab/tests/test_openwrt.py
@@ -656,17 +656,24 @@ async def test_openwrt_router_restart(
                 ["mkdir", "-p", "/etc/nordvpnlite"]
             ).execute()
 
-            # start nordvpnlite without a cleanup as we want to validate vpn connection restore
-            async with nordvpnlite.start(cleanup=False):
-                log.debug("NordVPN Lite started, waiting for connected vpn state...")
-                await nordvpnlite.wait_for_vpn_connected_state()
-                await check_gateway_and_client_ip(
-                    gateway_connection, client_connection, WG_SERVER["ipv4"], gw_tag
-                )
-                await exit_stack.enter_async_context(
-                    gateway_connection.create_process(["reboot"]).run()
-                )
-                await wait_until_unreachable_after_reboot(gateway_connection)
+            # TODO(LLT-7676): This restart is a workaround, shouldn't be needed when LLT-7676 is done
+            await nordvpnlite.remove_logs()
+            await nordvpnlite.save_config()
+            await nordvpnlite.login()
+            await gateway_connection.create_process(
+                ["/etc/init.d/nordvpnlite", "restart"]
+            ).execute()
+            await nordvpnlite.wait_for_nordvpnlite_start()
+
+            log.debug("NordVPN Lite started, waiting for connected vpn state...")
+            await nordvpnlite.wait_for_vpn_connected_state()
+            await check_gateway_and_client_ip(
+                gateway_connection, client_connection, WG_SERVER["ipv4"], gw_tag
+            )
+            await exit_stack.enter_async_context(
+                gateway_connection.create_process(["reboot"]).run()
+            )
+            await wait_until_unreachable_after_reboot(gateway_connection)
     except (
         asyncssh.misc.ConnectionLost,
         asyncssh.misc.ChannelOpenError,


### PR DESCRIPTION
### Problem
When `test_openwrt_router_restart` executed in the first order in pytest session we've got a following:
1. Installs nordvpnlite and starts the procd service
2. Daemon has no credentials, exits immediately, and procd respawns it every 5s
3. Test writes a valid config and auth file to the default paths the service reads
4. Next respawn finds both and starts successfully
5. In test nordvpnlite start fails with `DaemonIsRunning`

It's not happening when procd already died (crash loop is already over).

### Solution
Temporary  solution is to restart nordvpnlite instead of start in test_openwrt_router_restart.
The permanent fix is described in LLT-7676.



### :ballot_box_with_check: Definition of Done checklist
- [x] Commit history is clean ([requirements](../blob/main/docs/git_commit_messages_requirements.md))
- [x] README.md is updated
- [x] Functionality is covered by unit or integration tests
